### PR TITLE
Terminal Core: add alternate screen and mode state

### DIFF
--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -4,16 +4,16 @@
 //! PTY bytes enter through [`TerminalEngine::feed_bytes`]; renderers receive an
 //! immutable [`TerminalSnapshot`] and never depend on PTY or parser types.
 //!
-//! This first foundation deliberately supports printable ASCII, line feed,
-//! carriage return, backspace, and a small CSI cursor-movement subset. It is
-//! not a VT100/xterm compatibility claim.
+//! This foundation supports a bounded ASCII/CSI subset, scrolling regions,
+//! cursor save/restore, and DEC private mode 1049 screen switching. It is not
+//! a VT100/xterm compatibility claim.
 
 mod parser;
 mod state;
 
 pub use state::{
     Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
-    TerminalSnapshot, TerminalState,
+    TerminalModes, TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -25,6 +25,14 @@ pub(crate) enum Action {
     SetScrollRegion { top: u16, bottom: Option<u16> },
     ScrollUp(u16),
     ScrollDown(u16),
+    SaveCursor,
+    RestoreCursor,
+    SetPrivateMode { mode: PrivateMode, enabled: bool },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PrivateMode {
+    AlternateScreen,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -101,6 +109,14 @@ impl Parser {
                 self.state = ParserState::Ground;
                 return Some(Action::ReverseIndex);
             }
+            b'7' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SaveCursor);
+            }
+            b'8' => {
+                self.state = ParserState::Ground;
+                return Some(Action::RestoreCursor);
+            }
             _ => self.state = ParserState::Ground,
         }
         None
@@ -125,6 +141,7 @@ struct Csi {
     has_current: bool,
     overflowed: bool,
     ignored: bool,
+    private_marker: Option<u8>,
 }
 
 impl Default for Csi {
@@ -136,6 +153,7 @@ impl Default for Csi {
             has_current: false,
             overflowed: false,
             ignored: false,
+            private_marker: None,
         }
     }
 }
@@ -155,7 +173,11 @@ impl Csi {
                 self.push_current();
                 CsiAdvance::pending()
             }
-            b'?' | b'>' if self.len == 0 && !self.has_current => {
+            b'?' | b'>' if self.len == 0 && !self.has_current && self.private_marker.is_none() => {
+                self.private_marker = Some(byte);
+                CsiAdvance::pending()
+            }
+            b'?' | b'>' => {
                 self.ignored = true;
                 CsiAdvance::pending()
             }
@@ -187,6 +209,14 @@ impl Csi {
     }
 
     fn action(&self, final_byte: u8) -> Option<Action> {
+        match self.private_marker {
+            None => self.standard_action(final_byte),
+            Some(b'?') => self.private_action(final_byte),
+            Some(_) => None,
+        }
+    }
+
+    fn standard_action(&self, final_byte: u8) -> Option<Action> {
         let count = self.param_or(0, 1);
         match final_byte {
             b'A' => Some(Action::MoveUp(count)),
@@ -207,8 +237,35 @@ impl Csi {
                 top: self.param_or(0, 1).saturating_sub(1),
                 bottom: self.zero_based_param(1),
             }),
+            b's' if self.is_default_only() => Some(Action::SaveCursor),
+            b'u' if self.is_default_only() => Some(Action::RestoreCursor),
             _ => None,
         }
+    }
+
+    fn private_action(&self, final_byte: u8) -> Option<Action> {
+        if self.len != 1 {
+            return None;
+        }
+        let mode = match self.params[0] {
+            1049 => PrivateMode::AlternateScreen,
+            _ => return None,
+        };
+        match final_byte {
+            b'h' => Some(Action::SetPrivateMode {
+                mode,
+                enabled: true,
+            }),
+            b'l' => Some(Action::SetPrivateMode {
+                mode,
+                enabled: false,
+            }),
+            _ => None,
+        }
+    }
+
+    fn is_default_only(&self) -> bool {
+        self.len == 1 && self.params[0] == 0
     }
 
     fn param_or(&self, index: usize, default: u16) -> u16 {
@@ -320,5 +377,27 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn parses_cursor_save_restore_and_alternate_screen_mode() {
+        assert_eq!(
+            actions(b"\x1b7\x1b8\x1b[s\x1b[u\x1b[?1049h\x1b[?1049l"),
+            [
+                Action::SaveCursor,
+                Action::RestoreCursor,
+                Action::SaveCursor,
+                Action::RestoreCursor,
+                Action::SetPrivateMode {
+                    mode: PrivateMode::AlternateScreen,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::AlternateScreen,
+                    enabled: false,
+                },
+            ]
+        );
+        assert!(actions(b"\x1b[?2004h\x1b[?1049;1h\x1b[>1049h").is_empty());
     }
 }

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,4 +1,4 @@
-use crate::parser::{Action, Parser};
+use crate::parser::{Action, Parser, PrivateMode};
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
@@ -136,6 +136,20 @@ impl ScrollRegion {
     }
 }
 
+/// Renderer-independent terminal modes that affect visible state selection.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerminalModes {
+    alternate_screen: bool,
+}
+
+impl TerminalModes {
+    /// Whether DEC private mode 1049 currently selects the alternate screen.
+    #[must_use]
+    pub const fn is_alternate_screen_active(self) -> bool {
+        self.alternate_screen
+    }
+}
+
 /// Fixed-size visible screen buffer in row-major order.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ScreenBuffer {
@@ -253,12 +267,67 @@ impl fmt::Display for TerminalError {
 
 impl std::error::Error for TerminalError {}
 
-/// Noren-owned mutable terminal state.
-pub struct TerminalState {
+struct ScreenState {
     screen: ScreenBuffer,
     cursor: Cursor,
+    saved_cursor: Option<Cursor>,
     scroll_region: ScrollRegion,
     wrap_pending: bool,
+}
+
+impl ScreenState {
+    fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
+        Ok(Self {
+            screen: ScreenBuffer::new(rows, cols)?,
+            cursor: Cursor::default(),
+            saved_cursor: None,
+            scroll_region: ScrollRegion::full_screen(rows),
+            wrap_pending: false,
+        })
+    }
+
+    fn blank_like(&self) -> Self {
+        Self {
+            screen: ScreenBuffer {
+                rows: self.screen.rows,
+                cols: self.screen.cols,
+                cells: vec![Cell::blank(); self.screen.cells.len()],
+            },
+            cursor: Cursor::default(),
+            saved_cursor: None,
+            scroll_region: ScrollRegion::full_screen(self.screen.rows),
+            wrap_pending: false,
+        }
+    }
+
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
+        self.screen.resize(rows, cols)?;
+        self.cursor = clamp_cursor(self.cursor, rows, cols);
+        self.saved_cursor = self
+            .saved_cursor
+            .map(|cursor| clamp_cursor(cursor, rows, cols));
+        self.scroll_region = ScrollRegion::full_screen(rows);
+        self.wrap_pending = false;
+        Ok(())
+    }
+
+    fn save_cursor(&mut self) {
+        self.saved_cursor = Some(self.cursor);
+    }
+
+    fn restore_cursor(&mut self) {
+        if let Some(cursor) = self.saved_cursor {
+            self.cursor = clamp_cursor(cursor, self.screen.rows, self.screen.cols);
+        }
+        self.wrap_pending = false;
+    }
+}
+
+/// Noren-owned mutable terminal state.
+pub struct TerminalState {
+    active: ScreenState,
+    primary_screen: Option<ScreenState>,
+    modes: TerminalModes,
     parser: Parser,
 }
 
@@ -266,10 +335,9 @@ impl TerminalState {
     /// Create a bounded non-zero visible terminal.
     pub fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
         Ok(Self {
-            screen: ScreenBuffer::new(rows, cols)?,
-            cursor: Cursor::default(),
-            scroll_region: ScrollRegion::full_screen(rows),
-            wrap_pending: false,
+            active: ScreenState::new(rows, cols)?,
+            primary_screen: None,
+            modes: TerminalModes::default(),
             parser: Parser::default(),
         })
     }
@@ -287,87 +355,110 @@ impl TerminalState {
         }
     }
 
-    /// Resize while preserving the overlapping top-left screen area.
+    /// Resize active and inactive screens while preserving their overlap.
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
-        self.screen.resize(rows, cols)?;
-        self.cursor.row = self.cursor.row.min(rows - 1);
-        self.cursor.column = self.cursor.column.min(cols - 1);
-        self.scroll_region = ScrollRegion::full_screen(rows);
-        self.wrap_pending = false;
+        checked_cell_count(rows, cols)?;
+        self.active.resize(rows, cols)?;
+        if let Some(primary) = &mut self.primary_screen {
+            primary.resize(rows, cols)?;
+        }
         Ok(())
     }
 
     /// Current `(rows, cols)`.
     #[must_use]
     pub const fn size(&self) -> (u16, u16) {
-        (self.screen.rows, self.screen.cols)
+        (self.active.screen.rows, self.active.screen.cols)
     }
 
     /// Current cursor position.
     #[must_use]
     pub const fn cursor(&self) -> Cursor {
-        self.cursor
+        self.active.cursor
     }
 
     /// Current visible screen.
     #[must_use]
     pub const fn screen(&self) -> &ScreenBuffer {
-        &self.screen
+        &self.active.screen
     }
 
     /// Active inclusive vertical scrolling margins.
     #[must_use]
     pub const fn scroll_region(&self) -> ScrollRegion {
-        self.scroll_region
+        self.active.scroll_region
     }
 
     /// Whether the next printable byte will wrap before it is written.
     #[must_use]
     pub const fn is_wrap_pending(&self) -> bool {
-        self.wrap_pending
+        self.active.wrap_pending
+    }
+
+    /// Current renderer-independent terminal mode state.
+    #[must_use]
+    pub const fn modes(&self) -> TerminalModes {
+        self.modes
+    }
+
+    /// Save the active screen's cursor position.
+    pub fn save_cursor(&mut self) {
+        self.active.save_cursor();
+    }
+
+    /// Restore the active screen's saved cursor position, if present.
+    pub fn restore_cursor(&mut self) {
+        self.active.restore_cursor();
     }
 
     /// Set zero-based inclusive scrolling margins and move the cursor home.
     pub fn set_scroll_region(&mut self, top: u16, bottom: u16) -> Result<(), TerminalError> {
-        self.scroll_region = ScrollRegion::checked(self.screen.rows, top, bottom)?;
-        self.cursor = Cursor::default();
-        self.wrap_pending = false;
+        self.active.scroll_region = ScrollRegion::checked(self.active.screen.rows, top, bottom)?;
+        self.active.cursor = Cursor::default();
+        self.active.wrap_pending = false;
         Ok(())
     }
 
     /// Apply a clamped renderer-independent cursor operation.
     pub fn move_cursor(&mut self, movement: CursorMove) {
-        self.wrap_pending = false;
-        let last_row = self.screen.rows - 1;
-        let last_column = self.screen.cols - 1;
+        self.active.wrap_pending = false;
+        let last_row = self.active.screen.rows - 1;
+        let last_column = self.active.screen.cols - 1;
         match movement {
-            CursorMove::Up(count) => self.cursor.row = self.cursor.row.saturating_sub(count),
+            CursorMove::Up(count) => {
+                self.active.cursor.row = self.active.cursor.row.saturating_sub(count);
+            }
             CursorMove::Down(count) => {
-                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
+                self.active.cursor.row = self.active.cursor.row.saturating_add(count).min(last_row);
             }
             CursorMove::Right(count) => {
-                self.cursor.column = self.cursor.column.saturating_add(count).min(last_column);
+                self.active.cursor.column = self
+                    .active
+                    .cursor
+                    .column
+                    .saturating_add(count)
+                    .min(last_column);
             }
             CursorMove::Left(count) => {
-                self.cursor.column = self.cursor.column.saturating_sub(count);
+                self.active.cursor.column = self.active.cursor.column.saturating_sub(count);
             }
             CursorMove::NextLine(count) => {
-                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
-                self.cursor.column = 0;
+                self.active.cursor.row = self.active.cursor.row.saturating_add(count).min(last_row);
+                self.active.cursor.column = 0;
             }
             CursorMove::PreviousLine(count) => {
-                self.cursor.row = self.cursor.row.saturating_sub(count);
-                self.cursor.column = 0;
+                self.active.cursor.row = self.active.cursor.row.saturating_sub(count);
+                self.active.cursor.column = 0;
             }
             CursorMove::To { row, column } => {
-                self.cursor.row = row.min(last_row);
-                self.cursor.column = column.min(last_column);
+                self.active.cursor.row = row.min(last_row);
+                self.active.cursor.column = column.min(last_column);
             }
             CursorMove::ToColumn(column) => {
-                self.cursor.column = column.min(last_column);
+                self.active.cursor.column = column.min(last_column);
             }
             CursorMove::ToRow(row) => {
-                self.cursor.row = row.min(last_row);
+                self.active.cursor.row = row.min(last_row);
             }
         }
     }
@@ -383,12 +474,12 @@ impl TerminalState {
             Action::Print(byte) => self.print_ascii(byte),
             Action::LineFeed => self.line_feed(),
             Action::CarriageReturn => {
-                self.cursor.column = 0;
-                self.wrap_pending = false;
+                self.active.cursor.column = 0;
+                self.active.wrap_pending = false;
             }
             Action::Backspace => {
-                self.cursor.column = self.cursor.column.saturating_sub(1);
-                self.wrap_pending = false;
+                self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
+                self.active.wrap_pending = false;
             }
             Action::Index => self.index(),
             Action::NextLine => self.next_line(),
@@ -409,74 +500,114 @@ impl TerminalState {
             }
             Action::ScrollUp(count) => self.scroll_up(count),
             Action::ScrollDown(count) => self.scroll_down(count),
+            Action::SaveCursor => self.save_cursor(),
+            Action::RestoreCursor => self.restore_cursor(),
+            Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
         }
     }
 
     fn print_ascii(&mut self, byte: u8) {
-        if self.wrap_pending {
-            self.cursor.column = 0;
+        if self.active.wrap_pending {
+            self.active.cursor.column = 0;
             self.index();
         }
-        self.screen
-            .put(self.cursor.row, self.cursor.column, Cell::from_ascii(byte));
-        if self.cursor.column == self.screen.cols - 1 {
-            self.wrap_pending = true;
+        self.active.screen.put(
+            self.active.cursor.row,
+            self.active.cursor.column,
+            Cell::from_ascii(byte),
+        );
+        if self.active.cursor.column == self.active.screen.cols - 1 {
+            self.active.wrap_pending = true;
         } else {
-            self.cursor.column += 1;
+            self.active.cursor.column += 1;
         }
     }
 
     fn line_feed(&mut self) {
-        self.wrap_pending = false;
+        self.active.wrap_pending = false;
         self.index();
     }
 
     fn index(&mut self) {
-        self.wrap_pending = false;
-        if self.cursor.row == self.scroll_region.bottom {
-            self.screen.scroll_up(self.scroll_region, 1);
-        } else if self.cursor.row < self.screen.rows - 1 {
-            self.cursor.row += 1;
+        self.active.wrap_pending = false;
+        if self.active.cursor.row == self.active.scroll_region.bottom {
+            self.active.screen.scroll_up(self.active.scroll_region, 1);
+        } else if self.active.cursor.row < self.active.screen.rows - 1 {
+            self.active.cursor.row += 1;
         }
     }
 
     fn next_line(&mut self) {
-        self.cursor.column = 0;
+        self.active.cursor.column = 0;
         self.index();
     }
 
     fn reverse_index(&mut self) {
-        self.wrap_pending = false;
-        if self.cursor.row == self.scroll_region.top {
-            self.screen.scroll_down(self.scroll_region, 1);
-        } else if self.cursor.row > 0 {
-            self.cursor.row -= 1;
+        self.active.wrap_pending = false;
+        if self.active.cursor.row == self.active.scroll_region.top {
+            self.active.screen.scroll_down(self.active.scroll_region, 1);
+        } else if self.active.cursor.row > 0 {
+            self.active.cursor.row -= 1;
         }
     }
 
     fn scroll_up(&mut self, count: u16) {
-        self.wrap_pending = false;
-        self.screen.scroll_up(self.scroll_region, count);
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .scroll_up(self.active.scroll_region, count);
     }
 
     fn scroll_down(&mut self, count: u16) {
-        self.wrap_pending = false;
-        self.screen.scroll_down(self.scroll_region, count);
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .scroll_down(self.active.scroll_region, count);
     }
 
     fn reset_scroll_region(&mut self) {
-        self.scroll_region = ScrollRegion::full_screen(self.screen.rows);
-        self.cursor = Cursor::default();
-        self.wrap_pending = false;
+        self.active.scroll_region = ScrollRegion::full_screen(self.active.screen.rows);
+        self.active.cursor = Cursor::default();
+        self.active.wrap_pending = false;
     }
 
     fn apply_scroll_region(&mut self, top: u16, bottom: Option<u16>) {
         if top == 0 && bottom.is_none() {
             self.reset_scroll_region();
         } else {
-            let bottom = bottom.unwrap_or(self.screen.rows - 1);
+            let bottom = bottom.unwrap_or(self.active.screen.rows - 1);
             let _ = self.set_scroll_region(top, bottom);
         }
+    }
+
+    fn set_private_mode(&mut self, mode: PrivateMode, enabled: bool) {
+        match (mode, enabled) {
+            (PrivateMode::AlternateScreen, true) => self.enter_alternate_screen(),
+            (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
+        }
+    }
+
+    fn enter_alternate_screen(&mut self) {
+        if self.modes.alternate_screen {
+            return;
+        }
+        self.active.save_cursor();
+        let alternate = self.active.blank_like();
+        let primary = std::mem::replace(&mut self.active, alternate);
+        debug_assert!(self.primary_screen.is_none());
+        self.primary_screen = Some(primary);
+        self.modes.alternate_screen = true;
+    }
+
+    fn leave_alternate_screen(&mut self) {
+        if !self.modes.alternate_screen {
+            return;
+        }
+        if let Some(primary) = self.primary_screen.take() {
+            self.active = primary;
+            self.active.restore_cursor();
+        }
+        self.modes.alternate_screen = false;
     }
 }
 
@@ -484,9 +615,10 @@ impl fmt::Debug for TerminalState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TerminalState")
             .field("size", &self.size())
-            .field("cursor", &self.cursor)
-            .field("scroll_region", &self.scroll_region)
-            .field("wrap_pending", &self.wrap_pending)
+            .field("cursor", &self.active.cursor)
+            .field("scroll_region", &self.active.scroll_region)
+            .field("wrap_pending", &self.active.wrap_pending)
+            .field("modes", &self.modes)
             .finish_non_exhaustive()
     }
 }
@@ -498,17 +630,19 @@ pub struct TerminalSnapshot {
     cursor: Cursor,
     scroll_region: ScrollRegion,
     wrap_pending: bool,
+    modes: TerminalModes,
     lines: Vec<String>,
 }
 
 impl TerminalSnapshot {
     fn from_state(state: &TerminalState) -> Self {
         Self {
-            screen: state.screen.clone(),
-            cursor: state.cursor,
-            scroll_region: state.scroll_region,
-            wrap_pending: state.wrap_pending,
-            lines: visible_lines(&state.screen),
+            screen: state.active.screen.clone(),
+            cursor: state.active.cursor,
+            scroll_region: state.active.scroll_region,
+            wrap_pending: state.active.wrap_pending,
+            modes: state.modes,
+            lines: visible_lines(&state.active.screen),
         }
     }
 
@@ -542,6 +676,12 @@ impl TerminalSnapshot {
         self.wrap_pending
     }
 
+    /// Terminal modes captured with the visible screen.
+    #[must_use]
+    pub const fn modes(&self) -> TerminalModes {
+        self.modes
+    }
+
     /// Captured visible screen.
     #[must_use]
     pub const fn screen(&self) -> &ScreenBuffer {
@@ -564,6 +704,13 @@ fn checked_cell_count(rows: u16, cols: u16) -> Result<usize, TerminalError> {
         Err(TerminalError::ScreenTooLarge)
     } else {
         Ok(count)
+    }
+}
+
+fn clamp_cursor(cursor: Cursor, rows: u16, cols: u16) -> Cursor {
+    Cursor {
+        row: cursor.row.min(rows - 1),
+        column: cursor.column.min(cols - 1),
     }
 }
 

--- a/crates/noren-terminal/tests/alternate_screen.rs
+++ b/crates/noren-terminal/tests/alternate_screen.rs
@@ -1,0 +1,138 @@
+use noren_terminal::{Cell, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+#[test]
+fn entering_1049_selects_a_blank_home_positioned_alternate_buffer() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDEFGHIJ\x1b[3;4HZ");
+
+    state.feed_bytes(b"\x1b[?1049h");
+
+    assert_eq!(state.size(), (3, 5));
+    assert_eq!(cursor(&state), (0, 0));
+    assert!(state.screen().cells().iter().all(Cell::is_blank));
+    assert!(state.snapshot().lines().is_empty());
+    assert!(!state.is_wrap_pending());
+    assert_eq!(
+        (state.scroll_region().top(), state.scroll_region().bottom()),
+        (0, 2)
+    );
+}
+
+#[test]
+fn alternate_mode_is_visible_on_state_and_captured_snapshots() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    let primary = state.snapshot();
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert!(!primary.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049h");
+    let alternate = state.snapshot();
+
+    assert!(state.modes().is_alternate_screen_active());
+    assert!(alternate.modes().is_alternate_screen_active());
+    assert!(!primary.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert!(!state.snapshot().modes().is_alternate_screen_active());
+    assert!(alternate.modes().is_alternate_screen_active());
+}
+
+#[test]
+fn leaving_1049_restores_the_isolated_primary_buffer_and_entry_cursor() {
+    let mut state = TerminalState::new(4, 8).expect("valid terminal");
+    state.feed_bytes(b"PRIMARY\x1b[3;4H");
+    let primary = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[4;8HZ");
+    assert_eq!(state.snapshot().lines(), ["ALT", "", "", "       Z"]);
+    assert_ne!(state.snapshot(), primary);
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert_eq!(state.snapshot(), primary);
+    assert_eq!(cursor(&state), (2, 3));
+}
+
+#[test]
+fn esc_and_csi_save_restore_sequences_restore_the_public_cursor() {
+    let sequences: &[(&[u8], &[u8])] = &[
+        (b"\x1b7".as_slice(), b"\x1b8".as_slice()),
+        (b"\x1b[s".as_slice(), b"\x1b[u".as_slice()),
+    ];
+
+    for (save, restore) in sequences {
+        let mut state = TerminalState::new(4, 6).expect("valid terminal");
+        state.feed_bytes(b"\x1b[2;3H");
+        state.feed_bytes(save);
+        state.feed_bytes(b"\x1b[4;6H");
+        assert_eq!(cursor(&state), (3, 5), "move after save {save:?}");
+
+        state.feed_bytes(restore);
+        assert_eq!(cursor(&state), (1, 2), "restore sequence {restore:?}");
+    }
+}
+
+#[test]
+fn repeated_1049_set_and_reset_are_idempotent() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes(b"PRIMARY\x1b[2;2H");
+    let primary = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[3;5H");
+    let alternate = state.snapshot();
+    state.feed_bytes(b"\x1b[?1049h");
+    assert_eq!(state.snapshot(), alternate);
+
+    state.feed_bytes(b"\x1b[?1049l");
+    assert_eq!(state.snapshot(), primary);
+    state.feed_bytes(b"\x1b[?1049l");
+    assert_eq!(state.snapshot(), primary);
+}
+
+#[test]
+fn resize_while_alternate_is_active_updates_visible_and_saved_buffers() {
+    let mut state = TerminalState::new(4, 5).expect("valid terminal");
+    state.feed_bytes(b"AB\x1b[2;1HCD\x1b[3;1HEF\x1b[4;1HGH\x1b[4;5H");
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[3;3HZ\x1b[4;5H");
+
+    state.resize(3, 4).expect("valid resize");
+
+    let alternate = state.snapshot();
+    assert_eq!(state.size(), (3, 4));
+    assert_eq!((alternate.rows(), alternate.cols()), (3, 4));
+    assert_eq!(alternate.lines(), ["ALT", "", "  Z"]);
+    assert_eq!(cursor(&state), (2, 3));
+    assert!(state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    let primary = state.snapshot();
+    assert_eq!(state.size(), (3, 4));
+    assert_eq!((primary.rows(), primary.cols()), (3, 4));
+    assert_eq!(primary.lines(), ["AB", "CD", "EF"]);
+    assert_eq!(cursor(&state), (2, 3));
+    assert!(!state.modes().is_alternate_screen_active());
+}
+
+#[test]
+fn unsupported_private_modes_leave_public_state_unchanged() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes(b"base\x1b[2;3H");
+    let before = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?47h\x1b[?1047h\x1b[?2004h\x1b[?47l\x1b[?1047l\x1b[?2004l");
+
+    assert_eq!(state.snapshot(), before);
+    assert!(!state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"X");
+    assert_eq!(state.snapshot().lines(), ["base", "  X"]);
+    assert_eq!(cursor(&state), (1, 3));
+}

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -2,7 +2,10 @@
 
 - Status: PR [#19](https://github.com/ta-061/noren/pull/19) merged as
   `c695920`; the scroll-region slice is in progress as Draft PR
-  [#21](https://github.com/ta-061/noren/pull/21)
+  [#21](https://github.com/ta-061/noren/pull/21); the alternate-screen slice
+  (core commit `84da736`) is stacked on top as Draft PR
+  [#23](https://github.com/ta-061/noren/pull/23) for Issue
+  [#22](https://github.com/ta-061/noren/issues/22)
 - Supersedes nothing: the accepted [local-PTY PoC
   architecture](minimal-local-pty-poc.md) still applies
 
@@ -17,10 +20,11 @@ PTY bytes -> TerminalState::feed_bytes -> parser -> bounded screen/cursor state
 TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
 ```
 
-- `TerminalState` owns the screen, cursor, dimensions, and parser state.
-- The visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
+- `TerminalState` owns the active screen, the parked primary screen while the
+  alternate screen is active, and the parser state.
+- Each visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
   `MAX_SCREEN_CELLS` (1,048,576 cells).
-- `resize` rebuilds the grid, preserves the overlapping top-left region, and
+- `resize` rebuilds the grids, preserves each overlapping top-left region, and
   resets scroll margins and pending autowrap.
 - The renderer consumes the immutable `TerminalSnapshot` and never depends on
   PTY or parser types.
@@ -45,8 +49,37 @@ Added by Draft PR #21 (scrolling regions):
 - Delayed autowrap: wrapping is deferred until the next printable byte.
 - Resize resets margins and pending autowrap.
 
+Added by Draft PR #23 / Issue #22 (alternate screen, stacked on #21):
+
+- `TerminalState` owns an active screen plus a parked primary screen; only
+  the active screen receives bytes and appears in snapshots.
+- CSI `?1049h` saves the primary cursor, parks the primary screen, and
+  enters a blank alternate screen with the cursor homed, full-screen
+  margins, and no pending wrap. CSI `?1049l` restores the primary screen
+  contents and the cursor saved at entry. Both switches are idempotent:
+  entering while already alternate, or leaving while already primary, is a
+  no-op. Only `1049` is recognized; other parameter lists or `>` markers
+  are ignored.
+- ESC 7/8 and parameterless CSI `s`/`u` save and restore the cursor on the
+  active screen only. Each screen keeps its own saved cursor (position
+  only), and restoring with no saved cursor leaves the cursor unmoved and
+  clears pending autowrap.
+- `TerminalModes` (DEC private mode 1049) is captured in
+  `TerminalSnapshot::modes` so renderers can tell which screen is visible.
+- `resize` rebuilds both the active and parked buffers, preserving each
+  one's overlapping top-left region, clamps cursors and saved cursors, and
+  resets margins and pending autowrap; the `MAX_SCREEN_CELLS` bound is
+  checked before either buffer is rebuilt.
+- The renderer boundary is unchanged: renderers still consume only the
+  immutable `TerminalSnapshot` and never PTY or parser types.
+
+This slice makes `?1049` round-trips reliable; it is not full xterm, vim,
+tmux, or zellij compatibility.
+
 ## Deferred
 
-Alternate screen, SGR/erase/insert/delete, cell attributes, tabs, origin
-mode, and query/reply sequences remain deferred. Unicode and IME remain
-later.
+SGR/erase/insert/delete, cell attributes, tabs, origin mode, and
+query/reply sequences remain deferred, along with other DEC private modes
+(such as 1047/1048, 25, and 2004), application cursor/keypad modes, OSC
+titles, alternate-screen scrollback, and saved-cursor state beyond
+position. Unicode and IME remain later.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -2,20 +2,22 @@
 
 Last updated: 2026-08-03 (Asia/Tokyo). PR
 [#19](https://github.com/ta-061/noren/pull/19) is merged into `main` as
-`c695920d8bc99990447d0b451754ea96c91181fc`. The only open PR is Draft
-[#21](https://github.com/ta-061/noren/pull/21), branch
-`agent/terminal-scroll-regions`, for Issue
-[#20](https://github.com/ta-061/noren/issues/20). Historical sections below
+`c695920d8bc99990447d0b451754ea96c91181fc`. Draft PR
+[#21](https://github.com/ta-061/noren/pull/21) remains in review for Issue
+[#20](https://github.com/ta-061/noren/issues/20). Draft PR
+[#23](https://github.com/ta-061/noren/pull/23), branch
+`agent/terminal-alternate-screen`, is stacked on #21 for Issue
+[#22](https://github.com/ta-061/noren/issues/22). Historical sections below
 preserve the PR #17 record at implementation/test head
 `c1f66dc27ddce37a60665d319a7ca061c300947e`, corrected only where an active
 claim went stale; coordination head `ac410a82` also passed both GitHub checks.
 
 ## Current phase
 
-Terminal foundation, scrolling-region slice. PR #19 merged the Noren-owned,
-renderer-independent `TerminalState`. Draft PR #21 adds DECSTBM margins,
-region-scoped LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed
-autowrap, and resize-reset behavior. See
+Terminal foundation, alternate-screen slice. PR #19 merged the Noren-owned,
+renderer-independent `TerminalState`; Draft PR #21 adds scrolling regions.
+Stacked Draft PR #23 adds primary/alternate screen ownership, DEC private mode
+1049, cursor save/restore, mode snapshots, and both-buffer resize behavior. See
 [terminal core foundation](../architecture/terminal-core-foundation.md). This
 is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
@@ -23,9 +25,11 @@ is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
 Verified on 2026-08-03:
 
-- The only open Issue is [#20](https://github.com/ta-061/noren/issues/20), the
-  scrolling-region behavior slice. The only open PR is its Draft
-  [#21](https://github.com/ta-061/noren/pull/21).
+- The open Issues are [#20](https://github.com/ta-061/noren/issues/20), the
+  scrolling-region behavior slice, and stacked alternate-screen Issue
+  [#22](https://github.com/ta-061/noren/issues/22). Their open Draft PRs are
+  [#21](https://github.com/ta-061/noren/pull/21) and
+  [#23](https://github.com/ta-061/noren/pull/23), respectively.
 - PR [#19](https://github.com/ta-061/noren/pull/19) and Issue
   [#18](https://github.com/ta-061/noren/issues/18) are complete after owner
   acceptance of the renderer-independent Terminal Core foundation.
@@ -60,6 +64,17 @@ Verified on 2026-08-03:
 | GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
 | Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
 | Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
+| Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
+
+## Draft PR #23 alternate-screen handoff
+
+| Lane | Saved evidence | State |
+| --- | --- | --- |
+| Codex core | Signed `84da736`: screen ownership, mode 1049, cursor save/restore, and resize behavior | Complete |
+| codex-lab tests | Signed `454d995`: seven public-API alternate/mode/cursor/resize tests | Complete |
+| GLM helper | PR #23 review: parser/enum/module organization is clean; no change needed | Complete |
+| Claude Code review | PR #23 review: `BLOCKER: NONE` | Complete |
+| Qwen documentation | Signed `29f7362`: focused terminal-core architecture update | Complete |
 | Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
 
 ## PR #17 historical implementation checkpoints
@@ -112,10 +127,11 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #21 has passed exact-head local checks and CI, and the existing local-zsh
-application launch was rechecked. It remains Draft for owner review and
-acceptance. PR #19 has no remaining gate. This does not authorize deferred
-terminal features in the scrolling-region PR.
+PR #21 remains Draft for owner review and acceptance. Stacked PR #23 has passed
+local checks and CI, and the existing local-zsh application launch was
+rechecked; it remains Draft and based on `agent/terminal-scroll-regions` until
+#21 is accepted and merged. PR #19 has no remaining gate. This does not
+authorize deferred terminal features in either Draft PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -130,5 +146,7 @@ identity, and the public support/security contact before Preview publication.
 ## Next steps
 
 1. Review and accept Draft PR #21, then promote and merge its exact tested head.
-2. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
-   separate Issues and PRs.
+2. Retarget Draft PR #23 to `main` only after #21 merges, then review its exact
+   tested head.
+3. Keep SGR/erase, attributes, remaining modes, and later VT work in separate
+   Issues and PRs.


### PR DESCRIPTION
## Issue

Closes #22

## Status and stacked dependency

Draft integration is complete at exact head `c6a1e3fef469c09e243a0b5cc88c2bee2aedddb7`.

This PR remains based on `agent/terminal-scroll-regions` and depends on Draft PR #21. PR #21 remains unchanged and in review. Retarget this PR to `main` only after #21 is accepted and merged.

## Implemented

- `TerminalState` owns the active screen and parks the primary screen while DEC private mode 1049 is active.
- DECSET `CSI ?1049h` enters a blank, home-positioned alternate screen with full margins and no pending wrap.
- DECRST `CSI ?1049l` restores the isolated primary buffer and cursor saved on entry.
- DEC `ESC 7` / `ESC 8` and ANSI `CSI s` / `CSI u` save and restore the active screen cursor.
- Public renderer-independent `TerminalModes` is available from `TerminalState` and immutable snapshots.
- Repeated set/reset operations are idempotent; unsupported private modes remain ignored.
- Resize preserves both active alternate and parked primary overlap, clamps current/saved cursors, resets margins, and clears pending wrap.
- The PTY → Parser → TerminalState → Renderer boundary remains unchanged.

## Exact-head validation

- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed, 61 tests.
- `python3 scripts/check_docs.py` — passed.
- `python3 -m unittest scripts/test_check_docs.py` — passed, 7 tests.
- `git diff --check` — passed.
- All four PR commits contain a `Signed-off-by` trailer.
- [Rust CI](https://github.com/ta-061/noren/actions/runs/30800915464/job/91645008274) — passed on exact head.
- [Documentation CI](https://github.com/ta-061/noren/actions/runs/30800915462/job/91645008268) — passed on exact head.

## macOS smoke

`cargo run -p noren-app` launched `noren-app` and its local `/bin/zsh` child. Both were observed alive and terminated by exact PID. This is a bounded process/startup smoke, not a new interactive-rendering compatibility claim.

## Delegated lanes

- [x] **codex-lab:** signed `454d995`; seven public-API alternate-screen/mode/cursor/resize regression tests.
- [x] **GLM:** `CLEAN`; no parser/enum/module change was warranted.
- [x] **Claude Code:** read-only xterm/vim/tmux review; `BLOCKER: NONE`.
- [x] **Qwen:** signed `29f7362`; focused terminal-core architecture update.
- [x] **Codex:** core implementation, final integration, exact-head checks, CI, and macOS smoke.

## Non-goals

No renderer redesign, SGR/colors/attributes, erase/insert/delete operations, origin mode, tab stops, Unicode/IME/font work, scrollback, UI, SSH, AI features, tabs/panes, or full xterm/vim/tmux/zellij compatibility claim.

## Remaining compatibility gaps

DEC modes 1047/1048, bracketed paste, application cursor/keypad modes, erase/insert/delete behavior, SGR/cell attributes, origin mode, tabs, Unicode, and terminal query/reply behavior remain deferred. Each later slice requires a separate Issue and Draft PR.