### PR TITLE
Terminal Core: add SGR and cell attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ cargo test --workspace
 Dependency audit and license policy checks remain intended additions; the
 repository will not claim these pass before CI actually runs them.
 
+Changes to `crates/noren-terminal/` additionally keep these conventions:
+
+- Internal coordinates are zero-based; CSI parameters are one-based. Convert
+  at the parse boundary and keep the two schemes out of each other's layers.
+- Test through the public API with byte-driven fixtures: feed raw bytes into
+  `TerminalState::feed_bytes` and assert on `snapshot()`, not on internals.
+- Scrolling-region changes must preserve rows outside the active margins.
+- Renderer and PTY concerns stay out of `noren-terminal` tests; the core
+  neither reads from a PTY nor renders.
+
 ## Pull requests and review
 
 Open a Draft PR early. Complete the PR template and link the Issue. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,11 +15,16 @@ Only evidence-backed work is marked complete.
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | Not started |
 | 8 — Public Preview | Honest docs/site, binaries, checksums, release review, known limitations and `0.1.0-preview` | Not started |
 
-A renderer-independent terminal state core is in progress as Draft PR
-[#19](https://github.com/ta-061/noren/pull/19) (not merged), described in
+A renderer-independent terminal state core is merged as PR
+[#19](https://github.com/ta-061/noren/pull/19) (`c695920`), described in
 [terminal core foundation](docs/architecture/terminal-core-foundation.md).
-Deferred order: scroll regions, alternate screen, SGR/erase plus cell
-attributes, mode state; Unicode/IME remain later.
+Scrolling regions are in progress as Draft PR
+[#21](https://github.com/ta-061/noren/pull/21): inclusive full-screen-default
+scroll margins, DECSTBM with invalid-range rejection, region-only
+LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed autowrap, and
+resize resetting margins/wrap. Deferred: alternate screen,
+SGR/erase/insert/delete, cell attributes, tabs, origin mode, query/reply;
+Unicode/IME remain later.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.

--- a/crates/noren-app/src/input.rs
+++ b/crates/noren-app/src/input.rs
@@ -1,0 +1,188 @@
+//! Application input modes and bounded keypad key model.
+//!
+//! This is the input-side mirror of DECCKM (`CSI ?1 h/l`, DEC cursor key mode)
+//! and DECKPAM / DECKPNM (`ESC =` / `ESC >`, keypad application / numeric
+//! mode). The terminal-state parser that consumes those escapes from the PTY
+//! lives in `noren-terminal` and is wired only after Issue #24 releases
+//! `parser.rs` and `state.rs`; this module owns only the encoding-side
+//! selection so the PoC key encoder emits the byte sequence the active mode
+//! expects. DECCKM / DECKPAM parser and state integration is a later,
+//! documented checkpoint and is intentionally absent here.
+
+use crate::{Arrow, KeyPhase};
+
+/// DEC cursor key mode (DECCKM) input-side selector.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorKeyMode {
+    /// Arrow keys emit the normal cursor sequences (`ESC [ A` ... `ESC [ D`).
+    #[default]
+    Normal,
+    /// Arrow keys emit the application cursor sequences (`ESC O A` ... `ESC O D`).
+    Application,
+}
+
+/// Keypad mode (DECKPAM / DECKPNM) input-side selector.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum KeypadMode {
+    /// Keypad keys emit their literal numeric / operator characters.
+    #[default]
+    Numeric,
+    /// Keypad keys emit the application `SS3` sequences.
+    Application,
+}
+
+/// Explicit, immutable application input-mode snapshot consumed by the key
+/// encoder.
+///
+/// The two selectors are independent: a program may set application cursor keys
+/// while leaving the keypad numeric, matching how DECCKM and DECKPAM/DECKPNM
+/// are distinct private modes. Builders are pure value transforms, so repeated
+/// application of the same selector is idempotent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InputMode {
+    cursor: CursorKeyMode,
+    keypad: KeypadMode,
+}
+
+impl InputMode {
+    /// Normal cursor sequences and numeric keypad sequences (the PoC default).
+    #[must_use]
+    pub const fn normal() -> Self {
+        Self {
+            cursor: CursorKeyMode::Normal,
+            keypad: KeypadMode::Numeric,
+        }
+    }
+
+    /// Replace the cursor key mode, leaving the keypad mode unchanged.
+    #[must_use]
+    pub const fn with_cursor(self, cursor: CursorKeyMode) -> Self {
+        Self { cursor, ..self }
+    }
+
+    /// Replace the keypad mode, leaving the cursor key mode unchanged.
+    #[must_use]
+    pub const fn with_keypad(self, keypad: KeypadMode) -> Self {
+        Self { keypad, ..self }
+    }
+
+    /// Active cursor key mode.
+    #[must_use]
+    pub const fn cursor(self) -> CursorKeyMode {
+        self.cursor
+    }
+
+    /// Active keypad mode.
+    #[must_use]
+    pub const fn keypad(self) -> KeypadMode {
+        self.keypad
+    }
+}
+
+/// Bounded set of numeric-keypad keys the input encoder explicitly supports.
+///
+/// The set is deliberately bounded to a standard numeric keypad; function,
+/// editing, and PF keys remain a later integration concern and are not modeled
+/// by this checkpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeypadKey {
+    /// `0`.
+    Zero,
+    /// `1`.
+    One,
+    /// `2`.
+    Two,
+    /// `3`.
+    Three,
+    /// `4`.
+    Four,
+    /// `5`.
+    Five,
+    /// `6`.
+    Six,
+    /// `7`.
+    Seven,
+    /// `8`.
+    Eight,
+    /// `9`.
+    Nine,
+    /// Decimal separator (`.`).
+    Decimal,
+    /// `+`.
+    Plus,
+    /// `-`.
+    Minus,
+    /// `*`.
+    Star,
+    /// `/`.
+    Slash,
+    /// Keypad Enter.
+    Enter,
+}
+
+/// An app-owned numeric-keypad key event translated from platform callbacks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KeypadInput {
+    key: KeypadKey,
+    phase: KeyPhase,
+}
+
+impl KeypadInput {
+    /// Create a keypad key event.
+    #[must_use]
+    pub const fn new(key: KeypadKey, phase: KeyPhase) -> Self {
+        Self { key, phase }
+    }
+
+    /// The keypad key identity.
+    #[must_use]
+    pub const fn key(self) -> KeypadKey {
+        self.key
+    }
+
+    /// The press phase.
+    #[must_use]
+    pub const fn phase(self) -> KeyPhase {
+        self.phase
+    }
+}
+
+/// Select the cursor key byte sequence for the active mode.
+pub(crate) fn cursor_bytes(arrow: Arrow, mode: CursorKeyMode) -> &'static [u8] {
+    let (normal, application) = match arrow {
+        Arrow::Up => (b"\x1b[A", b"\x1bOA"),
+        Arrow::Down => (b"\x1b[B", b"\x1bOB"),
+        Arrow::Right => (b"\x1b[C", b"\x1bOC"),
+        Arrow::Left => (b"\x1b[D", b"\x1bOD"),
+    };
+    match mode {
+        CursorKeyMode::Normal => normal,
+        CursorKeyMode::Application => application,
+    }
+}
+
+/// Select the keypad byte sequence for the active mode.
+pub(crate) fn keypad_bytes(key: KeypadKey, mode: KeypadMode) -> &'static [u8] {
+    let (numeric, application) = match key {
+        KeypadKey::Zero => (b"0", b"\x1bOp"),
+        KeypadKey::One => (b"1", b"\x1bOq"),
+        KeypadKey::Two => (b"2", b"\x1bOr"),
+        KeypadKey::Three => (b"3", b"\x1bOs"),
+        KeypadKey::Four => (b"4", b"\x1bOt"),
+        KeypadKey::Five => (b"5", b"\x1bOu"),
+        KeypadKey::Six => (b"6", b"\x1bOv"),
+        KeypadKey::Seven => (b"7", b"\x1bOw"),
+        KeypadKey::Eight => (b"8", b"\x1bOx"),
+        KeypadKey::Nine => (b"9", b"\x1bOy"),
+        KeypadKey::Decimal => (b".", b"\x1bOn"),
+        KeypadKey::Plus => (b"+", b"\x1bOk"),
+        KeypadKey::Minus => (b"-", b"\x1bOm"),
+        KeypadKey::Star => (b"*", b"\x1bOj"),
+        KeypadKey::Slash => (b"/", b"\x1bOo"),
+        KeypadKey::Enter => (b"\r", b"\x1bOM"),
+    };
+    match mode {
+        KeypadMode::Numeric => numeric,
+        KeypadMode::Application => application,
+    }
+}

--- a/crates/noren-app/src/input.rs
+++ b/crates/noren-app/src/input.rs
@@ -2,14 +2,10 @@
 //!
 //! This is the input-side mirror of DECCKM (`CSI ?1 h/l`, DEC cursor key mode)
 //! and DECKPAM / DECKPNM (`ESC =` / `ESC >`, keypad application / numeric
-//! mode). The terminal-state parser that consumes those escapes from the PTY
-//! lives in `noren-terminal` and is wired only after Issue #24 releases
-//! `parser.rs` and `state.rs`; this module owns only the encoding-side
-//! selection so the PoC key encoder emits the byte sequence the active mode
-//! expects. DECCKM / DECKPAM parser and state integration is a later,
-//! documented checkpoint and is intentionally absent here.
+//! mode). `noren-terminal` owns the parser and mode state; this module owns the
+//! app-side encoding selection.
 
-use crate::{Arrow, KeyPhase};
+use crate::{Arrow, KeyPhase, Modifiers};
 
 /// DEC cursor key mode (DECCKM) input-side selector.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -125,13 +121,25 @@ pub enum KeypadKey {
 pub struct KeypadInput {
     key: KeypadKey,
     phase: KeyPhase,
+    modifiers: Modifiers,
 }
 
 impl KeypadInput {
-    /// Create a keypad key event.
+    /// Create a keypad key event without active modifiers.
     #[must_use]
     pub const fn new(key: KeypadKey, phase: KeyPhase) -> Self {
-        Self { key, phase }
+        Self {
+            key,
+            phase,
+            modifiers: Modifiers::empty(),
+        }
+    }
+
+    /// Return this event with the active modifiers captured by the window layer.
+    #[must_use]
+    pub const fn with_modifiers(mut self, modifiers: Modifiers) -> Self {
+        self.modifiers = modifiers;
+        self
     }
 
     /// The keypad key identity.
@@ -144,6 +152,12 @@ impl KeypadInput {
     #[must_use]
     pub const fn phase(self) -> KeyPhase {
         self.phase
+    }
+
+    /// Active modifiers captured with this event.
+    #[must_use]
+    pub const fn modifiers(self) -> Modifiers {
+        self.modifiers
     }
 }
 

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -378,14 +378,21 @@ impl KeyEncoder {
     /// mode.
     ///
     /// Numeric mode emits the literal key character; application mode emits the
-    /// `SS3` (`ESC O`) sequence. Releases are dropped for parity with the
-    /// main key path.
+    /// `SS3` (`ESC O`) sequence. Release, Control, Option, and Command handling
+    /// follows the main key path; Shift does not alter these bounded sequences.
     pub fn encode_keypad_with(
         input: KeypadInput,
         mode: InputMode,
     ) -> Result<Vec<u8>, KeyDropReason> {
         if input.phase() == KeyPhase::Released {
             return Err(KeyDropReason::Released);
+        }
+        let modifiers = input.modifiers();
+        if modifiers.is_alt() || modifiers.is_super() {
+            return Err(KeyDropReason::UnsupportedModifier);
+        }
+        if modifiers.is_ctrl() {
+            return Err(KeyDropReason::UnsupportedControl);
         }
         Ok(input::keypad_bytes(input.key(), mode.keypad()).to_vec())
     }
@@ -761,6 +768,31 @@ mod tests {
         assert_eq!(
             KeyEncoder::encode_keypad_with(released, application),
             Err(KeyDropReason::Released)
+        );
+    }
+
+    #[test]
+    fn keypad_encoder_preserves_the_existing_modifier_policy() {
+        let mode = InputMode::normal().with_keypad(KeypadMode::Application);
+        let pressed = KeypadInput::new(KeypadKey::One, KeyPhase::Pressed);
+
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(pressed.with_modifiers(Modifiers::empty().ctrl()), mode),
+            Err(KeyDropReason::UnsupportedControl)
+        );
+        for modifiers in [Modifiers::empty().alt(), Modifiers::empty().super_key()] {
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(pressed.with_modifiers(modifiers), mode),
+                Err(KeyDropReason::UnsupportedModifier)
+            );
+        }
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(
+                pressed.with_modifiers(Modifiers::empty().shift()),
+                mode
+            )
+            .as_deref(),
+            Ok(b"\x1bOq".as_slice())
         );
     }
 

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -8,6 +8,10 @@
 //! types stay inside `noren-app` and never cross into the PTY or terminal
 //! crates.
 
+mod input;
+
+pub use input::{CursorKeyMode, InputMode, KeypadInput, KeypadKey, KeypadMode};
+
 use std::fmt;
 use std::time::Duration;
 
@@ -317,8 +321,23 @@ pub enum KeyDropReason {
 pub struct KeyEncoder;
 
 impl KeyEncoder {
-    /// Encode one pressed or repeated key event.
+    /// Encode one pressed or repeated key event in the PoC default
+    /// ([`InputMode::normal`]) mode.
+    ///
+    /// This entry point preserves the original byte contract and stays
+    /// source-compatible with PoC callers that do not yet track terminal
+    /// modes. Mode-aware callers use [`KeyEncoder::encode_with`].
     pub fn encode(input: KeyInput) -> Result<Vec<u8>, KeyDropReason> {
+        Self::encode_with(input, InputMode::normal())
+    }
+
+    /// Encode one pressed or repeated key event for the active application
+    /// input mode.
+    ///
+    /// Only bare arrow keys observe [`CursorKeyMode`]; release, modifier,
+    /// control-byte, and printable handling is identical to
+    /// [`KeyEncoder::encode`], so the normal mode is byte-for-byte compatible.
+    pub fn encode_with(input: KeyInput, mode: InputMode) -> Result<Vec<u8>, KeyDropReason> {
         if input.phase() == KeyPhase::Released {
             return Err(KeyDropReason::Released);
         }
@@ -345,11 +364,30 @@ impl KeyEncoder {
             Key::Backspace => Ok(vec![0x7f]),
             Key::Tab => Ok(vec![0x09]),
             Key::Escape => Ok(vec![0x1b]),
-            Key::Arrow(Arrow::Up) => Ok(b"\x1b[A".to_vec()),
-            Key::Arrow(Arrow::Down) => Ok(b"\x1b[B".to_vec()),
-            Key::Arrow(Arrow::Right) => Ok(b"\x1b[C".to_vec()),
-            Key::Arrow(Arrow::Left) => Ok(b"\x1b[D".to_vec()),
+            Key::Arrow(arrow) => Ok(input::cursor_bytes(arrow, mode.cursor()).to_vec()),
         }
+    }
+
+    /// Encode one pressed or repeated keypad key event in the PoC default
+    /// ([`InputMode::normal`]) numeric-keypad mode.
+    pub fn encode_keypad(input: KeypadInput) -> Result<Vec<u8>, KeyDropReason> {
+        Self::encode_keypad_with(input, InputMode::normal())
+    }
+
+    /// Encode one pressed or repeated keypad key event for the active keypad
+    /// mode.
+    ///
+    /// Numeric mode emits the literal key character; application mode emits the
+    /// `SS3` (`ESC O`) sequence. Releases are dropped for parity with the
+    /// main key path.
+    pub fn encode_keypad_with(
+        input: KeypadInput,
+        mode: InputMode,
+    ) -> Result<Vec<u8>, KeyDropReason> {
+        if input.phase() == KeyPhase::Released {
+            return Err(KeyDropReason::Released);
+        }
+        Ok(input::keypad_bytes(input.key(), mode.keypad()).to_vec())
     }
 }
 
@@ -611,6 +649,157 @@ mod tests {
                 .lines()
                 .first()
                 .is_some_and(|line| line.contains('x'))
+        );
+    }
+
+    #[test]
+    fn input_mode_defaults_to_normal_cursor_and_numeric_keypad() {
+        let mode = InputMode::normal();
+        assert_eq!(mode.cursor(), CursorKeyMode::Normal);
+        assert_eq!(mode.keypad(), KeypadMode::Numeric);
+        assert_eq!(InputMode::default(), mode);
+    }
+
+    #[test]
+    fn cursor_keys_select_normal_or_application_sequences_by_mode() {
+        let normal = InputMode::normal();
+        let application = normal.with_cursor(CursorKeyMode::Application);
+        let cases = [
+            (Arrow::Up, b"\x1b[A".as_slice(), b"\x1bOA".as_slice()),
+            (Arrow::Down, b"\x1b[B", b"\x1bOB"),
+            (Arrow::Right, b"\x1b[C", b"\x1bOC"),
+            (Arrow::Left, b"\x1b[D", b"\x1bOD"),
+        ];
+        for (arrow, normal_bytes, application_bytes) in cases {
+            let input = KeyInput::new(Key::Arrow(arrow), KeyPhase::Pressed, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(input).as_deref(), Ok(normal_bytes));
+            assert_eq!(
+                KeyEncoder::encode_with(input, normal).as_deref(),
+                Ok(normal_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_with(input, application).as_deref(),
+                Ok(application_bytes)
+            );
+        }
+    }
+
+    #[test]
+    fn application_cursor_mode_leaves_modifier_and_control_paths_unchanged() {
+        let application = InputMode::normal().with_cursor(CursorKeyMode::Application);
+        for modifiers in [Modifiers::empty().alt(), Modifiers::empty().super_key()] {
+            let input = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, modifiers);
+            assert_eq!(
+                KeyEncoder::encode_with(input, application),
+                Err(KeyDropReason::UnsupportedModifier)
+            );
+        }
+        let ctrl_arrow = KeyInput::new(
+            Key::Arrow(Arrow::Up),
+            KeyPhase::Pressed,
+            Modifiers::empty().ctrl(),
+        );
+        assert_eq!(
+            KeyEncoder::encode_with(ctrl_arrow, application),
+            Err(KeyDropReason::UnsupportedControl)
+        );
+        let printable = KeyInput::new(Key::Character('a'), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(printable, application).as_deref(),
+            Ok(b"a".as_slice())
+        );
+    }
+
+    #[test]
+    fn keypad_keys_select_numeric_or_application_sequences_by_mode() {
+        let numeric = InputMode::normal();
+        let application = numeric.with_keypad(KeypadMode::Application);
+        let cases = [
+            (KeypadKey::Zero, b"0".as_slice(), b"\x1bOp".as_slice()),
+            (KeypadKey::One, b"1", b"\x1bOq"),
+            (KeypadKey::Two, b"2", b"\x1bOr"),
+            (KeypadKey::Three, b"3", b"\x1bOs"),
+            (KeypadKey::Four, b"4", b"\x1bOt"),
+            (KeypadKey::Five, b"5", b"\x1bOu"),
+            (KeypadKey::Six, b"6", b"\x1bOv"),
+            (KeypadKey::Seven, b"7", b"\x1bOw"),
+            (KeypadKey::Eight, b"8", b"\x1bOx"),
+            (KeypadKey::Nine, b"9", b"\x1bOy"),
+            (KeypadKey::Decimal, b".", b"\x1bOn"),
+            (KeypadKey::Plus, b"+", b"\x1bOk"),
+            (KeypadKey::Minus, b"-", b"\x1bOm"),
+            (KeypadKey::Star, b"*", b"\x1bOj"),
+            (KeypadKey::Slash, b"/", b"\x1bOo"),
+            (KeypadKey::Enter, b"\r", b"\x1bOM"),
+        ];
+        for (key, numeric_bytes, application_bytes) in cases {
+            let input = KeypadInput::new(key, KeyPhase::Pressed);
+            assert_eq!(
+                KeyEncoder::encode_keypad(input).as_deref(),
+                Ok(numeric_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(input, numeric).as_deref(),
+                Ok(numeric_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(input, application).as_deref(),
+                Ok(application_bytes)
+            );
+        }
+    }
+
+    #[test]
+    fn keypad_encoder_drops_releases_in_both_modes() {
+        let numeric = InputMode::normal();
+        let application = numeric.with_keypad(KeypadMode::Application);
+        let released = KeypadInput::new(KeypadKey::Five, KeyPhase::Released);
+        assert_eq!(
+            KeyEncoder::encode_keypad(released),
+            Err(KeyDropReason::Released)
+        );
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(released, application),
+            Err(KeyDropReason::Released)
+        );
+    }
+
+    #[test]
+    fn input_mode_setters_are_idempotent_and_independent() {
+        let base = InputMode::normal();
+        let once = base
+            .with_cursor(CursorKeyMode::Application)
+            .with_keypad(KeypadMode::Application);
+        let twice = once
+            .with_cursor(CursorKeyMode::Application)
+            .with_keypad(KeypadMode::Application);
+        assert_eq!(once, twice);
+
+        // Resetting to the already-active selector is a no-op.
+        assert_eq!(
+            InputMode::normal().with_cursor(CursorKeyMode::Normal),
+            InputMode::normal()
+        );
+        assert_eq!(
+            InputMode::normal().with_keypad(KeypadMode::Numeric),
+            InputMode::normal()
+        );
+
+        // Cursor and keypad selectors are independent.
+        let cursor_only = base.with_cursor(CursorKeyMode::Application);
+        assert_eq!(cursor_only.cursor(), CursorKeyMode::Application);
+        assert_eq!(cursor_only.keypad(), KeypadMode::Numeric);
+
+        // Idempotent modes produce byte-identical encodings for every key.
+        let arrow = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(arrow, once),
+            KeyEncoder::encode_with(arrow, twice)
+        );
+        let keypad = KeypadInput::new(KeypadKey::Enter, KeyPhase::Pressed);
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(keypad, once),
+            KeyEncoder::encode_keypad_with(keypad, twice)
         );
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3,8 +3,9 @@
 mod renderer;
 
 use noren_app::{
-    Arrow, GridGeometry, GridSize, Key, KeyDropReason, KeyEncoder, KeyInput, KeyPhase, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, Resize,
+    Arrow, CursorKeyMode, GridGeometry, GridSize, InputMode, Key, KeyDropReason, KeyEncoder,
+    KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, Modifiers, PARSE_BUDGET_BYTES_PER_TURN,
+    Resize,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
 use noren_terminal::{TerminalEngine, TerminalState};
@@ -15,7 +16,7 @@ use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, KeyEvent, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
+use winit::keyboard::{Key as WinitKey, KeyCode, ModifiersState, NamedKey, PhysicalKey};
 use winit::window::{Window, WindowId};
 
 const WINDOW_WIDTH: u32 = 900;
@@ -125,19 +126,46 @@ impl NorenApp {
     }
 
     fn handle_key(&mut self, event: &KeyEvent) {
-        let Ok(input) = translate_key(event, self.modifiers) else {
+        let input_mode = self.current_input_mode();
+        let encoded = if let Some(input) = translate_keypad_key(event) {
+            KeyEncoder::encode_keypad_with(input.with_modifiers(self.modifiers), input_mode)
+        } else {
+            translate_key(event, self.modifiers)
+                .and_then(|input| KeyEncoder::encode_with(input, input_mode))
+        };
+        let Ok(bytes) = encoded else {
             return;
         };
-        let Ok(bytes) = KeyEncoder::encode(input) else {
-            return;
-        };
+        self.send_input(&bytes);
+    }
+
+    fn send_input(&mut self, bytes: &[u8]) {
         if let Some(session) = &self.pty {
-            if session.send_input(&bytes).is_err() {
+            if session.send_input(bytes).is_err() {
                 self.status = "Noren PTY input failed";
                 self.show_status = true;
                 self.redraw_needed = true;
             }
         }
+    }
+
+    fn current_input_mode(&self) -> InputMode {
+        let Some(modes) = self.terminal.as_ref().map(TerminalState::modes) else {
+            return InputMode::normal();
+        };
+        let cursor_mode = if modes.is_application_cursor_key_mode() {
+            CursorKeyMode::Application
+        } else {
+            CursorKeyMode::Normal
+        };
+        let keypad_mode = if modes.is_application_keypad_mode() {
+            KeypadMode::Application
+        } else {
+            KeypadMode::Numeric
+        };
+        InputMode::normal()
+            .with_cursor(cursor_mode)
+            .with_keypad(keypad_mode)
     }
 
     fn handle_resize(&mut self, physical: PhysicalSize<u32>) {
@@ -323,12 +351,41 @@ fn pty_size(grid: GridSize) -> Result<PtySize, noren_pty::PtyError> {
 }
 
 fn translate_key(event: &KeyEvent, modifiers: Modifiers) -> Result<KeyInput, KeyDropReason> {
-    let phase = match event.state {
+    translate_logical_key(&event.logical_key, key_phase(event), modifiers)
+}
+
+fn key_phase(event: &KeyEvent) -> KeyPhase {
+    match event.state {
         ElementState::Released => KeyPhase::Released,
         ElementState::Pressed if event.repeat => KeyPhase::Repeat,
         ElementState::Pressed => KeyPhase::Pressed,
-    };
-    translate_logical_key(&event.logical_key, phase, modifiers)
+    }
+}
+
+fn translate_keypad_key(event: &KeyEvent) -> Option<KeypadInput> {
+    keypad_key(event.physical_key).map(|key| KeypadInput::new(key, key_phase(event)))
+}
+
+fn keypad_key(physical_key: PhysicalKey) -> Option<KeypadKey> {
+    Some(match physical_key {
+        PhysicalKey::Code(KeyCode::Numpad0) => KeypadKey::Zero,
+        PhysicalKey::Code(KeyCode::Numpad1) => KeypadKey::One,
+        PhysicalKey::Code(KeyCode::Numpad2) => KeypadKey::Two,
+        PhysicalKey::Code(KeyCode::Numpad3) => KeypadKey::Three,
+        PhysicalKey::Code(KeyCode::Numpad4) => KeypadKey::Four,
+        PhysicalKey::Code(KeyCode::Numpad5) => KeypadKey::Five,
+        PhysicalKey::Code(KeyCode::Numpad6) => KeypadKey::Six,
+        PhysicalKey::Code(KeyCode::Numpad7) => KeypadKey::Seven,
+        PhysicalKey::Code(KeyCode::Numpad8) => KeypadKey::Eight,
+        PhysicalKey::Code(KeyCode::Numpad9) => KeypadKey::Nine,
+        PhysicalKey::Code(KeyCode::NumpadDecimal) => KeypadKey::Decimal,
+        PhysicalKey::Code(KeyCode::NumpadAdd) => KeypadKey::Plus,
+        PhysicalKey::Code(KeyCode::NumpadSubtract) => KeypadKey::Minus,
+        PhysicalKey::Code(KeyCode::NumpadMultiply) => KeypadKey::Star,
+        PhysicalKey::Code(KeyCode::NumpadDivide) => KeypadKey::Slash,
+        PhysicalKey::Code(KeyCode::NumpadEnter) => KeypadKey::Enter,
+        _ => return None,
+    })
 }
 
 fn translate_logical_key(
@@ -387,6 +444,57 @@ mod tests {
                 .expect("space is supported terminal input");
             assert_eq!(KeyEncoder::encode(input), Ok(vec![0x20]));
         }
+    }
+
+    #[test]
+    fn terminal_modes_drive_cursor_and_keypad_encoding() {
+        let mut app = NorenApp::default();
+        assert_eq!(app.current_input_mode(), InputMode::normal());
+
+        let mut terminal = TerminalState::new(2, 4).expect("valid terminal");
+        terminal.feed_bytes(b"\x1b[?1h\x1b=");
+        app.terminal = Some(terminal);
+        let mode = app.current_input_mode();
+
+        let arrow = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(arrow, mode).as_deref(),
+            Ok(b"\x1bOA".as_slice())
+        );
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(
+                KeypadInput::new(KeypadKey::One, KeyPhase::Pressed),
+                mode
+            )
+            .as_deref(),
+            Ok(b"\x1bOq".as_slice())
+        );
+    }
+
+    #[test]
+    fn physical_keypad_mapping_is_bounded_to_numpad_codes() {
+        let cases = [
+            (KeyCode::Numpad0, KeypadKey::Zero),
+            (KeyCode::Numpad1, KeypadKey::One),
+            (KeyCode::Numpad2, KeypadKey::Two),
+            (KeyCode::Numpad3, KeypadKey::Three),
+            (KeyCode::Numpad4, KeypadKey::Four),
+            (KeyCode::Numpad5, KeypadKey::Five),
+            (KeyCode::Numpad6, KeypadKey::Six),
+            (KeyCode::Numpad7, KeypadKey::Seven),
+            (KeyCode::Numpad8, KeypadKey::Eight),
+            (KeyCode::Numpad9, KeypadKey::Nine),
+            (KeyCode::NumpadDecimal, KeypadKey::Decimal),
+            (KeyCode::NumpadAdd, KeypadKey::Plus),
+            (KeyCode::NumpadSubtract, KeypadKey::Minus),
+            (KeyCode::NumpadMultiply, KeypadKey::Star),
+            (KeyCode::NumpadDivide, KeypadKey::Slash),
+            (KeyCode::NumpadEnter, KeypadKey::Enter),
+        ];
+        for (code, expected) in cases {
+            assert_eq!(keypad_key(PhysicalKey::Code(code)), Some(expected));
+        }
+        assert_eq!(keypad_key(PhysicalKey::Code(KeyCode::Digit1)), None);
     }
 
     #[test]

--- a/crates/noren-terminal/src/attributes.rs
+++ b/crates/noren-terminal/src/attributes.rs
@@ -1,0 +1,185 @@
+/// One of the 16 colors in the ANSI terminal palette.
+///
+/// The discriminants are stable palette indexes: standard colors occupy
+/// `0..=7`, and their bright counterparts occupy `8..=15`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AnsiColor {
+    Black = 0,
+    Red = 1,
+    Green = 2,
+    Yellow = 3,
+    Blue = 4,
+    Magenta = 5,
+    Cyan = 6,
+    White = 7,
+    BrightBlack = 8,
+    BrightRed = 9,
+    BrightGreen = 10,
+    BrightYellow = 11,
+    BrightBlue = 12,
+    BrightMagenta = 13,
+    BrightCyan = 14,
+    BrightWhite = 15,
+}
+
+impl AnsiColor {
+    /// All ANSI colors in palette order.
+    pub const ALL: [Self; 16] = [
+        Self::Black,
+        Self::Red,
+        Self::Green,
+        Self::Yellow,
+        Self::Blue,
+        Self::Magenta,
+        Self::Cyan,
+        Self::White,
+        Self::BrightBlack,
+        Self::BrightRed,
+        Self::BrightGreen,
+        Self::BrightYellow,
+        Self::BrightBlue,
+        Self::BrightMagenta,
+        Self::BrightCyan,
+        Self::BrightWhite,
+    ];
+
+    /// Zero-based index into an ANSI 16-color palette.
+    #[must_use]
+    pub const fn palette_index(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Renderer-independent color selection for a terminal cell.
+///
+/// [`Default`](Self::Default) means the renderer's default foreground or
+/// background according to the field in which the value is used.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Color {
+    #[default]
+    Default,
+    Ansi(AnsiColor),
+}
+
+impl Color {
+    /// Select an ANSI palette color.
+    #[must_use]
+    pub const fn ansi(color: AnsiColor) -> Self {
+        Self::Ansi(color)
+    }
+
+    /// Whether this selection uses the renderer's contextual default color.
+    #[must_use]
+    pub const fn is_default(self) -> bool {
+        matches!(self, Self::Default)
+    }
+
+    /// The selected ANSI color, or `None` for the contextual default.
+    #[must_use]
+    pub const fn ansi_color(self) -> Option<AnsiColor> {
+        match self {
+            Self::Default => None,
+            Self::Ansi(color) => Some(color),
+        }
+    }
+}
+
+const BOLD: u8 = 1 << 0;
+const UNDERLINE: u8 = 1 << 1;
+const REVERSE: u8 = 1 << 2;
+
+/// Renderer-independent visual attributes for a terminal cell.
+///
+/// The default uses contextual foreground and background colors with all
+/// style flags disabled.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CellAttributes {
+    foreground: Color,
+    background: Color,
+    flags: u8,
+}
+
+impl CellAttributes {
+    /// Baseline cell attributes used by [`Default`].
+    pub const DEFAULT: Self = Self {
+        foreground: Color::Default,
+        background: Color::Default,
+        flags: 0,
+    };
+
+    /// Construct baseline cell attributes in a const context.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::DEFAULT
+    }
+
+    /// Foreground color selection.
+    #[must_use]
+    pub const fn foreground(self) -> Color {
+        self.foreground
+    }
+
+    /// Background color selection.
+    #[must_use]
+    pub const fn background(self) -> Color {
+        self.background
+    }
+
+    /// Whether bold intensity is enabled.
+    #[must_use]
+    pub const fn is_bold(self) -> bool {
+        self.flags & BOLD != 0
+    }
+
+    /// Whether underlining is enabled.
+    #[must_use]
+    pub const fn is_underlined(self) -> bool {
+        self.flags & UNDERLINE != 0
+    }
+
+    /// Whether foreground and background should be rendered in reverse.
+    #[must_use]
+    pub const fn is_reversed(self) -> bool {
+        self.flags & REVERSE != 0
+    }
+
+    /// Return these attributes with a different foreground selection.
+    #[must_use]
+    pub const fn with_foreground(mut self, foreground: Color) -> Self {
+        self.foreground = foreground;
+        self
+    }
+
+    /// Return these attributes with a different background selection.
+    #[must_use]
+    pub const fn with_background(mut self, background: Color) -> Self {
+        self.background = background;
+        self
+    }
+
+    /// Return these attributes with bold intensity enabled or disabled.
+    #[must_use]
+    pub const fn with_bold(mut self, enabled: bool) -> Self {
+        self.flags = update_flag(self.flags, BOLD, enabled);
+        self
+    }
+
+    /// Return these attributes with underlining enabled or disabled.
+    #[must_use]
+    pub const fn with_underline(mut self, enabled: bool) -> Self {
+        self.flags = update_flag(self.flags, UNDERLINE, enabled);
+        self
+    }
+
+    /// Return these attributes with reverse rendering enabled or disabled.
+    #[must_use]
+    pub const fn with_reverse(mut self, enabled: bool) -> Self {
+        self.flags = update_flag(self.flags, REVERSE, enabled);
+        self
+    }
+}
+
+const fn update_flag(flags: u8, flag: u8, enabled: bool) -> u8 {
+    if enabled { flags | flag } else { flags & !flag }
+}

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -4,16 +4,16 @@
 //! PTY bytes enter through [`TerminalEngine::feed_bytes`]; renderers receive an
 //! immutable [`TerminalSnapshot`] and never depend on PTY or parser types.
 //!
-//! This first foundation deliberately supports printable ASCII, line feed,
-//! carriage return, backspace, and a small CSI cursor-movement subset. It is
-//! not a VT100/xterm compatibility claim.
+//! This foundation supports a bounded ASCII/CSI subset, scrolling regions,
+//! cursor save/restore, and DEC private mode 1049 screen switching. It is not
+//! a VT100/xterm compatibility claim.
 
 mod parser;
 mod state;
 
 pub use state::{
     Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
-    TerminalSnapshot, TerminalState,
+    TerminalModes, TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -4,9 +4,9 @@
 //! PTY bytes enter through [`TerminalEngine::feed_bytes`]; renderers receive an
 //! immutable [`TerminalSnapshot`] and never depend on PTY or parser types.
 //!
-//! This foundation supports a bounded ASCII/CSI subset, scrolling regions,
-//! cursor save/restore, and DEC private mode 1049 screen switching. It is not
-//! a VT100/xterm compatibility claim.
+//! This foundation supports a bounded ASCII/CSI subset, basic SGR attributes,
+//! scrolling regions, cursor save/restore, and DEC private mode 1049 screen
+//! switching. It is not a VT100/xterm compatibility claim.
 
 mod attributes;
 mod parser;

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -12,8 +12,8 @@ mod parser;
 mod state;
 
 pub use state::{
-    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, TerminalError, TerminalSnapshot,
-    TerminalState,
+    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
+    TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -8,9 +8,11 @@
 //! cursor save/restore, and DEC private mode 1049 screen switching. It is not
 //! a VT100/xterm compatibility claim.
 
+mod attributes;
 mod parser;
 mod state;
 
+pub use attributes::{AnsiColor, CellAttributes, Color};
 pub use state::{
     Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
     TerminalModes, TerminalSnapshot, TerminalState,

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -25,9 +25,23 @@ pub(crate) enum Action {
     SetScrollRegion { top: u16, bottom: Option<u16> },
     ScrollUp(u16),
     ScrollDown(u16),
+    EraseInDisplay(EraseMode),
+    EraseInLine(EraseMode),
+    EraseCharacters(u16),
+    InsertCharacters(u16),
+    DeleteCharacters(u16),
+    InsertLines(u16),
+    DeleteLines(u16),
     SaveCursor,
     RestoreCursor,
     SetPrivateMode { mode: PrivateMode, enabled: bool },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EraseMode {
+    ToEnd,
+    ToBeginning,
+    All,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -219,6 +233,7 @@ impl Csi {
     fn standard_action(&self, final_byte: u8) -> Option<Action> {
         let count = self.param_or(0, 1);
         match final_byte {
+            b'@' if self.len == 1 => Some(Action::InsertCharacters(count)),
             b'A' => Some(Action::MoveUp(count)),
             b'B' => Some(Action::MoveDown(count)),
             b'C' => Some(Action::MoveRight(count)),
@@ -230,9 +245,15 @@ impl Csi {
                 row: self.param_or(0, 1).saturating_sub(1),
                 col: self.param_or(1, 1).saturating_sub(1),
             }),
+            b'J' => self.erase_mode().map(Action::EraseInDisplay),
+            b'K' => self.erase_mode().map(Action::EraseInLine),
+            b'L' if self.len == 1 => Some(Action::InsertLines(count)),
+            b'P' if self.len == 1 => Some(Action::DeleteCharacters(count)),
             b'S' if self.len <= 1 => Some(Action::ScrollUp(count)),
             b'T' if self.len <= 1 => Some(Action::ScrollDown(count)),
+            b'X' if self.len == 1 => Some(Action::EraseCharacters(count)),
             b'd' => Some(Action::MoveToRow(count.saturating_sub(1))),
+            b'M' if self.len == 1 => Some(Action::DeleteLines(count)),
             b'r' if self.len <= 2 => Some(Action::SetScrollRegion {
                 top: self.param_or(0, 1).saturating_sub(1),
                 bottom: self.zero_based_param(1),
@@ -266,6 +287,18 @@ impl Csi {
 
     fn is_default_only(&self) -> bool {
         self.len == 1 && self.params[0] == 0
+    }
+
+    fn erase_mode(&self) -> Option<EraseMode> {
+        if self.len != 1 {
+            return None;
+        }
+        match self.params[0] {
+            0 => Some(EraseMode::ToEnd),
+            1 => Some(EraseMode::ToBeginning),
+            2 => Some(EraseMode::All),
+            _ => None,
+        }
     }
 
     fn param_or(&self, index: usize, default: u16) -> u16 {

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -25,6 +25,14 @@ pub(crate) enum Action {
     SetScrollRegion { top: u16, bottom: Option<u16> },
     ScrollUp(u16),
     ScrollDown(u16),
+    SaveCursor,
+    RestoreCursor,
+    SetPrivateMode { mode: PrivateMode, enabled: bool },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PrivateMode {
+    AlternateScreen,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -101,6 +109,14 @@ impl Parser {
                 self.state = ParserState::Ground;
                 return Some(Action::ReverseIndex);
             }
+            b'7' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SaveCursor);
+            }
+            b'8' => {
+                self.state = ParserState::Ground;
+                return Some(Action::RestoreCursor);
+            }
             _ => self.state = ParserState::Ground,
         }
         None
@@ -125,6 +141,7 @@ struct Csi {
     has_current: bool,
     overflowed: bool,
     ignored: bool,
+    private_marker: Option<u8>,
 }
 
 impl Default for Csi {
@@ -136,6 +153,7 @@ impl Default for Csi {
             has_current: false,
             overflowed: false,
             ignored: false,
+            private_marker: None,
         }
     }
 }
@@ -155,7 +173,11 @@ impl Csi {
                 self.push_current();
                 CsiAdvance::pending()
             }
-            b'?' | b'>' if self.len == 0 && !self.has_current => {
+            b'?' | b'>' if self.len == 0 && !self.has_current && self.private_marker.is_none() => {
+                self.private_marker = Some(byte);
+                CsiAdvance::pending()
+            }
+            b'?' | b'>' => {
                 self.ignored = true;
                 CsiAdvance::pending()
             }
@@ -187,6 +209,14 @@ impl Csi {
     }
 
     fn action(&self, final_byte: u8) -> Option<Action> {
+        match self.private_marker {
+            None => self.standard_action(final_byte),
+            Some(b'?') => self.private_action(final_byte),
+            Some(_) => None,
+        }
+    }
+
+    fn standard_action(&self, final_byte: u8) -> Option<Action> {
         let count = self.param_or(0, 1);
         match final_byte {
             b'A' => Some(Action::MoveUp(count)),
@@ -207,8 +237,35 @@ impl Csi {
                 top: self.param_or(0, 1).saturating_sub(1),
                 bottom: self.zero_based_param(1),
             }),
+            b's' if self.is_default_only() => Some(Action::SaveCursor),
+            b'u' if self.is_default_only() => Some(Action::RestoreCursor),
             _ => None,
         }
+    }
+
+    fn private_action(&self, final_byte: u8) -> Option<Action> {
+        if self.len != 1 {
+            return None;
+        }
+        let mode = match self.params[0] {
+            1049 => PrivateMode::AlternateScreen,
+            _ => return None,
+        };
+        match final_byte {
+            b'h' => Some(Action::SetPrivateMode {
+                mode,
+                enabled: true,
+            }),
+            b'l' => Some(Action::SetPrivateMode {
+                mode,
+                enabled: false,
+            }),
+            _ => None,
+        }
+    }
+
+    fn is_default_only(&self) -> bool {
+        self.len == 1 && self.params[0] == 0
     }
 
     fn param_or(&self, index: usize, default: u16) -> u16 {
@@ -320,5 +377,27 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn parses_cursor_save_restore_and_alternate_screen_mode() {
+        assert_eq!(
+            actions(b"\x1b7\x1b8\x1b[s\x1b[u\x1b[?1049h\x1b[?1049l"),
+            [
+                Action::SaveCursor,
+                Action::RestoreCursor,
+                Action::SaveCursor,
+                Action::RestoreCursor,
+                Action::SetPrivateMode {
+                    mode: PrivateMode::AlternateScreen,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::AlternateScreen,
+                    enabled: false,
+                },
+            ]
+        );
+        assert!(actions(b"\x1b[?2004h\x1b[?1049;1h\x1b[>1049h").is_empty());
     }
 }

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -10,12 +10,21 @@ pub(crate) enum Action {
     LineFeed,
     CarriageReturn,
     Backspace,
+    Index,
+    NextLine,
+    ReverseIndex,
     MoveUp(u16),
     MoveDown(u16),
     MoveRight(u16),
     MoveLeft(u16),
+    MoveNextLine(u16),
+    MovePreviousLine(u16),
     MoveTo { row: u16, col: u16 },
     MoveToColumn(u16),
+    MoveToRow(u16),
+    SetScrollRegion { top: u16, bottom: Option<u16> },
+    ScrollUp(u16),
+    ScrollDown(u16),
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -67,7 +76,7 @@ impl Parser {
                 self.state = ParserState::Escape;
                 None
             }
-            b'\n' => Some(Action::LineFeed),
+            b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
             b'\r' => Some(Action::CarriageReturn),
             0x08 => Some(Action::Backspace),
             0x20..=0x7e => Some(Action::Print(byte)),
@@ -76,12 +85,24 @@ impl Parser {
     }
 
     fn advance_escape(&mut self, byte: u8) -> Option<Action> {
-        self.state = match byte {
-            b'[' => ParserState::Csi(Csi::default()),
-            b']' => ParserState::Osc,
-            ESC => ParserState::Escape,
-            _ => ParserState::Ground,
-        };
+        match byte {
+            b'[' => self.state = ParserState::Csi(Csi::default()),
+            b']' => self.state = ParserState::Osc,
+            ESC => self.state = ParserState::Escape,
+            b'D' => {
+                self.state = ParserState::Ground;
+                return Some(Action::Index);
+            }
+            b'E' => {
+                self.state = ParserState::Ground;
+                return Some(Action::NextLine);
+            }
+            b'M' => {
+                self.state = ParserState::Ground;
+                return Some(Action::ReverseIndex);
+            }
+            _ => self.state = ParserState::Ground,
+        }
         None
     }
 }
@@ -172,10 +193,19 @@ impl Csi {
             b'B' => Some(Action::MoveDown(count)),
             b'C' => Some(Action::MoveRight(count)),
             b'D' => Some(Action::MoveLeft(count)),
+            b'E' => Some(Action::MoveNextLine(count)),
+            b'F' => Some(Action::MovePreviousLine(count)),
             b'G' => Some(Action::MoveToColumn(count.saturating_sub(1))),
             b'H' | b'f' => Some(Action::MoveTo {
                 row: self.param_or(0, 1).saturating_sub(1),
                 col: self.param_or(1, 1).saturating_sub(1),
+            }),
+            b'S' if self.len <= 1 => Some(Action::ScrollUp(count)),
+            b'T' if self.len <= 1 => Some(Action::ScrollDown(count)),
+            b'd' => Some(Action::MoveToRow(count.saturating_sub(1))),
+            b'r' if self.len <= 2 => Some(Action::SetScrollRegion {
+                top: self.param_or(0, 1).saturating_sub(1),
+                bottom: self.zero_based_param(1),
             }),
             _ => None,
         }
@@ -187,6 +217,13 @@ impl Csi {
             .copied()
             .filter(|value| *value != 0)
             .unwrap_or(default)
+    }
+
+    fn zero_based_param(&self, index: usize) -> Option<u16> {
+        if index >= self.len {
+            return None;
+        }
+        self.params[index].checked_sub(1)
     }
 }
 
@@ -226,9 +263,11 @@ mod tests {
     #[test]
     fn parses_basic_text_controls_and_cursor_sequences() {
         assert_eq!(
-            actions(b"A\n\r\x08\x1b[2A\x1b[3;4H"),
+            actions(b"A\n\x0b\x0c\r\x08\x1b[2A\x1b[3;4H"),
             [
                 Action::Print(b'A'),
+                Action::LineFeed,
+                Action::LineFeed,
                 Action::LineFeed,
                 Action::CarriageReturn,
                 Action::Backspace,
@@ -247,5 +286,39 @@ mod tests {
     #[test]
     fn escape_restarts_an_incomplete_csi_sequence() {
         assert_eq!(actions(b"\x1b[9\x1b[2A"), [Action::MoveUp(2)]);
+    }
+
+    #[test]
+    fn parses_index_scroll_region_and_extended_cursor_actions() {
+        assert_eq!(
+            actions(b"\x1bD\x1bE\x1bM\x1b[2;4r\x1b[3S\x1b[T\x1b[2E\x1b[F\x1b[4d"),
+            [
+                Action::Index,
+                Action::NextLine,
+                Action::ReverseIndex,
+                Action::SetScrollRegion {
+                    top: 1,
+                    bottom: Some(3),
+                },
+                Action::ScrollUp(3),
+                Action::ScrollDown(1),
+                Action::MoveNextLine(2),
+                Action::MovePreviousLine(1),
+                Action::MoveToRow(3),
+            ]
+        );
+        assert_eq!(
+            actions(b"\x1b[r\x1b[2r"),
+            [
+                Action::SetScrollRegion {
+                    top: 0,
+                    bottom: None,
+                },
+                Action::SetScrollRegion {
+                    top: 1,
+                    bottom: None,
+                },
+            ]
+        );
     }
 }

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -19,10 +19,16 @@ pub(crate) enum Action {
     MoveLeft(u16),
     MoveNextLine(u16),
     MovePreviousLine(u16),
-    MoveTo { row: u16, col: u16 },
+    MoveTo {
+        row: u16,
+        col: u16,
+    },
     MoveToColumn(u16),
     MoveToRow(u16),
-    SetScrollRegion { top: u16, bottom: Option<u16> },
+    SetScrollRegion {
+        top: u16,
+        bottom: Option<u16>,
+    },
     ScrollUp(u16),
     ScrollDown(u16),
     EraseInDisplay(EraseMode),
@@ -32,9 +38,16 @@ pub(crate) enum Action {
     DeleteCharacters(u16),
     InsertLines(u16),
     DeleteLines(u16),
+    SelectGraphicRendition {
+        params: [u16; MAX_CSI_PARAMS],
+        len: usize,
+    },
     SaveCursor,
     RestoreCursor,
-    SetPrivateMode { mode: PrivateMode, enabled: bool },
+    SetPrivateMode {
+        mode: PrivateMode,
+        enabled: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -257,6 +270,10 @@ impl Csi {
             b'r' if self.len <= 2 => Some(Action::SetScrollRegion {
                 top: self.param_or(0, 1).saturating_sub(1),
                 bottom: self.zero_based_param(1),
+            }),
+            b'm' => Some(Action::SelectGraphicRendition {
+                params: self.params,
+                len: self.len,
             }),
             b's' if self.is_default_only() => Some(Action::SaveCursor),
             b'u' if self.is_default_only() => Some(Action::RestoreCursor),

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -10,6 +10,7 @@ pub(crate) enum Action {
     LineFeed,
     CarriageReturn,
     Backspace,
+    Tab,
     Index,
     NextLine,
     ReverseIndex,
@@ -75,6 +76,14 @@ impl Parser {
         match state {
             ParserState::Ground => self.advance_ground(byte),
             ParserState::Escape => self.advance_escape(byte),
+            ParserState::EscapeIntermediate => {
+                self.state = match byte {
+                    ESC => ParserState::Escape,
+                    0x30..=0x7e => ParserState::Ground,
+                    _ => ParserState::EscapeIntermediate,
+                };
+                None
+            }
             ParserState::Csi(mut csi) => {
                 if byte == ESC {
                     self.state = ParserState::Escape;
@@ -115,6 +124,7 @@ impl Parser {
             }
             b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
             b'\r' => Some(Action::CarriageReturn),
+            b'\t' => Some(Action::Tab),
             0x08 => Some(Action::Backspace),
             0x20..=0x7e => Some(Action::Print(byte)),
             _ => None,
@@ -154,6 +164,11 @@ impl Parser {
                 self.state = ParserState::Ground;
                 return Some(Action::RestoreCursor);
             }
+            // Intermediate bytes (0x20..=0x2f) such as `(`, `)`, `#`, and SP
+            // begin a multi-byte escape (e.g. SCS `ESC ( B`). Collect them and
+            // the following final byte without emitting anything, so the final
+            // never leaks to Ground as printable text.
+            0x20..=0x2f => self.state = ParserState::EscapeIntermediate,
             _ => self.state = ParserState::Ground,
         }
         None
@@ -165,6 +180,7 @@ enum ParserState {
     #[default]
     Ground,
     Escape,
+    EscapeIntermediate,
     Csi(Csi),
     Osc,
     OscEscape,
@@ -393,6 +409,49 @@ mod tests {
                 Action::MoveTo { row: 2, col: 3 },
             ]
         );
+    }
+
+    #[test]
+    fn horizontal_tab_emits_a_tab_action() {
+        assert_eq!(
+            actions(b"\ta\tb"),
+            [
+                Action::Tab,
+                Action::Print(b'a'),
+                Action::Tab,
+                Action::Print(b'b'),
+            ]
+        );
+    }
+
+    #[test]
+    fn escape_intermediate_sequences_emit_nothing_and_keep_the_final_byte() {
+        // Regression for the byte-leak: `ESC ( B` previously printed 'B'.
+        for sequence in [
+            b"\x1b(B".as_slice(),
+            b"\x1b)0",
+            b"\x1b#8",
+            b"\x1b F",
+            b"\x1b()B",
+        ] {
+            assert!(actions(sequence).is_empty(), "sequence {sequence:?}");
+        }
+        // An unsupported single-byte escape final is still consumed whole.
+        assert!(actions(b"\x1bc").is_empty());
+
+        // The final byte after an intermediate must not leak when followed by
+        // printable text.
+        let mut parser = Parser::default();
+        let emitted: Vec<Action> = b"\x1b(BX"
+            .iter()
+            .filter_map(|byte| parser.advance(*byte))
+            .collect();
+        assert_eq!(emitted, [Action::Print(b'X')]);
+    }
+
+    #[test]
+    fn escape_intermediate_aborts_on_a_new_escape() {
+        assert_eq!(actions(b"\x1b(\x1b[D"), [Action::MoveLeft(1)]);
     }
 
     #[test]

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -44,6 +44,7 @@ pub(crate) enum Action {
     },
     SaveCursor,
     RestoreCursor,
+    SetKeypadApplication(bool),
     SetPrivateMode {
         mode: PrivateMode,
         enabled: bool,
@@ -60,6 +61,7 @@ pub(crate) enum EraseMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PrivateMode {
     AlternateScreen,
+    ApplicationCursorKey,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -124,6 +126,14 @@ impl Parser {
             b'[' => self.state = ParserState::Csi(Csi::default()),
             b']' => self.state = ParserState::Osc,
             ESC => self.state = ParserState::Escape,
+            b'=' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SetKeypadApplication(true));
+            }
+            b'>' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SetKeypadApplication(false));
+            }
             b'D' => {
                 self.state = ParserState::Ground;
                 return Some(Action::Index);
@@ -286,6 +296,7 @@ impl Csi {
             return None;
         }
         let mode = match self.params[0] {
+            1 => PrivateMode::ApplicationCursorKey,
             1049 => PrivateMode::AlternateScreen,
             _ => return None,
         };

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -34,7 +34,7 @@ pub(crate) struct Parser {
 
 impl Parser {
     pub(crate) fn advance(&mut self, byte: u8) -> Option<Action> {
-        let state = std::mem::take(&mut self.state);
+        let state = self.state;
         match state {
             ParserState::Ground => self.advance_ground(byte),
             ParserState::Escape => self.advance_escape(byte),

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,4 +1,4 @@
-use crate::parser::{Action, Parser, PrivateMode};
+use crate::parser::{Action, EraseMode, Parser, PrivateMode};
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
@@ -235,6 +235,61 @@ impl ScreenBuffer {
         let shift = rows * columns;
         self.cells[start..end].rotate_right(shift);
         self.cells[start..start + shift].fill(Cell::blank());
+    }
+
+    fn erase_in_display(&mut self, cursor: Cursor, mode: EraseMode) {
+        let Some(cursor_index) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        match mode {
+            EraseMode::ToEnd => self.cells[cursor_index..].fill(Cell::default()),
+            EraseMode::ToBeginning => self.cells[..cursor_index + 1].fill(Cell::default()),
+            EraseMode::All => self.cells.fill(Cell::default()),
+        }
+    }
+
+    fn erase_in_line(&mut self, cursor: Cursor, mode: EraseMode) {
+        let Some(cursor_index) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_start = usize::from(cursor.row) * usize::from(self.cols);
+        let row_end = row_start + usize::from(self.cols);
+        match mode {
+            EraseMode::ToEnd => self.cells[cursor_index..row_end].fill(Cell::default()),
+            EraseMode::ToBeginning => {
+                self.cells[row_start..cursor_index + 1].fill(Cell::default());
+            }
+            EraseMode::All => self.cells[row_start..row_end].fill(Cell::default()),
+        }
+    }
+
+    fn erase_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..start + count].fill(Cell::default());
+    }
+
+    fn insert_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..row_end].rotate_right(count);
+        self.cells[start..start + count].fill(Cell::default());
+    }
+
+    fn delete_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..row_end].rotate_left(count);
+        self.cells[row_end - count..row_end].fill(Cell::default());
     }
 
     fn index(&self, row: u16, column: u16) -> Option<usize> {
@@ -500,6 +555,13 @@ impl TerminalState {
             }
             Action::ScrollUp(count) => self.scroll_up(count),
             Action::ScrollDown(count) => self.scroll_down(count),
+            Action::EraseInDisplay(mode) => self.erase_in_display(mode),
+            Action::EraseInLine(mode) => self.erase_in_line(mode),
+            Action::EraseCharacters(count) => self.erase_characters(count),
+            Action::InsertCharacters(count) => self.insert_characters(count),
+            Action::DeleteCharacters(count) => self.delete_characters(count),
+            Action::InsertLines(count) => self.insert_lines(count),
+            Action::DeleteLines(count) => self.delete_lines(count),
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
@@ -563,6 +625,69 @@ impl TerminalState {
         self.active
             .screen
             .scroll_down(self.active.scroll_region, count);
+    }
+
+    fn erase_in_display(&mut self, mode: EraseMode) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .erase_in_display(self.active.cursor, mode);
+    }
+
+    fn erase_in_line(&mut self, mode: EraseMode) {
+        self.active.wrap_pending = false;
+        self.active.screen.erase_in_line(self.active.cursor, mode);
+    }
+
+    fn erase_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .erase_characters(self.active.cursor, count);
+    }
+
+    fn insert_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .insert_characters(self.active.cursor, count);
+    }
+
+    fn delete_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .delete_characters(self.active.cursor, count);
+    }
+
+    fn insert_lines(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        let cursor_row = self.active.cursor.row;
+        let region = self.active.scroll_region;
+        if (region.top..=region.bottom).contains(&cursor_row) {
+            self.active.screen.scroll_down(
+                ScrollRegion {
+                    top: cursor_row,
+                    bottom: region.bottom,
+                },
+                count,
+            );
+        }
+    }
+
+    fn delete_lines(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        let cursor_row = self.active.cursor.row;
+        let region = self.active.scroll_region;
+        if (region.top..=region.bottom).contains(&cursor_row) {
+            self.active.screen.scroll_up(
+                ScrollRegion {
+                    top: cursor_row,
+                    bottom: region.bottom,
+                },
+                count,
+            );
+        }
     }
 
     fn reset_scroll_region(&mut self) {

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,4 +1,4 @@
-use crate::parser::{Action, Parser};
+use crate::parser::{Action, Parser, PrivateMode};
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
@@ -136,6 +136,20 @@ impl ScrollRegion {
     }
 }
 
+/// Renderer-independent terminal modes that affect visible state selection.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerminalModes {
+    alternate_screen: bool,
+}
+
+impl TerminalModes {
+    /// Whether DEC private mode 1049 currently selects the alternate screen.
+    #[must_use]
+    pub const fn is_alternate_screen_active(self) -> bool {
+        self.alternate_screen
+    }
+}
+
 /// Fixed-size visible screen buffer in row-major order.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ScreenBuffer {
@@ -253,12 +267,67 @@ impl fmt::Display for TerminalError {
 
 impl std::error::Error for TerminalError {}
 
-/// Noren-owned mutable terminal state.
-pub struct TerminalState {
+struct ScreenState {
     screen: ScreenBuffer,
     cursor: Cursor,
+    saved_cursor: Option<Cursor>,
     scroll_region: ScrollRegion,
     wrap_pending: bool,
+}
+
+impl ScreenState {
+    fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
+        Ok(Self {
+            screen: ScreenBuffer::new(rows, cols)?,
+            cursor: Cursor::default(),
+            saved_cursor: None,
+            scroll_region: ScrollRegion::full_screen(rows),
+            wrap_pending: false,
+        })
+    }
+
+    fn blank_like(&self) -> Self {
+        Self {
+            screen: ScreenBuffer {
+                rows: self.screen.rows,
+                cols: self.screen.cols,
+                cells: vec![Cell::blank(); self.screen.cells.len()],
+            },
+            cursor: Cursor::default(),
+            saved_cursor: None,
+            scroll_region: ScrollRegion::full_screen(self.screen.rows),
+            wrap_pending: false,
+        }
+    }
+
+    fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
+        self.screen.resize(rows, cols)?;
+        self.cursor = clamp_cursor(self.cursor, rows, cols);
+        self.saved_cursor = self
+            .saved_cursor
+            .map(|cursor| clamp_cursor(cursor, rows, cols));
+        self.scroll_region = ScrollRegion::full_screen(rows);
+        self.wrap_pending = false;
+        Ok(())
+    }
+
+    fn save_cursor(&mut self) {
+        self.saved_cursor = Some(self.cursor);
+    }
+
+    fn restore_cursor(&mut self) {
+        if let Some(cursor) = self.saved_cursor {
+            self.cursor = clamp_cursor(cursor, self.screen.rows, self.screen.cols);
+        }
+        self.wrap_pending = false;
+    }
+}
+
+/// Noren-owned mutable terminal state.
+pub struct TerminalState {
+    active: ScreenState,
+    primary_screen: Option<ScreenState>,
+    modes: TerminalModes,
     parser: Parser,
 }
 
@@ -266,10 +335,9 @@ impl TerminalState {
     /// Create a bounded non-zero visible terminal.
     pub fn new(rows: u16, cols: u16) -> Result<Self, TerminalError> {
         Ok(Self {
-            screen: ScreenBuffer::new(rows, cols)?,
-            cursor: Cursor::default(),
-            scroll_region: ScrollRegion::full_screen(rows),
-            wrap_pending: false,
+            active: ScreenState::new(rows, cols)?,
+            primary_screen: None,
+            modes: TerminalModes::default(),
             parser: Parser::default(),
         })
     }
@@ -287,87 +355,110 @@ impl TerminalState {
         }
     }
 
-    /// Resize while preserving the overlapping top-left screen area.
+    /// Resize active and inactive screens while preserving their overlap.
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
-        self.screen.resize(rows, cols)?;
-        self.cursor.row = self.cursor.row.min(rows - 1);
-        self.cursor.column = self.cursor.column.min(cols - 1);
-        self.scroll_region = ScrollRegion::full_screen(rows);
-        self.wrap_pending = false;
+        checked_cell_count(rows, cols)?;
+        self.active.resize(rows, cols)?;
+        if let Some(primary) = &mut self.primary_screen {
+            primary.resize(rows, cols)?;
+        }
         Ok(())
     }
 
     /// Current `(rows, cols)`.
     #[must_use]
     pub const fn size(&self) -> (u16, u16) {
-        (self.screen.rows, self.screen.cols)
+        (self.active.screen.rows, self.active.screen.cols)
     }
 
     /// Current cursor position.
     #[must_use]
     pub const fn cursor(&self) -> Cursor {
-        self.cursor
+        self.active.cursor
     }
 
     /// Current visible screen.
     #[must_use]
     pub const fn screen(&self) -> &ScreenBuffer {
-        &self.screen
+        &self.active.screen
     }
 
     /// Active inclusive vertical scrolling margins.
     #[must_use]
     pub const fn scroll_region(&self) -> ScrollRegion {
-        self.scroll_region
+        self.active.scroll_region
     }
 
     /// Whether the next printable byte will wrap before it is written.
     #[must_use]
     pub const fn is_wrap_pending(&self) -> bool {
-        self.wrap_pending
+        self.active.wrap_pending
+    }
+
+    /// Current renderer-independent terminal mode state.
+    #[must_use]
+    pub const fn modes(&self) -> TerminalModes {
+        self.modes
+    }
+
+    /// Save the active screen's cursor position.
+    pub fn save_cursor(&mut self) {
+        self.active.save_cursor();
+    }
+
+    /// Restore the active screen's saved cursor position, if present.
+    pub fn restore_cursor(&mut self) {
+        self.active.restore_cursor();
     }
 
     /// Set zero-based inclusive scrolling margins and move the cursor home.
     pub fn set_scroll_region(&mut self, top: u16, bottom: u16) -> Result<(), TerminalError> {
-        self.scroll_region = ScrollRegion::checked(self.screen.rows, top, bottom)?;
-        self.cursor = Cursor::default();
-        self.wrap_pending = false;
+        self.active.scroll_region = ScrollRegion::checked(self.active.screen.rows, top, bottom)?;
+        self.active.cursor = Cursor::default();
+        self.active.wrap_pending = false;
         Ok(())
     }
 
     /// Apply a clamped renderer-independent cursor operation.
     pub fn move_cursor(&mut self, movement: CursorMove) {
-        self.wrap_pending = false;
-        let last_row = self.screen.rows - 1;
-        let last_column = self.screen.cols - 1;
+        self.active.wrap_pending = false;
+        let last_row = self.active.screen.rows - 1;
+        let last_column = self.active.screen.cols - 1;
         match movement {
-            CursorMove::Up(count) => self.cursor.row = self.cursor.row.saturating_sub(count),
+            CursorMove::Up(count) => {
+                self.active.cursor.row = self.active.cursor.row.saturating_sub(count);
+            }
             CursorMove::Down(count) => {
-                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
+                self.active.cursor.row = self.active.cursor.row.saturating_add(count).min(last_row);
             }
             CursorMove::Right(count) => {
-                self.cursor.column = self.cursor.column.saturating_add(count).min(last_column);
+                self.active.cursor.column = self
+                    .active
+                    .cursor
+                    .column
+                    .saturating_add(count)
+                    .min(last_column);
             }
             CursorMove::Left(count) => {
-                self.cursor.column = self.cursor.column.saturating_sub(count);
+                self.active.cursor.column = self.active.cursor.column.saturating_sub(count);
             }
             CursorMove::NextLine(count) => {
-                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
-                self.cursor.column = 0;
+                self.active.cursor.row = self.active.cursor.row.saturating_add(count).min(last_row);
+                self.active.cursor.column = 0;
             }
             CursorMove::PreviousLine(count) => {
-                self.cursor.row = self.cursor.row.saturating_sub(count);
-                self.cursor.column = 0;
+                self.active.cursor.row = self.active.cursor.row.saturating_sub(count);
+                self.active.cursor.column = 0;
             }
             CursorMove::To { row, column } => {
-                self.cursor.row = row.min(last_row);
-                self.cursor.column = column.min(last_column);
+                self.active.cursor.row = row.min(last_row);
+                self.active.cursor.column = column.min(last_column);
             }
             CursorMove::ToColumn(column) => {
-                self.cursor.column = column.min(last_column);
+                self.active.cursor.column = column.min(last_column);
             }
             CursorMove::ToRow(row) => {
-                self.cursor.row = row.min(last_row);
+                self.active.cursor.row = row.min(last_row);
             }
         }
     }
@@ -383,12 +474,12 @@ impl TerminalState {
             Action::Print(byte) => self.print_ascii(byte),
             Action::LineFeed => self.line_feed(),
             Action::CarriageReturn => {
-                self.cursor.column = 0;
-                self.wrap_pending = false;
+                self.active.cursor.column = 0;
+                self.active.wrap_pending = false;
             }
             Action::Backspace => {
-                self.cursor.column = self.cursor.column.saturating_sub(1);
-                self.wrap_pending = false;
+                self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
+                self.active.wrap_pending = false;
             }
             Action::Index => self.index(),
             Action::NextLine => self.next_line(),
@@ -409,74 +500,114 @@ impl TerminalState {
             }
             Action::ScrollUp(count) => self.scroll_up(count),
             Action::ScrollDown(count) => self.scroll_down(count),
+            Action::SaveCursor => self.save_cursor(),
+            Action::RestoreCursor => self.restore_cursor(),
+            Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
         }
     }
 
     fn print_ascii(&mut self, byte: u8) {
-        if self.wrap_pending {
-            self.cursor.column = 0;
+        if self.active.wrap_pending {
+            self.active.cursor.column = 0;
             self.index();
         }
-        self.screen
-            .put(self.cursor.row, self.cursor.column, Cell::from_ascii(byte));
-        if self.cursor.column == self.screen.cols - 1 {
-            self.wrap_pending = true;
+        self.active.screen.put(
+            self.active.cursor.row,
+            self.active.cursor.column,
+            Cell::from_ascii(byte),
+        );
+        if self.active.cursor.column == self.active.screen.cols - 1 {
+            self.active.wrap_pending = true;
         } else {
-            self.cursor.column += 1;
+            self.active.cursor.column += 1;
         }
     }
 
     fn line_feed(&mut self) {
-        self.wrap_pending = false;
+        self.active.wrap_pending = false;
         self.index();
     }
 
     fn index(&mut self) {
-        self.wrap_pending = false;
-        if self.cursor.row == self.scroll_region.bottom {
-            self.screen.scroll_up(self.scroll_region, 1);
-        } else if self.cursor.row < self.screen.rows - 1 {
-            self.cursor.row += 1;
+        self.active.wrap_pending = false;
+        if self.active.cursor.row == self.active.scroll_region.bottom {
+            self.active.screen.scroll_up(self.active.scroll_region, 1);
+        } else if self.active.cursor.row < self.active.screen.rows - 1 {
+            self.active.cursor.row += 1;
         }
     }
 
     fn next_line(&mut self) {
-        self.cursor.column = 0;
+        self.active.cursor.column = 0;
         self.index();
     }
 
     fn reverse_index(&mut self) {
-        self.wrap_pending = false;
-        if self.cursor.row == self.scroll_region.top {
-            self.screen.scroll_down(self.scroll_region, 1);
-        } else if self.cursor.row > 0 {
-            self.cursor.row -= 1;
+        self.active.wrap_pending = false;
+        if self.active.cursor.row == self.active.scroll_region.top {
+            self.active.screen.scroll_down(self.active.scroll_region, 1);
+        } else if self.active.cursor.row > 0 {
+            self.active.cursor.row -= 1;
         }
     }
 
     fn scroll_up(&mut self, count: u16) {
-        self.wrap_pending = false;
-        self.screen.scroll_up(self.scroll_region, count);
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .scroll_up(self.active.scroll_region, count);
     }
 
     fn scroll_down(&mut self, count: u16) {
-        self.wrap_pending = false;
-        self.screen.scroll_down(self.scroll_region, count);
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .scroll_down(self.active.scroll_region, count);
     }
 
     fn reset_scroll_region(&mut self) {
-        self.scroll_region = ScrollRegion::full_screen(self.screen.rows);
-        self.cursor = Cursor::default();
-        self.wrap_pending = false;
+        self.active.scroll_region = ScrollRegion::full_screen(self.active.screen.rows);
+        self.active.cursor = Cursor::default();
+        self.active.wrap_pending = false;
     }
 
     fn apply_scroll_region(&mut self, top: u16, bottom: Option<u16>) {
         if top == 0 && bottom.is_none() {
             self.reset_scroll_region();
         } else {
-            let bottom = bottom.unwrap_or(self.screen.rows - 1);
+            let bottom = bottom.unwrap_or(self.active.screen.rows - 1);
             let _ = self.set_scroll_region(top, bottom);
         }
+    }
+
+    fn set_private_mode(&mut self, mode: PrivateMode, enabled: bool) {
+        match (mode, enabled) {
+            (PrivateMode::AlternateScreen, true) => self.enter_alternate_screen(),
+            (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
+        }
+    }
+
+    fn enter_alternate_screen(&mut self) {
+        if self.modes.alternate_screen {
+            return;
+        }
+        self.active.save_cursor();
+        let alternate = self.active.blank_like();
+        let primary = std::mem::replace(&mut self.active, alternate);
+        debug_assert!(self.primary_screen.is_none());
+        self.primary_screen = Some(primary);
+        self.modes.alternate_screen = true;
+    }
+
+    fn leave_alternate_screen(&mut self) {
+        if !self.modes.alternate_screen {
+            return;
+        }
+        if let Some(primary) = self.primary_screen.take() {
+            self.active = primary;
+            self.active.restore_cursor();
+        }
+        self.modes.alternate_screen = false;
     }
 }
 
@@ -484,9 +615,10 @@ impl fmt::Debug for TerminalState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TerminalState")
             .field("size", &self.size())
-            .field("cursor", &self.cursor)
-            .field("scroll_region", &self.scroll_region)
-            .field("wrap_pending", &self.wrap_pending)
+            .field("cursor", &self.active.cursor)
+            .field("scroll_region", &self.active.scroll_region)
+            .field("wrap_pending", &self.active.wrap_pending)
+            .field("modes", &self.modes)
             .finish_non_exhaustive()
     }
 }
@@ -498,17 +630,19 @@ pub struct TerminalSnapshot {
     cursor: Cursor,
     scroll_region: ScrollRegion,
     wrap_pending: bool,
+    modes: TerminalModes,
     lines: Vec<String>,
 }
 
 impl TerminalSnapshot {
     fn from_state(state: &TerminalState) -> Self {
         Self {
-            screen: state.screen.clone(),
-            cursor: state.cursor,
-            scroll_region: state.scroll_region,
-            wrap_pending: state.wrap_pending,
-            lines: visible_lines(&state.screen),
+            screen: state.active.screen.clone(),
+            cursor: state.active.cursor,
+            scroll_region: state.active.scroll_region,
+            wrap_pending: state.active.wrap_pending,
+            modes: state.modes,
+            lines: visible_lines(&state.active.screen),
         }
     }
 
@@ -542,6 +676,12 @@ impl TerminalSnapshot {
         self.wrap_pending
     }
 
+    /// Terminal modes captured with the visible screen.
+    #[must_use]
+    pub const fn modes(&self) -> TerminalModes {
+        self.modes
+    }
+
     /// Captured visible screen.
     #[must_use]
     pub const fn screen(&self) -> &ScreenBuffer {
@@ -564,6 +704,13 @@ fn checked_cell_count(rows: u16, cols: u16) -> Result<usize, TerminalError> {
         Err(TerminalError::ScreenTooLarge)
     } else {
         Ok(count)
+    }
+}
+
+fn clamp_cursor(cursor: Cursor, rows: u16, cols: u16) -> Cursor {
+    Cursor {
+        row: cursor.row.min(rows - 1),
+        column: cursor.column.min(cols - 1),
     }
 }
 

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -151,10 +151,12 @@ impl ScrollRegion {
     }
 }
 
-/// Renderer-independent terminal modes that affect visible state selection.
+/// Renderer-independent modes that affect screen selection or encoded input.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TerminalModes {
     alternate_screen: bool,
+    application_cursor_key: bool,
+    application_keypad: bool,
 }
 
 impl TerminalModes {
@@ -162,6 +164,18 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_alternate_screen_active(self) -> bool {
         self.alternate_screen
+    }
+
+    /// Whether DECCKM (DEC cursor key mode) is set to application mode.
+    #[must_use]
+    pub const fn is_application_cursor_key_mode(self) -> bool {
+        self.application_cursor_key
+    }
+
+    /// Whether DECKPAM (DEC keypad application mode) is set to application mode.
+    #[must_use]
+    pub const fn is_application_keypad_mode(self) -> bool {
+        self.application_keypad
     }
 }
 
@@ -592,6 +606,9 @@ impl TerminalState {
             }
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
+            Action::SetKeypadApplication(enabled) => {
+                self.modes.application_keypad = enabled;
+            }
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
         }
     }
@@ -785,6 +802,9 @@ impl TerminalState {
         match (mode, enabled) {
             (PrivateMode::AlternateScreen, true) => self.enter_alternate_screen(),
             (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
+            (PrivateMode::ApplicationCursorKey, enabled) => {
+                self.modes.application_cursor_key = enabled;
+            }
         }
     }
 

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -88,8 +88,52 @@ pub enum CursorMove {
     Down(u16),
     Right(u16),
     Left(u16),
+    NextLine(u16),
+    PreviousLine(u16),
     To { row: u16, column: u16 },
     ToColumn(u16),
+    ToRow(u16),
+}
+
+/// Inclusive vertical margins used by index and explicit scroll operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ScrollRegion {
+    top: u16,
+    bottom: u16,
+}
+
+impl ScrollRegion {
+    fn full_screen(rows: u16) -> Self {
+        Self {
+            top: 0,
+            bottom: rows - 1,
+        }
+    }
+
+    fn checked(rows: u16, top: u16, bottom: u16) -> Result<Self, TerminalError> {
+        if top >= bottom || bottom >= rows {
+            return Err(TerminalError::InvalidScrollRegion);
+        }
+        Ok(Self { top, bottom })
+    }
+
+    /// Zero-based first row in the region.
+    #[must_use]
+    pub const fn top(self) -> u16 {
+        self.top
+    }
+
+    /// Zero-based last row in the region.
+    #[must_use]
+    pub const fn bottom(self) -> u16 {
+        self.bottom
+    }
+
+    /// Number of rows in the inclusive region.
+    #[must_use]
+    pub const fn height(self) -> u16 {
+        self.bottom - self.top + 1
+    }
 }
 
 /// Fixed-size visible screen buffer in row-major order.
@@ -159,11 +203,24 @@ impl ScreenBuffer {
         Ok(())
     }
 
-    fn scroll_up(&mut self) {
+    fn scroll_up(&mut self, region: ScrollRegion, count: u16) {
         let columns = usize::from(self.cols);
-        self.cells.rotate_left(columns);
-        let first_blank = self.cells.len().saturating_sub(columns);
-        self.cells[first_blank..].fill(Cell::blank());
+        let rows = usize::from(count.min(region.height()));
+        let start = usize::from(region.top) * columns;
+        let end = (usize::from(region.bottom) + 1) * columns;
+        let shift = rows * columns;
+        self.cells[start..end].rotate_left(shift);
+        self.cells[end - shift..end].fill(Cell::blank());
+    }
+
+    fn scroll_down(&mut self, region: ScrollRegion, count: u16) {
+        let columns = usize::from(self.cols);
+        let rows = usize::from(count.min(region.height()));
+        let start = usize::from(region.top) * columns;
+        let end = (usize::from(region.bottom) + 1) * columns;
+        let shift = rows * columns;
+        self.cells[start..end].rotate_right(shift);
+        self.cells[start..start + shift].fill(Cell::blank());
     }
 
     fn index(&self, row: u16, column: u16) -> Option<usize> {
@@ -179,6 +236,7 @@ impl ScreenBuffer {
 pub enum TerminalError {
     InvalidSize,
     ScreenTooLarge,
+    InvalidScrollRegion,
 }
 
 impl fmt::Display for TerminalError {
@@ -186,6 +244,9 @@ impl fmt::Display for TerminalError {
         match self {
             Self::InvalidSize => f.write_str("terminal rows and columns must be non-zero"),
             Self::ScreenTooLarge => f.write_str("terminal screen exceeds the cell limit"),
+            Self::InvalidScrollRegion => {
+                f.write_str("terminal scroll region must be ordered and within the screen")
+            }
         }
     }
 }
@@ -196,6 +257,8 @@ impl std::error::Error for TerminalError {}
 pub struct TerminalState {
     screen: ScreenBuffer,
     cursor: Cursor,
+    scroll_region: ScrollRegion,
+    wrap_pending: bool,
     parser: Parser,
 }
 
@@ -205,6 +268,8 @@ impl TerminalState {
         Ok(Self {
             screen: ScreenBuffer::new(rows, cols)?,
             cursor: Cursor::default(),
+            scroll_region: ScrollRegion::full_screen(rows),
+            wrap_pending: false,
             parser: Parser::default(),
         })
     }
@@ -227,6 +292,8 @@ impl TerminalState {
         self.screen.resize(rows, cols)?;
         self.cursor.row = self.cursor.row.min(rows - 1);
         self.cursor.column = self.cursor.column.min(cols - 1);
+        self.scroll_region = ScrollRegion::full_screen(rows);
+        self.wrap_pending = false;
         Ok(())
     }
 
@@ -248,8 +315,29 @@ impl TerminalState {
         &self.screen
     }
 
+    /// Active inclusive vertical scrolling margins.
+    #[must_use]
+    pub const fn scroll_region(&self) -> ScrollRegion {
+        self.scroll_region
+    }
+
+    /// Whether the next printable byte will wrap before it is written.
+    #[must_use]
+    pub const fn is_wrap_pending(&self) -> bool {
+        self.wrap_pending
+    }
+
+    /// Set zero-based inclusive scrolling margins and move the cursor home.
+    pub fn set_scroll_region(&mut self, top: u16, bottom: u16) -> Result<(), TerminalError> {
+        self.scroll_region = ScrollRegion::checked(self.screen.rows, top, bottom)?;
+        self.cursor = Cursor::default();
+        self.wrap_pending = false;
+        Ok(())
+    }
+
     /// Apply a clamped renderer-independent cursor operation.
     pub fn move_cursor(&mut self, movement: CursorMove) {
+        self.wrap_pending = false;
         let last_row = self.screen.rows - 1;
         let last_column = self.screen.cols - 1;
         match movement {
@@ -263,12 +351,23 @@ impl TerminalState {
             CursorMove::Left(count) => {
                 self.cursor.column = self.cursor.column.saturating_sub(count);
             }
+            CursorMove::NextLine(count) => {
+                self.cursor.row = self.cursor.row.saturating_add(count).min(last_row);
+                self.cursor.column = 0;
+            }
+            CursorMove::PreviousLine(count) => {
+                self.cursor.row = self.cursor.row.saturating_sub(count);
+                self.cursor.column = 0;
+            }
             CursorMove::To { row, column } => {
                 self.cursor.row = row.min(last_row);
                 self.cursor.column = column.min(last_column);
             }
             CursorMove::ToColumn(column) => {
                 self.cursor.column = column.min(last_column);
+            }
+            CursorMove::ToRow(row) => {
+                self.cursor.row = row.min(last_row);
             }
         }
     }
@@ -283,35 +382,100 @@ impl TerminalState {
         match action {
             Action::Print(byte) => self.print_ascii(byte),
             Action::LineFeed => self.line_feed(),
-            Action::CarriageReturn => self.cursor.column = 0,
-            Action::Backspace => self.cursor.column = self.cursor.column.saturating_sub(1),
+            Action::CarriageReturn => {
+                self.cursor.column = 0;
+                self.wrap_pending = false;
+            }
+            Action::Backspace => {
+                self.cursor.column = self.cursor.column.saturating_sub(1);
+                self.wrap_pending = false;
+            }
+            Action::Index => self.index(),
+            Action::NextLine => self.next_line(),
+            Action::ReverseIndex => self.reverse_index(),
             Action::MoveUp(count) => self.move_cursor(CursorMove::Up(count)),
             Action::MoveDown(count) => self.move_cursor(CursorMove::Down(count)),
             Action::MoveRight(count) => self.move_cursor(CursorMove::Right(count)),
             Action::MoveLeft(count) => self.move_cursor(CursorMove::Left(count)),
+            Action::MoveNextLine(count) => self.move_cursor(CursorMove::NextLine(count)),
+            Action::MovePreviousLine(count) => self.move_cursor(CursorMove::PreviousLine(count)),
             Action::MoveTo { row, col } => {
                 self.move_cursor(CursorMove::To { row, column: col });
             }
             Action::MoveToColumn(column) => self.move_cursor(CursorMove::ToColumn(column)),
+            Action::MoveToRow(row) => self.move_cursor(CursorMove::ToRow(row)),
+            Action::SetScrollRegion { top, bottom } => {
+                self.apply_scroll_region(top, bottom);
+            }
+            Action::ScrollUp(count) => self.scroll_up(count),
+            Action::ScrollDown(count) => self.scroll_down(count),
         }
     }
 
     fn print_ascii(&mut self, byte: u8) {
+        if self.wrap_pending {
+            self.cursor.column = 0;
+            self.index();
+        }
         self.screen
             .put(self.cursor.row, self.cursor.column, Cell::from_ascii(byte));
         if self.cursor.column == self.screen.cols - 1 {
-            self.cursor.column = 0;
-            self.line_feed();
+            self.wrap_pending = true;
         } else {
             self.cursor.column += 1;
         }
     }
 
     fn line_feed(&mut self) {
-        if self.cursor.row == self.screen.rows - 1 {
-            self.screen.scroll_up();
-        } else {
+        self.wrap_pending = false;
+        self.index();
+    }
+
+    fn index(&mut self) {
+        self.wrap_pending = false;
+        if self.cursor.row == self.scroll_region.bottom {
+            self.screen.scroll_up(self.scroll_region, 1);
+        } else if self.cursor.row < self.screen.rows - 1 {
             self.cursor.row += 1;
+        }
+    }
+
+    fn next_line(&mut self) {
+        self.cursor.column = 0;
+        self.index();
+    }
+
+    fn reverse_index(&mut self) {
+        self.wrap_pending = false;
+        if self.cursor.row == self.scroll_region.top {
+            self.screen.scroll_down(self.scroll_region, 1);
+        } else if self.cursor.row > 0 {
+            self.cursor.row -= 1;
+        }
+    }
+
+    fn scroll_up(&mut self, count: u16) {
+        self.wrap_pending = false;
+        self.screen.scroll_up(self.scroll_region, count);
+    }
+
+    fn scroll_down(&mut self, count: u16) {
+        self.wrap_pending = false;
+        self.screen.scroll_down(self.scroll_region, count);
+    }
+
+    fn reset_scroll_region(&mut self) {
+        self.scroll_region = ScrollRegion::full_screen(self.screen.rows);
+        self.cursor = Cursor::default();
+        self.wrap_pending = false;
+    }
+
+    fn apply_scroll_region(&mut self, top: u16, bottom: Option<u16>) {
+        if top == 0 && bottom.is_none() {
+            self.reset_scroll_region();
+        } else {
+            let bottom = bottom.unwrap_or(self.screen.rows - 1);
+            let _ = self.set_scroll_region(top, bottom);
         }
     }
 }
@@ -321,6 +485,8 @@ impl fmt::Debug for TerminalState {
         f.debug_struct("TerminalState")
             .field("size", &self.size())
             .field("cursor", &self.cursor)
+            .field("scroll_region", &self.scroll_region)
+            .field("wrap_pending", &self.wrap_pending)
             .finish_non_exhaustive()
     }
 }
@@ -330,6 +496,8 @@ impl fmt::Debug for TerminalState {
 pub struct TerminalSnapshot {
     screen: ScreenBuffer,
     cursor: Cursor,
+    scroll_region: ScrollRegion,
+    wrap_pending: bool,
     lines: Vec<String>,
 }
 
@@ -338,6 +506,8 @@ impl TerminalSnapshot {
         Self {
             screen: state.screen.clone(),
             cursor: state.cursor,
+            scroll_region: state.scroll_region,
+            wrap_pending: state.wrap_pending,
             lines: visible_lines(&state.screen),
         }
     }
@@ -358,6 +528,18 @@ impl TerminalSnapshot {
     #[must_use]
     pub const fn cursor(&self) -> Cursor {
         self.cursor
+    }
+
+    /// Active scrolling margins captured with the screen.
+    #[must_use]
+    pub const fn scroll_region(&self) -> ScrollRegion {
+        self.scroll_region
+    }
+
+    /// Whether a printable byte would wrap before being written.
+    #[must_use]
+    pub const fn is_wrap_pending(&self) -> bool {
+        self.wrap_pending
     }
 
     /// Captured visible screen.
@@ -427,5 +609,31 @@ mod tests {
         assert_eq!(state.screen().cell(0, 1).map(Cell::text), Some("X"));
         assert_eq!(state.screen().cell(2, 3).map(Cell::text), Some("Y"));
         assert_eq!(state.cursor(), Cursor { row: 2, column: 4 });
+    }
+
+    #[test]
+    fn index_and_reverse_index_scroll_only_inside_the_active_region() {
+        let mut state = TerminalState::new(5, 2).expect("valid terminal");
+        state.feed_bytes(b"A\x1b[2;1HB\x1b[3;1HC\x1b[4;1HD\x1b[5;1HE");
+        state.feed_bytes(b"\x1b[2;4r\x1b[4;1H\x1bD");
+
+        assert_eq!(state.snapshot().lines(), ["A", "C", "D", "", "E"]);
+        assert_eq!(state.cursor(), Cursor { row: 3, column: 0 });
+
+        state.feed_bytes(b"\x1b[2;1H\x1bM");
+        assert_eq!(state.snapshot().lines(), ["A", "", "C", "D", "E"]);
+        assert_eq!(state.cursor(), Cursor { row: 1, column: 0 });
+    }
+
+    #[test]
+    fn carriage_return_cancels_delayed_wrap_without_scrolling() {
+        let mut state = TerminalState::new(2, 3).expect("valid terminal");
+        state.feed_bytes(b"abc");
+        assert!(state.is_wrap_pending());
+
+        state.feed_bytes(b"\rZ");
+        assert_eq!(state.snapshot().lines(), ["Zbc"]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 1 });
+        assert!(!state.is_wrap_pending());
     }
 }

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -575,6 +575,7 @@ impl TerminalState {
                 self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
                 self.active.wrap_pending = false;
             }
+            Action::Tab => self.tab(),
             Action::Index => self.index(),
             Action::NextLine => self.next_line(),
             Action::ReverseIndex => self.reverse_index(),
@@ -633,6 +634,14 @@ impl TerminalState {
     fn line_feed(&mut self) {
         self.active.wrap_pending = false;
         self.index();
+    }
+
+    fn tab(&mut self) {
+        self.active.wrap_pending = false;
+        let last_column = self.active.screen.cols - 1;
+        let next_stop = (usize::from(self.active.cursor.column) / 8 + 1) * 8;
+        self.active.cursor.column =
+            last_column.min(u16::try_from(next_stop).unwrap_or(last_column));
     }
 
     fn index(&mut self) {

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,4 +1,7 @@
-use crate::parser::{Action, EraseMode, Parser, PrivateMode};
+use crate::{
+    attributes::{AnsiColor, CellAttributes, Color},
+    parser::{Action, EraseMode, Parser, PrivateMode},
+};
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
@@ -13,6 +16,7 @@ pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
 pub struct Cell {
     text: String,
     width: u8,
+    attributes: CellAttributes,
 }
 
 impl Cell {
@@ -22,6 +26,7 @@ impl Cell {
         Self {
             text: text.into(),
             width,
+            attributes: CellAttributes::default(),
         }
     }
 
@@ -43,14 +48,24 @@ impl Cell {
         self.width
     }
 
+    /// Renderer-independent visual attributes captured when this cell was written.
+    #[must_use]
+    pub const fn attributes(&self) -> &CellAttributes {
+        &self.attributes
+    }
+
     /// Whether this is the baseline blank cell.
     #[must_use]
     pub fn is_blank(&self) -> bool {
         self.text == " "
     }
 
-    fn from_ascii(byte: u8) -> Self {
-        Self::new(char::from(byte).to_string(), 1)
+    fn from_ascii(byte: u8, attributes: CellAttributes) -> Self {
+        Self {
+            text: char::from(byte).to_string(),
+            width: 1,
+            attributes,
+        }
     }
 }
 
@@ -383,6 +398,9 @@ pub struct TerminalState {
     active: ScreenState,
     primary_screen: Option<ScreenState>,
     modes: TerminalModes,
+    // SGR is terminal-global in this bounded slice; cells retain the value
+    // captured when written, independently of screen-buffer selection.
+    pen: CellAttributes,
     parser: Parser,
 }
 
@@ -393,6 +411,7 @@ impl TerminalState {
             active: ScreenState::new(rows, cols)?,
             primary_screen: None,
             modes: TerminalModes::default(),
+            pen: CellAttributes::default(),
             parser: Parser::default(),
         })
     }
@@ -454,6 +473,12 @@ impl TerminalState {
     #[must_use]
     pub const fn modes(&self) -> TerminalModes {
         self.modes
+    }
+
+    /// Current renderer-independent attributes captured by newly printed cells.
+    #[must_use]
+    pub const fn attributes(&self) -> &CellAttributes {
+        &self.pen
     }
 
     /// Save the active screen's cursor position.
@@ -562,6 +587,9 @@ impl TerminalState {
             Action::DeleteCharacters(count) => self.delete_characters(count),
             Action::InsertLines(count) => self.insert_lines(count),
             Action::DeleteLines(count) => self.delete_lines(count),
+            Action::SelectGraphicRendition { params, len } => {
+                self.select_graphic_rendition(&params[..len]);
+            }
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
@@ -576,7 +604,7 @@ impl TerminalState {
         self.active.screen.put(
             self.active.cursor.row,
             self.active.cursor.column,
-            Cell::from_ascii(byte),
+            Cell::from_ascii(byte, self.pen),
         );
         if self.active.cursor.column == self.active.screen.cols - 1 {
             self.active.wrap_pending = true;
@@ -690,6 +718,54 @@ impl TerminalState {
         }
     }
 
+    fn select_graphic_rendition(&mut self, params: &[u16]) {
+        let mut index = 0;
+        while index < params.len() {
+            let param = params[index];
+            match param {
+                0 => self.pen = CellAttributes::default(),
+                1 => self.pen = self.pen.with_bold(true),
+                22 => self.pen = self.pen.with_bold(false),
+                4 => self.pen = self.pen.with_underline(true),
+                24 => self.pen = self.pen.with_underline(false),
+                7 => self.pen = self.pen.with_reverse(true),
+                27 => self.pen = self.pen.with_reverse(false),
+                30..=37 => {
+                    self.pen = self
+                        .pen
+                        .with_foreground(Color::Ansi(AnsiColor::ALL[usize::from(param - 30)]));
+                }
+                39 => self.pen = self.pen.with_foreground(Color::Default),
+                40..=47 => {
+                    self.pen = self
+                        .pen
+                        .with_background(Color::Ansi(AnsiColor::ALL[usize::from(param - 40)]));
+                }
+                49 => self.pen = self.pen.with_background(Color::Default),
+                90..=97 => {
+                    self.pen = self
+                        .pen
+                        .with_foreground(Color::Ansi(AnsiColor::ALL[usize::from(param - 90 + 8)]));
+                }
+                100..=107 => {
+                    self.pen = self
+                        .pen
+                        .with_background(Color::Ansi(AnsiColor::ALL[usize::from(param - 100 + 8)]));
+                }
+                // Indexed, direct, and underline colors are deferred. Consume
+                // their semicolon-form arguments as one unsupported group so
+                // channel values such as 1, 4, or 7 are never reinterpreted as
+                // independent bold/underline/reverse controls.
+                38 | 48 | 58 => {
+                    index += extended_color_parameter_count(&params[index..]);
+                    continue;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+    }
+
     fn reset_scroll_region(&mut self) {
         self.active.scroll_region = ScrollRegion::full_screen(self.active.screen.rows);
         self.active.cursor = Cursor::default();
@@ -733,6 +809,14 @@ impl TerminalState {
             self.active.restore_cursor();
         }
         self.modes.alternate_screen = false;
+    }
+}
+
+fn extended_color_parameter_count(params: &[u16]) -> usize {
+    match params.get(1) {
+        Some(5) => params.len().min(3),
+        Some(2) => params.len().min(5),
+        _ => 1,
     }
 }
 

--- a/crates/noren-terminal/tests/alternate_screen.rs
+++ b/crates/noren-terminal/tests/alternate_screen.rs
@@ -1,0 +1,138 @@
+use noren_terminal::{Cell, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+#[test]
+fn entering_1049_selects_a_blank_home_positioned_alternate_buffer() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDEFGHIJ\x1b[3;4HZ");
+
+    state.feed_bytes(b"\x1b[?1049h");
+
+    assert_eq!(state.size(), (3, 5));
+    assert_eq!(cursor(&state), (0, 0));
+    assert!(state.screen().cells().iter().all(Cell::is_blank));
+    assert!(state.snapshot().lines().is_empty());
+    assert!(!state.is_wrap_pending());
+    assert_eq!(
+        (state.scroll_region().top(), state.scroll_region().bottom()),
+        (0, 2)
+    );
+}
+
+#[test]
+fn alternate_mode_is_visible_on_state_and_captured_snapshots() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    let primary = state.snapshot();
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert!(!primary.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049h");
+    let alternate = state.snapshot();
+
+    assert!(state.modes().is_alternate_screen_active());
+    assert!(alternate.modes().is_alternate_screen_active());
+    assert!(!primary.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert!(!state.snapshot().modes().is_alternate_screen_active());
+    assert!(alternate.modes().is_alternate_screen_active());
+}
+
+#[test]
+fn leaving_1049_restores_the_isolated_primary_buffer_and_entry_cursor() {
+    let mut state = TerminalState::new(4, 8).expect("valid terminal");
+    state.feed_bytes(b"PRIMARY\x1b[3;4H");
+    let primary = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[4;8HZ");
+    assert_eq!(state.snapshot().lines(), ["ALT", "", "", "       Z"]);
+    assert_ne!(state.snapshot(), primary);
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert_eq!(state.snapshot(), primary);
+    assert_eq!(cursor(&state), (2, 3));
+}
+
+#[test]
+fn esc_and_csi_save_restore_sequences_restore_the_public_cursor() {
+    let sequences: &[(&[u8], &[u8])] = &[
+        (b"\x1b7".as_slice(), b"\x1b8".as_slice()),
+        (b"\x1b[s".as_slice(), b"\x1b[u".as_slice()),
+    ];
+
+    for (save, restore) in sequences {
+        let mut state = TerminalState::new(4, 6).expect("valid terminal");
+        state.feed_bytes(b"\x1b[2;3H");
+        state.feed_bytes(save);
+        state.feed_bytes(b"\x1b[4;6H");
+        assert_eq!(cursor(&state), (3, 5), "move after save {save:?}");
+
+        state.feed_bytes(restore);
+        assert_eq!(cursor(&state), (1, 2), "restore sequence {restore:?}");
+    }
+}
+
+#[test]
+fn repeated_1049_set_and_reset_are_idempotent() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes(b"PRIMARY\x1b[2;2H");
+    let primary = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[3;5H");
+    let alternate = state.snapshot();
+    state.feed_bytes(b"\x1b[?1049h");
+    assert_eq!(state.snapshot(), alternate);
+
+    state.feed_bytes(b"\x1b[?1049l");
+    assert_eq!(state.snapshot(), primary);
+    state.feed_bytes(b"\x1b[?1049l");
+    assert_eq!(state.snapshot(), primary);
+}
+
+#[test]
+fn resize_while_alternate_is_active_updates_visible_and_saved_buffers() {
+    let mut state = TerminalState::new(4, 5).expect("valid terminal");
+    state.feed_bytes(b"AB\x1b[2;1HCD\x1b[3;1HEF\x1b[4;1HGH\x1b[4;5H");
+    state.feed_bytes(b"\x1b[?1049hALT\x1b[3;3HZ\x1b[4;5H");
+
+    state.resize(3, 4).expect("valid resize");
+
+    let alternate = state.snapshot();
+    assert_eq!(state.size(), (3, 4));
+    assert_eq!((alternate.rows(), alternate.cols()), (3, 4));
+    assert_eq!(alternate.lines(), ["ALT", "", "  Z"]);
+    assert_eq!(cursor(&state), (2, 3));
+    assert!(state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1049l");
+
+    let primary = state.snapshot();
+    assert_eq!(state.size(), (3, 4));
+    assert_eq!((primary.rows(), primary.cols()), (3, 4));
+    assert_eq!(primary.lines(), ["AB", "CD", "EF"]);
+    assert_eq!(cursor(&state), (2, 3));
+    assert!(!state.modes().is_alternate_screen_active());
+}
+
+#[test]
+fn unsupported_private_modes_leave_public_state_unchanged() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes(b"base\x1b[2;3H");
+    let before = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?47h\x1b[?1047h\x1b[?2004h\x1b[?47l\x1b[?1047l\x1b[?2004l");
+
+    assert_eq!(state.snapshot(), before);
+    assert!(!state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"X");
+    assert_eq!(state.snapshot().lines(), ["base", "  X"]);
+    assert_eq!(cursor(&state), (1, 3));
+}

--- a/crates/noren-terminal/tests/application_modes.rs
+++ b/crates/noren-terminal/tests/application_modes.rs
@@ -1,0 +1,92 @@
+//! Focused state regressions for DECCKM and DECKPAM/DECKPNM.
+
+use noren_terminal::TerminalState;
+
+fn assert_modes(state: &TerminalState, cursor_keys: bool, keypad: bool) {
+    let modes = state.modes();
+    assert_eq!(modes.is_application_cursor_key_mode(), cursor_keys);
+    assert_eq!(modes.is_application_keypad_mode(), keypad);
+}
+
+#[test]
+fn decckm_set_reset_is_incremental_and_idempotent() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    assert_modes(&state, false, false);
+
+    state.feed_bytes(b"\x1b[?1");
+    assert_modes(&state, false, false);
+    state.feed_bytes(b"h\x1b[?1h");
+    assert_modes(&state, true, false);
+
+    state.feed_bytes(b"\x1b[?1l\x1b[?1l");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn deckpam_and_deckpnm_set_reset_keypad_mode() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b");
+    assert_modes(&state, false, false);
+    state.feed_bytes(b"=\x1b=");
+    assert_modes(&state, false, true);
+
+    state.feed_bytes(b"\x1b>\x1b>");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn cursor_and_keypad_modes_are_independent() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1h");
+    assert_modes(&state, true, false);
+    state.feed_bytes(b"\x1b=");
+    assert_modes(&state, true, true);
+    state.feed_bytes(b"\x1b[?1l");
+    assert_modes(&state, false, true);
+    state.feed_bytes(b"\x1b>");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn snapshots_capture_modes_without_following_later_changes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?1h\x1b=");
+    let snapshot = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1l\x1b>");
+
+    assert!(snapshot.modes().is_application_cursor_key_mode());
+    assert!(snapshot.modes().is_application_keypad_mode());
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn application_modes_survive_resize_and_alternate_screen_switching() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"P\x1b[?1h\x1b=\x1b[?1049hA");
+
+    assert!(state.modes().is_alternate_screen_active());
+    assert_modes(&state, true, true);
+    assert_eq!(state.snapshot().lines(), ["A"]);
+
+    state.resize(3, 5).expect("valid resize");
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert_modes(&state, true, true);
+    assert_eq!(state.snapshot().lines(), ["P"]);
+}
+
+#[test]
+fn unsupported_private_mode_lists_do_not_mutate_or_poison_modes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?999h\x1b[?1;1049h");
+    assert_modes(&state, false, false);
+    assert!(!state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1h\x1b=");
+    assert_modes(&state, true, true);
+}

--- a/crates/noren-terminal/tests/control_sequences.rs
+++ b/crates/noren-terminal/tests/control_sequences.rs
@@ -1,0 +1,146 @@
+//! Regressions for escape-intermediate consumption and horizontal tab handling.
+
+use noren_terminal::{Cell, CursorMove, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn cells(state: &TerminalState, row: u16) -> Vec<String> {
+    (0..state.screen().cols())
+        .map(|column| {
+            state
+                .screen()
+                .cell(row, column)
+                .map(Cell::text)
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect()
+}
+
+/// `ESC ( B`, `ESC ) 0`, `ESC # 8`, and `ESC SP F` must be swallowed whole:
+/// nothing prints and the cursor stays at the origin.
+#[test]
+fn escape_intermediate_sequences_print_nothing_and_keep_cursor_home() {
+    for sequence in [b"\x1b(B".as_slice(), b"\x1b)0", b"\x1b#8", b"\x1b F"] {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        state.feed_bytes(sequence);
+
+        assert!(state.snapshot().lines().is_empty(), "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, 0), "sequence {sequence:?}");
+    }
+}
+
+/// The same sequences split across `feed_bytes` chunk boundaries must still
+/// print nothing.
+#[test]
+fn escape_intermediate_sequences_consume_whole_across_chunk_boundaries() {
+    for sequence in [b"\x1b(B".as_slice(), b"\x1b)0", b"\x1b#8", b"\x1b F"] {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        // One byte per call, the worst case for parser state retention.
+        for byte in sequence {
+            state.feed_bytes(&[*byte]);
+        }
+
+        assert!(state.snapshot().lines().is_empty(), "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, 0), "sequence {sequence:?}");
+
+        // Output after the sequence is unaffected.
+        state.feed_bytes(b"Z");
+        assert_eq!(state.snapshot().lines(), ["Z".to_owned()]);
+    }
+}
+
+/// A second intermediate before the final byte is also consumed.
+#[test]
+fn stacked_escape_intermediates_still_print_nothing() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b()BZ");
+
+    assert_eq!(state.snapshot().lines(), ["Z".to_owned()]);
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// An unsupported single-byte escape final (e.g. `ESC c`, RIS) still consumes
+/// exactly its bytes and returns to Ground, matching the pre-fix behavior.
+#[test]
+fn unsupported_single_byte_escape_final_behaves_as_before() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1bcX");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// A new `ESC` aborts an in-progress intermediate escape, same as it does for
+/// CSI.
+#[test]
+fn escape_aborts_an_in_progress_intermediate_sequence() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b(\x1b[DX");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// `a\tb` lands `b` at the next 8-column tab stop.
+#[test]
+fn horizontal_tab_advances_to_the_next_eighth_column() {
+    let mut state = TerminalState::new(1, 12).expect("valid terminal");
+    state.feed_bytes(b"a\tb");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("a"));
+    assert_eq!(state.screen().cell(0, 8).map(Cell::text), Some("b"));
+    assert_eq!(cursor(&state), (0, 9));
+}
+
+/// A tab stops at the last column without wrapping, scrolling, or panicking
+/// when the next stop would be past the right edge.
+#[test]
+fn tab_near_the_right_edge_clamps_to_the_last_column() {
+    let mut state = TerminalState::new(2, 10).expect("valid terminal");
+    // Fill columns 0..=6; cursor sits at column 7. The next stop (8) is in
+    // range, so the following print lands at column 8.
+    state.feed_bytes(b"1234567\tX");
+
+    assert_eq!(state.screen().cell(0, 8).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 9));
+    assert_eq!(
+        cells(&state, 1),
+        [" ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+    );
+}
+
+/// A tab issued while the cursor is on the very last column must not panic,
+/// wrap, or scroll.
+#[test]
+fn tab_on_the_last_column_does_not_wrap_or_panic() {
+    let mut state = TerminalState::new(2, 10).expect("valid terminal");
+    state.feed_bytes(b"1234567890");
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"\t");
+
+    assert_eq!(cursor(&state), (0, 9));
+    assert!(!state.is_wrap_pending());
+    // Row 1 is untouched: the tab neither wrapped nor scrolled.
+    assert_eq!(
+        cells(&state, 1),
+        [" ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+    );
+}
+
+/// Tab handling is bounded for the widest grid the cell budget allows: no
+/// overflow in the next-stop computation.
+#[test]
+fn tab_is_bounded_on_the_widest_permitted_grid() {
+    let cols = 65535_u16;
+    let mut state = TerminalState::new(1, cols).expect("valid terminal");
+    // Cursor at the last column (cols - 1). The next-stop math must not
+    // overflow u16 for column 65534.
+    state.move_cursor(CursorMove::ToColumn(cols - 1));
+    state.feed_bytes(b"\t");
+
+    assert_eq!(cursor(&state), (0, cols - 1));
+}

--- a/crates/noren-terminal/tests/erase_operations.rs
+++ b/crates/noren-terminal/tests/erase_operations.rs
@@ -1,0 +1,156 @@
+use noren_terminal::{CursorMove, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn rows(state: &TerminalState) -> Vec<String> {
+    (0..state.screen().rows())
+        .map(|row| {
+            (0..state.screen().cols())
+                .map(|column| {
+                    state
+                        .screen()
+                        .cell(row, column)
+                        .expect("cell is in bounds")
+                        .text()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn filled_screen() -> TerminalState {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDE\x1b[2;1HFGHIJ\x1b[3;1HKLMNO");
+    state
+}
+
+fn labeled_rows() -> TerminalState {
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    state
+}
+
+fn operate_on_line(column: u16, sequence: &[u8]) -> TerminalState {
+    let mut state = TerminalState::new(1, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDE");
+    state.move_cursor(CursorMove::ToColumn(column));
+    state.feed_bytes(sequence);
+    state
+}
+
+#[test]
+fn ed_modes_include_the_cursor_cell_and_preserve_the_cursor() {
+    let cases: &[(&[u8], [&str; 3])] = &[
+        (b"\x1b[J", ["ABCDE", "FG   ", "     "]),
+        (b"\x1b[1J", ["     ", "   IJ", "KLMNO"]),
+        (b"\x1b[2J", ["     ", "     ", "     "]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = filled_screen();
+        state.feed_bytes(b"\x1b[2;3H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (1, 2), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn el_modes_only_change_the_active_row_and_preserve_the_cursor() {
+    let cases: &[(&[u8], [&str; 3])] = &[
+        (b"\x1b[0K", ["ABCDE", "FG   ", "KLMNO"]),
+        (b"\x1b[1K", ["ABCDE", "   IJ", "KLMNO"]),
+        (b"\x1b[2K", ["ABCDE", "     ", "KLMNO"]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = filled_screen();
+        state.feed_bytes(b"\x1b[2;3H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (1, 2), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn character_operations_default_zero_shift_and_clamp_at_the_line_boundary() {
+    let cases: &[(&[u8], u16, &str)] = &[
+        (b"\x1b[X", 1, "A CDE"),
+        (b"\x1b[0X", 1, "A CDE"),
+        (b"\x1b[2X", 1, "A  DE"),
+        (b"\x1b[99999X", 3, "ABC  "),
+        (b"\x1b[@", 1, "A BCD"),
+        (b"\x1b[0@", 1, "A BCD"),
+        (b"\x1b[2@", 1, "A  BC"),
+        (b"\x1b[99999@", 3, "ABC  "),
+        (b"\x1b[P", 1, "ACDE "),
+        (b"\x1b[0P", 1, "ACDE "),
+        (b"\x1b[2P", 1, "ADE  "),
+        (b"\x1b[99999P", 3, "ABC  "),
+    ];
+
+    for (sequence, column, expected) in cases {
+        let state = operate_on_line(*column, sequence);
+
+        assert_eq!(rows(&state), [*expected], "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, *column), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn line_operations_are_clamped_from_the_cursor_to_the_bottom_margin() {
+    let cases: &[(&[u8], [&str; 5])] = &[
+        (b"\x1b[L", ["AAA", "BBB", "   ", "CCC", "EEE"]),
+        (b"\x1b[0M", ["AAA", "BBB", "DDD", "   ", "EEE"]),
+        (b"\x1b[99999L", ["AAA", "BBB", "   ", "   ", "EEE"]),
+        (b"\x1b[99999M", ["AAA", "BBB", "   ", "   ", "EEE"]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r\x1b[3;2H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (2, 1), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn line_operations_are_ignored_when_the_cursor_is_outside_the_scroll_region() {
+    for (sequence, position, expected_cursor) in [
+        (b"\x1b[L".as_slice(), b"\x1b[1;2H".as_slice(), (0, 1)),
+        (b"\x1b[M".as_slice(), b"\x1b[5;2H".as_slice(), (4, 1)),
+    ] {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r");
+        state.feed_bytes(position);
+        let before = state.snapshot();
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(state.snapshot().screen(), before.screen());
+        assert_eq!(cursor(&state), expected_cursor, "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn unsupported_modes_extra_parameters_and_parameter_overflow_are_ignored() {
+    let mut state = filled_screen();
+    state.feed_bytes(b"\x1b[2;3H");
+    let before = state.snapshot();
+
+    state.feed_bytes(
+        b"\x1b[3J\x1b[1;2K\x1b[1;2X\x1b[1;2@\x1b[1;2P\x1b[1;2L\x1b[1;2M\
+          \x1b[1;1;1;1;1;1;1;1;1X",
+    );
+
+    assert_eq!(state.snapshot(), before);
+}

--- a/crates/noren-terminal/tests/scroll_regions.rs
+++ b/crates/noren-terminal/tests/scroll_regions.rs
@@ -1,0 +1,194 @@
+use noren_terminal::{CursorMove, TerminalError, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn region(state: &TerminalState) -> (u16, u16) {
+    (state.scroll_region().top(), state.scroll_region().bottom())
+}
+
+fn rows(state: &TerminalState) -> Vec<String> {
+    (0..state.screen().rows())
+        .map(|row| {
+            (0..state.screen().cols())
+                .map(|column| {
+                    state
+                        .screen()
+                        .cell(row, column)
+                        .expect("cell is in bounds")
+                        .text()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn labeled_rows() -> TerminalState {
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    state
+}
+
+#[test]
+fn decstbm_defaults_reset_invalid_ranges_and_preserves_outside_rows() {
+    let mut state = labeled_rows();
+
+    state.feed_bytes(b"\x1b[;4r");
+    assert_eq!(region(&state), (0, 3));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[2r");
+    assert_eq!(region(&state), (1, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[3;3r\x1b[5;2r\x1b[2;99r");
+    assert_eq!(region(&state), (1, 4));
+    assert_eq!(cursor(&state), (0, 0));
+    assert_eq!(rows(&state), ["AAA", "BBB", "CCC", "DDD", "EEE"]);
+
+    assert_eq!(
+        state.set_scroll_region(3, 3),
+        Err(TerminalError::InvalidScrollRegion)
+    );
+    assert_eq!(region(&state), (1, 4));
+
+    state.feed_bytes(b"\x1b[r");
+    assert_eq!(region(&state), (0, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[2;4r\x1b[4;1H\x1b[S");
+    assert_eq!(rows(&state), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+    assert_eq!(cursor(&state), (3, 0));
+}
+
+#[test]
+fn line_feed_vertical_tab_form_feed_and_index_scroll_at_bottom_margin() {
+    for control in [b"\n".as_slice(), b"\x0b", b"\x0c", b"\x1bD"] {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r\x1b[4;2H");
+        state.feed_bytes(control);
+
+        assert_eq!(rows(&state), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+        assert_eq!(cursor(&state), (3, 1));
+        assert_eq!(region(&state), (1, 3));
+    }
+}
+
+#[test]
+fn reverse_index_scrolls_at_top_margin_without_moving_cursor() {
+    let mut state = labeled_rows();
+    state.feed_bytes(b"\x1b[2;4r\x1b[2;3H\x1bM");
+
+    assert_eq!(rows(&state), ["AAA", "   ", "BBB", "CCC", "EEE"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert_eq!(region(&state), (1, 3));
+}
+
+#[test]
+fn explicit_scroll_defaults_and_bounds_counts_to_region_height() {
+    let mut up = labeled_rows();
+    up.feed_bytes(b"\x1b[2;4r\x1b[3;2H\x1b[S");
+    assert_eq!(rows(&up), ["AAA", "CCC", "DDD", "   ", "EEE"]);
+    assert_eq!(cursor(&up), (2, 1));
+
+    up.feed_bytes(b"\x1b[999S");
+    assert_eq!(rows(&up), ["AAA", "   ", "   ", "   ", "EEE"]);
+    assert_eq!(cursor(&up), (2, 1));
+
+    let mut down = labeled_rows();
+    down.feed_bytes(b"\x1b[2;4r\x1b[3;2H\x1b[T");
+    assert_eq!(rows(&down), ["AAA", "   ", "BBB", "CCC", "EEE"]);
+    assert_eq!(cursor(&down), (2, 1));
+
+    down.feed_bytes(b"\x1b[999T");
+    assert_eq!(rows(&down), ["AAA", "   ", "   ", "   ", "EEE"]);
+    assert_eq!(cursor(&down), (2, 1));
+}
+
+#[test]
+fn cnl_cpl_and_vpa_apply_defaults_reset_column_and_clamp() {
+    let mut state = TerminalState::new(4, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[2;4H\x1b[E");
+    assert_eq!(cursor(&state), (2, 0));
+
+    state.feed_bytes(b"\x1b[99E");
+    assert_eq!(cursor(&state), (3, 0));
+    state.feed_bytes(b"\x1b[4G\x1b[F");
+    assert_eq!(cursor(&state), (2, 0));
+    state.feed_bytes(b"\x1b[99F");
+    assert_eq!(cursor(&state), (0, 0));
+
+    state.feed_bytes(b"\x1b[5G\x1b[d");
+    assert_eq!(cursor(&state), (0, 4));
+    state.feed_bytes(b"\x1b[99d");
+    assert_eq!(cursor(&state), (3, 4));
+}
+
+#[test]
+fn cursor_and_control_actions_cancel_delayed_wrap() {
+    let cancellations: &[&[u8]] = &[
+        b"\x08",
+        b"\n",
+        b"\x0b",
+        b"\x0c",
+        b"\x1bD",
+        b"\x1bE",
+        b"\x1bM",
+        b"\x1b[A",
+        b"\x1b[B",
+        b"\x1b[C",
+        b"\x1b[D",
+        b"\x1b[E",
+        b"\x1b[F",
+        b"\x1b[G",
+        b"\x1b[H",
+        b"\x1b[d",
+        b"\x1b[S",
+        b"\x1b[T",
+        b"\x1b[2;3r",
+    ];
+
+    for sequence in cancellations {
+        let mut state = TerminalState::new(3, 3).expect("valid terminal");
+        state.feed_bytes(b"abc");
+        assert!(state.is_wrap_pending(), "precondition for {sequence:?}");
+
+        state.feed_bytes(sequence);
+        assert!(!state.is_wrap_pending(), "sequence {sequence:?}");
+    }
+
+    let mut via_api = TerminalState::new(2, 3).expect("valid terminal");
+    via_api.feed_bytes(b"abc");
+    via_api.move_cursor(CursorMove::ToRow(1));
+    assert!(!via_api.is_wrap_pending());
+}
+
+#[test]
+fn resize_preserves_overlap_clamps_cursor_and_resets_scroll_state() {
+    let mut state = TerminalState::new(4, 4).expect("valid terminal");
+    state.feed_bytes(b"ABCD\x1b[2;1HEF\x1b[3;1HGHI\x1b[4;1HJKLM");
+    state.feed_bytes(b"\x1b[2;4r\x1b[4;4HZ");
+    assert!(state.is_wrap_pending());
+
+    state.resize(3, 2).expect("valid resize");
+    assert_eq!(rows(&state), ["AB", "EF", "GH"]);
+    assert_eq!(cursor(&state), (2, 1));
+    assert_eq!(region(&state), (0, 2));
+    assert!(!state.is_wrap_pending());
+
+    state.resize(5, 5).expect("valid resize");
+    assert_eq!(rows(&state), ["AB   ", "EF   ", "GH   ", "     ", "     "]);
+    assert_eq!(cursor(&state), (2, 1));
+    assert_eq!(region(&state), (0, 4));
+}
+
+#[test]
+fn printable_ascii_and_ignored_controls_remain_stable() {
+    let mut state = TerminalState::new(2, 5).expect("valid terminal");
+    state.feed_bytes(b"A\0B\x07C\x7fD");
+
+    assert_eq!(rows(&state), ["ABCD ", "     "]);
+    assert_eq!(cursor(&state), (0, 4));
+    assert!(!state.is_wrap_pending());
+}

--- a/crates/noren-terminal/tests/sgr_attributes.rs
+++ b/crates/noren-terminal/tests/sgr_attributes.rs
@@ -1,4 +1,4 @@
-use noren_terminal::{AnsiColor, CellAttributes, Color};
+use noren_terminal::{AnsiColor, Cell, CellAttributes, Color, TerminalState};
 
 const STYLED: CellAttributes = CellAttributes::new()
     .with_foreground(Color::ansi(AnsiColor::BrightGreen))
@@ -52,4 +52,285 @@ fn cell_attribute_builders_are_const_and_independent() {
     assert!(!changed.is_bold());
     assert!(changed.is_underlined());
     assert!(changed.is_reversed());
+}
+
+#[test]
+fn cells_default_to_baseline_attributes_without_changing_cell_new() {
+    let cell = Cell::new("x", 1);
+
+    assert_eq!(cell.text(), "x");
+    assert_eq!(cell.width(), 1);
+    assert_eq!(cell.attributes(), &CellAttributes::default());
+    assert_eq!(Cell::blank().attributes(), &CellAttributes::default());
+}
+
+#[test]
+fn ordered_sgr_combinations_apply_supported_codes_around_unsupported_codes() {
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;31;999;44;22;4;7mX");
+
+    let attributes = state
+        .screen()
+        .cell(0, 0)
+        .expect("printed cell")
+        .attributes();
+    assert_eq!(attributes.foreground(), Color::Ansi(AnsiColor::Red));
+    assert_eq!(attributes.background(), Color::Ansi(AnsiColor::Blue));
+    assert!(!attributes.is_bold());
+    assert!(attributes.is_underlined());
+    assert!(attributes.is_reversed());
+}
+
+#[test]
+fn ordered_reset_and_selective_resets_only_change_their_attributes() {
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;4;7;93;46mA\x1b[22;24;27;39;49mB\x1b[1;0;4mC");
+
+    let first = state.screen().cell(0, 0).expect("first cell").attributes();
+    assert!(first.is_bold());
+    assert!(first.is_underlined());
+    assert!(first.is_reversed());
+    assert_eq!(first.foreground(), Color::Ansi(AnsiColor::BrightYellow));
+    assert_eq!(first.background(), Color::Ansi(AnsiColor::Cyan));
+
+    assert_eq!(
+        state.screen().cell(0, 1).expect("second cell").attributes(),
+        &CellAttributes::default()
+    );
+
+    let third = state.screen().cell(0, 2).expect("third cell").attributes();
+    assert!(!third.is_bold());
+    assert!(third.is_underlined());
+    assert!(!third.is_reversed());
+    assert_eq!(third.foreground(), Color::Default);
+    assert_eq!(third.background(), Color::Default);
+}
+
+#[test]
+fn all_sixteen_ansi_colors_are_captured_for_foreground_and_background() {
+    let mut state = TerminalState::new(1, 32).expect("valid terminal");
+    let mut input = Vec::new();
+    for index in 0_u8..16 {
+        let foreground = if index < 8 {
+            30 + index
+        } else {
+            90 + index - 8
+        };
+        let background = if index < 8 {
+            40 + index
+        } else {
+            100 + index - 8
+        };
+        input.extend_from_slice(format!("\x1b[{foreground}mF\x1b[{background}mB").as_bytes());
+    }
+    state.feed_bytes(&input);
+
+    for (index, color) in AnsiColor::ALL.into_iter().enumerate() {
+        let foreground = state
+            .screen()
+            .cell(0, u16::try_from(index * 2).expect("bounded index"))
+            .expect("foreground cell")
+            .attributes();
+        let background = state
+            .screen()
+            .cell(0, u16::try_from(index * 2 + 1).expect("bounded index"))
+            .expect("background cell")
+            .attributes();
+        assert_eq!(foreground.foreground(), Color::Ansi(color));
+        assert_eq!(background.background(), Color::Ansi(color));
+    }
+}
+
+#[test]
+fn printed_cells_capture_the_pen_without_retroactive_changes() {
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"\x1b[31mR\x1b[32mG\x1b[mD");
+
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("red cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Red)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("green cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Green)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 2)
+            .expect("default cell")
+            .attributes(),
+        &CellAttributes::default()
+    );
+    assert_eq!(state.attributes(), &CellAttributes::default());
+}
+
+#[test]
+fn snapshots_and_resize_preserve_captured_cell_attributes() {
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;95mX");
+    let snapshot = state.snapshot();
+
+    state.feed_bytes(b"\x1b[0mY");
+    state.resize(2, 3).expect("valid resize");
+
+    let captured = snapshot
+        .screen()
+        .cell(0, 0)
+        .expect("snapshot cell")
+        .attributes();
+    assert!(captured.is_bold());
+    assert_eq!(captured.foreground(), Color::Ansi(AnsiColor::BrightMagenta));
+    assert_eq!(snapshot.lines(), ["X".to_owned()]);
+
+    let resized = state
+        .screen()
+        .cell(0, 0)
+        .expect("resized cell")
+        .attributes();
+    assert_eq!(resized, captured);
+    assert_eq!(
+        state.screen().cell(1, 2).expect("new blank").attributes(),
+        &CellAttributes::default()
+    );
+}
+
+#[test]
+fn alternate_screen_cells_are_isolated_while_the_pen_is_preserved() {
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"\x1b[31mP\x1b[?1049h\x1b[32mA");
+
+    assert_eq!(state.snapshot().lines(), ["A".to_owned()]);
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("alternate cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Green)
+    );
+
+    state.feed_bytes(b"\x1b[?1049lG");
+    assert_eq!(state.snapshot().lines(), ["PG".to_owned()]);
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("primary cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Red)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("post-switch cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Green)
+    );
+}
+
+#[test]
+fn unsupported_codes_are_ignored_and_parameter_overflow_drops_the_sgr() {
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"\x1b[31;1234;1mA");
+    state.feed_bytes(b"\x1b[0m\x1b[31;1;4;7;40;90;100;22;24mB");
+    state.feed_bytes(b"\x1b[32mC");
+
+    let first = state.screen().cell(0, 0).expect("first cell").attributes();
+    assert_eq!(first.foreground(), Color::Ansi(AnsiColor::Red));
+    assert!(first.is_bold());
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("overflow cell")
+            .attributes(),
+        &CellAttributes::default()
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 2)
+            .expect("recovered cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Green)
+    );
+}
+
+#[test]
+fn deferred_extended_colors_do_not_leak_channel_values_into_style_flags() {
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"\x1b[38;5;1mI\x1b[48;2;1;4;7mR\x1b[1;38;5;123;4mS");
+
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("indexed cell")
+            .attributes(),
+        &CellAttributes::default()
+    );
+    assert_eq!(
+        state.screen().cell(0, 1).expect("direct cell").attributes(),
+        &CellAttributes::default()
+    );
+
+    let surrounded = state
+        .screen()
+        .cell(0, 2)
+        .expect("surrounded extended color")
+        .attributes();
+    assert!(surrounded.is_bold());
+    assert!(surrounded.is_underlined());
+    assert_eq!(surrounded.foreground(), Color::Default);
+    assert_eq!(surrounded.background(), Color::Default);
+}
+
+#[test]
+fn erase_and_inserted_blank_cells_use_default_attributes() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[31mAB\x1b[1G\x1b[@");
+
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("inserted blank")
+            .attributes(),
+        &CellAttributes::default()
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("shifted cell")
+            .attributes()
+            .foreground(),
+        Color::Ansi(AnsiColor::Red)
+    );
+
+    state.feed_bytes(b"\x1b[2K");
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| cell.attributes() == &CellAttributes::default())
+    );
+    assert_eq!(state.attributes().foreground(), Color::Ansi(AnsiColor::Red));
 }

--- a/crates/noren-terminal/tests/sgr_attributes.rs
+++ b/crates/noren-terminal/tests/sgr_attributes.rs
@@ -1,0 +1,55 @@
+use noren_terminal::{AnsiColor, CellAttributes, Color};
+
+const STYLED: CellAttributes = CellAttributes::new()
+    .with_foreground(Color::ansi(AnsiColor::BrightGreen))
+    .with_background(Color::ansi(AnsiColor::Blue))
+    .with_bold(true)
+    .with_underline(true)
+    .with_reverse(true);
+
+#[test]
+fn ansi_colors_have_stable_palette_indexes() {
+    for (index, color) in AnsiColor::ALL.into_iter().enumerate() {
+        assert_eq!(usize::from(color.palette_index()), index);
+    }
+}
+
+#[test]
+fn color_default_is_contextual_and_ansi_colors_round_trip() {
+    assert_eq!(Color::default(), Color::Default);
+    assert!(Color::Default.is_default());
+    assert_eq!(Color::Default.ansi_color(), None);
+
+    let red = Color::ansi(AnsiColor::Red);
+    assert!(!red.is_default());
+    assert_eq!(red.ansi_color(), Some(AnsiColor::Red));
+}
+
+#[test]
+fn cell_attributes_have_a_stable_baseline_default() {
+    let attributes = CellAttributes::default();
+
+    assert_eq!(attributes, CellAttributes::DEFAULT);
+    assert_eq!(attributes, CellAttributes::new());
+    assert_eq!(attributes.foreground(), Color::Default);
+    assert_eq!(attributes.background(), Color::Default);
+    assert!(!attributes.is_bold());
+    assert!(!attributes.is_underlined());
+    assert!(!attributes.is_reversed());
+}
+
+#[test]
+fn cell_attribute_builders_are_const_and_independent() {
+    assert_eq!(STYLED.foreground(), Color::Ansi(AnsiColor::BrightGreen));
+    assert_eq!(STYLED.background(), Color::Ansi(AnsiColor::Blue));
+    assert!(STYLED.is_bold());
+    assert!(STYLED.is_underlined());
+    assert!(STYLED.is_reversed());
+
+    let changed = STYLED.with_bold(false).with_background(Color::Default);
+    assert_eq!(changed.foreground(), STYLED.foreground());
+    assert_eq!(changed.background(), Color::Default);
+    assert!(!changed.is_bold());
+    assert!(changed.is_underlined());
+    assert!(changed.is_reversed());
+}

--- a/crates/noren-terminal/tests/terminal_state.rs
+++ b/crates/noren-terminal/tests/terminal_state.rs
@@ -75,16 +75,22 @@ fn cursor_commands_apply_defaults_absolute_positions_and_clamping() {
 }
 
 #[test]
-fn wrapping_at_the_bottom_scrolls_one_row_and_blanks_the_last() {
+fn delayed_wrap_scrolls_only_when_the_next_character_arrives() {
     let mut state = TerminalState::new(2, 3).expect("valid terminal");
     state.feed_bytes(b"abc");
     assert_eq!(state.snapshot().lines(), ["abc"]);
-    assert_eq!(cursor(&state), (1, 0));
+    assert_eq!(cursor(&state), (0, 2));
+    assert!(state.is_wrap_pending());
 
     state.feed_bytes(b"def");
-    assert_eq!(state.snapshot().lines(), ["def"]);
-    assert_eq!(cursor(&state), (1, 0));
-    assert!(state.screen().cell(1, 0).is_some_and(Cell::is_blank));
+    assert_eq!(state.snapshot().lines(), ["abc", "def"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"g");
+    assert_eq!(state.snapshot().lines(), ["def", "g"]);
+    assert_eq!(cursor(&state), (1, 1));
+    assert!(!state.is_wrap_pending());
 }
 
 #[test]

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -2,7 +2,10 @@
 
 - Status: PR [#19](https://github.com/ta-061/noren/pull/19) merged as
   `c695920`; the scroll-region slice is in progress as Draft PR
-  [#21](https://github.com/ta-061/noren/pull/21)
+  [#21](https://github.com/ta-061/noren/pull/21); the alternate-screen slice
+  (core commit `84da736`) is stacked on top as Draft PR
+  [#23](https://github.com/ta-061/noren/pull/23) for Issue
+  [#22](https://github.com/ta-061/noren/issues/22)
 - Supersedes nothing: the accepted [local-PTY PoC
   architecture](minimal-local-pty-poc.md) still applies
 
@@ -17,10 +20,11 @@ PTY bytes -> TerminalState::feed_bytes -> parser -> bounded screen/cursor state
 TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
 ```
 
-- `TerminalState` owns the screen, cursor, dimensions, and parser state.
-- The visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
+- `TerminalState` owns the active screen, the parked primary screen while the
+  alternate screen is active, and the parser state.
+- Each visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
   `MAX_SCREEN_CELLS` (1,048,576 cells).
-- `resize` rebuilds the grid, preserves the overlapping top-left region, and
+- `resize` rebuilds the grids, preserves each overlapping top-left region, and
   resets scroll margins and pending autowrap.
 - The renderer consumes the immutable `TerminalSnapshot` and never depends on
   PTY or parser types.
@@ -45,8 +49,37 @@ Added by Draft PR #21 (scrolling regions):
 - Delayed autowrap: wrapping is deferred until the next printable byte.
 - Resize resets margins and pending autowrap.
 
+Added by Draft PR #23 / Issue #22 (alternate screen, stacked on #21):
+
+- `TerminalState` owns an active screen plus a parked primary screen; only
+  the active screen receives bytes and appears in snapshots.
+- CSI `?1049h` saves the primary cursor, parks the primary screen, and
+  enters a blank alternate screen with the cursor homed, full-screen
+  margins, and no pending wrap. CSI `?1049l` restores the primary screen
+  contents and the cursor saved at entry. Both switches are idempotent:
+  entering while already alternate, or leaving while already primary, is a
+  no-op. Only `1049` is recognized; other parameter lists or `>` markers
+  are ignored.
+- ESC 7/8 and parameterless CSI `s`/`u` save and restore the cursor on the
+  active screen only. Each screen keeps its own saved cursor (position
+  only), and restoring with no saved cursor leaves the cursor unmoved and
+  clears pending autowrap.
+- `TerminalModes` (DEC private mode 1049) is captured in
+  `TerminalSnapshot::modes` so renderers can tell which screen is visible.
+- `resize` rebuilds both the active and parked buffers, preserving each
+  one's overlapping top-left region, clamps cursors and saved cursors, and
+  resets margins and pending autowrap; the `MAX_SCREEN_CELLS` bound is
+  checked before either buffer is rebuilt.
+- The renderer boundary is unchanged: renderers still consume only the
+  immutable `TerminalSnapshot` and never PTY or parser types.
+
+This slice makes `?1049` round-trips reliable; it is not full xterm, vim,
+tmux, or zellij compatibility.
+
 ## Deferred
 
-Alternate screen, SGR/erase/insert/delete, cell attributes, tabs, origin
-mode, and query/reply sequences remain deferred. Unicode and IME remain
-later.
+SGR/erase/insert/delete, cell attributes, tabs, origin mode, and
+query/reply sequences remain deferred, along with other DEC private modes
+(such as 1047/1048, 25, and 2004), application cursor/keypad modes, OSC
+titles, alternate-screen scrollback, and saved-cursor state beyond
+position. Unicode and IME remain later.

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -1,13 +1,14 @@
 # Terminal core foundation
 
-- Status: Draft, in progress on PR [#19](https://github.com/ta-061/noren/pull/19)
-  (branch `agent/terminal-core-foundation`); not merged
+- Status: PR [#19](https://github.com/ta-061/noren/pull/19) merged as
+  `c695920`; the scroll-region slice is in progress as Draft PR
+  [#21](https://github.com/ta-061/noren/pull/21)
 - Supersedes nothing: the accepted [local-PTY PoC
   architecture](minimal-local-pty-poc.md) still applies
 
 This foundation moves PTY output bytes through a renderer-independent terminal
 state core in `crates/noren-terminal/`. It is a foundation slice, not a
-VT100/xterm compatibility claim.
+VT100/xterm compatibility claim and not vim/tmux/zellij compatibility.
 
 ## Data flow
 
@@ -19,11 +20,14 @@ TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
 - `TerminalState` owns the screen, cursor, dimensions, and parser state.
 - The visible grid is a fixed-size `ScreenBuffer` of `Cell` values, bounded by
   `MAX_SCREEN_CELLS` (1,048,576 cells).
-- `resize` rebuilds the grid and preserves the overlapping top-left region.
+- `resize` rebuilds the grid, preserves the overlapping top-left region, and
+  resets scroll margins and pending autowrap.
 - The renderer consumes the immutable `TerminalSnapshot` and never depends on
   PTY or parser types.
 
 ## Supported behavior
+
+Merged in PR #19:
 
 - Printable ASCII bytes (`0x20..=0x7e`), line feed, carriage return, and
   backspace.
@@ -31,7 +35,18 @@ TerminalState::snapshot -> TerminalSnapshot -> renderer (lines only)
   absolute position, and absolute column.
 - Unsupported and OSC bytes are ignored without corrupting state.
 
-## Deferred order
+Added by Draft PR #21 (scrolling regions):
 
-Scroll regions, alternate screen, SGR/erase plus cell attributes, and mode
-state, in that order. Unicode and IME remain later.
+- Scroll margins default to the full screen and are inclusive on both ends;
+  DECSTBM sets them and rejects invalid ranges.
+- LF/VT/FF/IND/NEL/RI and CSI S/T scrolling act only within the active region;
+  rows outside the margins are preserved.
+- CNL, CPL, and VPA.
+- Delayed autowrap: wrapping is deferred until the next printable byte.
+- Resize resets margins and pending autowrap.
+
+## Deferred
+
+Alternate screen, SGR/erase/insert/delete, cell attributes, tabs, origin
+mode, and query/reply sequences remain deferred. Unicode and IME remain
+later.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,32 +1,34 @@
 # Coordination status
 
 Last updated: 2026-08-03 (Asia/Tokyo). PR
-[#17](https://github.com/ta-061/noren/pull/17) is merged into `main` as
-`b2bb87c20365dec5d1ab6b0122b2a987ec768744`. The only open PR is Draft
-[#19](https://github.com/ta-061/noren/pull/19), branch
-`agent/terminal-core-foundation`. The sections below preserve the PR #17
-record at implementation/test head
+[#19](https://github.com/ta-061/noren/pull/19) is merged into `main` as
+`c695920d8bc99990447d0b451754ea96c91181fc`. The only open PR is Draft
+[#21](https://github.com/ta-061/noren/pull/21), branch
+`agent/terminal-scroll-regions`, for Issue
+[#20](https://github.com/ta-061/noren/issues/20). Historical sections below
+preserve the PR #17 record at implementation/test head
 `c1f66dc27ddce37a60665d319a7ca061c300947e`, corrected only where an active
 claim went stale; coordination head `ac410a82` also passed both GitHub checks.
 
 ## Current phase
 
-Terminal foundation. The first macOS local-zsh PTY PoC (PR #17) is merged.
-Draft PR #19, not merged, replaces the `avt` dependency with a
-renderer-independent Noren `TerminalState`: bounded screen cells, cursor,
-resize, printable ASCII/LF/CR/backspace, and minimal CSI cursor movement. The
-renderer consumes `TerminalSnapshot`; see
+Terminal foundation, scrolling-region slice. PR #19 merged the Noren-owned,
+renderer-independent `TerminalState`. Draft PR #21 adds DECSTBM margins,
+region-scoped LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed
+autowrap, and resize-reset behavior. See
 [terminal core foundation](../architecture/terminal-core-foundation.md). This
-is not VT100/xterm compatibility. Deferred order: scroll regions, alternate
-screen, SGR/erase plus cell attributes, mode state; Unicode/IME remain later.
+is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
 ## GitHub state
 
 Verified on 2026-08-03:
 
-- The only open Issue is [#18](https://github.com/ta-061/noren/issues/18), the
-  Terminal Core foundation. The only open PR is its Draft
-  [#19](https://github.com/ta-061/noren/pull/19).
+- The only open Issue is [#20](https://github.com/ta-061/noren/issues/20), the
+  scrolling-region behavior slice. The only open PR is its Draft
+  [#21](https://github.com/ta-061/noren/pull/21).
+- PR [#19](https://github.com/ta-061/noren/pull/19) and Issue
+  [#18](https://github.com/ta-061/noren/issues/18) are complete after owner
+  acceptance of the renderer-independent Terminal Core foundation.
 - PR [#17](https://github.com/ta-061/noren/pull/17) and its Issue
   [#16](https://github.com/ta-061/noren/issues/16) are complete after the owner
   accepted the macOS local-PTY PoC.
@@ -35,11 +37,11 @@ Verified on 2026-08-03:
   [#14](https://github.com/ta-061/noren/pull/14) merged the bounded Discovery
   integration and PR [#15](https://github.com/ta-061/noren/pull/15) merged the
   lean Design Council.
-- `main` is at `b2bb87c20365dec5d1ab6b0122b2a987ec768744`, the merge commit
-  for PR #17. No Discovery PR remains open and no repeated large research or
+- `main` is at `c695920d8bc99990447d0b451754ea96c91181fc`, the merge commit
+  for PR #19. No Discovery PR remains open and no repeated large research or
   review is planned.
 
-## Terminal Core handoff
+## Merged PR #19 Terminal Core handoff
 
 | Lane | Saved evidence | State |
 | --- | --- | --- |
@@ -48,6 +50,17 @@ Verified on 2026-08-03:
 | GLM boundaries | PR #19 review: module, error, and crate boundaries pass without changes | Complete |
 | Claude Code architecture | PR #19 review: ACCEPT, no VT-evolution blocker | Complete |
 | Qwen documentation | Signed `b390531`: architecture, roadmap, contributor, and status updates | Complete |
+
+## Draft PR #21 scrolling-region handoff
+
+| Lane | Saved evidence | State |
+| --- | --- | --- |
+| Codex core | Signed `9ffe79c`: margins, region scrolling, cursor/index behavior, delayed autowrap | Complete |
+| codex-lab tests | Signed `6bbac87`: eight public-API scroll/cursor/resize regression tests | Complete |
+| GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
+| Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
+| Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
+| Codex integration | Exact-head local checks, CI, and launch smoke | In progress |
 
 ## PR #17 historical implementation checkpoints
 
@@ -99,10 +112,9 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #19 remains Draft until current-head CI is green and the owner can repeat a
-local macOS startup/output/resize/exit smoke check. PR #17 has no remaining
-gate; its manual verification was accepted before merge. This does not
-authorize deferred terminal features in the foundation PR.
+PR #21 remains Draft until exact-head local checks and CI pass and the existing
+local-zsh application launch is rechecked. PR #19 has no remaining gate. This
+does not authorize deferred terminal features in the scrolling-region PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -116,7 +128,7 @@ identity, and the public support/security contact before Preview publication.
 
 ## Next steps
 
-1. Save exact-head local checks and GitHub CI on Draft PR #19.
-2. Repeat the bounded macOS smoke check without changing OS security settings.
-3. Keep scroll regions and later VT work in a separate Issue/PR after this
-   foundation is accepted.
+1. Save exact-head local checks and GitHub CI on Draft PR #21.
+2. Repeat the bounded macOS launch smoke without changing OS security settings.
+3. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
+   separate Issues and PRs.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -2,20 +2,22 @@
 
 Last updated: 2026-08-03 (Asia/Tokyo). PR
 [#19](https://github.com/ta-061/noren/pull/19) is merged into `main` as
-`c695920d8bc99990447d0b451754ea96c91181fc`. The only open PR is Draft
-[#21](https://github.com/ta-061/noren/pull/21), branch
-`agent/terminal-scroll-regions`, for Issue
-[#20](https://github.com/ta-061/noren/issues/20). Historical sections below
+`c695920d8bc99990447d0b451754ea96c91181fc`. Draft PR
+[#21](https://github.com/ta-061/noren/pull/21) remains in review for Issue
+[#20](https://github.com/ta-061/noren/issues/20). Draft PR
+[#23](https://github.com/ta-061/noren/pull/23), branch
+`agent/terminal-alternate-screen`, is stacked on #21 for Issue
+[#22](https://github.com/ta-061/noren/issues/22). Historical sections below
 preserve the PR #17 record at implementation/test head
 `c1f66dc27ddce37a60665d319a7ca061c300947e`, corrected only where an active
 claim went stale; coordination head `ac410a82` also passed both GitHub checks.
 
 ## Current phase
 
-Terminal foundation, scrolling-region slice. PR #19 merged the Noren-owned,
-renderer-independent `TerminalState`. Draft PR #21 adds DECSTBM margins,
-region-scoped LF/VT/FF/IND/NEL/RI and CSI S/T scrolling, CNL/CPL/VPA, delayed
-autowrap, and resize-reset behavior. See
+Terminal foundation, alternate-screen slice. PR #19 merged the Noren-owned,
+renderer-independent `TerminalState`; Draft PR #21 adds scrolling regions.
+Stacked Draft PR #23 adds primary/alternate screen ownership, DEC private mode
+1049, cursor save/restore, mode snapshots, and both-buffer resize behavior. See
 [terminal core foundation](../architecture/terminal-core-foundation.md). This
 is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
@@ -23,9 +25,11 @@ is not a VT100/xterm or vim/tmux/zellij compatibility claim.
 
 Verified on 2026-08-03:
 
-- The only open Issue is [#20](https://github.com/ta-061/noren/issues/20), the
-  scrolling-region behavior slice. The only open PR is its Draft
-  [#21](https://github.com/ta-061/noren/pull/21).
+- The open Issues are [#20](https://github.com/ta-061/noren/issues/20), the
+  scrolling-region behavior slice, and stacked alternate-screen Issue
+  [#22](https://github.com/ta-061/noren/issues/22). Their open Draft PRs are
+  [#21](https://github.com/ta-061/noren/pull/21) and
+  [#23](https://github.com/ta-061/noren/pull/23), respectively.
 - PR [#19](https://github.com/ta-061/noren/pull/19) and Issue
   [#18](https://github.com/ta-061/noren/issues/18) are complete after owner
   acceptance of the renderer-independent Terminal Core foundation.
@@ -60,6 +64,17 @@ Verified on 2026-08-03:
 | GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
 | Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
 | Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
+| Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
+
+## Draft PR #23 alternate-screen handoff
+
+| Lane | Saved evidence | State |
+| --- | --- | --- |
+| Codex core | Signed `84da736`: screen ownership, mode 1049, cursor save/restore, and resize behavior | Complete |
+| codex-lab tests | Signed `454d995`: seven public-API alternate/mode/cursor/resize tests | Complete |
+| GLM helper | PR #23 review: parser/enum/module organization is clean; no change needed | Complete |
+| Claude Code review | PR #23 review: `BLOCKER: NONE` | Complete |
+| Qwen documentation | Signed `29f7362`: focused terminal-core architecture update | Complete |
 | Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
 
 ## PR #17 historical implementation checkpoints
@@ -112,10 +127,11 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #21 has passed exact-head local checks and CI, and the existing local-zsh
-application launch was rechecked. It remains Draft for owner review and
-acceptance. PR #19 has no remaining gate. This does not authorize deferred
-terminal features in the scrolling-region PR.
+PR #21 remains Draft for owner review and acceptance. Stacked PR #23 has passed
+local checks and CI, and the existing local-zsh application launch was
+rechecked; it remains Draft and based on `agent/terminal-scroll-regions` until
+#21 is accepted and merged. PR #19 has no remaining gate. This does not
+authorize deferred terminal features in either Draft PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -130,5 +146,7 @@ identity, and the public support/security contact before Preview publication.
 ## Next steps
 
 1. Review and accept Draft PR #21, then promote and merge its exact tested head.
-2. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
-   separate Issues and PRs.
+2. Retarget Draft PR #23 to `main` only after #21 merges, then review its exact
+   tested head.
+3. Keep SGR/erase, attributes, remaining modes, and later VT work in separate
+   Issues and PRs.

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -60,7 +60,7 @@ Verified on 2026-08-03:
 | GLM helper | Signed `32ca7da`: behavior-preserving parser-state idiom cleanup | Complete |
 | Claude Code review | PR #21 review: `BLOCKER: NONE` | Complete |
 | Qwen documentation | Signed `328c013`: architecture, roadmap, and contributor guidance | Complete |
-| Codex integration | Exact-head local checks, CI, and launch smoke | In progress |
+| Codex integration | Exact-head local checks, CI, and bounded local-zsh launch smoke | Complete |
 
 ## PR #17 historical implementation checkpoints
 
@@ -112,9 +112,10 @@ then passed both GitHub checks: runs `30783618745` (Rust) and `30783618743`
 
 ## Current Draft gate
 
-PR #21 remains Draft until exact-head local checks and CI pass and the existing
-local-zsh application launch is rechecked. PR #19 has no remaining gate. This
-does not authorize deferred terminal features in the scrolling-region PR.
+PR #21 has passed exact-head local checks and CI, and the existing local-zsh
+application launch was rechecked. It remains Draft for owner review and
+acceptance. PR #19 has no remaining gate. This does not authorize deferred
+terminal features in the scrolling-region PR.
 
 Full VT/xterm behavior, non-ASCII glyph quality, swash/font trials, production
 IME/accessibility, Linux, SSH, agent integration, tabs, panes, themes, and a
@@ -128,7 +129,6 @@ identity, and the public support/security contact before Preview publication.
 
 ## Next steps
 
-1. Save exact-head local checks and GitHub CI on Draft PR #21.
-2. Repeat the bounded macOS launch smoke without changing OS security settings.
-3. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
+1. Review and accept Draft PR #21, then promote and merge its exact tested head.
+2. Keep alternate screen, SGR/erase, attributes, modes, and later VT work in
    separate Issues and PRs.


### PR DESCRIPTION
Closes #25

## Purpose

Add renderer-independent SGR state and capture it on terminal cells, while keeping the existing PTY → Parser → TerminalState → Renderer boundary.

This PR is intentionally stacked on #31 (`agent/terminal-erase-ops`) because both change the central parser/state files.

## Changes

- Add `AnsiColor`, `Color`, and `CellAttributes` value types.
- Parse bounded `CSI ... m` sequences.
- Support reset, bold, underline, reverse, their selective resets, default foreground/background, and the 16 ANSI colors.
- Capture the active attributes when printable cells are written.
- Preserve cell attributes through snapshots, resize, scrolling, and alternate-screen buffer isolation.
- Consume deferred indexed/direct/underline-color argument groups without reinterpreting channel values as style controls.
- Add focused SGR, buffer, resize, and alternate-screen regression tests.

## Non-goals

- Renderer color/style presentation.
- 256-color or truecolor storage.
- Background-color erase semantics.
- Additional SGR styles.
- SSH, agent features, or UI work.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 81 passed
- `git diff --check`
- Claude Code compatibility review: **BLOCKER: NONE**
- Signed-off-by trailers present on both PR commits.

## Bounded compatibility risks

- The active SGR pen is terminal-global across `?1049` switching in this slice.
- Erased/inserted blanks use default attributes; background-color erase behavior is deferred.
- CSI parsing remains capped at eight parameters.
- The current renderer intentionally ignores the new attributes.

## Handoff

- Base head reviewed: `a630c93605e309c2fd23558c8807500ac12a684e`
- Exact PR head: `0daa7d6`
- Keep as Draft until CI succeeds on this exact head.