### PR TITLE
Terminal Core: add erase and edit operations

### DIFF
--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -25,9 +25,23 @@ pub(crate) enum Action {
     SetScrollRegion { top: u16, bottom: Option<u16> },
     ScrollUp(u16),
     ScrollDown(u16),
+    EraseInDisplay(EraseMode),
+    EraseInLine(EraseMode),
+    EraseCharacters(u16),
+    InsertCharacters(u16),
+    DeleteCharacters(u16),
+    InsertLines(u16),
+    DeleteLines(u16),
     SaveCursor,
     RestoreCursor,
     SetPrivateMode { mode: PrivateMode, enabled: bool },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EraseMode {
+    ToEnd,
+    ToBeginning,
+    All,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -219,6 +233,7 @@ impl Csi {
     fn standard_action(&self, final_byte: u8) -> Option<Action> {
         let count = self.param_or(0, 1);
         match final_byte {
+            b'@' if self.len == 1 => Some(Action::InsertCharacters(count)),
             b'A' => Some(Action::MoveUp(count)),
             b'B' => Some(Action::MoveDown(count)),
             b'C' => Some(Action::MoveRight(count)),
@@ -230,9 +245,15 @@ impl Csi {
                 row: self.param_or(0, 1).saturating_sub(1),
                 col: self.param_or(1, 1).saturating_sub(1),
             }),
+            b'J' => self.erase_mode().map(Action::EraseInDisplay),
+            b'K' => self.erase_mode().map(Action::EraseInLine),
+            b'L' if self.len == 1 => Some(Action::InsertLines(count)),
+            b'P' if self.len == 1 => Some(Action::DeleteCharacters(count)),
             b'S' if self.len <= 1 => Some(Action::ScrollUp(count)),
             b'T' if self.len <= 1 => Some(Action::ScrollDown(count)),
+            b'X' if self.len == 1 => Some(Action::EraseCharacters(count)),
             b'd' => Some(Action::MoveToRow(count.saturating_sub(1))),
+            b'M' if self.len == 1 => Some(Action::DeleteLines(count)),
             b'r' if self.len <= 2 => Some(Action::SetScrollRegion {
                 top: self.param_or(0, 1).saturating_sub(1),
                 bottom: self.zero_based_param(1),
@@ -266,6 +287,18 @@ impl Csi {
 
     fn is_default_only(&self) -> bool {
         self.len == 1 && self.params[0] == 0
+    }
+
+    fn erase_mode(&self) -> Option<EraseMode> {
+        if self.len != 1 {
+            return None;
+        }
+        match self.params[0] {
+            0 => Some(EraseMode::ToEnd),
+            1 => Some(EraseMode::ToBeginning),
+            2 => Some(EraseMode::All),
+            _ => None,
+        }
     }
 
     fn param_or(&self, index: usize, default: u16) -> u16 {

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,4 +1,4 @@
-use crate::parser::{Action, Parser, PrivateMode};
+use crate::parser::{Action, EraseMode, Parser, PrivateMode};
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
@@ -235,6 +235,61 @@ impl ScreenBuffer {
         let shift = rows * columns;
         self.cells[start..end].rotate_right(shift);
         self.cells[start..start + shift].fill(Cell::blank());
+    }
+
+    fn erase_in_display(&mut self, cursor: Cursor, mode: EraseMode) {
+        let Some(cursor_index) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        match mode {
+            EraseMode::ToEnd => self.cells[cursor_index..].fill(Cell::default()),
+            EraseMode::ToBeginning => self.cells[..cursor_index + 1].fill(Cell::default()),
+            EraseMode::All => self.cells.fill(Cell::default()),
+        }
+    }
+
+    fn erase_in_line(&mut self, cursor: Cursor, mode: EraseMode) {
+        let Some(cursor_index) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_start = usize::from(cursor.row) * usize::from(self.cols);
+        let row_end = row_start + usize::from(self.cols);
+        match mode {
+            EraseMode::ToEnd => self.cells[cursor_index..row_end].fill(Cell::default()),
+            EraseMode::ToBeginning => {
+                self.cells[row_start..cursor_index + 1].fill(Cell::default());
+            }
+            EraseMode::All => self.cells[row_start..row_end].fill(Cell::default()),
+        }
+    }
+
+    fn erase_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..start + count].fill(Cell::default());
+    }
+
+    fn insert_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..row_end].rotate_right(count);
+        self.cells[start..start + count].fill(Cell::default());
+    }
+
+    fn delete_characters(&mut self, cursor: Cursor, count: u16) {
+        let Some(start) = self.index(cursor.row, cursor.column) else {
+            return;
+        };
+        let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
+        let count = usize::from(count).min(row_end - start);
+        self.cells[start..row_end].rotate_left(count);
+        self.cells[row_end - count..row_end].fill(Cell::default());
     }
 
     fn index(&self, row: u16, column: u16) -> Option<usize> {
@@ -500,6 +555,13 @@ impl TerminalState {
             }
             Action::ScrollUp(count) => self.scroll_up(count),
             Action::ScrollDown(count) => self.scroll_down(count),
+            Action::EraseInDisplay(mode) => self.erase_in_display(mode),
+            Action::EraseInLine(mode) => self.erase_in_line(mode),
+            Action::EraseCharacters(count) => self.erase_characters(count),
+            Action::InsertCharacters(count) => self.insert_characters(count),
+            Action::DeleteCharacters(count) => self.delete_characters(count),
+            Action::InsertLines(count) => self.insert_lines(count),
+            Action::DeleteLines(count) => self.delete_lines(count),
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
@@ -563,6 +625,69 @@ impl TerminalState {
         self.active
             .screen
             .scroll_down(self.active.scroll_region, count);
+    }
+
+    fn erase_in_display(&mut self, mode: EraseMode) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .erase_in_display(self.active.cursor, mode);
+    }
+
+    fn erase_in_line(&mut self, mode: EraseMode) {
+        self.active.wrap_pending = false;
+        self.active.screen.erase_in_line(self.active.cursor, mode);
+    }
+
+    fn erase_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .erase_characters(self.active.cursor, count);
+    }
+
+    fn insert_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .insert_characters(self.active.cursor, count);
+    }
+
+    fn delete_characters(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        self.active
+            .screen
+            .delete_characters(self.active.cursor, count);
+    }
+
+    fn insert_lines(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        let cursor_row = self.active.cursor.row;
+        let region = self.active.scroll_region;
+        if (region.top..=region.bottom).contains(&cursor_row) {
+            self.active.screen.scroll_down(
+                ScrollRegion {
+                    top: cursor_row,
+                    bottom: region.bottom,
+                },
+                count,
+            );
+        }
+    }
+
+    fn delete_lines(&mut self, count: u16) {
+        self.active.wrap_pending = false;
+        let cursor_row = self.active.cursor.row;
+        let region = self.active.scroll_region;
+        if (region.top..=region.bottom).contains(&cursor_row) {
+            self.active.screen.scroll_up(
+                ScrollRegion {
+                    top: cursor_row,
+                    bottom: region.bottom,
+                },
+                count,
+            );
+        }
     }
 
     fn reset_scroll_region(&mut self) {

--- a/crates/noren-terminal/tests/erase_operations.rs
+++ b/crates/noren-terminal/tests/erase_operations.rs
@@ -1,0 +1,156 @@
+use noren_terminal::{CursorMove, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn rows(state: &TerminalState) -> Vec<String> {
+    (0..state.screen().rows())
+        .map(|row| {
+            (0..state.screen().cols())
+                .map(|column| {
+                    state
+                        .screen()
+                        .cell(row, column)
+                        .expect("cell is in bounds")
+                        .text()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn filled_screen() -> TerminalState {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDE\x1b[2;1HFGHIJ\x1b[3;1HKLMNO");
+    state
+}
+
+fn labeled_rows() -> TerminalState {
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    state
+}
+
+fn operate_on_line(column: u16, sequence: &[u8]) -> TerminalState {
+    let mut state = TerminalState::new(1, 5).expect("valid terminal");
+    state.feed_bytes(b"ABCDE");
+    state.move_cursor(CursorMove::ToColumn(column));
+    state.feed_bytes(sequence);
+    state
+}
+
+#[test]
+fn ed_modes_include_the_cursor_cell_and_preserve_the_cursor() {
+    let cases: &[(&[u8], [&str; 3])] = &[
+        (b"\x1b[J", ["ABCDE", "FG   ", "     "]),
+        (b"\x1b[1J", ["     ", "   IJ", "KLMNO"]),
+        (b"\x1b[2J", ["     ", "     ", "     "]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = filled_screen();
+        state.feed_bytes(b"\x1b[2;3H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (1, 2), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn el_modes_only_change_the_active_row_and_preserve_the_cursor() {
+    let cases: &[(&[u8], [&str; 3])] = &[
+        (b"\x1b[0K", ["ABCDE", "FG   ", "KLMNO"]),
+        (b"\x1b[1K", ["ABCDE", "   IJ", "KLMNO"]),
+        (b"\x1b[2K", ["ABCDE", "     ", "KLMNO"]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = filled_screen();
+        state.feed_bytes(b"\x1b[2;3H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (1, 2), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn character_operations_default_zero_shift_and_clamp_at_the_line_boundary() {
+    let cases: &[(&[u8], u16, &str)] = &[
+        (b"\x1b[X", 1, "A CDE"),
+        (b"\x1b[0X", 1, "A CDE"),
+        (b"\x1b[2X", 1, "A  DE"),
+        (b"\x1b[99999X", 3, "ABC  "),
+        (b"\x1b[@", 1, "A BCD"),
+        (b"\x1b[0@", 1, "A BCD"),
+        (b"\x1b[2@", 1, "A  BC"),
+        (b"\x1b[99999@", 3, "ABC  "),
+        (b"\x1b[P", 1, "ACDE "),
+        (b"\x1b[0P", 1, "ACDE "),
+        (b"\x1b[2P", 1, "ADE  "),
+        (b"\x1b[99999P", 3, "ABC  "),
+    ];
+
+    for (sequence, column, expected) in cases {
+        let state = operate_on_line(*column, sequence);
+
+        assert_eq!(rows(&state), [*expected], "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (0, *column), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn line_operations_are_clamped_from_the_cursor_to_the_bottom_margin() {
+    let cases: &[(&[u8], [&str; 5])] = &[
+        (b"\x1b[L", ["AAA", "BBB", "   ", "CCC", "EEE"]),
+        (b"\x1b[0M", ["AAA", "BBB", "DDD", "   ", "EEE"]),
+        (b"\x1b[99999L", ["AAA", "BBB", "   ", "   ", "EEE"]),
+        (b"\x1b[99999M", ["AAA", "BBB", "   ", "   ", "EEE"]),
+    ];
+
+    for (sequence, expected) in cases {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r\x1b[3;2H");
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(rows(&state), *expected, "sequence {sequence:?}");
+        assert_eq!(cursor(&state), (2, 1), "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn line_operations_are_ignored_when_the_cursor_is_outside_the_scroll_region() {
+    for (sequence, position, expected_cursor) in [
+        (b"\x1b[L".as_slice(), b"\x1b[1;2H".as_slice(), (0, 1)),
+        (b"\x1b[M".as_slice(), b"\x1b[5;2H".as_slice(), (4, 1)),
+    ] {
+        let mut state = labeled_rows();
+        state.feed_bytes(b"\x1b[2;4r");
+        state.feed_bytes(position);
+        let before = state.snapshot();
+
+        state.feed_bytes(sequence);
+
+        assert_eq!(state.snapshot().screen(), before.screen());
+        assert_eq!(cursor(&state), expected_cursor, "sequence {sequence:?}");
+    }
+}
+
+#[test]
+fn unsupported_modes_extra_parameters_and_parameter_overflow_are_ignored() {
+    let mut state = filled_screen();
+    state.feed_bytes(b"\x1b[2;3H");
+    let before = state.snapshot();
+
+    state.feed_bytes(
+        b"\x1b[3J\x1b[1;2K\x1b[1;2X\x1b[1;2@\x1b[1;2P\x1b[1;2L\x1b[1;2M\
+          \x1b[1;1;1;1;1;1;1;1;1X",
+    );
+
+    assert_eq!(state.snapshot(), before);
+}


### PR DESCRIPTION
## Issue

Closes #24 when this Draft is accepted and merged.

## Purpose

Add the bounded erase and in-line/in-region edit behavior needed by full-screen terminal applications without changing the renderer or PTY boundary.

## Changes

- Added ED modes 0/1/2 and EL modes 0/1/2.
- Added ECH, ICH, DCH, IL, and DL.
- Applied VT-style default count 1, zero-as-default, and bounded oversized counts.
- Preserved cursor positions and cleared pending wrap on applied edit operations.
- Restricted IL/DL to the cursor-through-bottom portion of the active scroll region; outside-margin operations are no-ops.
- Added public behavior tests for modes, boundaries, scroll regions, malformed/extra parameters, and parser overflow.

## Stacked dependency

Base: Draft PR #23, branch `agent/terminal-alternate-screen`, exact base head `c6a1e3fef469c09e243a0b5cc88c2bee2aedddb7`.

PR #23 depends on Draft PR #21. This PR must remain Draft and stacked until its dependencies are accepted.

## Checks

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed, 67 tests
- `git diff --cached --check` — passed before commit
- Commit `a630c93` includes a `Signed-off-by` trailer
- Claude Code compatibility review: no external blocker; planned state/parser gaps map directly to this issue

## Remaining risks

- This pre-SGR slice erases/inserts default blank cells. Attribute-aware blank semantics are integrated in #25 after this checkpoint.
- ED mode 3/scrollback erasure is intentionally unsupported because Terminal Core has no scrollback.
- This is bounded compatibility behavior, not a full VT100/xterm conformance claim.

## Non-goals

No SGR/cell attributes, application modes, renderer redesign, UI, SSH, AI integration, Unicode/IME, or scrollback.