### PR TITLE
Correct OpenCode executable provenance

### DIFF
--- a/docs/coordination/agent-calibration.md
+++ b/docs/coordination/agent-calibration.md
@@ -22,12 +22,19 @@ tests, security bounds, uncertainty, and deferral discipline.
 | Codex | configured `gpt-5.6-sol` | `codex exec --ephemeral --sandbox read-only` | Completed | 1,089 |
 | codex-lab | isolated config also `gpt-5.6-sol` | `codex-lab exec --ephemeral --sandbox read-only` | Completed | 1,025 |
 | Claude Code | result reported canonical `claude-opus-5` | `claude --print --permission-mode plan --tools "" --no-session-persistence` | Completed; exceeded limit | 3,048 |
-| Qwen | `qwencloud/qwen3.8-max-preview` from model list | `opencode run --pure --agent plan` | Completed; exceeded limit | 1,339 |
-| GLM | `zai-coding-plan/glm-5.2` from model list | `opencode run --pure --agent plan` | Completed; exceeded limit | 1,258 |
-| Fugu | `sakana/fugu-ultra` from model list | `opencode run --pure --agent plan` | Completed; high latency | 1,184 |
+| Qwen | `qwencloud/qwen3.8-max-preview` from the selected 1.18.11 model list | `opencode run --pure --agent plan`; PATH resolved to the selected executable | Completed; exceeded limit | 1,339 |
+| GLM | `zai-coding-plan/glm-5.2` from the selected 1.18.11 model list | `opencode run --pure --agent plan`; PATH resolved to the selected executable | Completed; exceeded limit | 1,258 |
+| Fugu | `sakana/fugu-ultra` from the selected 1.18.11 model list | `opencode run --pure --agent plan`; PATH resolved to the selected executable | Completed; high latency | 1,184 |
 
 Authentication identifiers, organization details, session IDs, and credential
 configuration are intentionally excluded.
+
+The original OpenCode help header named the Homebrew executable even though the
+captured `1.18.11` help/model output matches the PATH-preferred
+`$HOME/.opencode/bin/opencode`. A same-day audit found a separate Homebrew
+`1.14.31` installation. The [inventory](agent-inventory.md) records both
+path/version/digest tuples. This correction does not change or relabel any
+response; future runs use the selected absolute path.
 
 ## Rubric
 

--- a/docs/coordination/agent-calibration.md
+++ b/docs/coordination/agent-calibration.md
@@ -29,12 +29,14 @@ tests, security bounds, uncertainty, and deferral discipline.
 Authentication identifiers, organization details, session IDs, and credential
 configuration are intentionally excluded.
 
-The original OpenCode help header named the Homebrew executable even though the
-captured `1.18.11` help/model output matches the PATH-preferred
-`$HOME/.opencode/bin/opencode`. A same-day audit found a separate Homebrew
-`1.14.31` installation. The [inventory](agent-inventory.md) records both
-path/version/digest tuples. This correction does not change or relabel any
-response; future runs use the selected absolute path.
+The original OpenCode help header named the npm-global launcher under the
+Homebrew prefix even though the captured `1.18.11` help/model output matches the
+PATH-preferred
+`$HOME/.opencode/bin/opencode`. A same-day audit found the separate global npm
+package `opencode-ai@1.14.31`; Homebrew itself does not manage that installation.
+The [inventory](agent-inventory.md) records the selected executable and both
+artifacts in the shadowed launch chain. This correction does not change or
+relabel any response; future runs use the selected absolute path.
 
 ## Rubric
 

--- a/docs/coordination/agent-inventory.md
+++ b/docs/coordination/agent-inventory.md
@@ -16,15 +16,20 @@ non-secret configuration fields. Raw help output is stored in
 ## OpenCode executable provenance
 
 The initial help header incorrectly paired `/opt/homebrew/bin/opencode` with
-version `1.18.11`. Revalidation found two installations. The help and model-list
-body preserved in [`cli-help/opencode.txt`](cli-help/opencode.txt) matches the
-selected `1.18.11` executable; future runs must use its explicit path instead of
-relying on `PATH` order.
+version `1.18.11`. Revalidation found two installations. The shadowed path is a
+symlink to the JavaScript launcher from the global npm package
+`opencode-ai@1.14.31` under the Homebrew prefix; `brew info opencode` reports the
+Homebrew formula as not installed. That launcher executes a package-specific
+native payload. The help and model-list body preserved in
+[`cli-help/opencode.txt`](cli-help/opencode.txt) matches the selected `1.18.11`
+executable; future runs must use its explicit path instead of relying on `PATH`
+order.
 
-| Disposition | Sanitized path | Version | SHA-256 |
+| Disposition | Artifact | Version | SHA-256 |
 | --- | --- | --- | --- |
-| Selected for Noren evidence | `$HOME/.opencode/bin/opencode` | `1.18.11` | `f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c` |
-| Present but not selected | `/opt/homebrew/bin/opencode` | `1.14.31` | `3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b` |
+| Selected for Noren evidence | `$HOME/.opencode/bin/opencode` native executable | `1.18.11` | `f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c` |
+| Shadowed, not selected | `/opt/homebrew/bin/opencode` symlink target: global npm JavaScript launcher | `opencode-ai@1.14.31` | `3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b` |
+| Shadowed, not selected | npm launcher's `opencode-darwin-arm64` native payload | `1.14.31` | `40d5686fc86e94f833ac3e5855e12802464f2de0bcc1616013c62844bf6996d4` |
 
 No executable was installed, updated, or removed during this correction.
 

--- a/docs/coordination/agent-inventory.md
+++ b/docs/coordination/agent-inventory.md
@@ -9,9 +9,24 @@ non-secret configuration fields. Raw help output is stored in
 | Codex integrator | `codex`, `codex-cli 0.146.0` | `gpt-5.6-sol`, reasoning `max` in local config | `codex exec` | `codex resume [SESSION_ID]` or `--last` | Authenticated; calibration completed |
 | codex-lab QA | `codex-lab`, `codex-cli 0.146.0` | wrapper selects isolated `CODEX_HOME`; `gpt-5.6-sol`, reasoning `max` | `codex-lab exec` | `codex-lab resume [SESSION_ID]` or `--last` | Calibration completed |
 | Claude critical review | `claude`, `2.1.220` | configured alias `opus[1m]`; calibration reported canonical `claude-opus-5` | `claude --print` | `claude --resume [SESSION_ID]` or `--continue` | Authenticated; calibration completed |
-| Qwen UI/UX candidate | `opencode`, `1.18.11` | `qwencloud/qwen3.8-max-preview` from `opencode models` | `opencode run` | `--continue` or `--session ID` | Calibration completed |
-| GLM Rust-core candidate | `opencode`, `1.18.11` | `zai-coding-plan/glm-5.2` from `opencode models` | `opencode run` | `--continue` or `--session ID` | Calibration completed |
-| Fugu remote candidate | `opencode`, `1.18.11` | `sakana/fugu-ultra` and dated variant listed by `opencode models` | `opencode run` | `--continue` or `--session ID` | Calibration completed; high latency observed |
+| Qwen UI/UX candidate | `$HOME/.opencode/bin/opencode`, `1.18.11` | `qwencloud/qwen3.8-max-preview` from the selected binary's model list | `$HOME/.opencode/bin/opencode run` | `--continue` or `--session ID` | Calibration completed |
+| GLM Rust-core candidate | `$HOME/.opencode/bin/opencode`, `1.18.11` | `zai-coding-plan/glm-5.2` from the selected binary's model list | `$HOME/.opencode/bin/opencode run` | `--continue` or `--session ID` | Calibration completed |
+| Fugu remote candidate | `$HOME/.opencode/bin/opencode`, `1.18.11` | `sakana/fugu-ultra` and dated variant from the selected binary's model list | `$HOME/.opencode/bin/opencode run` | `--continue` or `--session ID` | Calibration completed; high latency observed |
+
+## OpenCode executable provenance
+
+The initial help header incorrectly paired `/opt/homebrew/bin/opencode` with
+version `1.18.11`. Revalidation found two installations. The help and model-list
+body preserved in [`cli-help/opencode.txt`](cli-help/opencode.txt) matches the
+selected `1.18.11` executable; future runs must use its explicit path instead of
+relying on `PATH` order.
+
+| Disposition | Sanitized path | Version | SHA-256 |
+| --- | --- | --- | --- |
+| Selected for Noren evidence | `$HOME/.opencode/bin/opencode` | `1.18.11` | `f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c` |
+| Present but not selected | `/opt/homebrew/bin/opencode` | `1.14.31` | `3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b` |
+
+No executable was installed, updated, or removed during this correction.
 
 ## Development environment
 

--- a/docs/coordination/cli-help/opencode.txt
+++ b/docs/coordination/cli-help/opencode.txt
@@ -3,7 +3,9 @@ Revalidated: 2026-08-03 (Asia/Tokyo)
 Selected binary: $HOME/.opencode/bin/opencode
 Version: 1.18.11
 SHA-256: f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c
-Shadowed binary: /opt/homebrew/bin/opencode, version 1.14.31, SHA-256 3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b
+Shadowed npm-global launcher: /opt/homebrew/bin/opencode -> /opt/homebrew/lib/node_modules/opencode-ai/bin/opencode, package opencode-ai@1.14.31, launcher SHA-256 3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b
+Shadowed native payload: opencode-darwin-arm64 1.14.31, SHA-256 40d5686fc86e94f833ac3e5855e12802464f2de0bcc1616013c62844bf6996d4
+Package-manager check: npm global package present; Homebrew formula not installed
 Configured providers: qwencloud, sakana, zai-coding-plan (credential details intentionally omitted)
 Body comparison: all four sections match the selected binary; embedded section separators account for final-newline-only differences in two help blocks.
 

--- a/docs/coordination/cli-help/opencode.txt
+++ b/docs/coordination/cli-help/opencode.txt
@@ -1,9 +1,13 @@
 Captured: 2026-08-03 (Asia/Tokyo)
-Binary: /opt/homebrew/bin/opencode
+Revalidated: 2026-08-03 (Asia/Tokyo)
+Selected binary: $HOME/.opencode/bin/opencode
 Version: 1.18.11
+SHA-256: f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c
+Shadowed binary: /opt/homebrew/bin/opencode, version 1.14.31, SHA-256 3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b
 Configured providers: qwencloud, sakana, zai-coding-plan (credential details intentionally omitted)
+Body comparison: all four sections match the selected binary; embedded section separators account for final-newline-only differences in two help blocks.
 
-$ env NO_COLOR=1 TERM=dumb opencode --help
+$ env NO_COLOR=1 TERM=dumb $HOME/.opencode/bin/opencode --help
 ⠀                                ▄     
 █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
 █  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀
@@ -61,7 +65,7 @@ Options:
       --no-replay     disable mini session history replay on resume and after resize       [boolean]
       --replay-limit  cap visible mini replay to the newest N messages                      [number]
 
-$ env NO_COLOR=1 TERM=dumb opencode run --help
+$ env NO_COLOR=1 TERM=dumb $HOME/.opencode/bin/opencode run --help
 opencode run [message..]
 
 run opencode with a message
@@ -100,7 +104,7 @@ Options:
       --auto         auto-approve permissions that are not explicitly denied (dangerous!)
                                                                           [boolean] [default: false]
 
-$ env NO_COLOR=1 TERM=dumb opencode session --help
+$ env NO_COLOR=1 TERM=dumb $HOME/.opencode/bin/opencode session --help
 opencode session
 
 manage sessions
@@ -116,7 +120,7 @@ Options:
       --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
       --pure        run without external plugins                                           [boolean]
 
-$ env NO_COLOR=1 TERM=dumb opencode models
+$ env NO_COLOR=1 TERM=dumb $HOME/.opencode/bin/opencode models
 opencode/big-pickle
 opencode/deepseek-v4-flash-free
 opencode/laguna-s-2.1-free


### PR DESCRIPTION
Closes #9

## Summary

- Corrects the 1.18.11 help evidence to the selected `$HOME/.opencode/bin/opencode` executable.
- Records path, version, and SHA-256 from that same selected native executable.
- Records the separate shadowed global npm package under `/opt/homebrew`, including its JavaScript launcher and native-payload digests, without modifying it.
- Requires explicit selected paths for future runs while preserving the actual PATH-based calibration command provenance.

## Design decisions

Executable identity is a path/version/digest tuple. For a launcher-based installation, the package manager, launcher, and executed native payload are separate provenance facts. A command name plus version is insufficient when PATH contains multiple installations.

## Changed files and forbidden scope

Changed only the three coordination files allowed by Issue #9. No executable, configuration, credential, response, or production code changed.

## Verification

- Selected absolute-path version: `1.18.11`
- Selected native-executable SHA-256: `f554a08dee4c34f4f43df63af72f0a6afbe57f955496853f411767718927bf2c`
- Shadowed global package: `opencode-ai@1.14.31`; npm-managed under the Homebrew prefix, while the Homebrew formula is not installed
- Shadowed JavaScript-launcher SHA-256: `3ab08cfdb3cf1213eaeae45f557fb3220e0999862d8dc90eb17ba4cacf97c57b`
- Shadowed executed native-payload SHA-256: `40d5686fc86e94f833ac3e5855e12802464f2de0bcc1616013c62844bf6996d4`
- Four stored help/model sections compared to selected binary: exact, except expected final-newline separators in two embedded blocks
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_docs.py`: passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_check_docs.py`: 7 passed
- `git diff --check`: passed
- GitHub `Validate repository documentation`: passed at head `9960106`

## Performance impact

None; documentation only.

## Security and privacy impact

No credentials or provider account details are recorded. `$HOME`-relative paths avoid publishing a user identity.

## Compatibility impact

Future Qwen, GLM, and Fugu runs become reproducible against the selected OpenCode 1.18.11 executable.

## Known limitations

The older npm-global installation remains present and may be selected by a different PATH. The selected executable's installation-manager provenance was not inferred; its path, Mach-O artifact, version, and digest were measured directly. Future automation must use the explicit selected path.

## Rollback

Revert the two signed commits; no executable or runtime state is affected.

## Independent review

- Implementer: Codex
- Reviewing agent: codex-lab found one P2 provenance-attribution error
- Resolution: commit `9960106` corrected npm/Homebrew attribution and separated launcher/payload evidence
- Independent QA: same codex-lab session returned exactly `All prior findings resolved.`
