### PR TITLE
Terminal Core: add scrolling regions and behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ cargo test --workspace
 Dependency audit and license policy checks remain intended additions; the
 repository will not claim these pass before CI actually runs them.
 
+Changes to `crates/noren-terminal/` additionally keep these conventions:
+
+- Internal coordinates are zero-based; CSI parameters are one-based. Convert
+  at the parse boundary and keep the two schemes out of each other's layers.
+- Test through the public API with byte-driven fixtures: feed raw bytes into
+  `TerminalState::feed_bytes` and assert on `snapshot()`, not on internals.
+- Scrolling-region changes must preserve rows outside the active margins.
+- Renderer and PTY concerns stay out of `noren-terminal` tests; the core
+  neither reads from a PTY nor renders.
+
 ## Pull requests and review
 
 Open a Draft PR early. Complete the PR template and link the Issue. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,11 +15,16 @@ Only evidence-backed work is marked complete.
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | Not started |
 | 8 — Public Preview | Honest docs/site, binaries, checksums, release review, known limitations and `0.1.0-preview` | Not started |
 
-A renderer-independent terminal state core is in progress as Draft PR
-[#19](https://github.com/ta-061/noren/pull/19) (not merged), described in
+A renderer-independent terminal state core is merged as PR
+[#19](https://github.com/ta-061/noren/pull/19) (`c695920`), described in
 [terminal core foundation](docs/architecture/terminal-core-foundation.md).
-Deferred order: scroll regions, alternate screen, SGR/erase plus cell
-attributes, mode state; Unicode/IME remain later.
+Scrolling regions are in progress as Draft PR
+[#21](https://github.com/ta-061/noren/pull/21): inclusive full-screen-default
+scroll margins, DECSTBM with invalid-range rejection, region-only
+LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed autowrap, and
+resize resetting margins/wrap. Deferred: alternate screen,
+SGR/erase/insert/delete, cell attributes, tabs, origin mode, query/reply;
+Unicode/IME remain later.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -12,8 +12,8 @@ mod parser;
 mod state;
 
 pub use state::{
-    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, TerminalError, TerminalSnapshot,
-    TerminalState,
+    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
+    TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -10,12 +10,21 @@ pub(crate) enum Action {
     LineFeed,
     CarriageReturn,
     Backspace,
+    Index,
+    NextLine,
+    ReverseIndex,
     MoveUp(u16),
     MoveDown(u16),
     MoveRight(u16),
     MoveLeft(u16),
+    MoveNextLine(u16),
+    MovePreviousLine(u16),
     MoveTo { row: u16, col: u16 },
     MoveToColumn(u16),
+    MoveToRow(u16),
+    SetScrollRegion { top: u16, bottom: Option<u16> },
+    ScrollUp(u16),
+    ScrollDown(u16),
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -67,7 +76,7 @@ impl Parser {
                 self.state = ParserState::Escape;
                 None
             }
-            b'\n' => Some(Action::LineFeed),
+            b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
             b'\r' => Some(Action::CarriageReturn),
             0x08 => Some(Action::Backspace),
             0x20..=0x7e => Some(Action::Print(byte)),
@@ -76,12 +85,24 @@ impl Parser {
     }
 
     fn advance_escape(&mut self, byte: u8) -> Option<Action> {
-        self.state = match byte {
-            b'[' => ParserState::Csi(Csi::default()),
-            b']' => ParserState::Osc,
-            ESC => ParserState::Escape,
-            _ => ParserState::Ground,
-        };
+        match byte {
+            b'[' => self.state = ParserState::Csi(Csi::default()),
+            b']' => self.state = ParserState::Osc,
+            ESC => self.state = ParserState::Escape,
+            b'D' => {
+                self.state = ParserState::Ground;
+                return Some(Action::Index);
+            }
+            b'E' => {
+                self.state = ParserState::Ground;
+                return Some(Action::NextLine);
+            }
+            b'M' => {
+                self.state = ParserState::Ground;
+                return Some(Action::ReverseIndex);
+            }
+            _ => self.state = ParserState::Ground,
+        }
         None
     }
 }
@@ -172,10 +193,19 @@ impl Csi {
             b'B' => Some(Action::MoveDown(count)),
             b'C' => Some(Action::MoveRight(count)),
             b'D' => Some(Action::MoveLeft(count)),
+            b'E' => Some(Action::MoveNextLine(count)),
+            b'F' => Some(Action::MovePreviousLine(count)),
             b'G' => Some(Action::MoveToColumn(count.saturating_sub(1))),
             b'H' | b'f' => Some(Action::MoveTo {
                 row: self.param_or(0, 1).saturating_sub(1),
                 col: self.param_or(1, 1).saturating_sub(1),
+            }),
+            b'S' if self.len <= 1 => Some(Action::ScrollUp(count)),
+            b'T' if self.len <= 1 => Some(Action::ScrollDown(count)),
+            b'd' => Some(Action::MoveToRow(count.saturating_sub(1))),
+            b'r' if self.len <= 2 => Some(Action::SetScrollRegion {
+                top: self.param_or(0, 1).saturating_sub(1),
+                bottom: self.zero_based_param(1),
             }),
             _ => None,
         }
@@ -187,6 +217,13 @@ impl Csi {
             .copied()
             .filter(|value| *value != 0)
             .unwrap_or(default)
+    }
+
+    fn zero_based_param(&self, index: usize) -> Option<u16> {
+        if index >= self.len {
+            return None;
+        }
+        self.params[index].checked_sub(1)
     }
 }
 
@@ -226,9 +263,11 @@ mod tests {
     #[test]
     fn parses_basic_text_controls_and_cursor_sequences() {
         assert_eq!(
-            actions(b"A\n\r\x08\x1b[2A\x1b[3;4H"),
+            actions(b"A\n\x0b\x0c\r\x08\x1b[2A\x1b[3;4H"),
             [
                 Action::Print(b'A'),
+                Action::LineFeed,
+                Action::LineFeed,
                 Action::LineFeed,
                 Action::CarriageReturn,
                 Action::Backspace,
@@ -247,5 +286,39 @@ mod tests {
     #[test]
     fn escape_restarts_an_incomplete_csi_sequence() {
         assert_eq!(actions(b"\x1b[9\x1b[2A"), [Action::MoveUp(2)]);
+    }
+
+    #[test]
+    fn parses_index_scroll_region_and_extended_cursor_actions() {
+        assert_eq!(
+            actions(b"\x1bD\x1bE\x1bM\x1b[2;4r\x1b[3S\x1b[T\x1b[2E\x1b[F\x1b[4d"),
+            [
+                Action::Index,
+                Action::NextLine,
+                Action::ReverseIndex,
+                Action::SetScrollRegion {
+                    top: 1,
+                    bottom: Some(3),
+                },
+                Action::ScrollUp(3),
+                Action::ScrollDown(1),
+                Action::MoveNextLine(2),
+                Action::MovePreviousLine(1),
+                Action::MoveToRow(3),
+            ]
+        );
+        assert_eq!(
+            actions(b"\x1b[r\x1b[2r"),
+            [
+                Action::SetScrollRegion {
+                    top: 0,
+                    bottom: None,
+                },
+                Action::SetScrollRegion {
+                    top: 1,
+                    bottom: None,
+                },
+            ]
+        );
     }
 }

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -34,7 +34,7 @@ pub(crate) struct Parser {
 
 impl Parser {
     pub(crate) fn advance(&mut self, byte: u8) -> Option<Action> {
-        let state = std::mem::take(&mut self.state);
+        let state = self.state;
         match state {
             ParserState::Ground => self.advance_ground(byte),
             ParserState::Escape => self.advance_escape(byte),

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -88,8 +88,52 @@ pub enum CursorMove {
     Down(u16),
     Right(u16),
     Left(u16),
+    NextLine(u16),
+    PreviousLine(u16),
     To { row: u16, column: u16 },
     ToColumn(u16),
+    ToRow(u16),
+}
+
+/// Inclusive vertical margins used by index and explicit scroll operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ScrollRegion {
+    top: u16,
+    bottom: u16,
+}
+
+impl ScrollRegion {
+    fn full_screen(rows: u16) -> Self {
+        Self {
+            top: 0,
+            bottom: rows - 1,
+        }
+    }
+
+    fn checked(rows: u16, top: u16, bottom: u16) -> Result<Self, TerminalError> {
+        if top >= bottom || bottom >= rows {
+            return Err(TerminalError::InvalidScrollRegion);
+        }
+        Ok(Self { top, bottom })
+    }
+
+    /// Zero-based first row in the region.
+    #[must_use]
+    pub const fn top(self) -> u16 {
+        self.top
+    }
+
+    /// Zero-based last row in the region.
+    #[must_use]
+    pub const fn bottom(self) -> u16 {
+        self.bottom
+    }
+
+    /// Number of rows in the inclusive region.
+    #[must_use]
+    pub const fn height(self) -> u16 {
+        self.bottom - self.top + 1
+    }
 }
 
 /// Fixed-size visible screen buffer in row-major order.
@@ -159,11 +203,24 @@ impl ScreenBuffer {
         Ok(())
     }
 
-    fn scroll_up(&mut self) {
+    fn scroll_up(&mut self, region: ScrollRegion, count: u16) {
         let columns = usize::from(self.cols);
-        self.cells.rotate_left(columns);
-        let first_blank = self.cells.len().saturating_sub(columns);
-        self.cells[first_blank..].fill(Cell::blank());
+        let rows = usize::from(count.min(region.height()));
+        let start = usize::from(region.top) * columns;
+        let end = (usize::from(region.bottom) + 1) * columns;
+        let shift = rows * columns;
+        self.cells[start..end].rotate_left(shift);
+        self.cells[end - shift..end].fill(Cell::blank());
+    }
+
+    fn scroll_down(&mut self, region: ScrollRegion, count: u16) {
+        let columns = usize::from(self.cols);
+        let rows = usize::from(count.min(region.height()));
+        let start = usize::from(region.top) * columns;
+        let end = (usize::from(region.bottom) + 1) * columns;
+        let shift = rows * columns;
+        self.cells[start..end].rotate_right(shift);
+        self.cells[start..start + shift].fill(Cell::blank());
     }
 
     fn index(&self, row: u16, column: u16) -> Option<usize> {
@@ -179,6 +236,7 @@ impl ScreenBuffer {
 pub enum TerminalError {
     InvalidSize,
     ScreenTooLarge,
+    InvalidScrollRegion,
 }
 
 impl fmt::Display for TerminalError {
@@ -186,6 +244,9 @@ impl fmt::Display for TerminalError {
         match self {
             Self::InvalidSize => f.write_str("terminal rows and columns must be non-zero"),
             Self::ScreenTooLarge => f.write_str("terminal screen exceeds the cell limit"),
+            Self::InvalidScrollRegion => {
+                f.write_str("terminal scroll region must be ordered and within the screen")
+            }
         }
     }
 }
@@ -196,6 +257,8 @@ impl std::error::Error for TerminalError {}
 pub struct TerminalState {
     screen: ScreenBuffer,
     cursor: Cursor,
+    scroll_region: ScrollRegion,
+    wrap_pending: bool,
     parser: Parser,
 }
 
@@ -205,6 +268,8 @@ impl TerminalState {
         Ok(Self {
             screen: ScreenBuffer::new(rows, cols)?,
             cursor: Cursor::default(),
+            scroll_region: ScrollRegion::full_screen(rows),
+            wrap_pending: false,
             parser: Parser::default(),
         })
     }
@@ -227,6 +292,8 @@ impl TerminalState {
         self.screen.resize(rows, cols)?;
         self.cursor.row = self.cursor.row.min(rows - 1);
         self.cursor.column = self.cursor.column.min(cols - 1);
+        self.scroll_region = ScrollRegion::full_screen(rows);
+        self.wrap_pending = false;
         Ok(())
     }
 
@@ -248,8 +315,29 @@ impl TerminalState {
         &self.screen
     }
 
+    /// Active inclusive vertical scrolling margins.
+    #[must_use]
+    pub const fn scroll_region(&self) -> ScrollRegion {
+        self.scroll_region
+    }
+
+    /// Whether the next printable byte will wrap before it is written.
+    #[must_use]
+    pub const fn is_wrap_pending(&self) -> bool {
+        self.wrap_pending
+    }
+
+    /// Set zero-based inclusive scrolling margins and move the cursor home.
+    pub fn set_scroll_region(&mut self, top: u16, bottom: u16) -> Result<(), TerminalError> {
+        self.scroll_region = ScrollRegion::checked(self.screen.rows, top, bottom)?;
+        self.cursor = Cursor::default();
+        self.wrap_pending = false;
+        Ok(())
+    }
+
     /// Apply a clamped renderer-independent cursor operation.
     pub fn move_cursor(&mut self, movement: CursorMove) {
+        self.wrap_pending = false;
         let last_row = self.screen.rows - 1;
         let last_column = self.screen.cols - 1;
         match movement {
@@ -263,12 +351,23 @@ impl TerminalState {
             CursorMove::Left(count) => {
                 self.cursor.column = self.cursor.column.saturating_sub(count);
             }
+            CursorMove::NextLine(count) => {
+                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
+                self.cursor.column = 0;
+            }
+            CursorMove::PreviousLine(count) => {
+                self.cursor.row = self.cursor.row.saturating_sub(count);
+                self.cursor.column = 0;
+            }
             CursorMove::To { row, column } => {
                 self.cursor.row = row.min(last_row);
                 self.cursor.column = column.min(last_column);
             }
             CursorMove::ToColumn(column) => {
                 self.cursor.column = column.min(last_column);
+            }
+            CursorMove::ToRow(row) => {
+                self.cursor.row = row.min(last_row);
             }
         }
     }
@@ -283,35 +382,100 @@ impl TerminalState {
         match action {
             Action::Print(byte) => self.print_ascii(byte),
             Action::LineFeed => self.line_feed(),
-            Action::CarriageReturn => self.cursor.column = 0,
-            Action::Backspace => self.cursor.column = self.cursor.column.saturating_sub(1),
+            Action::CarriageReturn => {
+                self.cursor.column = 0;
+                self.wrap_pending = false;
+            }
+            Action::Backspace => {
+                self.cursor.column = self.cursor.column.saturating_sub(1);
+                self.wrap_pending = false;
+            }
+            Action::Index => self.index(),
+            Action::NextLine => self.next_line(),
+            Action::ReverseIndex => self.reverse_index(),
             Action::MoveUp(count) => self.move_cursor(CursorMove::Up(count)),
             Action::MoveDown(count) => self.move_cursor(CursorMove::Down(count)),
             Action::MoveRight(count) => self.move_cursor(CursorMove::Right(count)),
             Action::MoveLeft(count) => self.move_cursor(CursorMove::Left(count)),
+            Action::MoveNextLine(count) => self.move_cursor(CursorMove::NextLine(count)),
+            Action::MovePreviousLine(count) => self.move_cursor(CursorMove::PreviousLine(count)),
             Action::MoveTo { row, col } => {
                 self.move_cursor(CursorMove::To { row, column: col });
             }
             Action::MoveToColumn(column) => self.move_cursor(CursorMove::ToColumn(column)),
+            Action::MoveToRow(row) => self.move_cursor(CursorMove::ToRow(row)),
+            Action::SetScrollRegion { top, bottom } => {
+                self.apply_scroll_region(top, bottom);
+            }
+            Action::ScrollUp(count) => self.scroll_up(count),
+            Action::ScrollDown(count) => self.scroll_down(count),
         }
     }
 
     fn print_ascii(&mut self, byte: u8) {
+        if self.wrap_pending {
+            self.cursor.column = 0;
+            self.index();
+        }
         self.screen
             .put(self.cursor.row, self.cursor.column, Cell::from_ascii(byte));
         if self.cursor.column == self.screen.cols - 1 {
-            self.cursor.column = 0;
-            self.line_feed();
+            self.wrap_pending = true;
         } else {
             self.cursor.column += 1;
         }
     }
 
     fn line_feed(&mut self) {
-        if self.cursor.row == self.screen.rows - 1 {
-            self.screen.scroll_up();
-        } else {
+        self.wrap_pending = false;
+        self.index();
+    }
+
+    fn index(&mut self) {
+        self.wrap_pending = false;
+        if self.cursor.row == self.scroll_region.bottom {
+            self.screen.scroll_up(self.scroll_region, 1);
+        } else if self.cursor.row < self.screen.rows - 1 {
             self.cursor.row += 1;
+        }
+    }
+
+    fn next_line(&mut self) {
+        self.cursor.column = 0;
+        self.index();
+    }
+
+    fn reverse_index(&mut self) {
+        self.wrap_pending = false;
+        if self.cursor.row == self.scroll_region.top {
+            self.screen.scroll_down(self.scroll_region, 1);
+        } else if self.cursor.row > 0 {
+            self.cursor.row -= 1;
+        }
+    }
+
+    fn scroll_up(&mut self, count: u16) {
+        self.wrap_pending = false;
+        self.screen.scroll_up(self.scroll_region, count);
+    }
+
+    fn scroll_down(&mut self, count: u16) {
+        self.wrap_pending = false;
+        self.screen.scroll_down(self.scroll_region, count);
+    }
+
+    fn reset_scroll_region(&mut self) {
+        self.scroll_region = ScrollRegion::full_screen(self.screen.rows);
+        self.cursor = Cursor::default();
+        self.wrap_pending = false;
+    }
+
+    fn apply_scroll_region(&mut self, top: u16, bottom: Option<u16>) {
+        if top == 0 && bottom.is_none() {
+            self.reset_scroll_region();
+        } else {
+            let bottom = bottom.unwrap_or(self.screen.rows - 1);
+            let _ = self.set_scroll_region(top, bottom);
         }
     }
 }
@@ -321,6 +485,8 @@ impl fmt::Debug for TerminalState {
         f.debug_struct("TerminalState")
             .field("size", &self.size())
             .field("cursor", &self.cursor)
+            .field("scroll_region", &self.scroll_region)
+            .field("wrap_pending", &self.wrap_pending)
             .finish_non_exhaustive()
     }
 }
@@ -330,6 +496,8 @@ impl fmt::Debug for TerminalState {
 pub struct TerminalSnapshot {
     screen: ScreenBuffer,
     cursor: Cursor,
+    scroll_region: ScrollRegion,
+    wrap_pending: bool,
     lines: Vec<String>,
 }
 
@@ -338,6 +506,8 @@ impl TerminalSnapshot {
         Self {
             screen: state.screen.clone(),
             cursor: state.cursor,
+            scroll_region: state.scroll_region,
+            wrap_pending: state.wrap_pending,
             lines: visible_lines(&state.screen),
         }
     }
@@ -358,6 +528,18 @@ impl TerminalSnapshot {
     #[must_use]
     pub const fn cursor(&self) -> Cursor {
         self.cursor
+    }
+
+    /// Active scrolling margins captured with the screen.
+    #[must_use]
+    pub const fn scroll_region(&self) -> ScrollRegion {
+        self.scroll_region
+    }
+
+    /// Whether a printable byte would wrap before being written.
+    #[must_use]
+    pub const fn is_wrap_pending(&self) -> bool {
+        self.wrap_pending
     }
 
     /// Captured visible screen.
@@ -427,5 +609,31 @@ mod tests {
         assert_eq!(state.screen().cell(0, 1).map(Cell::text), Some("X"));
         assert_eq!(state.screen().cell(2, 3).map(Cell::text), Some("Y"));
         assert_eq!(state.cursor(), Cursor { row: 2, column: 4 });
+    }
+
+    #[test]
+    fn index_and_reverse_index_scroll_only_inside_the_active_region() {
+        let mut state = TerminalState::new(5, 2).expect("valid terminal");
+        state.feed_bytes(b"A\x1b[2;1HB\x1b[3;1HC\x1b[4;1HD\x1b[5;1HE");
+        state.feed_bytes(b"\x1b[2;4r\x1b[4;1H\x1bD");
+
+        assert_eq!(state.snapshot().lines(), ["A", "C", "D", "", "E"]);
+        assert_eq!(state.cursor(), Cursor { row: 3, column: 0 });
+
+        state.feed_bytes(b"\x1b[2;1H\x1bM");
+        assert_eq!(state.snapshot().lines(), ["A", "", "C", "D", "E"]);
+        assert_eq!(state.cursor(), Cursor { row: 1, column: 0 });
+    }
+
+    #[test]
+    fn carriage_return_cancels_delayed_wrap_without_scrolling() {
+        let mut state = TerminalState::new(2, 3).expect("valid terminal");
+        state.feed_bytes(b"abc");
+        assert!(state.is_wrap_pending());
+
+        state.feed_bytes(b"\rZ");
+        assert_eq!(state.snapshot().lines(), ["Zbc"]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 1 });
+        assert!(!state.is_wrap_pending());
     }
 }

--- a/crates/noren-terminal/tests/scroll_regions.rs
+++ b/crates/noren-terminal/tests/scroll_regions.rs
@@ -1,0 +1,194 @@
+use noren_terminal::{CursorMove, TerminalError, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn region(state: &TerminalState) -> (u16, u16) {
+    (state.scroll_region().top(), state.scroll_region().bottom())
+}
+
+fn rows(state: &TerminalState) -> Vec<String> {
+    (0..state.screen().rows())
+        .map(|row| {
+            (0..state.screen().cols())
+                .map(|column| {
+                    state
+                        .screen()
+                        .cell(row, column)
+                        .expect("cell is in bounds")
+                        .text()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn labeled_rows() -> TerminalState {
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    state
+}
+
+#[test]
+fn decstbm_defaults_reset_invalid_ranges_and_preserves_outside_rows() {
+    let mut state = labeled_rows();
+
+    state.feed_bytes(b"\x1b[;4r");
+    assert_eq!(region(&state), (0, 3));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[2r");
+    assert_eq!(region(&state), (1, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[3;3r\x1b[5;2r\x1b[2;99r");
+    assert_eq!(region(&state), (1, 4));
+    assert_eq!(cursor(&state), (0, 0));
+    assert_eq!(rows(&state), ["AAA", "BBB", "CCC", "DDD", "EEE"]);
+
+    assert_eq!(
+        state.set_scroll_region(3, 3),
+        Err(TerminalError::InvalidScrollRegion)
+    );
+    assert_eq!(region(&state), (1, 4));
+
+    state.feed_bytes(b"\x1b[r");
+    assert_eq!(region(&state), (0, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[2;4r\x1b[4;1H\x1b[S");
+    assert_eq!(rows(&state), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+    assert_eq!(cursor(&state), (3, 0));
+}
+
+#[test]
+fn line_feed_vertical_tab_form_feed_and_index_scroll_at_bottom_margin() {
+    for control in [b"\n".as_slice(), b"\x0b", b"\x0c", b"\x1bD"] {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r\x1b[4;2H");
+        state.feed_bytes(control);
+
+        assert_eq!(rows(&state), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+        assert_eq!(cursor(&state), (3, 1));
+        assert_eq!(region(&state), (1, 3));
+    }
+}
+
+#[test]
+fn reverse_index_scrolls_at_top_margin_without_moving_cursor() {
+    let mut state = labeled_rows();
+    state.feed_bytes(b"\x1b[2;4r\x1b[2;3H\x1bM");
+
+    assert_eq!(rows(&state), ["AAA", "   ", "BBB", "CCC", "EEE"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert_eq!(region(&state), (1, 3));
+}
+
+#[test]
+fn explicit_scroll_defaults_and_bounds_counts_to_region_height() {
+    let mut up = labeled_rows();
+    up.feed_bytes(b"\x1b[2;4r\x1b[3;2H\x1b[S");
+    assert_eq!(rows(&up), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+    assert_eq!(cursor(&up), (2, 1));
+
+    up.feed_bytes(b"\x1b[999S");
+    assert_eq!(rows(&up), ["AAA", "   ", "   ", "   ", "EEE"]);
+    assert_eq!(cursor(&up), (2, 1));
+
+    let mut down = labeled_rows();
+    down.feed_bytes(b"\x1b[2;4r\x1b[3;2H\x1b[T");
+    assert_eq!(rows(&down), ["AAA", "   ", "BBB", "CCC", "EEE"]);
+    assert_eq!(cursor(&down), (2, 1));
+
+    down.feed_bytes(b"\x1b[999T");
+    assert_eq!(rows(&down), ["AAA", "   ", "   ", "   ", "EEE"]);
+    assert_eq!(cursor(&down), (2, 1));
+}
+
+#[test]
+fn cnl_cpl_and_vpa_apply_defaults_reset_column_and_clamp() {
+    let mut state = TerminalState::new(4, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[2;4H\x1b[E");
+    assert_eq!(cursor(&state), (2, 0));
+
+    state.feed_bytes(b"\x1b[99E");
+    assert_eq!(cursor(&state), (3, 0));
+    state.feed_bytes(b"\x1b[4G\x1b[F");
+    assert_eq!(cursor(&state), (2, 0));
+    state.feed_bytes(b"\x1b[99F");
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[5G\x1b[d");
+    assert_eq!(cursor(&state), (0, 4));
+    state.feed_bytes(b"\x1b[99d");
+    assert_eq!(cursor(&state), (3, 4));
+}
+
+#[test]
+fn cursor_and_control_actions_cancel_delayed_wrap() {
+    let cancellations: &[&[u8]] = &[
+        b"\x08",
+        b"\n",
+        b"\x0b",
+        b"\x0c",
+        b"\x1bD",
+        b"\x1bE",
+        b"\x1bM",
+        b"\x1b[A",
+        b"\x1b[B",
+        b"\x1b[C",
+        b"\x1b[D",
+        b"\x1b[E",
+        b"\x1b[F",
+        b"\x1b[G",
+        b"\x1b[H",
+        b"\x1b[d",
+        b"\x1b[S",
+        b"\x1b[T",
+        b"\x1b[2;3r",
+    ];
+
+    for sequence in cancellations {
+        let mut state = TerminalState::new(3, 3).expect("valid terminal");
+        state.feed_bytes(b"abc");
+        assert!(state.is_wrap_pending(), "precondition for {sequence:?}");
+
+        state.feed_bytes(sequence);
+        assert!(!state.is_wrap_pending(), "sequence {sequence:?}");
+    }
+
+    let mut via_api = TerminalState::new(2, 3).expect("valid terminal");
+    via_api.feed_bytes(b"abc");
+    via_api.move_cursor(CursorMove::ToRow(1));
+    assert!(!via_api.is_wrap_pending());
+}
+
+#[test]
+fn resize_preserves_overlap_clamps_cursor_and_resets_scroll_state() {
+    let mut state = TerminalState::new(4, 4).expect("valid terminal");
+    state.feed_bytes(b"ABCD\x1b[2;1HEF\x1b[3;1HGHI\x1b[4;1HJKLM");
+    state.feed_bytes(b"\x1b[2;4r\x1b[4;4HZ");
+    assert!(state.is_wrap_pending());
+
+    state.resize(3, 2).expect("valid resize");
+    assert_eq!(rows(&state), ["AB", "EF", "GH"]);
+    assert_eq!(cursor(&state), (2, 1));
+    assert_eq!(region(&state), (0, 2));
+    assert!(!state.is_wrap_pending());
+
+    state.resize(5, 5).expect("valid resize");
+    assert_eq!(rows(&state), ["AB   ", "EF   ", "GH   ", "     ", "     "]);
+    assert_eq!(cursor(&state), (2, 1));
+    assert_eq!(region(&state), (0, 4));
+}
+
+#[test]
+fn printable_ascii_and_ignored_controls_remain_stable() {
+    let mut state = TerminalState::new(2, 5).expect("valid terminal");
+    state.feed_bytes(b"A\0B\x07C\x7fD");
+
+    assert_eq!(rows(&state), ["ABCD ", "     "]);
+    assert_eq!(cursor(&state), (0, 4));
+    assert!(!state.is_wrap_pending());
+}

--- a/crates/noren-terminal/tests/terminal_state.rs
+++ b/crates/noren-terminal/tests/terminal_state.rs
@@ -75,16 +75,22 @@ fn cursor_commands_apply_defaults_absolute_positions_and_clamping() {
 }
 
 #[test]
-fn wrapping_at_the_bottom_scrolls_one_row_and_blanks_the_last() {
+fn delayed_wrap_scrolls_only_when_the_next_character_arrives() {
     let mut state = TerminalState::new(2, 3).expect("valid terminal");
     state.feed_bytes(b"abc");
     assert_eq!(state.snapshot().lines(), ["abc"]);
-    assert_eq!(cursor(&state), (1, 0));
+    assert_eq!(cursor(&state), (0, 2));
+    assert!(state.is_wrap_pending());
 
     state.feed_bytes(b"def");
-    assert_eq!(state.snapshot().lines(), ["def"]);
-    assert_eq!(cursor(&state), (1, 0));
-    assert!(state.screen().cell(1, 0).is_some_and(Cell::is_blank));
+    assert_eq!(state.snapshot().lines(), ["abc", "def"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"g");
+    assert_eq!(state.snapshot().lines(), ["def", "g"]);
+    assert_eq!(cursor(&state), (1, 1));
+    assert!(!state.is_wrap_pending());
 }
 
 #[test]

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -1,13 +1,14 @@
 # Terminal core foundation
 
-- Status: Draft, in progress on PR [#19](https://github.com/ta-061/noren/pull/19)
-  (branch `agent/terminal-core-foundation`); not merged
+- Status: PR [#19](https://github.com/ta-061/noren/pull/19) merged as
+  `c695920`; the scroll-region slice is in progress as Draft PR
+  [#21](https://github.com/ta-061/noren/pull/21)
 - Supersedes nothing: the accepted [local-PTY PoC
   architecture](minimal-local-pty-poc.md) still applies
 
 This foundation moves PTY output bytes through a renderer-independent terminal
 state core in `crates/noren-terminal/`. It is a foundation slice, not a
-VT100/xterm compatibility claim.
+VT100/xterm compatibility claim and not vim/tmux/zellij compatibility.
 
 ## Data flow
 
@@ -19,11 +20,14 @@ TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
 - `TerminalState` owns the screen, cursor, dimensions, and parser state.
 - The visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
   `MAX_SCREEN_CELLS` (1,048,576 cells).
-- `resize` rebuilds the grid and preserves the overlapping top-left region.
+- `resize` rebuilds the grid, preserves the overlapping top-left region, and
+  resets scroll margins and pending autowrap.
 - The renderer consumes the immutable `TerminalSnapshot` and never depends on
   PTY or parser types.
 
 ## Supported behavior
+
+Merged in PR #19:
 
 - Printable ASCII bytes (`0x20..=0x7e`), line feed, carriage return, and
   backspace.
@@ -31,7 +35,18 @@ TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
   absolute position, and absolute column.
 - Unsupported and OSC bytes are ignored without corrupting state.
 
-## Deferred order
+Added by Draft PR #21 (scrolling regions):
 
-Scroll regions, alternate screen, SGR/erase plus cell attributes, and mode
-state, in that order. Unicode and IME remain later.
+- Scroll margins default to the full screen and are inclusive on both ends;
+  DECSTBM sets them and rejects invalid ranges.
+- LF/VT/FF/IND/NEL/RI and CSI S/T scrolling act only within the active region;
+  rows outside the margins are preserved.
+- CNL, CPL, and VPA.
+- Delayed autowrap: wrapping is deferred until the next printable byte.
+- Resize resets margins and pending autowrap.
+
+## Deferred
+
+Alternate screen, SGR/erase/insert/delete, cell attributes, tabs, origin
+mode, and query/reply sequences remain deferred. Unicode and IME remain
+later.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,32 +1,34 @@
 # Coordination status
 
 Last updated: 2026-08-03 (Asia/Tokyo). PR
-[#17](https://github.com/ta-061/noren/pull/17) is merged into `main` as
-`b2bb87c20365dec5d1ab6b0122b2a987ec768744`. The only open PR is Draft
-[#19](https://github.com/ta-061/noren/pull/19), branch
-`agent/terminal-core-foundation`. The sections below preserve the PR #17
-record at implementation/test head
+[#19](https://github.com/ta-061/noren/pull/19) is merged into `main` as
+`c695920d8bc99990447d0b451754ea96c91181fc`. The only open PR is Draft
+[#21](https://github.com/ta-061/noren/pull/21), branch
+`agent/terminal-scroll-regions`, for Issue
+[#20](https://github.com/ta-061/noren/issues/20). Historical sections below
+preserve the PR #17 record at implementation/test head
 `c1f66dc27ddce37a60665d319a7ca061c300947e`, corrected only where an active
 claim went stale; coordination head `ac410a82` also passed both GitHub checks.
 
 ## Current phase
 
-Terminal foundation. The first macOS local-zsh PTY PoC (PR #17) is merged.
-Draft PR #19, not merged, replaces the `avt` dependency with a
-renderer-independent Noren `TerminalState`: bounded screen cells, cursor,
-resize, printable ASCII/LF/CR/backspace, and minimal CSI cursor movement. The
-renderer consumes `TerminalSnapshot`; see
+Terminal foundation, scrolling-region slice. PR #19 merged the Noren-owned,
+renderer-independent `TerminalState`. Draft PR #21 adds DECSTBM margins,
+region-scoped LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed
+autowrap, and resize-reset behavior. See
 [terminal core foundation](../architecture/terminal-core-foundation.md). This
-is not VT100/xterm compatibility. Deferred order: scroll regions, alternate
-screen, SGR/erase plus cell attributes, mode state; Unicode/IME remain later.
+is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
 ## GitHub state
 
 Verified on 2026-08-03:
 
-- The only open Issue is [#18](https://github.com/ta-061/noren/issues/18), the
-  Terminal Core foundation. The only open PR is its Draft
-  [#19](https://github.com/ta-061/noren/pull/19).
+- The only open Issue is [#20](https://github.com/ta-061/noren/issues/20), the
+  scrolling-region behavior slice. The only open PR is its Draft
+  [#21](https://github.com/ta-061/noren/pull/21).
+- PR [#19](https://github.com/ta-061/noren/pull/19) and Issue
+  [#18](https://github.com/ta-061/noren/issues/18) are complete after owner
+  acceptance of the renderer-independent Terminal Core foundation.
 - PR [#17](https://github.com/ta-061/noren/pull/17) and its Issue
   [#16](https://github.com/ta-061/noren/issues/16) are complete after the owner
   accepted the macOS local-PTY PoC.
@@ -35,11 +37,11 @@ Verified on 2026-08-03:
   [#14](https://github.com/ta-061/noren/pull/14) merged the bounded Discovery
   integration and PR [#15](https://github.com/ta-061/noren/pull/15) merged the
   lean Design Council.
-- `main` is at `b2bb87c20365dec5d1ab6b0122b2a987ec768744`, the merge commit
-  for PR #17. No Discovery PR remains open and no repeated large research or
+- `main` is at `c695920d8bc99990447d0b451754ea96c91181fc`, the merge commit
+  for PR #19. No Discovery PR remains open and no repeated large research or
   review is planned.
 
-## Terminal Core handoff
+## Merged PR #19 Terminal Core handoff
 
 | Lane | Saved evidence | State |
 | --- | --- | --- |
@@ -48,6 +50,17 @@ Verified on 2026-08-03:
 | GLM boundaries | PR #19 review: module, error, and crate boundaries pass without changes | Complete |
 | Claude Code architecture | PR #19 review: ACCEPT, no VT-evolution blocker | Complete |
 | Qwen documentation | Signed `b390531`: architecture, roadmap, contributor, and status updates | Complete |
+
+## Draft PR #21 scrolling-region handoff
+
+| Lane | Saved evidence | State |
+| --- | --- | --- |
+| Codex core | Signed `9ffe79c`: margins, region scrolling, cursor/index behavior, delayed autowrap | Complete |
+| codex-lab tests | Signed `6bbac87`: eight public-API scroll/cursor/resize regression tests | Complete |
+| GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
+| Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
+| Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
+| Codex integration | Exact-head local checks, CI, and launch smoke | In progress |
 
 ## PR #17 historical implementation checkpoints
 
@@ -99,10 +112,9 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #19 remains Draft until current-head CI is green and the owner can repeat a
-local macOS startup/output/resize/exit smoke check. PR #17 has no remaining
-gate; its manual verification was accepted before merge. This does not
-authorize deferred terminal features in the foundation PR.
+PR #21 remains Draft until exact-head local checks and CI pass and the existing
+local-zsh application launch is rechecked. PR #19 has no remaining gate. This
+does not authorize deferred terminal features in the scrolling-region PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -116,7 +128,7 @@ identity, and the public support/security contact before Preview publication.
 
 ## Next steps
 
-1. Save exact-head local checks and GitHub CI on Draft PR #19.
-2. Repeat the bounded macOS smoke check without changing OS security settings.
-3. Keep scroll regions and later VT work in a separate Issue/PR after this
-   foundation is accepted.
+1. Save exact-head local checks and GitHub CI on Draft PR #21.
+2. Repeat the bounded macOS launch smoke without changing OS security settings.
+3. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
+   separate Issues and PRs.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -60,7 +60,7 @@ Verified on 2026-08-03:
 | GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
 | Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
 | Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
-| Codex integration | Exact-head local checks, CI, and launch smoke | In progress |
+| Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
 
 ## PR #17 historical implementation checkpoints
 
@@ -112,9 +112,10 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #21 remains Draft until exact-head local checks and CI pass and the existing
-local-zsh application launch is rechecked. PR #19 has no remaining gate. This
-does not authorize deferred terminal features in the scrolling-region PR.
+PR #21 has passed exact-head local checks and CI, and the existing local-zsh
+application launch was rechecked. It remains Draft for owner review and
+acceptance. PR #19 has no remaining gate. This does not authorize deferred
+terminal features in the scrolling-region PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -128,7 +129,6 @@ identity, and the public support/security contact before Preview publication.
 
 ## Next steps
 
-1. Save exact-head local checks and GitHub CI on Draft PR #21.
-2. Repeat the bounded macOS launch smoke without changing OS security settings.
-3. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
+1. Review and accept Draft PR #21, then promote and merge its exact tested head.
+2. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
    separate Issues and PRs.


### PR DESCRIPTION
## Issue

Closes #20

## Status

Draft integration is complete at exact head `2543f18a06ed492f01e2336bcd42ca06a1cd6c6c`. It remains Draft for owner review and acceptance.

## Implemented

- Added an inclusive `ScrollRegion` to `TerminalState`, defaulting to the full screen and exposed through immutable snapshots.
- Added DECSTBM parsing/application with default parameters, ordered/in-bounds validation, cursor-home behavior, and full-margin reset.
- Added region-scoped buffer scroll-up/down behavior for LF/VT/FF, IND, NEL, RI, and `CSI S` / `CSI T`.
- Added CNL, CPL, and VPA cursor movement with screen clamping.
- Added delayed right-margin autowrap; cursor/control/resize operations cancel pending wrap.
- Resize preserves the top-left overlap, clamps the cursor, clears pending wrap, and resets margins to the resized screen.
- Preserved the PTY → `TerminalState` → renderer boundary and existing macOS local-zsh application behavior.

## Exact-head validation

- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed, 53 tests.
- `python3 scripts/check_docs.py` — passed.
- `python3 -m unittest scripts/test_check_docs.py` — passed, 7 tests.
- `git diff --check` — passed.
- All six PR commits contain a `Signed-off-by` trailer.
- [Rust CI](https://github.com/ta-061/noren/actions/runs/30798773089/job/91638292906) — passed on exact head.
- [Documentation CI](https://github.com/ta-061/noren/actions/runs/30798773040/job/91638293153) — passed on exact head.

## Launch smoke

`cargo run -p noren-app` launched `noren-app` and its local `/bin/zsh` child on macOS. Both processes were observed alive and then terminated by their exact PIDs. This is a bounded process/startup smoke, not a new interactive-rendering compatibility claim.

## Delegated lanes

- [x] **codex-lab:** signed `6bbac87`; eight public-API scroll, cursor-edge, resize-buffer, and regression tests.
- [x] **GLM:** signed `32ca7da`; one behavior-preserving parser-state idiom cleanup.
- [x] **Claude Code:** read-only VT review; `BLOCKER: NONE`.
- [x] **Qwen:** signed `328c013`; concise architecture, roadmap, and contributor-guide updates.
- [x] **Codex:** core implementation, integration, exact-head checks, CI, and launch smoke.

## Non-goals

No alternate screen, SGR/colors/attributes, erase/insert/delete operations, tab stops, Unicode/IME/font work, scrollback, renderer redesign, UI, SSH, AI features, tabs/panes, remote daemon, or full VT100/xterm compatibility claim.

## Remaining compatibility gaps

Origin mode, alternate screen, erase/insert/delete behavior, attributes, tabs, Unicode, and terminal query/reply behavior remain deferred. The next compatibility slice must use a separate Issue and Draft PR.