### PR TITLE
Terminal Core: add application cursor and keypad modes

### DIFF
--- a/crates/noren-app/src/input.rs
+++ b/crates/noren-app/src/input.rs
@@ -1,0 +1,188 @@
+//! Application input modes and bounded keypad key model.
+//!
+//! This is the input-side mirror of DECCKM (`CSI ?1 h/l`, DEC cursor key mode)
+//! and DECKPAM / DECKPNM (`ESC =` / `ESC >`, keypad application / numeric
+//! mode). The terminal-state parser that consumes those escapes from the PTY
+//! lives in `noren-terminal` and is wired only after Issue #24 releases
+//! `parser.rs` and `state.rs`; this module owns only the encoding-side
+//! selection so the PoC key encoder emits the byte sequence the active mode
+//! expects. DECCKM / DECKPAM parser and state integration is a later,
+//! documented checkpoint and is intentionally absent here.
+
+use crate::{Arrow, KeyPhase};
+
+/// DEC cursor key mode (DECCKM) input-side selector.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorKeyMode {
+    /// Arrow keys emit the normal cursor sequences (`ESC [ A` ... `ESC [ D`).
+    #[default]
+    Normal,
+    /// Arrow keys emit the application cursor sequences (`ESC O A` ... `ESC O D`).
+    Application,
+}
+
+/// Keypad mode (DECKPAM / DECKPNM) input-side selector.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum KeypadMode {
+    /// Keypad keys emit their literal numeric / operator characters.
+    #[default]
+    Numeric,
+    /// Keypad keys emit the application `SS3` sequences.
+    Application,
+}
+
+/// Explicit, immutable application input-mode snapshot consumed by the key
+/// encoder.
+///
+/// The two selectors are independent: a program may set application cursor keys
+/// while leaving the keypad numeric, matching how DECCKM and DECKPAM/DECKPNM
+/// are distinct private modes. Builders are pure value transforms, so repeated
+/// application of the same selector is idempotent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InputMode {
+    cursor: CursorKeyMode,
+    keypad: KeypadMode,
+}
+
+impl InputMode {
+    /// Normal cursor sequences and numeric keypad sequences (the PoC default).
+    #[must_use]
+    pub const fn normal() -> Self {
+        Self {
+            cursor: CursorKeyMode::Normal,
+            keypad: KeypadMode::Numeric,
+        }
+    }
+
+    /// Replace the cursor key mode, leaving the keypad mode unchanged.
+    #[must_use]
+    pub const fn with_cursor(self, cursor: CursorKeyMode) -> Self {
+        Self { cursor, ..self }
+    }
+
+    /// Replace the keypad mode, leaving the cursor key mode unchanged.
+    #[must_use]
+    pub const fn with_keypad(self, keypad: KeypadMode) -> Self {
+        Self { keypad, ..self }
+    }
+
+    /// Active cursor key mode.
+    #[must_use]
+    pub const fn cursor(self) -> CursorKeyMode {
+        self.cursor
+    }
+
+    /// Active keypad mode.
+    #[must_use]
+    pub const fn keypad(self) -> KeypadMode {
+        self.keypad
+    }
+}
+
+/// Bounded set of numeric-keypad keys the input encoder explicitly supports.
+///
+/// The set is deliberately bounded to a standard numeric keypad; function,
+/// editing, and PF keys remain a later integration concern and are not modeled
+/// by this checkpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeypadKey {
+    /// `0`.
+    Zero,
+    /// `1`.
+    One,
+    /// `2`.
+    Two,
+    /// `3`.
+    Three,
+    /// `4`.
+    Four,
+    /// `5`.
+    Five,
+    /// `6`.
+    Six,
+    /// `7`.
+    Seven,
+    /// `8`.
+    Eight,
+    /// `9`.
+    Nine,
+    /// Decimal separator (`.`).
+    Decimal,
+    /// `+`.
+    Plus,
+    /// `-`.
+    Minus,
+    /// `*`.
+    Star,
+    /// `/`.
+    Slash,
+    /// Keypad Enter.
+    Enter,
+}
+
+/// An app-owned numeric-keypad key event translated from platform callbacks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KeypadInput {
+    key: KeypadKey,
+    phase: KeyPhase,
+}
+
+impl KeypadInput {
+    /// Create a keypad key event.
+    #[must_use]
+    pub const fn new(key: KeypadKey, phase: KeyPhase) -> Self {
+        Self { key, phase }
+    }
+
+    /// The keypad key identity.
+    #[must_use]
+    pub const fn key(self) -> KeypadKey {
+        self.key
+    }
+
+    /// The press phase.
+    #[must_use]
+    pub const fn phase(self) -> KeyPhase {
+        self.phase
+    }
+}
+
+/// Select the cursor key byte sequence for the active mode.
+pub(crate) fn cursor_bytes(arrow: Arrow, mode: CursorKeyMode) -> &'static [u8] {
+    let (normal, application) = match arrow {
+        Arrow::Up => (b"\x1b[A", b"\x1bOA"),
+        Arrow::Down => (b"\x1b[B", b"\x1bOB"),
+        Arrow::Right => (b"\x1b[C", b"\x1bOC"),
+        Arrow::Left => (b"\x1b[D", b"\x1bOD"),
+    };
+    match mode {
+        CursorKeyMode::Normal => normal,
+        CursorKeyMode::Application => application,
+    }
+}
+
+/// Select the keypad byte sequence for the active mode.
+pub(crate) fn keypad_bytes(key: KeypadKey, mode: KeypadMode) -> &'static [u8] {
+    let (numeric, application) = match key {
+        KeypadKey::Zero => (b"0", b"\x1bOp"),
+        KeypadKey::One => (b"1", b"\x1bOq"),
+        KeypadKey::Two => (b"2", b"\x1bOr"),
+        KeypadKey::Three => (b"3", b"\x1bOs"),
+        KeypadKey::Four => (b"4", b"\x1bOt"),
+        KeypadKey::Five => (b"5", b"\x1bOu"),
+        KeypadKey::Six => (b"6", b"\x1bOv"),
+        KeypadKey::Seven => (b"7", b"\x1bOw"),
+        KeypadKey::Eight => (b"8", b"\x1bOx"),
+        KeypadKey::Nine => (b"9", b"\x1bOy"),
+        KeypadKey::Decimal => (b".", b"\x1bOn"),
+        KeypadKey::Plus => (b"+", b"\x1bOk"),
+        KeypadKey::Minus => (b"-", b"\x1bOm"),
+        KeypadKey::Star => (b"*", b"\x1bOj"),
+        KeypadKey::Slash => (b"/", b"\x1bOo"),
+        KeypadKey::Enter => (b"\r", b"\x1bOM"),
+    };
+    match mode {
+        KeypadMode::Numeric => numeric,
+        KeypadMode::Application => application,
+    }
+}

--- a/crates/noren-app/src/input.rs
+++ b/crates/noren-app/src/input.rs
@@ -2,14 +2,10 @@
 //!
 //! This is the input-side mirror of DECCKM (`CSI ?1 h/l`, DEC cursor key mode)
 //! and DECKPAM / DECKPNM (`ESC =` / `ESC >`, keypad application / numeric
-//! mode). The terminal-state parser that consumes those escapes from the PTY
-//! lives in `noren-terminal` and is wired only after Issue #24 releases
-//! `parser.rs` and `state.rs`; this module owns only the encoding-side
-//! selection so the PoC key encoder emits the byte sequence the active mode
-//! expects. DECCKM / DECKPAM parser and state integration is a later,
-//! documented checkpoint and is intentionally absent here.
+//! mode). `noren-terminal` owns the parser and mode state; this module owns the
+//! app-side encoding selection.
 
-use crate::{Arrow, KeyPhase};
+use crate::{Arrow, KeyPhase, Modifiers};
 
 /// DEC cursor key mode (DECCKM) input-side selector.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -125,13 +121,25 @@ pub enum KeypadKey {
 pub struct KeypadInput {
     key: KeypadKey,
     phase: KeyPhase,
+    modifiers: Modifiers,
 }
 
 impl KeypadInput {
-    /// Create a keypad key event.
+    /// Create a keypad key event without active modifiers.
     #[must_use]
     pub const fn new(key: KeypadKey, phase: KeyPhase) -> Self {
-        Self { key, phase }
+        Self {
+            key,
+            phase,
+            modifiers: Modifiers::empty(),
+        }
+    }
+
+    /// Return this event with the active modifiers captured by the window layer.
+    #[must_use]
+    pub const fn with_modifiers(mut self, modifiers: Modifiers) -> Self {
+        self.modifiers = modifiers;
+        self
     }
 
     /// The keypad key identity.
@@ -144,6 +152,12 @@ impl KeypadInput {
     #[must_use]
     pub const fn phase(self) -> KeyPhase {
         self.phase
+    }
+
+    /// Active modifiers captured with this event.
+    #[must_use]
+    pub const fn modifiers(self) -> Modifiers {
+        self.modifiers
     }
 }
 

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -378,14 +378,21 @@ impl KeyEncoder {
     /// mode.
     ///
     /// Numeric mode emits the literal key character; application mode emits the
-    /// `SS3` (`ESC O`) sequence. Releases are dropped for parity with the
-    /// main key path.
+    /// `SS3` (`ESC O`) sequence. Release, Control, Option, and Command handling
+    /// follows the main key path; Shift does not alter these bounded sequences.
     pub fn encode_keypad_with(
         input: KeypadInput,
         mode: InputMode,
     ) -> Result<Vec<u8>, KeyDropReason> {
         if input.phase() == KeyPhase::Released {
             return Err(KeyDropReason::Released);
+        }
+        let modifiers = input.modifiers();
+        if modifiers.is_alt() || modifiers.is_super() {
+            return Err(KeyDropReason::UnsupportedModifier);
+        }
+        if modifiers.is_ctrl() {
+            return Err(KeyDropReason::UnsupportedControl);
         }
         Ok(input::keypad_bytes(input.key(), mode.keypad()).to_vec())
     }
@@ -761,6 +768,31 @@ mod tests {
         assert_eq!(
             KeyEncoder::encode_keypad_with(released, application),
             Err(KeyDropReason::Released)
+        );
+    }
+
+    #[test]
+    fn keypad_encoder_preserves_the_existing_modifier_policy() {
+        let mode = InputMode::normal().with_keypad(KeypadMode::Application);
+        let pressed = KeypadInput::new(KeypadKey::One, KeyPhase::Pressed);
+
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(pressed.with_modifiers(Modifiers::empty().ctrl()), mode),
+            Err(KeyDropReason::UnsupportedControl)
+        );
+        for modifiers in [Modifiers::empty().alt(), Modifiers::empty().super_key()] {
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(pressed.with_modifiers(modifiers), mode),
+                Err(KeyDropReason::UnsupportedModifier)
+            );
+        }
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(
+                pressed.with_modifiers(Modifiers::empty().shift()),
+                mode
+            )
+            .as_deref(),
+            Ok(b"\x1bOq".as_slice())
         );
     }
 

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -8,6 +8,10 @@
 //! types stay inside `noren-app` and never cross into the PTY or terminal
 //! crates.
 
+mod input;
+
+pub use input::{CursorKeyMode, InputMode, KeypadInput, KeypadKey, KeypadMode};
+
 use std::fmt;
 use std::time::Duration;
 
@@ -317,8 +321,23 @@ pub enum KeyDropReason {
 pub struct KeyEncoder;
 
 impl KeyEncoder {
-    /// Encode one pressed or repeated key event.
+    /// Encode one pressed or repeated key event in the PoC default
+    /// ([`InputMode::normal`]) mode.
+    ///
+    /// This entry point preserves the original byte contract and stays
+    /// source-compatible with PoC callers that do not yet track terminal
+    /// modes. Mode-aware callers use [`KeyEncoder::encode_with`].
     pub fn encode(input: KeyInput) -> Result<Vec<u8>, KeyDropReason> {
+        Self::encode_with(input, InputMode::normal())
+    }
+
+    /// Encode one pressed or repeated key event for the active application
+    /// input mode.
+    ///
+    /// Only bare arrow keys observe [`CursorKeyMode`]; release, modifier,
+    /// control-byte, and printable handling is identical to
+    /// [`KeyEncoder::encode`], so the normal mode is byte-for-byte compatible.
+    pub fn encode_with(input: KeyInput, mode: InputMode) -> Result<Vec<u8>, KeyDropReason> {
         if input.phase() == KeyPhase::Released {
             return Err(KeyDropReason::Released);
         }
@@ -345,11 +364,30 @@ impl KeyEncoder {
             Key::Backspace => Ok(vec![0x7f]),
             Key::Tab => Ok(vec![0x09]),
             Key::Escape => Ok(vec![0x1b]),
-            Key::Arrow(Arrow::Up) => Ok(b"\x1b[A".to_vec()),
-            Key::Arrow(Arrow::Down) => Ok(b"\x1b[B".to_vec()),
-            Key::Arrow(Arrow::Right) => Ok(b"\x1b[C".to_vec()),
-            Key::Arrow(Arrow::Left) => Ok(b"\x1b[D".to_vec()),
+            Key::Arrow(arrow) => Ok(input::cursor_bytes(arrow, mode.cursor()).to_vec()),
         }
+    }
+
+    /// Encode one pressed or repeated keypad key event in the PoC default
+    /// ([`InputMode::normal`]) numeric-keypad mode.
+    pub fn encode_keypad(input: KeypadInput) -> Result<Vec<u8>, KeyDropReason> {
+        Self::encode_keypad_with(input, InputMode::normal())
+    }
+
+    /// Encode one pressed or repeated keypad key event for the active keypad
+    /// mode.
+    ///
+    /// Numeric mode emits the literal key character; application mode emits the
+    /// `SS3` (`ESC O`) sequence. Releases are dropped for parity with the
+    /// main key path.
+    pub fn encode_keypad_with(
+        input: KeypadInput,
+        mode: InputMode,
+    ) -> Result<Vec<u8>, KeyDropReason> {
+        if input.phase() == KeyPhase::Released {
+            return Err(KeyDropReason::Released);
+        }
+        Ok(input::keypad_bytes(input.key(), mode.keypad()).to_vec())
     }
 }
 
@@ -611,6 +649,157 @@ mod tests {
                 .lines()
                 .first()
                 .is_some_and(|line| line.contains('x'))
+        );
+    }
+
+    #[test]
+    fn input_mode_defaults_to_normal_cursor_and_numeric_keypad() {
+        let mode = InputMode::normal();
+        assert_eq!(mode.cursor(), CursorKeyMode::Normal);
+        assert_eq!(mode.keypad(), KeypadMode::Numeric);
+        assert_eq!(InputMode::default(), mode);
+    }
+
+    #[test]
+    fn cursor_keys_select_normal_or_application_sequences_by_mode() {
+        let normal = InputMode::normal();
+        let application = normal.with_cursor(CursorKeyMode::Application);
+        let cases = [
+            (Arrow::Up, b"\x1b[A".as_slice(), b"\x1bOA".as_slice()),
+            (Arrow::Down, b"\x1b[B", b"\x1bOB"),
+            (Arrow::Right, b"\x1b[C", b"\x1bOC"),
+            (Arrow::Left, b"\x1b[D", b"\x1bOD"),
+        ];
+        for (arrow, normal_bytes, application_bytes) in cases {
+            let input = KeyInput::new(Key::Arrow(arrow), KeyPhase::Pressed, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(input).as_deref(), Ok(normal_bytes));
+            assert_eq!(
+                KeyEncoder::encode_with(input, normal).as_deref(),
+                Ok(normal_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_with(input, application).as_deref(),
+                Ok(application_bytes)
+            );
+        }
+    }
+
+    #[test]
+    fn application_cursor_mode_leaves_modifier_and_control_paths_unchanged() {
+        let application = InputMode::normal().with_cursor(CursorKeyMode::Application);
+        for modifiers in [Modifiers::empty().alt(), Modifiers::empty().super_key()] {
+            let input = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, modifiers);
+            assert_eq!(
+                KeyEncoder::encode_with(input, application),
+                Err(KeyDropReason::UnsupportedModifier)
+            );
+        }
+        let ctrl_arrow = KeyInput::new(
+            Key::Arrow(Arrow::Up),
+            KeyPhase::Pressed,
+            Modifiers::empty().ctrl(),
+        );
+        assert_eq!(
+            KeyEncoder::encode_with(ctrl_arrow, application),
+            Err(KeyDropReason::UnsupportedControl)
+        );
+        let printable = KeyInput::new(Key::Character('a'), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(printable, application).as_deref(),
+            Ok(b"a".as_slice())
+        );
+    }
+
+    #[test]
+    fn keypad_keys_select_numeric_or_application_sequences_by_mode() {
+        let numeric = InputMode::normal();
+        let application = numeric.with_keypad(KeypadMode::Application);
+        let cases = [
+            (KeypadKey::Zero, b"0".as_slice(), b"\x1bOp".as_slice()),
+            (KeypadKey::One, b"1", b"\x1bOq"),
+            (KeypadKey::Two, b"2", b"\x1bOr"),
+            (KeypadKey::Three, b"3", b"\x1bOs"),
+            (KeypadKey::Four, b"4", b"\x1bOt"),
+            (KeypadKey::Five, b"5", b"\x1bOu"),
+            (KeypadKey::Six, b"6", b"\x1bOv"),
+            (KeypadKey::Seven, b"7", b"\x1bOw"),
+            (KeypadKey::Eight, b"8", b"\x1bOx"),
+            (KeypadKey::Nine, b"9", b"\x1bOy"),
+            (KeypadKey::Decimal, b".", b"\x1bOn"),
+            (KeypadKey::Plus, b"+", b"\x1bOk"),
+            (KeypadKey::Minus, b"-", b"\x1bOm"),
+            (KeypadKey::Star, b"*", b"\x1bOj"),
+            (KeypadKey::Slash, b"/", b"\x1bOo"),
+            (KeypadKey::Enter, b"\r", b"\x1bOM"),
+        ];
+        for (key, numeric_bytes, application_bytes) in cases {
+            let input = KeypadInput::new(key, KeyPhase::Pressed);
+            assert_eq!(
+                KeyEncoder::encode_keypad(input).as_deref(),
+                Ok(numeric_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(input, numeric).as_deref(),
+                Ok(numeric_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_keypad_with(input, application).as_deref(),
+                Ok(application_bytes)
+            );
+        }
+    }
+
+    #[test]
+    fn keypad_encoder_drops_releases_in_both_modes() {
+        let numeric = InputMode::normal();
+        let application = numeric.with_keypad(KeypadMode::Application);
+        let released = KeypadInput::new(KeypadKey::Five, KeyPhase::Released);
+        assert_eq!(
+            KeyEncoder::encode_keypad(released),
+            Err(KeyDropReason::Released)
+        );
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(released, application),
+            Err(KeyDropReason::Released)
+        );
+    }
+
+    #[test]
+    fn input_mode_setters_are_idempotent_and_independent() {
+        let base = InputMode::normal();
+        let once = base
+            .with_cursor(CursorKeyMode::Application)
+            .with_keypad(KeypadMode::Application);
+        let twice = once
+            .with_cursor(CursorKeyMode::Application)
+            .with_keypad(KeypadMode::Application);
+        assert_eq!(once, twice);
+
+        // Resetting to the already-active selector is a no-op.
+        assert_eq!(
+            InputMode::normal().with_cursor(CursorKeyMode::Normal),
+            InputMode::normal()
+        );
+        assert_eq!(
+            InputMode::normal().with_keypad(KeypadMode::Numeric),
+            InputMode::normal()
+        );
+
+        // Cursor and keypad selectors are independent.
+        let cursor_only = base.with_cursor(CursorKeyMode::Application);
+        assert_eq!(cursor_only.cursor(), CursorKeyMode::Application);
+        assert_eq!(cursor_only.keypad(), KeypadMode::Numeric);
+
+        // Idempotent modes produce byte-identical encodings for every key.
+        let arrow = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(arrow, once),
+            KeyEncoder::encode_with(arrow, twice)
+        );
+        let keypad = KeypadInput::new(KeypadKey::Enter, KeyPhase::Pressed);
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(keypad, once),
+            KeyEncoder::encode_keypad_with(keypad, twice)
         );
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3,8 +3,9 @@
 mod renderer;
 
 use noren_app::{
-    Arrow, GridGeometry, GridSize, Key, KeyDropReason, KeyEncoder, KeyInput, KeyPhase, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, Resize,
+    Arrow, CursorKeyMode, GridGeometry, GridSize, InputMode, Key, KeyDropReason, KeyEncoder,
+    KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, Modifiers, PARSE_BUDGET_BYTES_PER_TURN,
+    Resize,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
 use noren_terminal::{TerminalEngine, TerminalState};
@@ -15,7 +16,7 @@ use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, KeyEvent, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
+use winit::keyboard::{Key as WinitKey, KeyCode, ModifiersState, NamedKey, PhysicalKey};
 use winit::window::{Window, WindowId};
 
 const WINDOW_WIDTH: u32 = 900;
@@ -125,19 +126,46 @@ impl NorenApp {
     }
 
     fn handle_key(&mut self, event: &KeyEvent) {
-        let Ok(input) = translate_key(event, self.modifiers) else {
+        let input_mode = self.current_input_mode();
+        let encoded = if let Some(input) = translate_keypad_key(event) {
+            KeyEncoder::encode_keypad_with(input.with_modifiers(self.modifiers), input_mode)
+        } else {
+            translate_key(event, self.modifiers)
+                .and_then(|input| KeyEncoder::encode_with(input, input_mode))
+        };
+        let Ok(bytes) = encoded else {
             return;
         };
-        let Ok(bytes) = KeyEncoder::encode(input) else {
-            return;
-        };
+        self.send_input(&bytes);
+    }
+
+    fn send_input(&mut self, bytes: &[u8]) {
         if let Some(session) = &self.pty {
-            if session.send_input(&bytes).is_err() {
+            if session.send_input(bytes).is_err() {
                 self.status = "Noren PTY input failed";
                 self.show_status = true;
                 self.redraw_needed = true;
             }
         }
+    }
+
+    fn current_input_mode(&self) -> InputMode {
+        let Some(modes) = self.terminal.as_ref().map(TerminalState::modes) else {
+            return InputMode::normal();
+        };
+        let cursor_mode = if modes.is_application_cursor_key_mode() {
+            CursorKeyMode::Application
+        } else {
+            CursorKeyMode::Normal
+        };
+        let keypad_mode = if modes.is_application_keypad_mode() {
+            KeypadMode::Application
+        } else {
+            KeypadMode::Numeric
+        };
+        InputMode::normal()
+            .with_cursor(cursor_mode)
+            .with_keypad(keypad_mode)
     }
 
     fn handle_resize(&mut self, physical: PhysicalSize<u32>) {
@@ -323,12 +351,41 @@ fn pty_size(grid: GridSize) -> Result<PtySize, noren_pty::PtyError> {
 }
 
 fn translate_key(event: &KeyEvent, modifiers: Modifiers) -> Result<KeyInput, KeyDropReason> {
-    let phase = match event.state {
+    translate_logical_key(&event.logical_key, key_phase(event), modifiers)
+}
+
+fn key_phase(event: &KeyEvent) -> KeyPhase {
+    match event.state {
         ElementState::Released => KeyPhase::Released,
         ElementState::Pressed if event.repeat => KeyPhase::Repeat,
         ElementState::Pressed => KeyPhase::Pressed,
-    };
-    translate_logical_key(&event.logical_key, phase, modifiers)
+    }
+}
+
+fn translate_keypad_key(event: &KeyEvent) -> Option<KeypadInput> {
+    keypad_key(event.physical_key).map(|key| KeypadInput::new(key, key_phase(event)))
+}
+
+fn keypad_key(physical_key: PhysicalKey) -> Option<KeypadKey> {
+    Some(match physical_key {
+        PhysicalKey::Code(KeyCode::Numpad0) => KeypadKey::Zero,
+        PhysicalKey::Code(KeyCode::Numpad1) => KeypadKey::One,
+        PhysicalKey::Code(KeyCode::Numpad2) => KeypadKey::Two,
+        PhysicalKey::Code(KeyCode::Numpad3) => KeypadKey::Three,
+        PhysicalKey::Code(KeyCode::Numpad4) => KeypadKey::Four,
+        PhysicalKey::Code(KeyCode::Numpad5) => KeypadKey::Five,
+        PhysicalKey::Code(KeyCode::Numpad6) => KeypadKey::Six,
+        PhysicalKey::Code(KeyCode::Numpad7) => KeypadKey::Seven,
+        PhysicalKey::Code(KeyCode::Numpad8) => KeypadKey::Eight,
+        PhysicalKey::Code(KeyCode::Numpad9) => KeypadKey::Nine,
+        PhysicalKey::Code(KeyCode::NumpadDecimal) => KeypadKey::Decimal,
+        PhysicalKey::Code(KeyCode::NumpadAdd) => KeypadKey::Plus,
+        PhysicalKey::Code(KeyCode::NumpadSubtract) => KeypadKey::Minus,
+        PhysicalKey::Code(KeyCode::NumpadMultiply) => KeypadKey::Star,
+        PhysicalKey::Code(KeyCode::NumpadDivide) => KeypadKey::Slash,
+        PhysicalKey::Code(KeyCode::NumpadEnter) => KeypadKey::Enter,
+        _ => return None,
+    })
 }
 
 fn translate_logical_key(
@@ -387,6 +444,57 @@ mod tests {
                 .expect("space is supported terminal input");
             assert_eq!(KeyEncoder::encode(input), Ok(vec![0x20]));
         }
+    }
+
+    #[test]
+    fn terminal_modes_drive_cursor_and_keypad_encoding() {
+        let mut app = NorenApp::default();
+        assert_eq!(app.current_input_mode(), InputMode::normal());
+
+        let mut terminal = TerminalState::new(2, 4).expect("valid terminal");
+        terminal.feed_bytes(b"\x1b[?1h\x1b=");
+        app.terminal = Some(terminal);
+        let mode = app.current_input_mode();
+
+        let arrow = KeyInput::new(Key::Arrow(Arrow::Up), KeyPhase::Pressed, Modifiers::empty());
+        assert_eq!(
+            KeyEncoder::encode_with(arrow, mode).as_deref(),
+            Ok(b"\x1bOA".as_slice())
+        );
+        assert_eq!(
+            KeyEncoder::encode_keypad_with(
+                KeypadInput::new(KeypadKey::One, KeyPhase::Pressed),
+                mode
+            )
+            .as_deref(),
+            Ok(b"\x1bOq".as_slice())
+        );
+    }
+
+    #[test]
+    fn physical_keypad_mapping_is_bounded_to_numpad_codes() {
+        let cases = [
+            (KeyCode::Numpad0, KeypadKey::Zero),
+            (KeyCode::Numpad1, KeypadKey::One),
+            (KeyCode::Numpad2, KeypadKey::Two),
+            (KeyCode::Numpad3, KeypadKey::Three),
+            (KeyCode::Numpad4, KeypadKey::Four),
+            (KeyCode::Numpad5, KeypadKey::Five),
+            (KeyCode::Numpad6, KeypadKey::Six),
+            (KeyCode::Numpad7, KeypadKey::Seven),
+            (KeyCode::Numpad8, KeypadKey::Eight),
+            (KeyCode::Numpad9, KeypadKey::Nine),
+            (KeyCode::NumpadDecimal, KeypadKey::Decimal),
+            (KeyCode::NumpadAdd, KeypadKey::Plus),
+            (KeyCode::NumpadSubtract, KeypadKey::Minus),
+            (KeyCode::NumpadMultiply, KeypadKey::Star),
+            (KeyCode::NumpadDivide, KeypadKey::Slash),
+            (KeyCode::NumpadEnter, KeypadKey::Enter),
+        ];
+        for (code, expected) in cases {
+            assert_eq!(keypad_key(PhysicalKey::Code(code)), Some(expected));
+        }
+        assert_eq!(keypad_key(PhysicalKey::Code(KeyCode::Digit1)), None);
     }
 
     #[test]

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -10,6 +10,7 @@ pub(crate) enum Action {
     LineFeed,
     CarriageReturn,
     Backspace,
+    Tab,
     Index,
     NextLine,
     ReverseIndex,
@@ -75,6 +76,14 @@ impl Parser {
         match state {
             ParserState::Ground => self.advance_ground(byte),
             ParserState::Escape => self.advance_escape(byte),
+            ParserState::EscapeIntermediate => {
+                self.state = match byte {
+                    ESC => ParserState::Escape,
+                    0x30..=0x7e => ParserState::Ground,
+                    _ => ParserState::EscapeIntermediate,
+                };
+                None
+            }
             ParserState::Csi(mut csi) => {
                 if byte == ESC {
                     self.state = ParserState::Escape;
@@ -115,6 +124,7 @@ impl Parser {
             }
             b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
             b'\r' => Some(Action::CarriageReturn),
+            b'\t' => Some(Action::Tab),
             0x08 => Some(Action::Backspace),
             0x20..=0x7e => Some(Action::Print(byte)),
             _ => None,
@@ -154,6 +164,11 @@ impl Parser {
                 self.state = ParserState::Ground;
                 return Some(Action::RestoreCursor);
             }
+            // Intermediate bytes (0x20..=0x2f) such as `(`, `)`, `#`, and SP
+            // begin a multi-byte escape (e.g. SCS `ESC ( B`). Collect them and
+            // the following final byte without emitting anything, so the final
+            // never leaks to Ground as printable text.
+            0x20..=0x2f => self.state = ParserState::EscapeIntermediate,
             _ => self.state = ParserState::Ground,
         }
         None
@@ -165,6 +180,7 @@ enum ParserState {
     #[default]
     Ground,
     Escape,
+    EscapeIntermediate,
     Csi(Csi),
     Osc,
     OscEscape,
@@ -393,6 +409,49 @@ mod tests {
                 Action::MoveTo { row: 2, col: 3 },
             ]
         );
+    }
+
+    #[test]
+    fn horizontal_tab_emits_a_tab_action() {
+        assert_eq!(
+            actions(b"\ta\tb"),
+            [
+                Action::Tab,
+                Action::Print(b'a'),
+                Action::Tab,
+                Action::Print(b'b'),
+            ]
+        );
+    }
+
+    #[test]
+    fn escape_intermediate_sequences_emit_nothing_and_keep_the_final_byte() {
+        // Regression for the byte-leak: `ESC ( B` previously printed 'B'.
+        for sequence in [
+            b"\x1b(B".as_slice(),
+            b"\x1b)0",
+            b"\x1b#8",
+            b"\x1b F",
+            b"\x1b()B",
+        ] {
+            assert!(actions(sequence).is_empty(), "sequence {sequence:?}");
+        }
+        // An unsupported single-byte escape final is still consumed whole.
+        assert!(actions(b"\x1bc").is_empty());
+
+        // The final byte after an intermediate must not leak when followed by
+        // printable text.
+        let mut parser = Parser::default();
+        let emitted: Vec<Action> = b"\x1b(BX"
+            .iter()
+            .filter_map(|byte| parser.advance(*byte))
+            .collect();
+        assert_eq!(emitted, [Action::Print(b'X')]);
+    }
+
+    #[test]
+    fn escape_intermediate_aborts_on_a_new_escape() {
+        assert_eq!(actions(b"\x1b(\x1b[D"), [Action::MoveLeft(1)]);
     }
 
     #[test]

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -44,6 +44,7 @@ pub(crate) enum Action {
     },
     SaveCursor,
     RestoreCursor,
+    SetKeypadApplication(bool),
     SetPrivateMode {
         mode: PrivateMode,
         enabled: bool,
@@ -60,6 +61,7 @@ pub(crate) enum EraseMode {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PrivateMode {
     AlternateScreen,
+    ApplicationCursorKey,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -124,6 +126,14 @@ impl Parser {
             b'[' => self.state = ParserState::Csi(Csi::default()),
             b']' => self.state = ParserState::Osc,
             ESC => self.state = ParserState::Escape,
+            b'=' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SetKeypadApplication(true));
+            }
+            b'>' => {
+                self.state = ParserState::Ground;
+                return Some(Action::SetKeypadApplication(false));
+            }
             b'D' => {
                 self.state = ParserState::Ground;
                 return Some(Action::Index);
@@ -286,6 +296,7 @@ impl Csi {
             return None;
         }
         let mode = match self.params[0] {
+            1 => PrivateMode::ApplicationCursorKey,
             1049 => PrivateMode::AlternateScreen,
             _ => return None,
         };

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -151,10 +151,12 @@ impl ScrollRegion {
     }
 }
 
-/// Renderer-independent terminal modes that affect visible state selection.
+/// Renderer-independent modes that affect screen selection or encoded input.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TerminalModes {
     alternate_screen: bool,
+    application_cursor_key: bool,
+    application_keypad: bool,
 }
 
 impl TerminalModes {
@@ -162,6 +164,18 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_alternate_screen_active(self) -> bool {
         self.alternate_screen
+    }
+
+    /// Whether DECCKM (DEC cursor key mode) is set to application mode.
+    #[must_use]
+    pub const fn is_application_cursor_key_mode(self) -> bool {
+        self.application_cursor_key
+    }
+
+    /// Whether DECKPAM (DEC keypad application mode) is set to application mode.
+    #[must_use]
+    pub const fn is_application_keypad_mode(self) -> bool {
+        self.application_keypad
     }
 }
 
@@ -592,6 +606,9 @@ impl TerminalState {
             }
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
+            Action::SetKeypadApplication(enabled) => {
+                self.modes.application_keypad = enabled;
+            }
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
         }
     }
@@ -785,6 +802,9 @@ impl TerminalState {
         match (mode, enabled) {
             (PrivateMode::AlternateScreen, true) => self.enter_alternate_screen(),
             (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
+            (PrivateMode::ApplicationCursorKey, enabled) => {
+                self.modes.application_cursor_key = enabled;
+            }
         }
     }
 

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -575,6 +575,7 @@ impl TerminalState {
                 self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
                 self.active.wrap_pending = false;
             }
+            Action::Tab => self.tab(),
             Action::Index => self.index(),
             Action::NextLine => self.next_line(),
             Action::ReverseIndex => self.reverse_index(),
@@ -633,6 +634,14 @@ impl TerminalState {
     fn line_feed(&mut self) {
         self.active.wrap_pending = false;
         self.index();
+    }
+
+    fn tab(&mut self) {
+        self.active.wrap_pending = false;
+        let last_column = self.active.screen.cols - 1;
+        let next_stop = (usize::from(self.active.cursor.column) / 8 + 1) * 8;
+        self.active.cursor.column =
+            last_column.min(u16::try_from(next_stop).unwrap_or(last_column));
     }
 
     fn index(&mut self) {

--- a/crates/noren-terminal/tests/application_modes.rs
+++ b/crates/noren-terminal/tests/application_modes.rs
@@ -1,0 +1,92 @@
+//! Focused state regressions for DECCKM and DECKPAM/DECKPNM.
+
+use noren_terminal::TerminalState;
+
+fn assert_modes(state: &TerminalState, cursor_keys: bool, keypad: bool) {
+    let modes = state.modes();
+    assert_eq!(modes.is_application_cursor_key_mode(), cursor_keys);
+    assert_eq!(modes.is_application_keypad_mode(), keypad);
+}
+
+#[test]
+fn decckm_set_reset_is_incremental_and_idempotent() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    assert_modes(&state, false, false);
+
+    state.feed_bytes(b"\x1b[?1");
+    assert_modes(&state, false, false);
+    state.feed_bytes(b"h\x1b[?1h");
+    assert_modes(&state, true, false);
+
+    state.feed_bytes(b"\x1b[?1l\x1b[?1l");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn deckpam_and_deckpnm_set_reset_keypad_mode() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b");
+    assert_modes(&state, false, false);
+    state.feed_bytes(b"=\x1b=");
+    assert_modes(&state, false, true);
+
+    state.feed_bytes(b"\x1b>\x1b>");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn cursor_and_keypad_modes_are_independent() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1h");
+    assert_modes(&state, true, false);
+    state.feed_bytes(b"\x1b=");
+    assert_modes(&state, true, true);
+    state.feed_bytes(b"\x1b[?1l");
+    assert_modes(&state, false, true);
+    state.feed_bytes(b"\x1b>");
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn snapshots_capture_modes_without_following_later_changes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?1h\x1b=");
+    let snapshot = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1l\x1b>");
+
+    assert!(snapshot.modes().is_application_cursor_key_mode());
+    assert!(snapshot.modes().is_application_keypad_mode());
+    assert_modes(&state, false, false);
+}
+
+#[test]
+fn application_modes_survive_resize_and_alternate_screen_switching() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"P\x1b[?1h\x1b=\x1b[?1049hA");
+
+    assert!(state.modes().is_alternate_screen_active());
+    assert_modes(&state, true, true);
+    assert_eq!(state.snapshot().lines(), ["A"]);
+
+    state.resize(3, 5).expect("valid resize");
+    state.feed_bytes(b"\x1b[?1049l");
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert_modes(&state, true, true);
+    assert_eq!(state.snapshot().lines(), ["P"]);
+}
+
+#[test]
+fn unsupported_private_mode_lists_do_not_mutate_or_poison_modes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?999h\x1b[?1;1049h");
+    assert_modes(&state, false, false);
+    assert!(!state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1h\x1b=");
+    assert_modes(&state, true, true);
+}

--- a/crates/noren-terminal/tests/control_sequences.rs
+++ b/crates/noren-terminal/tests/control_sequences.rs
@@ -1,0 +1,146 @@
+//! Regressions for escape-intermediate consumption and horizontal tab handling.
+
+use noren_terminal::{Cell, CursorMove, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn cells(state: &TerminalState, row: u16) -> Vec<String> {
+    (0..state.screen().cols())
+        .map(|column| {
+            state
+                .screen()
+                .cell(row, column)
+                .map(Cell::text)
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect()
+}
+
+/// `ESC ( B`, `ESC ) 0`, `ESC # 8`, and `ESC SP F` must be swallowed whole:
+/// nothing prints and the cursor stays at the origin.
+#[test]
+fn escape_intermediate_sequences_print_nothing_and_keep_cursor_home() {
+    for sequence in [b"\x1b(B".as_slice(), b"\x1b)0", b"\x1b#8", b"\x1b F"] {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        state.feed_bytes(sequence);
+
+        assert!(state.snapshot().lines().is_empty(), "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, 0), "sequence {sequence:?}");
+    }
+}
+
+/// The same sequences split across `feed_bytes` chunk boundaries must still
+/// print nothing.
+#[test]
+fn escape_intermediate_sequences_consume_whole_across_chunk_boundaries() {
+    for sequence in [b"\x1b(B".as_slice(), b"\x1b)0", b"\x1b#8", b"\x1b F"] {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        // One byte per call, the worst case for parser state retention.
+        for byte in sequence {
+            state.feed_bytes(&[*byte]);
+        }
+
+        assert!(state.snapshot().lines().is_empty(), "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, 0), "sequence {sequence:?}");
+
+        // Output after the sequence is unaffected.
+        state.feed_bytes(b"Z");
+        assert_eq!(state.snapshot().lines(), ["Z".to_owned()]);
+    }
+}
+
+/// A second intermediate before the final byte is also consumed.
+#[test]
+fn stacked_escape_intermediates_still_print_nothing() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b()BZ");
+
+    assert_eq!(state.snapshot().lines(), ["Z".to_owned()]);
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// An unsupported single-byte escape final (e.g. `ESC c`, RIS) still consumes
+/// exactly its bytes and returns to Ground, matching the pre-fix behavior.
+#[test]
+fn unsupported_single_byte_escape_final_behaves_as_before() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1bcX");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// A new `ESC` aborts an in-progress intermediate escape, same as it does for
+/// CSI.
+#[test]
+fn escape_aborts_an_in_progress_intermediate_sequence() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b(\x1b[DX");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+/// `a\tb` lands `b` at the next 8-column tab stop.
+#[test]
+fn horizontal_tab_advances_to_the_next_eighth_column() {
+    let mut state = TerminalState::new(1, 12).expect("valid terminal");
+    state.feed_bytes(b"a\tb");
+
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("a"));
+    assert_eq!(state.screen().cell(0, 8).map(Cell::text), Some("b"));
+    assert_eq!(cursor(&state), (0, 9));
+}
+
+/// A tab stops at the last column without wrapping, scrolling, or panicking
+/// when the next stop would be past the right edge.
+#[test]
+fn tab_near_the_right_edge_clamps_to_the_last_column() {
+    let mut state = TerminalState::new(2, 10).expect("valid terminal");
+    // Fill columns 0..=6; cursor sits at column 7. The next stop (8) is in
+    // range, so the following print lands at column 8.
+    state.feed_bytes(b"1234567\tX");
+
+    assert_eq!(state.screen().cell(0, 8).map(Cell::text), Some("X"));
+    assert_eq!(cursor(&state), (0, 9));
+    assert_eq!(
+        cells(&state, 1),
+        [" ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+    );
+}
+
+/// A tab issued while the cursor is on the very last column must not panic,
+/// wrap, or scroll.
+#[test]
+fn tab_on_the_last_column_does_not_wrap_or_panic() {
+    let mut state = TerminalState::new(2, 10).expect("valid terminal");
+    state.feed_bytes(b"1234567890");
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"\t");
+
+    assert_eq!(cursor(&state), (0, 9));
+    assert!(!state.is_wrap_pending());
+    // Row 1 is untouched: the tab neither wrapped nor scrolled.
+    assert_eq!(
+        cells(&state, 1),
+        [" ", " ", " ", " ", " ", " ", " ", " ", " ", " "]
+    );
+}
+
+/// Tab handling is bounded for the widest grid the cell budget allows: no
+/// overflow in the next-stop computation.
+#[test]
+fn tab_is_bounded_on_the_widest_permitted_grid() {
+    let cols = 65535_u16;
+    let mut state = TerminalState::new(1, cols).expect("valid terminal");
+    // Cursor at the last column (cols - 1). The next-stop math must not
+    // overflow u16 for column 65534.
+    state.move_cursor(CursorMove::ToColumn(cols - 1));
+    state.feed_bytes(b"\t");
+
+    assert_eq!(cursor(&state), (0, cols - 1));
+}


### PR DESCRIPTION
Closes #26

## Purpose

Add bounded DEC application cursor/keypad mode support and wire the current terminal mode into live macOS input encoding.

This PR is intentionally stacked on #29 (`agent/terminal-sgr-attributes`) because it follows the central `parser.rs` / `state.rs` file lease.

## Changes

- Parse DECCKM `CSI ?1h/l`.
- Parse DECKPAM `ESC =` and DECKPNM `ESC >`.
- Store cursor-key and keypad application modes in `TerminalModes` and snapshots.
- Keep the two input modes independent and terminal-global across resize and alternate-screen switching.
- Preserve the existing normal-mode `KeyEncoder::encode` byte contract.
- Emit SS3 application cursor sequences for arrows.
- Add a bounded physical numeric-keypad model and application/numeric encodings.
- Wire winit `Numpad*` physical codes to the keypad encoder.
- Apply the existing release, Ctrl, Option, and Command rejection policy to the new keypad path.
- Add parser/state, encoder, modifier-policy, alternate-screen, and live-wiring regressions.

## Non-goals

- Function-key or extended modifier protocols.
- Renderer changes.
- SSH, agent features, tabs, panes, or new UI.
- Full xterm compatibility.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — **96 passed**
- `git diff --check`
- Claude Code compatibility review: **BLOCKER: NONE**
- Both PR commits contain Signed-off-by trailers.

## Review notes

- GLM implemented parser/state and live-input wiring.
- Codex integration review prevented the new keypad route from bypassing existing modifier rejection, separated DECKPAM from the DEC-private-mode enum, and reduced the state suite to focused regressions.
- Physical keypad dispatch is unit-tested by winit key code; a real external keyboard remains a manual smoke-test item.
- Unsupported escape finals continue to be swallowed by the bounded parser.

## Handoff

- Base head: `0daa7d6aff2dbcdc547358288346a9804fa35011`
- Exact PR head: `fd1ea69584acbfdf2d0c08debbd148989f3f9f6b`
- Keep as Draft until CI succeeds on this exact head.