### PR TITLE
Terminal Core: add renderer-independent state foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to Noren
 
-Thank you for helping build Noren. The project is in Discovery: documentation,
-research, test design, fixtures, and narrowly approved experiments are welcome,
-but production terminal implementation is gated on Milestone 1.
+Thank you for helping build Noren. Discovery and the first macOS local-zsh PTY
+PoC are merged, and terminal foundation work is in progress; contributions
+follow the [roadmap](ROADMAP.md) through Issue-backed, narrowly scoped Draft
+PRs.
 
 ## Before starting
 
@@ -29,10 +30,16 @@ Before opening a PR:
 - ensure no credentials, cookies, SSH keys, passphrases, or private data appear
   in the diff or logs.
 
-Rust-specific commands will become mandatory once the workspace and pinned
-toolchain exist. The intended baseline is formatting, Clippy with warnings
-denied, all workspace tests/features, dependency audit, and license policy
-checks; the repository will not claim these pass before CI actually runs them.
+The Rust workspace and pinned toolchain exist, so Rust changes must pass:
+
+```text
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Dependency audit and license policy checks remain intended additions; the
+repository will not claim these pass before CI actually runs them.
 
 ## Pull requests and review
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,16 +52,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "avt"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7179c44abe2ac36173d4713bfed24136e5988f005c7fe2c4fcde621d3d4d29b9"
-dependencies = [
- "rgb",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +178,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -710,8 +700,7 @@ dependencies = [
 name = "noren-terminal"
 version = "0.1.0"
 dependencies = [
- "avt",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1241,15 +1230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,12 +1521,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ unsafe_code = "deny"
 # these as the measured PoC candidates, not floating ranges.
 [workspace.dependencies]
 portable-pty = { version = "=0.9.0" }
-avt = { version = "=0.18.0" }
 unicode-width = { version = "=0.2.2" }
 winit = { version = "=0.30.13", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "=30.0.0", default-features = false, features = ["std", "metal", "wgsl"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,13 +7,19 @@ Only evidence-backed work is marked complete.
 | --- | --- | --- |
 | 0 — Discovery | Landscape, feature/library matrices, risks, agent inventory and calibration | In progress |
 | 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Not started |
-| 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | Not started |
+| 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | In progress |
 | 3 — Workspace | Tabs, panes, workspaces, persistence, sidebar, palette, configurable keybindings, Zellij pass-through | Not started |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | Not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | Not started |
 | 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | Not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | Not started |
 | 8 — Public Preview | Honest docs/site, binaries, checksums, release review, known limitations and `0.1.0-preview` | Not started |
+
+A renderer-independent terminal state core is in progress as Draft PR
+[#19](https://github.com/ta-061/noren/pull/19) (not merged), described in
+[terminal core foundation](docs/architecture/terminal-core-foundation.md).
+Deferred order: scroll regions, alternate screen, SGR/erase plus cell
+attributes, mode state; Unicode/IME remain later.
 
 No milestone date is promised before Milestone 1 converts its dependencies and
 release gates into measurable Issues.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@ Only evidence-backed work is marked complete.
 
 | Milestone | Scope | Status |
 | --- | --- | --- |
-| 0 — Discovery | Landscape, feature/library matrices, risks, agent inventory and calibration | In progress |
-| 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Not started |
+| 0 — Discovery | Landscape, feature/library matrices, risks, agent inventory and calibration | Complete |
+| 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Complete |
 | 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | In progress |
 | 3 — Workspace | Tabs, panes, workspaces, persistence, sidebar, palette, configurable keybindings, Zellij pass-through | Not started |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | Not started |
@@ -21,5 +21,5 @@ A renderer-independent terminal state core is in progress as Draft PR
 Deferred order: scroll regions, alternate screen, SGR/erase plus cell
 attributes, mode state; Unicode/IME remain later.
 
-No milestone date is promised before Milestone 1 converts its dependencies and
-release gates into measurable Issues.
+No milestone date is promised. Implementation advances through scoped Issues,
+Draft PRs, and current-head CI evidence.

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -414,7 +414,6 @@ impl std::error::Error for AppError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noren_terminal::TerminalEngine;
     use std::num::NonZeroU16;
 
     #[test]
@@ -599,7 +598,8 @@ mod tests {
     fn crates_wire_without_boundary_leak() {
         let size =
             noren_pty::PtySize::new(NonZeroU16::new(4).unwrap(), NonZeroU16::new(8).unwrap());
-        let mut engine = noren_terminal::AvtEngine::new(size.rows(), size.cols());
+        let mut engine = noren_terminal::TerminalState::new(size.rows(), size.cols())
+            .expect("valid terminal state");
         engine.feed_bytes(b"x");
         let snapshot = engine.snapshot();
         assert_eq!(

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -7,7 +7,7 @@ use noren_app::{
     PARSE_BUDGET_BYTES_PER_TURN, Resize,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
-use noren_terminal::{AvtEngine, TerminalEngine};
+use noren_terminal::{TerminalEngine, TerminalState};
 use renderer::{RenderOutcome, Renderer};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -27,7 +27,7 @@ struct NorenApp {
     renderer: Option<Renderer>,
     geometry: GridGeometry,
     pending_grid: Option<GridSize>,
-    terminal: Option<AvtEngine>,
+    terminal: Option<TerminalState>,
     pty: Option<PtySession>,
     modifiers: Modifiers,
     status: &'static str,
@@ -76,7 +76,12 @@ impl NorenApp {
             return;
         };
 
-        self.terminal = Some(AvtEngine::new(grid.rows(), grid.cols()));
+        let Ok(terminal) = TerminalState::new(grid.rows(), grid.cols()) else {
+            eprintln!("Noren terminal state creation failed");
+            event_loop.exit();
+            return;
+        };
+        self.terminal = Some(terminal);
         self.pty = match pty_size(grid).and_then(PtySession::spawn) {
             Ok(session) => {
                 self.status = "Noren PoC ready";
@@ -153,7 +158,10 @@ impl NorenApp {
             return;
         };
         if let Some(terminal) = &mut self.terminal {
-            terminal.resize(grid.rows(), grid.cols());
+            if terminal.resize(grid.rows(), grid.cols()).is_err() {
+                self.status = "Noren terminal resize failed";
+                self.show_status = true;
+            }
         }
         if let (Some(session), Ok(size)) = (&self.pty, pty_size(grid)) {
             if session.resize(size).is_err() {
@@ -227,18 +235,20 @@ impl NorenApp {
     }
 
     fn redraw(&mut self, event_loop: &ActiveEventLoop) {
-        let mut lines = self
-            .terminal
-            .as_ref()
-            .map(|terminal| terminal.snapshot().lines().to_vec())
-            .unwrap_or_default();
-        if lines.is_empty() || self.show_status {
-            lines.push(self.status.to_owned());
-        }
+        let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
+        let status = if self.show_status
+            || snapshot
+                .as_ref()
+                .is_none_or(|snapshot| snapshot.lines().is_empty())
+        {
+            Some(self.status)
+        } else {
+            None
+        };
         let outcome = self
             .renderer
             .as_mut()
-            .map(|renderer| renderer.render(&lines));
+            .map(|renderer| renderer.render(snapshot.as_ref(), status));
         match outcome {
             Some(RenderOutcome::DeviceLost) => {
                 self.status = "Noren renderer device lost";

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -11,6 +11,7 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use noren_app::{POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
+use noren_terminal::TerminalSnapshot;
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_RENDER_ROWS: usize = 60;
@@ -168,12 +169,16 @@ impl Renderer {
         self.surface.configure(&self.device, &self.config);
     }
 
-    pub(crate) fn render(&mut self, lines: &[String]) -> RenderOutcome {
+    pub(crate) fn render(
+        &mut self,
+        terminal: Option<&TerminalSnapshot>,
+        status: Option<&str>,
+    ) -> RenderOutcome {
         if self.device_lost.load(Ordering::Acquire) {
             return RenderOutcome::DeviceLost;
         }
 
-        let vertices = glyph_vertices(lines, self.config.width, self.config.height);
+        let vertices = glyph_vertices(terminal, status, self.config.width, self.config.height);
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
         if required > self.vertex_capacity {
@@ -267,7 +272,12 @@ fn block_on<F: Future>(future: F) -> F::Output {
     }
 }
 
-fn glyph_vertices(lines: &[String], width: u32, height: u32) -> Vec<[f32; 2]> {
+fn glyph_vertices(
+    terminal: Option<&TerminalSnapshot>,
+    status: Option<&str>,
+    width: u32,
+    height: u32,
+) -> Vec<[f32; 2]> {
     if width == 0 || height == 0 {
         return Vec::new();
     }
@@ -277,10 +287,17 @@ fn glyph_vertices(lines: &[String], width: u32, height: u32) -> Vec<[f32; 2]> {
     let visible_cols = usize::try_from(width / CELL_WIDTH)
         .unwrap_or(usize::MAX)
         .clamp(1, MAX_RENDER_COLS);
-    let first_line = lines.len().saturating_sub(visible_rows);
+    let lines = terminal.map(TerminalSnapshot::lines).unwrap_or_default();
+    let total_lines = lines.len() + usize::from(status.is_some());
+    let first_line = total_lines.saturating_sub(visible_rows);
     let mut vertices = Vec::new();
 
-    for (row, line) in lines[first_line..].iter().enumerate() {
+    for (row, line_index) in (first_line..total_lines).enumerate() {
+        let line = if line_index < lines.len() {
+            lines[line_index].as_str()
+        } else {
+            status.unwrap_or_default()
+        };
         for (col, character) in line.chars().take(visible_cols).enumerate() {
             let glyph = glyph_rows(character);
             for (glyph_y, bits) in glyph.into_iter().enumerate() {
@@ -407,18 +424,27 @@ fn glyph_rows(character: char) -> [u8; 7] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noren_terminal::TerminalState;
+
+    fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
+        let mut terminal = TerminalState::new(rows, cols).expect("valid test terminal");
+        terminal.feed_bytes(bytes);
+        terminal.snapshot()
+    }
 
     #[test]
     fn glyph_input_is_bounded_to_visible_poc_grid() {
-        let lines = vec!["A".repeat(500); 100];
-        let vertices = glyph_vertices(&lines, u32::MAX, u32::MAX);
+        let terminal = snapshot(100, 500, &vec![b'A'; 50_000]);
+        let vertices = glyph_vertices(Some(&terminal), None, u32::MAX, u32::MAX);
         assert!(vertices.len() <= MAX_VERTICES);
     }
 
     #[test]
     fn empty_and_zero_sized_inputs_have_no_vertices() {
-        assert!(glyph_vertices(&[], 900, 600).is_empty());
-        assert!(glyph_vertices(&["text".to_owned()], 0, 600).is_empty());
+        let empty = snapshot(1, 1, b"");
+        let text = snapshot(1, 8, b"text");
+        assert!(glyph_vertices(Some(&empty), None, 900, 600).is_empty());
+        assert!(glyph_vertices(Some(&text), None, 0, 600).is_empty());
     }
 
     #[test]
@@ -430,7 +456,8 @@ mod tests {
 
     #[test]
     fn vertex_encoding_has_two_floats_per_vertex() {
-        let vertices = glyph_vertices(&["A".to_owned()], 900, 600);
+        let terminal = snapshot(1, 2, b"A");
+        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
         assert_eq!(vertex_bytes(&vertices).len(), vertices.len() * 8);
     }
 }

--- a/crates/noren-terminal/Cargo.toml
+++ b/crates/noren-terminal/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-avt.workspace = true
 unicode-width.workspace = true
 
 [lints]

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -1,200 +1,66 @@
-//! Noren-owned terminal state, cell-width, and bounded snapshot contracts.
+//! Renderer-independent terminal state and bounded VT/ANSI parsing foundation.
 //!
-//! This crate owns the [`TerminalEngine`] contract from the
-//! [minimum architecture](https://github.com/ta-061/noren/blob/main/docs/architecture/minimal-local-pty-poc.md):
-//! bytes and dimensions in; bounded snapshot out. Replies, damage, and a
-//! stricter byte budget are wired by the application drain loop.
+//! [`TerminalState`] owns the screen, cursor, dimensions, and parser state.
+//! PTY bytes enter through [`TerminalEngine::feed_bytes`]; renderers receive an
+//! immutable [`TerminalSnapshot`] and never depend on PTY or parser types.
 //!
-//! The PoC trials `avt` 0.18.0 behind [`AvtEngine`]. Passing this baseline
-//! makes no terminal-compatibility claim: the adapter is a replaceable
-//! candidate and full VT/xterm semantics remain deferred. A bounded streaming
-//! UTF-8 boundary preserves code points split across PTY reads and replaces
-//! malformed sequences. `unicode-width` 0.2.2 is the direct cell-width policy
-//! seed; `avt` itself uses an older `unicode-width` internally and the two
-//! coexist.
+//! This first foundation deliberately supports printable ASCII, line feed,
+//! carriage return, backspace, and a small CSI cursor-movement subset. It is
+//! not a VT100/xterm compatibility claim.
+
+mod parser;
+mod state;
+
+pub use state::{
+    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, TerminalError, TerminalSnapshot,
+    TerminalState,
+};
 
 use unicode_width::UnicodeWidthChar;
 
-/// One grid cell in a [`TerminalSnapshot`].
+/// Terminal state contract: bytes and dimensions in, immutable snapshot out.
 ///
-/// `width` follows the [`cell_width`] policy so the renderer can reserve the
-/// correct number of columns for wide and combining glyphs.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Cell {
-    text: String,
-    width: u8,
-}
-
-impl Cell {
-    /// Build a cell from its display text and precomputed column width.
-    #[must_use]
-    pub fn new(text: impl Into<String>, width: u8) -> Self {
-        Self {
-            text: text.into(),
-            width,
-        }
-    }
-
-    /// The cell's display text.
-    #[must_use]
-    pub fn text(&self) -> &str {
-        &self.text
-    }
-
-    /// The cell's column width.
-    #[must_use]
-    pub fn width(&self) -> u8 {
-        self.width
-    }
-}
-
-/// A bounded, immutable view of the terminal grid.
-///
-/// `lines` is bounded by the current grid plus retained scrollback; a stricter
-/// per-turn byte budget is applied by the main-loop drain layer, not here.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TerminalSnapshot {
-    rows: u16,
-    cols: u16,
-    lines: Vec<String>,
-}
-
-impl TerminalSnapshot {
-    /// Number of rows in the grid.
-    #[must_use]
-    pub fn rows(&self) -> u16 {
-        self.rows
-    }
-
-    /// Number of columns in the grid.
-    #[must_use]
-    pub fn cols(&self) -> u16 {
-        self.cols
-    }
-
-    /// The snapshot lines, oldest first.
-    #[must_use]
-    pub fn lines(&self) -> &[String] {
-        &self.lines
-    }
-}
-
-/// Terminal state contract: bytes and dimensions in, bounded snapshot out.
-///
-/// The trait carries no third-party types so a candidate library can be
-/// replaced behind it without leaking its API across crate boundaries.
+/// The trait carries no window, GPU, PTY, or third-party parser types, keeping
+/// the core replaceable and directly testable.
 pub trait TerminalEngine {
-    /// Feed PTY output bytes to the terminal. Bytes are non-authoritative.
+    /// Feed non-authoritative PTY output bytes into terminal state.
     fn feed_bytes(&mut self, bytes: &[u8]);
 
-    /// Resize the grid. Noren convention is rows-first; implementations map to
-    /// their candidate's ordering.
-    fn resize(&mut self, rows: u16, cols: u16);
+    /// Resize the visible grid while preserving the overlapping top-left area.
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError>;
 
     /// Current grid size as `(rows, cols)`.
     fn size(&self) -> (u16, u16);
 
-    /// Take a bounded immutable snapshot of the grid.
+    /// Take a bounded immutable snapshot for a renderer or test oracle.
     fn snapshot(&self) -> TerminalSnapshot;
 }
 
-/// Cell-width policy seed.
-///
-/// Returns the Unicode column width for a single char, or `0` for control
-/// characters. Grapheme clustering and the explicit ambiguous-width policy are
-/// deferred; this is the minimal seed that exercises `unicode-width` 0.2.2.
-#[must_use]
-pub fn cell_width(ch: char) -> usize {
-    UnicodeWidthChar::width(ch).unwrap_or(0)
-}
-
-/// `avt` 0.18.0 candidate adapter behind [`TerminalEngine`].
-///
-/// Provisional and replaceable: the byte boundary here is a lossy placeholder
-/// (a streaming UTF-8 buffer lands later) and no compatibility is claimed.
-pub struct AvtEngine {
-    vt: avt::Vt,
-    pending_utf8: Vec<u8>,
-}
-
-impl AvtEngine {
-    /// Create an engine sized to `rows` x `cols`.
-    #[must_use]
-    pub fn new(rows: u16, cols: u16) -> Self {
-        Self {
-            vt: avt::Vt::new(usize::from(cols), usize::from(rows)),
-            pending_utf8: Vec::with_capacity(4),
-        }
-    }
-}
-
-impl TerminalEngine for AvtEngine {
+impl TerminalEngine for TerminalState {
     fn feed_bytes(&mut self, bytes: &[u8]) {
-        self.pending_utf8.extend_from_slice(bytes);
-        let mut consumed = 0;
-        while consumed < self.pending_utf8.len() {
-            match std::str::from_utf8(&self.pending_utf8[consumed..]) {
-                Ok(text) => {
-                    let _ = self.vt.feed_str(text);
-                    consumed = self.pending_utf8.len();
-                }
-                Err(error) => {
-                    let valid_end = consumed + error.valid_up_to();
-                    if valid_end > consumed {
-                        let text = std::str::from_utf8(&self.pending_utf8[consumed..valid_end])
-                            .expect("valid_up_to identifies valid UTF-8");
-                        let _ = self.vt.feed_str(text);
-                        consumed = valid_end;
-                    }
-                    let Some(error_len) = error.error_len() else {
-                        break;
-                    };
-                    let _ = self.vt.feed_str("\u{fffd}");
-                    consumed = consumed.saturating_add(error_len);
-                }
-            }
-        }
-        if consumed > 0 {
-            self.pending_utf8.drain(..consumed);
-        }
+        Self::feed_bytes(self, bytes);
     }
 
-    fn resize(&mut self, rows: u16, cols: u16) {
-        let _ = self.vt.resize(usize::from(cols), usize::from(rows));
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
+        Self::resize(self, rows, cols)
     }
 
     fn size(&self) -> (u16, u16) {
-        to_rows_cols(self.vt.size())
+        Self::size(self)
     }
 
     fn snapshot(&self) -> TerminalSnapshot {
-        let (rows, cols) = self.size();
-        TerminalSnapshot {
-            rows,
-            cols,
-            lines: trim_trailing_empty(self.vt.text()),
-        }
+        Self::snapshot(self)
     }
 }
 
-/// Drop trailing empty grid rows from a snapshot's line buffer.
+/// Current Unicode column-width seed for future non-ASCII cell handling.
 ///
-/// Grid dimensions (`rows`/`cols`) keep reporting the full allocated grid; the
-/// line buffer reports only rows that carry content, so a bounded snapshot never
-/// pays the byte budget for unused trailing rows.
-fn trim_trailing_empty(mut lines: Vec<String>) -> Vec<String> {
-    while lines.last().is_some_and(String::is_empty) {
-        lines.pop();
-    }
-    lines
-}
-
-fn to_rows_cols(avt_size: (usize, usize)) -> (u16, u16) {
-    let (cols, rows) = avt_size;
-    (
-        u16::try_from(rows).unwrap_or(u16::MAX),
-        u16::try_from(cols).unwrap_or(u16::MAX),
-    )
+/// Terminal Core v1 writes printable ASCII only. This policy remains public so
+/// later grapheme/ambiguous-width work can evolve behind the same boundary.
+#[must_use]
+pub fn cell_width(ch: char) -> usize {
+    UnicodeWidthChar::width(ch).unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -202,70 +68,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cell_carries_text_and_width() {
-        let cell = Cell::new("A", 1);
-        assert_eq!(cell.text(), "A");
-        assert_eq!(cell.width(), 1);
-    }
-
-    #[test]
-    fn cell_width_reports_expected_columns() {
-        assert_eq!(cell_width('A'), 1);
-        assert_eq!(cell_width(' '), 1);
-        // CJK ideograph is East Asian Wide (width 2).
-        assert_eq!(cell_width('\u{5168}'), 2);
-        // Control characters report no width.
-        assert_eq!(cell_width('\u{0}'), 0);
-    }
-
-    #[test]
-    fn avt_engine_records_text_and_dimensions() {
-        let mut engine = AvtEngine::new(3, 5);
-        engine.feed_bytes(b"hi");
-        let snapshot = engine.snapshot();
-        assert_eq!((snapshot.rows(), snapshot.cols()), (3, 5));
-        assert_eq!(snapshot.lines(), ["hi".to_owned()]);
-    }
-
-    #[test]
-    fn avt_engine_preserves_utf8_split_across_reads() {
-        let mut engine = AvtEngine::new(2, 4);
-        let bytes = "全".as_bytes();
-        engine.feed_bytes(&bytes[..2]);
-        assert!(engine.snapshot().lines().is_empty());
-        engine.feed_bytes(&bytes[2..]);
-        assert_eq!(engine.snapshot().lines(), ["全".to_owned()]);
-    }
-
-    #[test]
-    fn avt_engine_replaces_malformed_utf8_and_continues() {
-        let mut engine = AvtEngine::new(2, 8);
-        engine.feed_bytes(&[0xff, b'A']);
-        assert_eq!(engine.snapshot().lines(), ["�A".to_owned()]);
-    }
-
-    #[test]
-    fn avt_engine_resize_updates_size() {
-        let mut engine = AvtEngine::new(3, 5);
-        engine.resize(10, 20);
-        assert_eq!(engine.size(), (10, 20));
-        let snapshot = engine.snapshot();
-        assert_eq!((snapshot.rows(), snapshot.cols()), (10, 20));
-    }
-
-    #[test]
-    fn engine_is_usable_through_the_trait() {
-        let mut engine: Box<dyn TerminalEngine> = Box::new(AvtEngine::new(2, 4));
+    fn state_is_usable_through_the_renderer_independent_trait() {
+        let mut engine: Box<dyn TerminalEngine> =
+            Box::new(TerminalState::new(2, 4).expect("valid terminal"));
         engine.feed_bytes(b"ok");
-        engine.resize(4, 8);
+        engine.resize(4, 8).expect("valid resize");
+
         assert_eq!(engine.size(), (4, 8));
         let snapshot = engine.snapshot();
         assert_eq!((snapshot.rows(), snapshot.cols()), (4, 8));
-        assert!(
-            snapshot
-                .lines()
-                .first()
-                .is_some_and(|line| line.contains("ok"))
-        );
+        assert_eq!(snapshot.lines(), ["ok".to_owned()]);
+    }
+
+    #[test]
+    fn cell_width_keeps_the_future_unicode_policy_separate() {
+        assert_eq!(cell_width('A'), 1);
+        assert_eq!(cell_width(' '), 1);
+        assert_eq!(cell_width('\u{5168}'), 2);
+        assert_eq!(cell_width('\u{0}'), 0);
     }
 }

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -1,0 +1,251 @@
+//! Small, bounded byte parser for the first Terminal Core slice.
+
+const ESC: u8 = 0x1b;
+const BEL: u8 = 0x07;
+const MAX_CSI_PARAMS: usize = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Action {
+    Print(u8),
+    LineFeed,
+    CarriageReturn,
+    Backspace,
+    MoveUp(u16),
+    MoveDown(u16),
+    MoveRight(u16),
+    MoveLeft(u16),
+    MoveTo { row: u16, col: u16 },
+    MoveToColumn(u16),
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Parser {
+    state: ParserState,
+}
+
+impl Parser {
+    pub(crate) fn advance(&mut self, byte: u8) -> Option<Action> {
+        let state = std::mem::take(&mut self.state);
+        match state {
+            ParserState::Ground => self.advance_ground(byte),
+            ParserState::Escape => self.advance_escape(byte),
+            ParserState::Csi(mut csi) => {
+                if byte == ESC {
+                    self.state = ParserState::Escape;
+                    return None;
+                }
+                let action = csi.advance(byte);
+                self.state = if action.finished {
+                    ParserState::Ground
+                } else {
+                    ParserState::Csi(csi)
+                };
+                action.action
+            }
+            ParserState::Osc => {
+                self.state = match byte {
+                    BEL => ParserState::Ground,
+                    ESC => ParserState::OscEscape,
+                    _ => ParserState::Osc,
+                };
+                None
+            }
+            ParserState::OscEscape => {
+                self.state = match byte {
+                    b'\\' => ParserState::Ground,
+                    ESC => ParserState::OscEscape,
+                    _ => ParserState::Osc,
+                };
+                None
+            }
+        }
+    }
+
+    fn advance_ground(&mut self, byte: u8) -> Option<Action> {
+        match byte {
+            ESC => {
+                self.state = ParserState::Escape;
+                None
+            }
+            b'\n' => Some(Action::LineFeed),
+            b'\r' => Some(Action::CarriageReturn),
+            0x08 => Some(Action::Backspace),
+            0x20..=0x7e => Some(Action::Print(byte)),
+            _ => None,
+        }
+    }
+
+    fn advance_escape(&mut self, byte: u8) -> Option<Action> {
+        self.state = match byte {
+            b'[' => ParserState::Csi(Csi::default()),
+            b']' => ParserState::Osc,
+            ESC => ParserState::Escape,
+            _ => ParserState::Ground,
+        };
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ParserState {
+    #[default]
+    Ground,
+    Escape,
+    Csi(Csi),
+    Osc,
+    OscEscape,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Csi {
+    params: [u16; MAX_CSI_PARAMS],
+    len: usize,
+    current: u16,
+    has_current: bool,
+    overflowed: bool,
+    ignored: bool,
+}
+
+impl Default for Csi {
+    fn default() -> Self {
+        Self {
+            params: [0; MAX_CSI_PARAMS],
+            len: 0,
+            current: 0,
+            has_current: false,
+            overflowed: false,
+            ignored: false,
+        }
+    }
+}
+
+impl Csi {
+    fn advance(&mut self, byte: u8) -> CsiAdvance {
+        match byte {
+            b'0'..=b'9' => {
+                self.has_current = true;
+                self.current = self
+                    .current
+                    .saturating_mul(10)
+                    .saturating_add(u16::from(byte - b'0'));
+                CsiAdvance::pending()
+            }
+            b';' => {
+                self.push_current();
+                CsiAdvance::pending()
+            }
+            b'?' | b'>' if self.len == 0 && !self.has_current => {
+                self.ignored = true;
+                CsiAdvance::pending()
+            }
+            b':' | 0x20..=0x2f => {
+                self.ignored = true;
+                CsiAdvance::pending()
+            }
+            0x40..=0x7e => {
+                self.push_current();
+                CsiAdvance::finished(if self.overflowed || self.ignored {
+                    None
+                } else {
+                    self.action(byte)
+                })
+            }
+            _ => CsiAdvance::pending(),
+        }
+    }
+
+    fn push_current(&mut self) {
+        if self.len < MAX_CSI_PARAMS {
+            self.params[self.len] = self.current;
+            self.len += 1;
+        } else {
+            self.overflowed = true;
+        }
+        self.current = 0;
+        self.has_current = false;
+    }
+
+    fn action(&self, final_byte: u8) -> Option<Action> {
+        let count = self.param_or(0, 1);
+        match final_byte {
+            b'A' => Some(Action::MoveUp(count)),
+            b'B' => Some(Action::MoveDown(count)),
+            b'C' => Some(Action::MoveRight(count)),
+            b'D' => Some(Action::MoveLeft(count)),
+            b'G' => Some(Action::MoveToColumn(count.saturating_sub(1))),
+            b'H' | b'f' => Some(Action::MoveTo {
+                row: self.param_or(0, 1).saturating_sub(1),
+                col: self.param_or(1, 1).saturating_sub(1),
+            }),
+            _ => None,
+        }
+    }
+
+    fn param_or(&self, index: usize, default: u16) -> u16 {
+        self.params
+            .get(index)
+            .copied()
+            .filter(|value| *value != 0)
+            .unwrap_or(default)
+    }
+}
+
+struct CsiAdvance {
+    action: Option<Action>,
+    finished: bool,
+}
+
+impl CsiAdvance {
+    const fn pending() -> Self {
+        Self {
+            action: None,
+            finished: false,
+        }
+    }
+
+    const fn finished(action: Option<Action>) -> Self {
+        Self {
+            action,
+            finished: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actions(bytes: &[u8]) -> Vec<Action> {
+        let mut parser = Parser::default();
+        bytes
+            .iter()
+            .filter_map(|byte| parser.advance(*byte))
+            .collect()
+    }
+
+    #[test]
+    fn parses_basic_text_controls_and_cursor_sequences() {
+        assert_eq!(
+            actions(b"A\n\r\x08\x1b[2A\x1b[3;4H"),
+            [
+                Action::Print(b'A'),
+                Action::LineFeed,
+                Action::CarriageReturn,
+                Action::Backspace,
+                Action::MoveUp(2),
+                Action::MoveTo { row: 2, col: 3 },
+            ]
+        );
+    }
+
+    #[test]
+    fn swallows_unsupported_csi_and_osc_payloads() {
+        assert_eq!(actions(b"a\x1b[?2004hb\x1b]0;secret\x07c"), actions(b"abc"));
+        assert!(actions(b"\x1b[?2A\x1b[1:2A").is_empty());
+    }
+
+    #[test]
+    fn escape_restarts_an_incomplete_csi_sequence() {
+        assert_eq!(actions(b"\x1b[9\x1b[2A"), [Action::MoveUp(2)]);
+    }
+}

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,0 +1,431 @@
+use crate::parser::{Action, Parser};
+use std::fmt;
+
+/// Hard allocation bound for a visible Terminal Core screen.
+pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
+
+/// One basic terminal cell.
+///
+/// Text remains an owned string so later grapheme work does not require a
+/// renderer-facing shape change. Terminal Core v1 writes one ASCII character
+/// with width one into each cell.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Cell {
+    text: String,
+    width: u8,
+}
+
+impl Cell {
+    /// Construct a cell from display text and a precomputed column width.
+    #[must_use]
+    pub fn new(text: impl Into<String>, width: u8) -> Self {
+        Self {
+            text: text.into(),
+            width,
+        }
+    }
+
+    /// A blank, single-column cell.
+    #[must_use]
+    pub fn blank() -> Self {
+        Self::new(" ", 1)
+    }
+
+    /// Display text owned by the cell.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Display width in terminal columns.
+    #[must_use]
+    pub const fn width(&self) -> u8 {
+        self.width
+    }
+
+    /// Whether this is the baseline blank cell.
+    #[must_use]
+    pub fn is_blank(&self) -> bool {
+        self.text == " "
+    }
+
+    fn from_ascii(byte: u8) -> Self {
+        Self::new(char::from(byte).to_string(), 1)
+    }
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self::blank()
+    }
+}
+
+/// Zero-based cursor position within the visible screen.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Cursor {
+    row: u16,
+    column: u16,
+}
+
+impl Cursor {
+    /// Zero-based row.
+    #[must_use]
+    pub const fn row(self) -> u16 {
+        self.row
+    }
+
+    /// Zero-based column.
+    #[must_use]
+    pub const fn column(self) -> u16 {
+        self.column
+    }
+}
+
+/// Renderer-independent cursor operations used by the parser and future APIs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CursorMove {
+    Up(u16),
+    Down(u16),
+    Right(u16),
+    Left(u16),
+    To { row: u16, column: u16 },
+    ToColumn(u16),
+}
+
+/// Fixed-size visible screen buffer in row-major order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScreenBuffer {
+    rows: u16,
+    cols: u16,
+    cells: Vec<Cell>,
+}
+
+impl ScreenBuffer {
+    fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
+        let count = checked_cell_count(rows, cols)?;
+        Ok(Self {
+            rows,
+            cols,
+            cells: vec![Cell::blank(); count],
+        })
+    }
+
+    /// Number of visible rows.
+    #[must_use]
+    pub const fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    /// Number of visible columns.
+    #[must_use]
+    pub const fn cols(&self) -> u16 {
+        self.cols
+    }
+
+    /// All visible cells in row-major order.
+    #[must_use]
+    pub fn cells(&self) -> &[Cell] {
+        &self.cells
+    }
+
+    /// Cell at a zero-based visible position.
+    #[must_use]
+    pub fn cell(&self, row: u16, column: u16) -> Option<&Cell> {
+        self.index(row, column)
+            .and_then(|index| self.cells.get(index))
+    }
+
+    fn put(&mut self, row: u16, column: u16, cell: Cell) {
+        if let Some(index) = self.index(row, column) {
+            self.cells[index] = cell;
+        }
+    }
+
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
+        let count = checked_cell_count(rows, cols)?;
+        let mut next = vec![Cell::blank(); count];
+        let retained_rows = self.rows.min(rows);
+        let retained_cols = self.cols.min(cols);
+        for row in 0..retained_rows {
+            for column in 0..retained_cols {
+                let old_index = usize::from(row) * usize::from(self.cols) + usize::from(column);
+                let new_index = usize::from(row) * usize::from(cols) + usize::from(column);
+                next[new_index] = self.cells[old_index].clone();
+            }
+        }
+        self.rows = rows;
+        self.cols = cols;
+        self.cells = next;
+        Ok(())
+    }
+
+    fn scroll_up(&mut self) {
+        let columns = usize::from(self.cols);
+        self.cells.rotate_left(columns);
+        let first_blank = self.cells.len().saturating_sub(columns);
+        self.cells[first_blank..].fill(Cell::blank());
+    }
+
+    fn index(&self, row: u16, column: u16) -> Option<usize> {
+        if row >= self.rows || column >= self.cols {
+            return None;
+        }
+        Some(usize::from(row) * usize::from(self.cols) + usize::from(column))
+    }
+}
+
+/// Errors at the bounded Terminal Core state boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalError {
+    InvalidSize,
+    ScreenTooLarge,
+}
+
+impl fmt::Display for TerminalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSize => f.write_str("terminal rows and columns must be non-zero"),
+            Self::ScreenTooLarge => f.write_str("terminal screen exceeds the cell limit"),
+        }
+    }
+}
+
+impl std::error::Error for TerminalError {}
+
+/// Noren-owned mutable terminal state.
+pub struct TerminalState {
+    screen: ScreenBuffer,
+    cursor: Cursor,
+    parser: Parser,
+}
+
+impl TerminalState {
+    /// Create a bounded non-zero visible terminal.
+    pub fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
+        Ok(Self {
+            screen: ScreenBuffer::new(rows, cols)?,
+            cursor: Cursor::default(),
+            parser: Parser::default(),
+        })
+    }
+
+    /// Apply PTY bytes in order.
+    ///
+    /// Non-ASCII bytes and unsupported control sequences are ignored in this
+    /// foundation. They are never interpreted as authority or rendered as raw
+    /// escape-sequence payload.
+    pub fn feed_bytes(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            if let Some(action) = self.parser.advance(*byte) {
+                self.apply(action);
+            }
+        }
+    }
+
+    /// Resize while preserving the overlapping top-left screen area.
+    pub fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
+        self.screen.resize(rows, cols)?;
+        self.cursor.row = self.cursor.row.min(rows - 1);
+        self.cursor.column = self.cursor.column.min(cols - 1);
+        Ok(())
+    }
+
+    /// Current `(rows, cols)`.
+    #[must_use]
+    pub const fn size(&self) -> (u16, u16) {
+        (self.screen.rows, self.screen.cols)
+    }
+
+    /// Current cursor position.
+    #[must_use]
+    pub const fn cursor(&self) -> Cursor {
+        self.cursor
+    }
+
+    /// Current visible screen.
+    #[must_use]
+    pub const fn screen(&self) -> &ScreenBuffer {
+        &self.screen
+    }
+
+    /// Apply a clamped renderer-independent cursor operation.
+    pub fn move_cursor(&mut self, movement: CursorMove) {
+        let last_row = self.screen.rows - 1;
+        let last_column = self.screen.cols - 1;
+        match movement {
+            CursorMove::Up(count) => self.cursor.row = self.cursor.row.saturating_sub(count),
+            CursorMove::Down(count) => {
+                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
+            }
+            CursorMove::Right(count) => {
+                self.cursor.column = self.cursor.column.saturating_add(count).min(last_column);
+            }
+            CursorMove::Left(count) => {
+                self.cursor.column = self.cursor.column.saturating_sub(count);
+            }
+            CursorMove::To { row, column } => {
+                self.cursor.row = row.min(last_row);
+                self.cursor.column = column.min(last_column);
+            }
+            CursorMove::ToColumn(column) => {
+                self.cursor.column = column.min(last_column);
+            }
+        }
+    }
+
+    /// Clone a bounded immutable renderer/test view.
+    #[must_use]
+    pub fn snapshot(&self) -> TerminalSnapshot {
+        TerminalSnapshot::from_state(self)
+    }
+
+    fn apply(&mut self, action: Action) {
+        match action {
+            Action::Print(byte) => self.print_ascii(byte),
+            Action::LineFeed => self.line_feed(),
+            Action::CarriageReturn => self.cursor.column = 0,
+            Action::Backspace => self.cursor.column = self.cursor.column.saturating_sub(1),
+            Action::MoveUp(count) => self.move_cursor(CursorMove::Up(count)),
+            Action::MoveDown(count) => self.move_cursor(CursorMove::Down(count)),
+            Action::MoveRight(count) => self.move_cursor(CursorMove::Right(count)),
+            Action::MoveLeft(count) => self.move_cursor(CursorMove::Left(count)),
+            Action::MoveTo { row, col } => {
+                self.move_cursor(CursorMove::To { row, column: col });
+            }
+            Action::MoveToColumn(column) => self.move_cursor(CursorMove::ToColumn(column)),
+        }
+    }
+
+    fn print_ascii(&mut self, byte: u8) {
+        self.screen
+            .put(self.cursor.row, self.cursor.column, Cell::from_ascii(byte));
+        if self.cursor.column == self.screen.cols - 1 {
+            self.cursor.column = 0;
+            self.line_feed();
+        } else {
+            self.cursor.column += 1;
+        }
+    }
+
+    fn line_feed(&mut self) {
+        if self.cursor.row == self.screen.rows - 1 {
+            self.screen.scroll_up();
+        } else {
+            self.cursor.row += 1;
+        }
+    }
+}
+
+impl fmt::Debug for TerminalState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TerminalState")
+            .field("size", &self.size())
+            .field("cursor", &self.cursor)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Immutable snapshot passed to renderers and deterministic test oracles.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalSnapshot {
+    screen: ScreenBuffer,
+    cursor: Cursor,
+    lines: Vec<String>,
+}
+
+impl TerminalSnapshot {
+    fn from_state(state: &TerminalState) -> Self {
+        Self {
+            screen: state.screen.clone(),
+            cursor: state.cursor,
+            lines: visible_lines(&state.screen),
+        }
+    }
+
+    /// Number of visible rows.
+    #[must_use]
+    pub const fn rows(&self) -> u16 {
+        self.screen.rows
+    }
+
+    /// Number of visible columns.
+    #[must_use]
+    pub const fn cols(&self) -> u16 {
+        self.screen.cols
+    }
+
+    /// Cursor captured with the screen.
+    #[must_use]
+    pub const fn cursor(&self) -> Cursor {
+        self.cursor
+    }
+
+    /// Captured visible screen.
+    #[must_use]
+    pub const fn screen(&self) -> &ScreenBuffer {
+        &self.screen
+    }
+
+    /// Renderer-compatible text rows with trailing blank rows/columns removed.
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+}
+
+fn checked_cell_count(rows: u16, cols: u16) -> Result<usize, TerminalError> {
+    if rows == 0 || cols == 0 {
+        return Err(TerminalError::InvalidSize);
+    }
+    let count = usize::from(rows) * usize::from(cols);
+    if count > MAX_SCREEN_CELLS {
+        Err(TerminalError::ScreenTooLarge)
+    } else {
+        Ok(count)
+    }
+}
+
+fn visible_lines(screen: &ScreenBuffer) -> Vec<String> {
+    let mut lines = Vec::with_capacity(usize::from(screen.rows));
+    for row in 0..screen.rows {
+        let mut line = String::new();
+        for column in 0..screen.cols {
+            if let Some(cell) = screen.cell(row, column) {
+                line.push_str(cell.text());
+            }
+        }
+        while line.ends_with(' ') {
+            line.pop();
+        }
+        lines.push(line);
+    }
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ascii_and_controls_update_owned_state() {
+        let mut state = TerminalState::new(3, 5).expect("valid terminal");
+        state.feed_bytes(b"ab\rZ\nQ\x08R");
+
+        assert_eq!(state.snapshot().lines(), ["Zb", " R"]);
+        assert_eq!(state.cursor(), Cursor { row: 1, column: 2 });
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("Z"));
+    }
+
+    #[test]
+    fn csi_cursor_foundation_is_clamped_and_renderer_independent() {
+        let mut state = TerminalState::new(3, 5).expect("valid terminal");
+        state.feed_bytes(b"abc\x1b[2DX\x1b[3;4HY");
+
+        assert_eq!(state.screen().cell(0, 1).map(Cell::text), Some("X"));
+        assert_eq!(state.screen().cell(2, 3).map(Cell::text), Some("Y"));
+        assert_eq!(state.cursor(), Cursor { row: 2, column: 4 });
+    }
+}

--- a/crates/noren-terminal/tests/terminal_state.rs
+++ b/crates/noren-terminal/tests/terminal_state.rs
@@ -1,0 +1,117 @@
+use noren_terminal::{Cell, CursorMove, MAX_SCREEN_CELLS, TerminalError, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+#[test]
+fn rejects_zero_and_over_limit_sizes_without_changing_state() {
+    assert!(matches!(
+        TerminalState::new(0, 1),
+        Err(TerminalError::InvalidSize)
+    ));
+    assert!(matches!(
+        TerminalState::new(1, 0),
+        Err(TerminalError::InvalidSize)
+    ));
+
+    let over_limit_rows = u16::try_from(MAX_SCREEN_CELLS / 1024 + 1).expect("bounded row count");
+    assert!(matches!(
+        TerminalState::new(over_limit_rows, 1024),
+        Err(TerminalError::ScreenTooLarge)
+    ));
+
+    let mut state = TerminalState::new(2, 2).expect("valid terminal");
+    state.feed_bytes(b"A");
+    assert_eq!(state.resize(0, 2), Err(TerminalError::InvalidSize));
+    assert_eq!(state.size(), (2, 2));
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("A"));
+}
+
+#[test]
+fn resize_preserves_overlap_and_clamps_cursor() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"AB\x1b[2;3HZ");
+    state.move_cursor(CursorMove::To { row: 2, column: 3 });
+
+    state.resize(2, 3).expect("valid resize");
+    assert_eq!(state.size(), (2, 3));
+    assert_eq!(cursor(&state), (1, 2));
+    assert_eq!(state.snapshot().lines(), ["AB", "  Z"]);
+
+    state.resize(4, 5).expect("valid resize");
+    assert_eq!(state.snapshot().lines(), ["AB", "  Z"]);
+    assert_eq!(state.screen().cells().len(), 20);
+}
+
+#[test]
+fn printable_ascii_lf_cr_and_backspace_remain_stable() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"AB\nC\rD\x08E");
+
+    assert_eq!(state.snapshot().lines(), ["AB", "E C"]);
+    assert_eq!(cursor(&state), (1, 1));
+}
+
+#[test]
+fn cursor_commands_apply_defaults_absolute_positions_and_clamping() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.move_cursor(CursorMove::To { row: 1, column: 1 });
+
+    state.feed_bytes(b"\x1b[A");
+    assert_eq!(cursor(&state), (0, 1));
+    state.feed_bytes(b"\x1b[D");
+    assert_eq!(cursor(&state), (0, 0));
+    state.feed_bytes(b"\x1b[B\x1b[C");
+    assert_eq!(cursor(&state), (1, 1));
+    state.feed_bytes(b"\x1b[99B\x1b[99C");
+    assert_eq!(cursor(&state), (2, 3));
+    state.feed_bytes(b"\x1b[99A\x1b[99D");
+    assert_eq!(cursor(&state), (0, 0));
+    state.feed_bytes(b"\x1b[2;3H");
+    assert_eq!(cursor(&state), (1, 2));
+    state.feed_bytes(b"\x1b[H");
+    assert_eq!(cursor(&state), (0, 0));
+}
+
+#[test]
+fn wrapping_at_the_bottom_scrolls_one_row_and_blanks_the_last() {
+    let mut state = TerminalState::new(2, 3).expect("valid terminal");
+    state.feed_bytes(b"abc");
+    assert_eq!(state.snapshot().lines(), ["abc"]);
+    assert_eq!(cursor(&state), (1, 0));
+
+    state.feed_bytes(b"def");
+    assert_eq!(state.snapshot().lines(), ["def"]);
+    assert_eq!(cursor(&state), (1, 0));
+    assert!(state.screen().cell(1, 0).is_some_and(Cell::is_blank));
+}
+
+#[test]
+fn split_sequences_are_retained_and_unsupported_bytes_do_not_leak() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b");
+    state.feed_bytes(b"[2;");
+    state.feed_bytes(b"3H");
+    assert_eq!(cursor(&state), (1, 2));
+
+    state.feed_bytes(b"\x1b[31m\xff\xc3\xa9");
+    state.feed_bytes(b"Q");
+    assert_eq!(state.snapshot().lines(), ["", "  Q"]);
+}
+
+#[test]
+fn snapshots_are_immutable_and_cells_are_row_major() {
+    let mut state = TerminalState::new(2, 2).expect("valid terminal");
+    state.feed_bytes(b"AB");
+    let before = state.snapshot();
+
+    state.feed_bytes(b"C");
+    assert_eq!(before.lines(), ["AB"]);
+    assert_eq!(state.snapshot().lines(), ["AB", "C"]);
+
+    let texts: Vec<_> = state.screen().cells().iter().map(Cell::text).collect();
+    assert_eq!(texts, ["A", "B", "C", " "]);
+    assert!(state.screen().cell(2, 0).is_none());
+    assert!(state.screen().cell(0, 2).is_none());
+}

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -1,0 +1,37 @@
+# Terminal core foundation
+
+- Status: Draft, in progress on PR [#19](https://github.com/ta-061/noren/pull/19)
+  (branch `agent/terminal-core-foundation`); not merged
+- Supersedes nothing: the accepted [local-PTY PoC
+  architecture](minimal-local-pty-poc.md) still applies
+
+This foundation moves PTY output bytes through a renderer-independent terminal
+state core in `crates/noren-terminal/`. It is a foundation slice, not a
+VT100/xterm compatibility claim.
+
+## Data flow
+
+```text
+PTY bytes -> TerminalState::feed_bytes -> parser -> bounded screen/cursor state
+TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
+```
+
+- `TerminalState` owns the screen, cursor, dimensions, and parser state.
+- The visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
+  `MAX_SCREEN_CELLS` (1,048,576 cells).
+- `resize` rebuilds the grid and preserves the overlapping top-left region.
+- The renderer consumes the immutable `TerminalSnapshot` and never depends on
+  PTY or parser types.
+
+## Supported behavior
+
+- Printable ASCII bytes (`0x20..=0x7e`), line feed, carriage return, and
+  backspace.
+- A minimal CSI cursor-movement subset: cursor up, down, forward, back,
+  absolute position, and absolute column.
+- Unsupported and OSC bytes are ignored without corrupting state.
+
+## Deferred order
+
+Scroll regions, alternate screen, SGR/erase plus cell attributes, and mode
+state, in that order. Unicode and IME remain later.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -24,21 +24,32 @@ screen, SGR/erase plus cell attributes, mode state; Unicode/IME remain later.
 
 Verified on 2026-08-03:
 
-- The only open Issue is [#16](https://github.com/ta-061/noren/issues/16), the
-  scoped macOS local-zsh PTY PoC.
-- Draft [#17](https://github.com/ta-061/noren/pull/17),
-  `feat/macos-local-pty-poc` into `main`, had a clean merge state and is now
-  merged.
+- The only open Issue is [#18](https://github.com/ta-061/noren/issues/18), the
+  Terminal Core foundation. The only open PR is its Draft
+  [#19](https://github.com/ta-061/noren/pull/19).
+- PR [#17](https://github.com/ta-061/noren/pull/17) and its Issue
+  [#16](https://github.com/ta-061/noren/issues/16) are complete after the owner
+  accepted the macOS local-PTY PoC.
 - Issues [#6](https://github.com/ta-061/noren/issues/6) and
   [#8](https://github.com/ta-061/noren/issues/8) are closed. PR
   [#14](https://github.com/ta-061/noren/pull/14) merged the bounded Discovery
   integration and PR [#15](https://github.com/ta-061/noren/pull/15) merged the
   lean Design Council.
-- `main` was at `54ed3cfc9abaab97bd45ad8dedac71070832b54e`, the merge commit
-  for PR #15, at this verification. No Discovery PR remains open and no
-  repeated large research or review is planned.
+- `main` is at `b2bb87c20365dec5d1ab6b0122b2a987ec768744`, the merge commit
+  for PR #17. No Discovery PR remains open and no repeated large research or
+  review is planned.
 
-## Implementation checkpoints
+## Terminal Core handoff
+
+| Lane | Saved evidence | State |
+| --- | --- | --- |
+| Codex core | Signed `d62b36e`: Noren-owned state/parser and renderer snapshot integration | Complete |
+| codex-lab tests | Signed `053216f`: seven public-API state/cursor/buffer regression tests | Complete |
+| GLM boundaries | PR #19 review: module, error, and crate boundaries pass without changes | Complete |
+| Claude Code architecture | PR #19 review: ACCEPT, no VT-evolution blocker | Complete |
+| Qwen documentation | Signed `b390531`: architecture, roadmap, contributor, and status updates | Complete |
+
+## PR #17 historical implementation checkpoints
 
 | Lane | Saved evidence | State |
 | --- | --- | --- |
@@ -54,7 +65,7 @@ The stopped GLM/Qwen lanes left no uncommitted or competing implementation.
 Codex performed only the minimum fallback integration on the same Draft PR;
 codex-lab and Claude reviewed distinct concerns.
 
-## Current PoC behavior and evidence
+## Merged PR #17 behavior and evidence
 
 | Required step | Evidence | State |
 | --- | --- | --- |
@@ -86,14 +97,12 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 - No async runtime, SSH, agent-state UI, tabs, panes, themes, persistence, or
   remote daemon was added.
 
-## Remaining scoped gate
+## Current Draft gate
 
-Before making PR #17 ready, save one local macOS checkpoint that captures a
-rendered frame containing a deterministic shell marker and exercises key input,
-non-zero window resize, and the close action. The automated Computer Use path
-timed out on local Accessibility/Screen Recording access; no OS permission or
-security setting was changed. This is an evidence gap, not authorization to add
-features or repeat architecture/security review.
+PR #19 remains Draft until current-head CI is green and the owner can repeat a
+local macOS startup/output/resize/exit smoke check. PR #17 has no remaining
+gate; its manual verification was accepted before merge. This does not
+authorize deferred terminal features in the foundation PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -107,9 +116,7 @@ identity, and the public support/security contact before Preview publication.
 
 ## Next steps
 
-1. Capture the one remaining local window checkpoint without changing OS
-   security settings; if unavailable, leave the PR Draft with this exact gap.
-2. Save that evidence in Issue #16 and PR #17. If code changes, require new
-   exact-head CI; otherwise preserve the already-passing implementation gates.
-3. Mark ready and merge only after the scoped rendered-frame/window checkpoint;
-   do not open deferred feature work in this PR.
+1. Save exact-head local checks and GitHub CI on Draft PR #19.
+2. Repeat the bounded macOS smoke check without changing OS security settings.
+3. Keep scroll regions and later VT work in a separate Issue/PR after this
+   foundation is accepted.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,19 +1,24 @@
 # Coordination status
 
-Last updated: 2026-08-03 (Asia/Tokyo), implementation/test head
-`c1f66dc27ddce37a60665d319a7ca061c300947e` on Draft PR
-[#17](https://github.com/ta-061/noren/pull/17), branch
-`feat/macos-local-pty-poc`. Coordination head `ac410a82` also passed both
-GitHub checks; this final status-only update follows those verified heads.
+Last updated: 2026-08-03 (Asia/Tokyo). PR
+[#17](https://github.com/ta-061/noren/pull/17) is merged into `main` as
+`b2bb87c20365dec5d1ab6b0122b2a987ec768744`. The only open PR is Draft
+[#19](https://github.com/ta-061/noren/pull/19), branch
+`agent/terminal-core-foundation`. The sections below preserve the PR #17
+record at implementation/test head
+`c1f66dc27ddce37a60665d319a7ca061c300947e`, corrected only where an active
+claim went stale; coordination head `ac410a82` also passed both GitHub checks.
 
 ## Current phase
 
-Milestone 1 — first macOS local-zsh PTY PoC implementation. Discovery and the
-lean Design Council are merged. The Rust workspace, CI, local PTY, window,
-input adapter, terminal state, bounded GPU view, resize path, and shutdown path
-now exist on one Draft PR. The PR stays Draft until the remaining local rendered
-frame and real window-interaction checkpoint is saved; deferred product features
-remain closed.
+Terminal foundation. The first macOS local-zsh PTY PoC (PR #17) is merged.
+Draft PR #19, not merged, replaces the `avt` dependency with a
+renderer-independent Noren `TerminalState`: bounded screen cells, cursor,
+resize, printable ASCII/LF/CR/backspace, and minimal CSI cursor movement. The
+renderer consumes `TerminalSnapshot`; see
+[terminal core foundation](../architecture/terminal-core-foundation.md). This
+is not VT100/xterm compatibility. Deferred order: scroll regions, alternate
+screen, SGR/erase plus cell attributes, mode state; Unicode/IME remain later.
 
 ## GitHub state
 
@@ -21,16 +26,17 @@ Verified on 2026-08-03:
 
 - The only open Issue is [#16](https://github.com/ta-061/noren/issues/16), the
   scoped macOS local-zsh PTY PoC.
-- The only open PR is Draft [#17](https://github.com/ta-061/noren/pull/17),
-  `feat/macos-local-pty-poc` into `main`; GitHub reports the merge state clean.
+- Draft [#17](https://github.com/ta-061/noren/pull/17),
+  `feat/macos-local-pty-poc` into `main`, had a clean merge state and is now
+  merged.
 - Issues [#6](https://github.com/ta-061/noren/issues/6) and
   [#8](https://github.com/ta-061/noren/issues/8) are closed. PR
   [#14](https://github.com/ta-061/noren/pull/14) merged the bounded Discovery
   integration and PR [#15](https://github.com/ta-061/noren/pull/15) merged the
   lean Design Council.
-- `main` is at `54ed3cfc9abaab97bd45ad8dedac71070832b54e`, the merge commit for
-  PR #15. No Discovery PR remains open and no repeated large research or review
-  is planned.
+- `main` was at `54ed3cfc9abaab97bd45ad8dedac71070832b54e`, the merge commit
+  for PR #15, at this verification. No Discovery PR remains open and no
+  repeated large research or review is planned.
 
 ## Implementation checkpoints
 
@@ -71,11 +77,12 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 - `rustc 1.88.0 (6b00bc388 2025-06-23)`, `cargo 1.88.0
   (873a06493 2025-05-10)`, active/installed target
   `aarch64-apple-darwin`; local host arm64 on macOS 26.4.1.
-- Direct implementation candidates are exact `portable-pty 0.9.0`, `avt
-  0.18.0`, `unicode-width 0.2.2`, `winit 0.30.13`, and `wgpu 30.0.0` with
-  Metal/WGSL features. The first view uses a bounded built-in ASCII raster
-  fallback; `swash 0.2.10` remains an accepted but unmeasured replacement seam,
-  not a claimed implementation dependency.
+- At this head, direct implementation candidates were exact `portable-pty
+  0.9.0`, `avt 0.18.0`, `unicode-width 0.2.2`, `winit 0.30.13`, and `wgpu
+  30.0.0` with Metal/WGSL features. On branch `agent/terminal-core-foundation`,
+  `avt` is removed and the terminal state is Noren-owned. The first view uses a
+  bounded built-in ASCII raster fallback; `swash 0.2.10` remains an accepted
+  but unmeasured replacement seam, not a claimed implementation dependency.
 - No async runtime, SSH, agent-state UI, tabs, panes, themes, persistence, or
   remote daemon was added.
 


### PR DESCRIPTION
## Issue

Closes #18

## Current checkpoint

Current head: `05fb148b9db23a614ca2a3003ee6aa439984473a`.

### Implemented

- Noren-owned `TerminalState` with a bounded row-major `ScreenBuffer`, basic `Cell`, terminal dimensions, zero-based `Cursor`, resize preservation/clamping, and immutable `TerminalSnapshot`.
- Bounded byte parser for printable ASCII, LF, CR, Backspace, and CSI cursor up/down/right/left/column/position.
- Unsupported CSI and OSC payloads are swallowed without leaking control bytes into cells.
- App flow is now `PTY output -> TerminalState -> TerminalSnapshot -> Renderer`; renderer accepts no PTY or parser types.
- Removed the former `avt` runtime dependency and lockfile entries.
- Added concise architecture, roadmap, contributor, and current coordination documentation.

### Exact-head verification

- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed, 42 tests.
- `python3 scripts/check_docs.py` — passed.
- `python3 -m unittest scripts/test_check_docs.py` — passed, 7 tests.
- `git diff --check` — passed.
- [Rust CI](https://github.com/ta-061/noren/actions/runs/30795106991) — passed at `05fb148`.
- [Documentation CI](https://github.com/ta-061/noren/actions/runs/30795106988) — passed at `05fb148`.
- `cargo run -p noren-app` process smoke — app stayed live and owned a local `/bin/zsh`; both test processes were explicitly cleaned up. A current-head visual input/output/resize/exit smoke remains for the owner before readiness.

### Serial delegated work

- [x] **codex-lab:** 7 public-API TerminalState/cursor/buffer/regression tests (`053216f`).
- [x] **GLM:** module organization, error handling, and crate-boundary review — PASS, no correction.
- [x] **Claude Code:** bounded VT/vim/tmux/zellij architecture review — ACCEPT, no blocker.
- [x] **Qwen:** concise architecture, roadmap, contributor, and status documentation (`b390531`).
- [x] **Codex:** core implementation, integration corrections, exact-head checks, CI verification, and Draft decision.

Detailed lane handoffs are preserved in this PR conversation and `docs/coordination/status.md`.

## Non-goals

No complete VT100/xterm semantics, scroll regions, alternate screen, scrollback, selection, clipboard, Unicode/IME/font work, renderer redesign, SSH, tabs/panes, agent features, Zellij integration, or async runtime.

## Known foundation limits / next risk

The current slice is ASCII plus a minimal CSI cursor subset. Scrolling is whole-screen; there are no DEC modes, SGR/erase, cell attributes, tab stops, alternate screen, or compatibility oracle. Architecture review recommends the next separate slice begin with explicit scroll-region state, then alternate screen, SGR/erase plus attributes, and mode state.