### PR TITLE
Define design council execution protocol

### DIFF
--- a/docs/coordination/proposals/task.md
+++ b/docs/coordination/proposals/task.md
@@ -1,0 +1,172 @@
+# Independent design proposal task
+
+Status: **Draft — do not execute until the Discovery input commit below is
+filled in and all listed reports pass review.**
+
+## Provenance
+
+- Issue: #6
+- Shared-input commit: `TBD`
+- Prompt revision: 1
+- Execution date: `TBD` (Asia/Tokyo)
+
+Every proposer receives this file and the same immutable input snapshot. Model
+responses are captured verbatim in separate files; command, tool version, model
+identifier, outcome, duration, and word count are recorded outside the response.
+Do not read another proposal or any cross-critique.
+
+## Shared evidence
+
+Read only these project inputs before answering:
+
+- `README.md`
+- `ROADMAP.md`
+- `ARCHITECTURE.md`
+- `docs/project-principles.md`
+- `docs/research/terminal-landscape.md`
+- `docs/research/library-comparison.md`
+- `docs/compatibility/cmux-parity.md`
+- `docs/compatibility/zellij.md`
+- `docs/research/ssh-and-remote.md`
+- `docs/research/agent-integrations.md`
+
+Treat the reports as evidence, not as predetermined architecture. Do not browse,
+modify files, run project commands, or inspect proposal/review outputs. If an
+answer is absent from the shared evidence, label it `Unknown` or propose a
+bounded experiment; do not invent an upstream API, behavior, benchmark, license,
+or compatibility claim.
+
+## Product brief
+
+Noren is a new open-source Rust terminal for macOS and Linux. Its intended value
+is a coherent workspace for local shells, SSH hosts, and existing CLI coding
+agents while preserving input expected by Zellij, tmux, editors, shells, and
+full-screen terminal applications. It may offer native tabs, panes, workspaces,
+recovery, themes, notifications, and agent-aware navigation, but it is not a
+Zellij replacement or an embedded LLM chat product. Input integrity, honest
+feature status, recoverability, security, accessibility, and measurable release
+evidence take priority over feature count.
+
+The first public target is `0.1.0-preview`. Production implementation cannot
+begin until requirements, architecture, threat model, test strategy, and
+material ADR/RFC decisions pass independent review. Disposable experiments are
+allowed only to resolve stated unknowns.
+
+The requested product surface includes a local PTY; bash, zsh, and fish; modern
+ANSI/VT behavior; Unicode, CJK, emoji, IME, and HiDPI; bounded scrollback,
+selection, copy, paste, search, URLs, fonts, and zoom; multiple workspaces, tabs,
+horizontal and vertical panes, layout save/restore, crash recovery, a command
+palette, sidebar, and notification history; OpenSSH configuration and host-key
+behavior; reconnectable SSH workspaces; existing CLI-agent launchers and only
+evidence-backed agent state; separate UI themes and terminal palettes; and user
+control over keybindings, layouts, notifications, and future extensions.
+
+The requested Preview release floor includes successful macOS Apple Silicon and
+Linux x86_64 builds; usable bash/zsh/fish sessions; stable local PTY and text I/O;
+copy, paste, and search; tabs and panes; workspace save/restore; tested Zellij
+input preservation and pass-through; SSH connection, disconnect detection, and
+reconnect; light and dark themes; basic Codex, Claude Code, and OpenCode use;
+jump from a notification to its pane; passing CI; no known critical crash or
+security issue; license and secret scans; installation and known-limitations
+documentation; an independent Claude security review; and a codex-lab release
+verdict. A proposal may challenge feasibility or sequence, but it must identify
+any requested floor it would defer and explain the release consequence.
+
+## Fixed constraints and provisional goals
+
+- When a terminal pane is focused, preservation of Ctrl, Alt, Ctrl+Alt, function
+  keys, terminal protocols, and application input takes precedence over Noren
+  convenience. Prefer Command-based defaults on macOS and avoid a large fixed
+  Ctrl map on Linux. Every Noren shortcut must be rebindable or disableable.
+- Zellij pass-through must minimize captured keys and allow a configurable
+  leader, command-palette exit, and GUI fallback. Invalid configuration must be
+  diagnosed while input continues to the child.
+- SSH must respect existing OpenSSH config, agents, and `known_hosts`; Noren must
+  not store private keys or passphrases. Ordinary OpenSSH remains available if a
+  remote-session enhancement fails or is deferred. A daemon, if justified, uses
+  SSH stdio or a tunnel by default rather than a public listening port.
+- Agent state signal priority is official hook, official plugin API, structured
+  output, explicit shell integration, OSC notification, then process metadata.
+  Unsupported state is `Unknown`; a process name alone is insufficient.
+- UI themes and terminal ANSI palettes are separate. Include light, dark, high-
+  contrast, and color-vision-friendly intent; do not silently rewrite a user's
+  chosen terminal colors.
+- Provisional performance goals are input-to-render p95 within one frame, warm
+  start within 500 ms on a recorded reference machine, responsive 100 MB output,
+  usable eight-pane operation, bounded scrollback memory, no continuing memory
+  growth in an eight-hour soak, and no whole-UI block during SSH failure. These
+  are hypotheses to validate and may be revised by measured ADR.
+- Required targets are macOS Apple Silicon and Linux x86_64 on Wayland and X11,
+  with bash, zsh, and fish. macOS Intel, Linux ARM64, and Windows are Later unless
+  evidence supports a smaller safe inclusion.
+- Persisted configuration/workspace data uses versioning and atomic replacement;
+  failed reload or migration preserves the last valid state. Bound OSC, config,
+  IPC, diagnostic, and scrollback inputs. Keep `unsafe` minimal and explain each
+  use with a `SAFETY` invariant.
+- Do not select a terminal parser, PTY, SSH/crypto, renderer, font shaper, or
+  plugin runtime without official-source/license/maintenance evidence and a PoC
+  when the risk cannot be resolved on paper. Do not copy cmux code, assets, or
+  marks.
+- Begin with one repository. A remote daemon, conformance suite, site, or
+  extension repository may split only when an independent release cycle or
+  security boundary is demonstrated.
+
+## Assignment
+
+Write an independent, decision-oriented proposal for the smallest credible
+Preview. Use exactly the 27 numbered headings below, in this order; they mirror
+the project owner's required Round 1 submissions. Prefer concrete contracts,
+failure semantics, measurable gates, and explicit deferral. Keep the response at
+or below 4,000 words.
+
+1. **Noren's central value**
+2. **Target users**
+3. **Problems Noren solves**
+4. **Problems Noren does not solve**
+5. **v0.1 Preview scope**
+6. **Architecture proposal**
+7. **Crate structure**
+8. **Repository structure**
+9. **Candidate libraries**
+10. **Rendering approach**
+11. **PTY approach**
+12. **SSH approach**
+13. **Remote-daemon approach**
+14. **Zellij compatibility design**
+15. **Keybinding design**
+16. **CLI-agent integration**
+17. **Theme approach**
+18. **Plugin approach**
+19. **Security risks**
+20. **Performance risks**
+21. **Portability risks**
+22. **Ten greatest technical risks**
+23. **Test strategy**
+24. **Implementation order**
+25. **Preview release conditions**
+26. **Design decisions that should remain easy to discard**
+27. **Overengineering to avoid**
+
+## Required decision quality
+
+- Distinguish `Preview`, `Later`, `Experiment`, and `Rejected` scope.
+- Name the user-visible behavior and failure behavior of every Preview subsystem.
+- Cover workspace interaction, persistence/recovery, rendering/fonts/IME/
+  accessibility, Noren-owned API/data boundaries, packaging, rollback, support,
+  and repository/crate dependency direction under the relevant required heading.
+- Prefer Noren-owned interfaces around replaceable or security-sensitive
+  dependencies; avoid speculative abstraction elsewhere.
+- State which work can proceed in parallel and which dependencies serialize it.
+- Give each performance target a measurement method and target environment; mark
+  an ungrounded number as a proposed budget, not a measured fact.
+- Give each compatibility claim a fixture or conformance-test path.
+- Treat agent state as `Unknown` unless a trusted, documented signal proves it.
+- Never store SSH private keys, passphrases, agent secrets, or API credentials.
+- Preserve valid state when reload, migration, child process, remote transport,
+  or plugin/adapter operations fail.
+- Section 22 must contain exactly ten ranked risks. Each risk needs impact,
+  trigger, mitigation, evidence needed, and release consequence.
+- End section 27 with unresolved questions that could change the architecture.
+
+This is a proposal, not an approval. The integration round will retain dissent
+and may reject any recommendation that lacks evidence or a practical test.

--- a/docs/coordination/proposals/task.md
+++ b/docs/coordination/proposals/task.md
@@ -1,14 +1,14 @@
 # Independent design proposal task
 
-Status: **Draft — do not execute until the Discovery input commit below is
-filled in and all listed reports pass review.**
+Status: **Draft — do not execute until all listed reports exist and pass review,
+and `run-manifest.md` records their immutable commit plus this task's blob hash.**
 
 ## Provenance
 
 - Issue: #6
-- Shared-input commit: `TBD`
 - Prompt revision: 1
-- Execution date: `TBD` (Asia/Tokyo)
+- Run-specific commit, task-blob, date, CLI, model, control, outcome, duration,
+  and word-count evidence belongs in `run-manifest.md`, not in this prompt.
 
 Every proposer receives this file and the same immutable input snapshot. Model
 responses are captured verbatim in separate files; command, tool version, model
@@ -117,8 +117,9 @@ any requested floor it would defer and explain the release consequence.
 
 Do not execute this task from a repository, worktree, or persisted session. For
 each proposer, construct a fresh temporary directory containing only a serialized
-copy of this task and the files listed under Shared evidence, all from the exact
-shared-input commit. Start a new non-interactive session; do not resume it later.
+copy of this task plus the files listed under Shared evidence from the exact
+evidence commit recorded in `run-manifest.md`. Verify this task's blob hash against
+that manifest. Start a new non-interactive session; do not resume it later.
 Use the verified CLI-specific ephemeral/read-only/no-tool/no-persistence controls
 from the run manifest wherever the CLI provides them, disable browsing, and deny
 writes. Record the exact command and effective controls without credentials.

--- a/docs/coordination/proposals/task.md
+++ b/docs/coordination/proposals/task.md
@@ -29,6 +29,7 @@ Read only these project inputs before answering:
 - `docs/compatibility/zellij.md`
 - `docs/research/ssh-and-remote.md`
 - `docs/research/agent-integrations.md`
+- `docs/roadmap/risk-register.md`
 
 Treat the reports as evidence, not as predetermined architecture. Do not browse,
 modify files, run project commands, or inspect proposal/review outputs. If an
@@ -77,7 +78,8 @@ any requested floor it would defer and explain the release consequence.
 - When a terminal pane is focused, preservation of Ctrl, Alt, Ctrl+Alt, function
   keys, terminal protocols, and application input takes precedence over Noren
   convenience. Prefer Command-based defaults on macOS and avoid a large fixed
-  Ctrl map on Linux. Every Noren shortcut must be rebindable or disableable.
+  Ctrl map on Linux. Every Noren shortcut must be both rebindable and
+  disableable.
 - Zellij pass-through must minimize captured keys and allow a configurable
   leader, command-palette exit, and GUI fallback. Invalid configuration must be
   diagnosed while input continues to the child.
@@ -110,6 +112,21 @@ any requested floor it would defer and explain the release consequence.
 - Begin with one repository. A remote daemon, conformance suite, site, or
   extension repository may split only when an independent release cycle or
   security boundary is demonstrated.
+
+## Execution isolation
+
+Do not execute this task from a repository, worktree, or persisted session. For
+each proposer, construct a fresh temporary directory containing only a serialized
+copy of this task and the files listed under Shared evidence, all from the exact
+shared-input commit. Start a new non-interactive session; do not resume it later.
+Use the verified CLI-specific ephemeral/read-only/no-tool/no-persistence controls
+from the run manifest wherever the CLI provides them, disable browsing, and deny
+writes. Record the exact command and effective controls without credentials.
+
+If a CLI cannot technically disable a capability, record that residual isolation
+limitation before the run and retain the explicit no-tool/no-network instruction;
+never silently claim stronger isolation than the command provides. A run that can
+see another proposal is invalid and must be repeated from a clean snapshot.
 
 ## Assignment
 

--- a/docs/coordination/reviews/protocol-codex-lab.md
+++ b/docs/coordination/reviews/protocol-codex-lab.md
@@ -6,6 +6,7 @@
 - Reviewer: codex-lab, configured `gpt-5.6-sol`
 - Command: `codex-lab review --base main`
 - First follow-up: same session via `codex-lab exec resume`
+- Second follow-up: same session via `codex-lab exec resume`
 - Review mode: read-only
 
 ## Findings and resolution
@@ -37,4 +38,9 @@ now states both requirements explicitly.
 
 ## Follow-up status
 
-Pending a second codex-lab follow-up review of the corrected diff.
+> All prior findings resolved.
+
+The second follow-up inspected only commit `f4e9c7a` and confirmed that the
+external-manifest design removes the self-reference, the reviewer-visible
+placeholder preserves anonymity, and neither correction introduced a new
+actionable finding.

--- a/docs/coordination/reviews/protocol-codex-lab.md
+++ b/docs/coordination/reviews/protocol-codex-lab.md
@@ -1,0 +1,32 @@
+# Design council protocol independent QA
+
+- Issue: [#6](https://github.com/ta-061/noren/issues/6)
+- Pull request: [#7](https://github.com/ta-061/noren/pull/7)
+- Commit reviewed: `5d630ae`
+- Reviewer: codex-lab, configured `gpt-5.6-sol`
+- Command: `codex-lab review --base main`
+- Review mode: read-only
+
+## Findings and resolution
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| P1 | Reviewers did not receive the governing proposal task, so they could not reliably distinguish an allowed deferral from a missed requirement. | Every review pack now includes the exact executed proposal-task revision as a required input. |
+| P1 | Prompt-only restrictions did not enforce independent proposal/review runs when a CLI could access a worktree, persisted session, network, or other outputs. | Both protocols now require fresh minimal temporary snapshots, new non-resumed sessions, verified CLI-specific controls, recorded residual limitations, and invalidation/retry if hidden outputs were visible. |
+| P2 | The Discovery risk register was absent from the Round 1 evidence list. | `docs/roadmap/risk-register.md` is now a mandatory shared input and must exist at the recorded commit before execution. |
+| P2 | A failed or timed-out proposer could satisfy the outcome gate but left the required five-label review pack undefined. | Failed, timed-out, or unavailable outcomes now use provenance-only `Unavailable` placeholders; another model's text cannot replace them. |
+
+During review, two repository-checker tests could not create temporary fixtures
+because the reviewer sandbox was read-only. This is an expected limitation of
+the review environment, not a passing test result. The integrator reruns the
+checks in the normal repository environment after every correction.
+
+## Additional integrator correction
+
+The project goal requires every Noren shortcut to be both changeable and
+disableable. The proposal task previously said "rebindable or disableable"; it
+now states both requirements explicitly.
+
+## Follow-up status
+
+Pending a codex-lab follow-up review of the corrected diff.

--- a/docs/coordination/reviews/protocol-codex-lab.md
+++ b/docs/coordination/reviews/protocol-codex-lab.md
@@ -5,6 +5,7 @@
 - Commit reviewed: `5d630ae`
 - Reviewer: codex-lab, configured `gpt-5.6-sol`
 - Command: `codex-lab review --base main`
+- First follow-up: same session via `codex-lab exec resume`
 - Review mode: read-only
 
 ## Findings and resolution
@@ -27,6 +28,13 @@ The project goal requires every Noren shortcut to be both changeable and
 disableable. The proposal task previously said "rebindable or disableable"; it
 now states both requirements explicitly.
 
+## First follow-up findings and resolution
+
+| Priority | Finding | Resolution |
+| --- | --- | --- |
+| P1 | Putting the shared-input commit inside the task made the provenance requirement self-referential because inserting the hash changes the commit. | Run-specific evidence commit and final task blob hash now live in an external run manifest; the prompt contains no self-hash placeholder. |
+| P1 | Detailed command/model/failure provenance inside an unavailable placeholder disclosed the hidden author-label mapping. | Reviewer-visible placeholders now contain only the opaque label and normalized `Unavailable`; detailed provenance is withheld until every review is captured. |
+
 ## Follow-up status
 
-Pending a codex-lab follow-up review of the corrected diff.
+Pending a second codex-lab follow-up review of the corrected diff.

--- a/docs/coordination/reviews/task.md
+++ b/docs/coordination/reviews/task.md
@@ -1,0 +1,80 @@
+# Independent cross-critique task
+
+Status: **Draft — do not execute until all six proposal outcomes are recorded and
+the immutable review-pack commit below is filled in.**
+
+## Provenance
+
+- Issue: #6
+- Shared-input commit: `TBD`
+- Review-pack commit: `TBD`
+- Prompt revision: 1
+- Execution date: `TBD` (Asia/Tokyo)
+
+Every reviewer receives this file, the same Discovery evidence, and the five
+other Round 1 proposals labeled Proposal A through Proposal E. A reviewer never
+receives its own proposal. The per-reviewer label mappings are hidden during
+review and published after every review is captured. Responses are stored
+verbatim; command, tool version, model identifier, outcome, duration, and word
+count are recorded outside the response.
+
+## Assignment
+
+Review the proposals as claims and designs, not as model output. Do not guess
+authorship or reward writing style. Do not browse, modify files, run project
+commands, or inspect another review. Check upstream claims only against the
+provided Discovery evidence. Label absent evidence `Unknown`; propose a bounded
+experiment when it can resolve a decision.
+
+Produce one decision-oriented review of no more than 3,500 words using exactly
+these headings:
+
+1. **Gate verdict** — `Proceed`, `Proceed after listed changes`, or `Do not
+   proceed`, with the reasons that determine the verdict.
+2. **Proposal comparison** — a compact table of the strongest, weakest, and
+   uniquely useful parts of A–E.
+3. **Requirement and scope gaps** — missing user behavior, failure semantics,
+   non-goals, and Preview cut-line problems.
+4. **Feasibility and dependencies** — unsupported APIs, maintenance/license
+   risks, platform constraints, and experiments required before selection.
+5. **Security and data-loss risks** — trust boundaries, secrets, OSC/config/IPC,
+   plugins/adapters, child processes, SSH, persistence, rollback, and recovery.
+6. **Input and compatibility risks** — key capture, pass-through liveness,
+   Zellij/tmux/full-screen applications, keyboard protocols, and versioned
+   fixtures.
+7. **Performance and portability risks** — unmeasured claims, resource budgets,
+   target environments, macOS/Linux differences, fonts, IME, and accessibility.
+8. **Testability and release evidence** — measurable requirements, oracles,
+   fault injection, conformance, CI, packaging, rollback, and known limitations.
+9. **Repository and API boundaries** — cohesion, dependency direction, stable
+   contracts, replaceable libraries, unsafe ownership, and unjustified services
+   or repositories.
+10. **Smaller alternatives and deferrals** — the least complex design that still
+    delivers a credible Preview.
+11. **Ranked findings** — up to fifteen findings labeled `Blocker`, `High`,
+    `Medium`, or `Low`; each names affected proposals, evidence, consequence, and
+    a concrete correction or experiment.
+12. **Recommended synthesis** — decisions to adopt, reject, keep reversible, and
+    record as ADRs/RFCs, plus any material dissent that must remain visible.
+
+## Review rules
+
+- Correctness, data-loss prevention, security, compatibility, verifiability,
+  maintainability, feasibility, performance, extensibility, appearance, then
+  fashion is the decision order.
+- A feature is not Preview-ready unless its user-visible behavior, failure
+  behavior, test oracle, owner, and target environment are identifiable.
+- A dependency is not selected merely because proposals agree. Require official
+  evidence, compatible license, maintained status, platform fit, security notes,
+  and a PoC where the boundary is high-risk.
+- A daemon, plugin runtime, custom protocol, separate repository, or compatibility
+  promise carries the burden of proof.
+- Process-name-only agent detection is not trustworthy state.
+- Invalid keybinding configuration must be diagnosable while terminal input is
+  preserved. Pass-through requires a reachable configurable exit and a
+  non-keyboard fallback.
+- Do not silently resolve disagreement. State the competing choices and the
+  evidence or experiment that should decide them.
+
+This is a critique, not the integration decision. The integrator must answer all
+Blocker and High findings or explicitly retain the risk in an ADR.

--- a/docs/coordination/reviews/task.md
+++ b/docs/coordination/reviews/task.md
@@ -1,15 +1,15 @@
 # Independent cross-critique task
 
 Status: **Draft — do not execute until all six proposal outcomes are recorded and
-the immutable review-pack commit below is filled in.**
+`run-manifest.md` pins the proposal-task blob, evidence commit, and per-review
+pack digest.**
 
 ## Provenance
 
 - Issue: #6
-- Shared-input commit: `TBD`
-- Review-pack commit: `TBD`
 - Prompt revision: 1
-- Execution date: `TBD` (Asia/Tokyo)
+- Run-specific hashes, label mappings, date, CLI, model, controls, outcomes,
+  durations, and word counts belong in `run-manifest.md`, not in this prompt.
 
 Every reviewer receives this file, the exact executed revision of
 `docs/coordination/proposals/task.md`, the same Discovery evidence, and the five
@@ -19,12 +19,14 @@ review and published after every review is captured. Responses are stored
 verbatim; command, tool version, model identifier, outcome, duration, and word
 count are recorded outside the response.
 
-An outcome that failed, timed out, or was unavailable is represented by a
-placeholder containing only the label, outcome, attempted command/model
-provenance, elapsed time, and failure reason. It is never filled with another
-model's text. The reviewer lists that label as `Unavailable`, does not score its
-proposal quality, and still evaluates the remaining labels. The comparison table
-must contain A through E even when one or more rows are unavailable.
+An outcome that failed, timed out, or was unavailable is represented in the
+reviewer-visible pack only by its opaque label and the normalized status
+`Unavailable`. It is never filled with another model's text. Command/model,
+duration, outcome category, and failure detail remain outside the pack until all
+reviews are captured and the mappings are published in `run-manifest.md`. The
+reviewer does not score an unavailable proposal and still evaluates the remaining
+labels. The comparison table must contain A through E even when one or more rows
+are unavailable.
 
 ## Execution isolation
 

--- a/docs/coordination/reviews/task.md
+++ b/docs/coordination/reviews/task.md
@@ -11,12 +11,32 @@ the immutable review-pack commit below is filled in.**
 - Prompt revision: 1
 - Execution date: `TBD` (Asia/Tokyo)
 
-Every reviewer receives this file, the same Discovery evidence, and the five
-other Round 1 proposals labeled Proposal A through Proposal E. A reviewer never
+Every reviewer receives this file, the exact executed revision of
+`docs/coordination/proposals/task.md`, the same Discovery evidence, and the five
+other Round 1 outcomes labeled Proposal A through Proposal E. A reviewer never
 receives its own proposal. The per-reviewer label mappings are hidden during
 review and published after every review is captured. Responses are stored
 verbatim; command, tool version, model identifier, outcome, duration, and word
 count are recorded outside the response.
+
+An outcome that failed, timed out, or was unavailable is represented by a
+placeholder containing only the label, outcome, attempted command/model
+provenance, elapsed time, and failure reason. It is never filled with another
+model's text. The reviewer lists that label as `Unavailable`, does not score its
+proposal quality, and still evaluates the remaining labels. The comparison table
+must contain A through E even when one or more rows are unavailable.
+
+## Execution isolation
+
+Run every review in a fresh temporary directory containing only this task, the
+executed proposal-task revision, the shared Discovery evidence, and its five
+anonymized outcomes. Do not use a repository, worktree, or persisted/resumed
+session. Apply and record the verified per-CLI ephemeral/read-only/no-tool/no-
+persistence controls, disable browsing, and deny writes wherever supported. If a
+CLI cannot technically disable a capability, record the residual limitation and
+retain the explicit no-tool/no-network instruction. A review that can see its own
+proposal, another review, or the author-label mapping is invalid and must be
+repeated.
 
 ## Assignment
 


### PR DESCRIPTION
Relates to #6

## Summary

- Defines the identical, evidence-bounded Round 1 task with the project owner's exact 27 required topics.
- Carries the fixed Preview floor and input/security/recovery constraints into every proposal.
- Defines anonymous cross-critique packs that exclude each reviewer's own proposal.
- Records TBD input commits so neither round can run before its immutable evidence exists.

## Design decisions

The protocol preserves model responses verbatim, separates provenance from response text, prohibits invented upstream claims, and keeps unsupported facts Unknown or experiment-gated. Cross-reviews rank evidence and risk rather than model identity.

## Changed files

- docs/coordination/proposals/task.md
- docs/coordination/reviews/task.md

## Verification

- Documentation checker: passed
- Documentation checker unit tests: 7 passed
- Git whitespace check: passed

## Screenshots

Not applicable; documentation-only change.

## Performance impact

None at runtime.

## Security impact

The protocol adds explicit secret, SSH, IPC, OSC, rollback, and evidence constraints. It grants no credentials or repository permissions.

## Known limitations

Both tasks remain Draft. Discovery reports and immutable input commits are deliberately TBD; proposal execution is still gated.

## Rollback

Revert commit 5d630ae; no runtime or persisted data is affected.