### PR TITLE
fix(app): keep PTY, terminal, and rendered grids in agreement

### DIFF
--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -45,6 +45,17 @@ pub const POC_CELL_WIDTH: u32 = 10;
 /// Fixed PoC cell height in physical pixels.
 pub const POC_CELL_HEIGHT: u32 = 20;
 
+/// Maximum terminal grid rows the PoC renderer can draw.
+///
+/// [`GridGeometry::update`] clamps every grid handed to the terminal state and
+/// the PTY to this cap, so the PTY, terminal, and rendered grids always agree.
+/// The renderer module imports this constant rather than redefining it.
+pub const MAX_RENDER_ROWS: u16 = 60;
+/// Maximum terminal grid columns the PoC renderer can draw.
+///
+/// See [`MAX_RENDER_ROWS`] for the shared-cap invariant.
+pub const MAX_RENDER_COLS: u16 = 160;
+
 /// Physical window size reported by the platform, before pixel-to-cell
 /// conversion.
 ///
@@ -85,7 +96,8 @@ impl Resize {
     }
 }
 
-/// Non-zero terminal grid calculated from physical window pixels.
+/// Non-zero terminal grid calculated from physical window pixels, bounded by
+/// the renderer's drawable grid ([`MAX_RENDER_ROWS`] by [`MAX_RENDER_COLS`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GridSize {
     rows: u16,
@@ -93,13 +105,13 @@ pub struct GridSize {
 }
 
 impl GridSize {
-    /// Row count, always non-zero.
+    /// Row count, always non-zero and at most [`MAX_RENDER_ROWS`].
     #[must_use]
     pub const fn rows(self) -> u16 {
         self.rows
     }
 
-    /// Column count, always non-zero.
+    /// Column count, always non-zero and at most [`MAX_RENDER_COLS`].
     #[must_use]
     pub const fn cols(self) -> u16 {
         self.cols
@@ -134,20 +146,23 @@ impl GridGeometry {
     /// Convert a physical resize and return only a changed, non-zero grid.
     ///
     /// A zero physical dimension keeps the previous grid. Pixel sizes smaller
-    /// than one cell still produce a one-by-one PTY. Values are capped to
-    /// `u16::MAX` before crossing the PTY boundary.
+    /// than one cell still produce a one-by-one PTY. Values are capped to the
+    /// renderer's drawable grid ([`MAX_RENDER_ROWS`] by [`MAX_RENDER_COLS`])
+    /// before crossing the PTY boundary, so the PTY, terminal state, and
+    /// rendered grids can never disagree. This is the only place a grid is
+    /// calculated; every consumer observes the same clamp.
     pub fn update(&mut self, resize: Resize) -> Option<GridSize> {
         if resize.is_zero() {
             return None;
         }
         let cols = (resize.width() / self.cell_width)
-            .clamp(1, u32::from(u16::MAX))
+            .clamp(1, u32::from(MAX_RENDER_COLS))
             .try_into()
-            .unwrap_or(u16::MAX);
+            .unwrap_or(MAX_RENDER_COLS);
         let rows = (resize.height() / self.cell_height)
-            .clamp(1, u32::from(u16::MAX))
+            .clamp(1, u32::from(MAX_RENDER_ROWS))
             .try_into()
-            .unwrap_or(u16::MAX);
+            .unwrap_or(MAX_RENDER_ROWS);
         let next = GridSize { rows, cols };
         if self.current == Some(next) {
             None
@@ -501,12 +516,70 @@ mod tests {
     }
 
     #[test]
-    fn geometry_caps_values_before_the_pty_boundary() {
+    fn geometry_clamps_extreme_resizes_without_overflow() {
         let mut geometry = GridGeometry::poc();
         let grid = geometry
             .update(Resize::new(u32::MAX, u32::MAX))
             .expect("new grid");
-        assert_eq!((grid.rows(), grid.cols()), (u16::MAX, u16::MAX));
+        assert_eq!(
+            (grid.rows(), grid.cols()),
+            (MAX_RENDER_ROWS, MAX_RENDER_COLS)
+        );
+    }
+
+    #[test]
+    fn geometry_clamps_oversized_resizes_to_the_render_grid() {
+        let mut geometry = GridGeometry::poc();
+        let beyond = geometry
+            .update(Resize::new(
+                u32::from(MAX_RENDER_COLS + 40) * POC_CELL_WIDTH,
+                u32::from(MAX_RENDER_ROWS + 20) * POC_CELL_HEIGHT,
+            ))
+            .expect("new grid");
+        assert_eq!(
+            (beyond.rows(), beyond.cols()),
+            (MAX_RENDER_ROWS, MAX_RENDER_COLS)
+        );
+
+        let mut fresh = GridGeometry::poc();
+        let one_dimension_over = fresh
+            .update(Resize::new(
+                u32::from(MAX_RENDER_COLS + 1) * POC_CELL_WIDTH,
+                u32::from(MAX_RENDER_ROWS) * POC_CELL_HEIGHT,
+            ))
+            .expect("new grid");
+        assert_eq!(
+            (one_dimension_over.rows(), one_dimension_over.cols()),
+            (MAX_RENDER_ROWS, MAX_RENDER_COLS)
+        );
+    }
+
+    #[test]
+    fn geometry_keeps_resizes_within_the_render_cap_unaffected() {
+        let mut geometry = GridGeometry::poc();
+        let normal = geometry.update(Resize::new(900, 600)).expect("new grid");
+        assert_eq!((normal.rows(), normal.cols()), (30, 90));
+
+        let at_cap = geometry
+            .update(Resize::new(
+                u32::from(MAX_RENDER_COLS) * POC_CELL_WIDTH,
+                u32::from(MAX_RENDER_ROWS) * POC_CELL_HEIGHT,
+            ))
+            .expect("changed grid");
+        assert_eq!(
+            (at_cap.rows(), at_cap.cols()),
+            (MAX_RENDER_ROWS, MAX_RENDER_COLS)
+        );
+    }
+
+    #[test]
+    fn geometry_rejects_zero_resizes_and_keeps_the_last_grid() {
+        let mut geometry = GridGeometry::poc();
+        let valid = geometry.update(Resize::new(900, 600)).expect("new grid");
+        assert_eq!(geometry.update(Resize::new(0, 600)), None);
+        assert_eq!(geometry.update(Resize::new(900, 0)), None);
+        assert_eq!(geometry.update(Resize::new(0, 0)), None);
+        assert_eq!(geometry.current(), Some(valid));
     }
 
     #[test]

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -10,13 +10,13 @@ use wgpu::CurrentSurfaceTexture;
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
-use noren_app::{POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
+use noren_app::{
+    MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH,
+};
 use noren_terminal::TerminalSnapshot;
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
-const MAX_RENDER_ROWS: usize = 60;
-const MAX_RENDER_COLS: usize = 160;
-const MAX_VERTICES: usize = MAX_RENDER_ROWS * MAX_RENDER_COLS * 35 * 6;
+const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize) * (MAX_RENDER_COLS as usize) * 35 * 6;
 
 const SHADER: &str = r#"
 struct VertexOutput {
@@ -283,10 +283,10 @@ fn glyph_vertices(
     }
     let visible_rows = usize::try_from(height / CELL_HEIGHT)
         .unwrap_or(usize::MAX)
-        .clamp(1, MAX_RENDER_ROWS);
+        .clamp(1, usize::from(MAX_RENDER_ROWS));
     let visible_cols = usize::try_from(width / CELL_WIDTH)
         .unwrap_or(usize::MAX)
-        .clamp(1, MAX_RENDER_COLS);
+        .clamp(1, usize::from(MAX_RENDER_COLS));
     let lines = terminal.map(TerminalSnapshot::lines).unwrap_or_default();
     let total_lines = lines.len() + usize::from(status.is_some());
     let first_line = total_lines.saturating_sub(visible_rows);


### PR DESCRIPTION
Closes #35.

## Problem

The drawn grid and the grid handed to the PTY were capped in two different
places, so they could disagree:

- `renderer.rs` clamped the drawn grid to 60 rows by 160 columns.
- `GridGeometry::update` computed the PTY and terminal-state grid from the same
  physical pixel size, capped only at `u16::MAX`.

On any large Retina window the shell wrapped and positioned content on a grid the
renderer never drew, so full-screen TUIs (vim, htop, zellij) placed UI outside
the visible area with nothing surfaced to the user.

## Fix

Cap the grid in one place. `MAX_RENDER_ROWS` / `MAX_RENDER_COLS` now live in the
`noren-app` library, `GridGeometry::update` clamps every calculated grid to them,
and the renderer imports the same constants instead of redefining them — so the
two can no longer drift apart.

## Tests

- an oversized resize clamps to the render grid, including when only one
  dimension exceeds the cap;
- a resize within the cap is unaffected, and a resize exactly at the cap is
  reported;
- zero-dimension resizes are still rejected and keep the previous grid;
- the pre-existing extreme-resize test continues to pass without overflow.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, and 115 workspace tests pass (was 112) with
0 failures.

Rebased onto `main` after PR #32 landed; `git diff --stat origin/main...HEAD`
touches only `crates/noren-app/src/lib.rs` and `renderer.rs`, deleting no landed
test.

## Provenance

Found by the Qwen application-layer review of the Terminal Core stack
(`docs/coordination/reviews/terminal-stack-qwen.md`), confirmed by coordinator
code reading, and fixed by the same lane.