### PR TITLE
feat(app): encode Delete, navigation, and function keys

### DIFF
--- a/crates/noren-app/src/input.rs
+++ b/crates/noren-app/src/input.rs
@@ -1,4 +1,4 @@
-//! Application input modes and bounded keypad key model.
+//! Application input modes and bounded keypad/function key model.
 //!
 //! This is the input-side mirror of DECCKM (`CSI ?1 h/l`, DEC cursor key mode)
 //! and DECKPAM / DECKPNM (`ESC =` / `ESC >`, keypad application / numeric
@@ -77,9 +77,9 @@ impl InputMode {
 
 /// Bounded set of numeric-keypad keys the input encoder explicitly supports.
 ///
-/// The set is deliberately bounded to a standard numeric keypad; function,
-/// editing, and PF keys remain a later integration concern and are not modeled
-/// by this checkpoint.
+/// The set is deliberately bounded to a standard numeric keypad; PF keys
+/// remain a later integration concern and are not modeled by this checkpoint.
+/// Function keys are modeled separately as [`FunctionKey`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeypadKey {
     /// `0`.
@@ -198,5 +198,81 @@ pub(crate) fn keypad_bytes(key: KeypadKey, mode: KeypadMode) -> &'static [u8] {
     match mode {
         KeypadMode::Numeric => numeric,
         KeypadMode::Application => application,
+    }
+}
+
+/// Bounded set of function keys the input encoder explicitly supports.
+///
+/// F1 through F4 emit `SS3` sequences while F5 through F12 emit `CSI <n> ~`
+/// sequences, matching xterm's asymmetry. Function keys ignore both
+/// application cursor and application keypad modes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FunctionKey {
+    /// `F1`.
+    F1,
+    /// `F2`.
+    F2,
+    /// `F3`.
+    F3,
+    /// `F4`.
+    F4,
+    /// `F5`.
+    F5,
+    /// `F6`.
+    F6,
+    /// `F7`.
+    F7,
+    /// `F8`.
+    F8,
+    /// `F9`.
+    F9,
+    /// `F10`.
+    F10,
+    /// `F11`.
+    F11,
+    /// `F12`.
+    F12,
+}
+
+/// Select the function key byte sequence.
+///
+/// F1-F4 use the `SS3` finals `P`-`S`; F5-F12 use `CSI <n> ~` with xterm's
+/// parameter gaps at 16 and 22. DECCKM does not change any of these.
+pub(crate) fn function_key_bytes(key: FunctionKey) -> &'static [u8] {
+    match key {
+        FunctionKey::F1 => b"\x1bOP",
+        FunctionKey::F2 => b"\x1bOQ",
+        FunctionKey::F3 => b"\x1bOR",
+        FunctionKey::F4 => b"\x1bOS",
+        FunctionKey::F5 => b"\x1b[15~",
+        FunctionKey::F6 => b"\x1b[17~",
+        FunctionKey::F7 => b"\x1b[18~",
+        FunctionKey::F8 => b"\x1b[19~",
+        FunctionKey::F9 => b"\x1b[20~",
+        FunctionKey::F10 => b"\x1b[21~",
+        FunctionKey::F11 => b"\x1b[23~",
+        FunctionKey::F12 => b"\x1b[24~",
+    }
+}
+
+/// Select the Home byte sequence for the active cursor key mode.
+///
+/// xterm sends `CSI H` in normal mode and `SS3 H` under DECCKM, matching the
+/// terminfo `khome=\EOH` capability that applies between `smkx` and `rmkx`.
+pub(crate) fn home_bytes(mode: CursorKeyMode) -> &'static [u8] {
+    match mode {
+        CursorKeyMode::Normal => b"\x1b[H",
+        CursorKeyMode::Application => b"\x1bOH",
+    }
+}
+
+/// Select the End byte sequence for the active cursor key mode.
+///
+/// xterm sends `CSI F` in normal mode and `SS3 F` under DECCKM
+/// (`kend=\EOF` between `smkx` and `rmkx`).
+pub(crate) fn end_bytes(mode: CursorKeyMode) -> &'static [u8] {
+    match mode {
+        CursorKeyMode::Normal => b"\x1b[F",
+        CursorKeyMode::Application => b"\x1bOF",
     }
 }

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -10,7 +10,7 @@
 
 mod input;
 
-pub use input::{CursorKeyMode, InputMode, KeypadInput, KeypadKey, KeypadMode};
+pub use input::{CursorKeyMode, FunctionKey, InputMode, KeypadInput, KeypadKey, KeypadMode};
 
 use std::fmt;
 use std::time::Duration;
@@ -262,9 +262,10 @@ pub enum Arrow {
 
 /// Supported app-owned key identities.
 ///
-/// The PoC encodes printable UTF-8, Enter, Backspace, Tab, Escape, arrows, and
-/// Ctrl control bytes. Releases and unsupported combinations emit zero bytes;
-/// they are not part of this baseline's encoding step.
+/// The PoC encodes printable UTF-8, Enter, Backspace, Tab, Escape, arrows,
+/// Delete, Insert, Home, End, PageUp, PageDown, F1-F12, and Ctrl control
+/// bytes. Releases and unsupported combinations emit zero bytes; they are not
+/// part of this baseline's encoding step.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Key {
     /// A printable UTF-8 character.
@@ -274,6 +275,20 @@ pub enum Key {
     Tab,
     Escape,
     Arrow(Arrow),
+    /// Forward delete (xterm `CSI 3 ~`), distinct from [`Key::Backspace`].
+    Delete,
+    /// Insert / toggle key (xterm `CSI 2 ~`).
+    Insert,
+    /// Home (xterm `CSI H`, or `SS3 H` under DECCKM).
+    Home,
+    /// End (xterm `CSI F`, or `SS3 F` under DECCKM).
+    End,
+    /// Page up (xterm `CSI 5 ~`).
+    PageUp,
+    /// Page down (xterm `CSI 6 ~`).
+    PageDown,
+    /// Function key F1 through F12.
+    Function(FunctionKey),
 }
 
 /// Whether a key event is a press, an autorepeat, or a release.
@@ -349,8 +364,9 @@ impl KeyEncoder {
     /// Encode one pressed or repeated key event for the active application
     /// input mode.
     ///
-    /// Only bare arrow keys observe [`CursorKeyMode`]; release, modifier,
-    /// control-byte, and printable handling is identical to
+    /// Bare arrow keys, Home, and End observe [`CursorKeyMode`]; Delete,
+    /// Insert, PageUp, PageDown, and F1-F12 are mode-independent. Release,
+    /// modifier, control-byte, and printable handling is identical to
     /// [`KeyEncoder::encode`], so the normal mode is byte-for-byte compatible.
     pub fn encode_with(input: KeyInput, mode: InputMode) -> Result<Vec<u8>, KeyDropReason> {
         if input.phase() == KeyPhase::Released {
@@ -380,6 +396,13 @@ impl KeyEncoder {
             Key::Tab => Ok(vec![0x09]),
             Key::Escape => Ok(vec![0x1b]),
             Key::Arrow(arrow) => Ok(input::cursor_bytes(arrow, mode.cursor()).to_vec()),
+            Key::Delete => Ok(b"\x1b[3~".to_vec()),
+            Key::Insert => Ok(b"\x1b[2~".to_vec()),
+            Key::Home => Ok(input::home_bytes(mode.cursor()).to_vec()),
+            Key::End => Ok(input::end_bytes(mode.cursor()).to_vec()),
+            Key::PageUp => Ok(b"\x1b[5~".to_vec()),
+            Key::PageDown => Ok(b"\x1b[6~".to_vec()),
+            Key::Function(function_key) => Ok(input::function_key_bytes(function_key).to_vec()),
         }
     }
 
@@ -906,5 +929,172 @@ mod tests {
             KeyEncoder::encode_keypad_with(keypad, once),
             KeyEncoder::encode_keypad_with(keypad, twice)
         );
+    }
+
+    fn all_function_keys() -> [FunctionKey; 12] {
+        [
+            FunctionKey::F1,
+            FunctionKey::F2,
+            FunctionKey::F3,
+            FunctionKey::F4,
+            FunctionKey::F5,
+            FunctionKey::F6,
+            FunctionKey::F7,
+            FunctionKey::F8,
+            FunctionKey::F9,
+            FunctionKey::F10,
+            FunctionKey::F11,
+            FunctionKey::F12,
+        ]
+    }
+
+    #[test]
+    fn navigation_keys_emit_their_xterm_bytes() {
+        let cases = [
+            (Key::Delete, b"\x1b[3~".as_slice()),
+            (Key::Insert, b"\x1b[2~"),
+            (Key::Home, b"\x1b[H"),
+            (Key::End, b"\x1b[F"),
+            (Key::PageUp, b"\x1b[5~"),
+            (Key::PageDown, b"\x1b[6~"),
+        ];
+        for (key, expected) in cases {
+            let input = KeyInput::new(key, KeyPhase::Pressed, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(input).as_deref(), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn function_keys_emit_the_xterm_ss3_and_csi_bytes() {
+        let cases = [
+            (FunctionKey::F1, b"\x1bOP".as_slice()),
+            (FunctionKey::F2, b"\x1bOQ"),
+            (FunctionKey::F3, b"\x1bOR"),
+            (FunctionKey::F4, b"\x1bOS"),
+            (FunctionKey::F5, b"\x1b[15~"),
+            (FunctionKey::F6, b"\x1b[17~"),
+            (FunctionKey::F7, b"\x1b[18~"),
+            (FunctionKey::F8, b"\x1b[19~"),
+            (FunctionKey::F9, b"\x1b[20~"),
+            (FunctionKey::F10, b"\x1b[21~"),
+            (FunctionKey::F11, b"\x1b[23~"),
+            (FunctionKey::F12, b"\x1b[24~"),
+        ];
+        for (function_key, expected) in cases {
+            let input = KeyInput::new(
+                Key::Function(function_key),
+                KeyPhase::Pressed,
+                Modifiers::empty(),
+            );
+            assert_eq!(KeyEncoder::encode(input).as_deref(), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn home_and_end_switch_to_ss3_under_application_cursor_mode() {
+        let application = InputMode::normal().with_cursor(CursorKeyMode::Application);
+        let cases = [
+            (Key::Home, b"\x1b[H".as_slice(), b"\x1bOH".as_slice()),
+            (Key::End, b"\x1b[F".as_slice(), b"\x1bOF".as_slice()),
+        ];
+        for (key, normal_bytes, application_bytes) in cases {
+            let input = KeyInput::new(key, KeyPhase::Pressed, Modifiers::empty());
+            assert_eq!(
+                KeyEncoder::encode_with(input, InputMode::normal()).as_deref(),
+                Ok(normal_bytes)
+            );
+            assert_eq!(
+                KeyEncoder::encode_with(input, application).as_deref(),
+                Ok(application_bytes)
+            );
+        }
+    }
+
+    #[test]
+    fn mode_independent_keys_ignore_application_cursor_mode() {
+        let application = InputMode::normal().with_cursor(CursorKeyMode::Application);
+        for key in [Key::Delete, Key::Insert, Key::PageUp, Key::PageDown] {
+            let input = KeyInput::new(key, KeyPhase::Pressed, Modifiers::empty());
+            let expected = KeyEncoder::encode(input);
+            assert_eq!(KeyEncoder::encode_with(input, application), expected);
+        }
+        for function_key in all_function_keys() {
+            let input = KeyInput::new(
+                Key::Function(function_key),
+                KeyPhase::Pressed,
+                Modifiers::empty(),
+            );
+            let expected = KeyEncoder::encode(input);
+            assert_eq!(KeyEncoder::encode_with(input, application), expected);
+        }
+    }
+
+    #[test]
+    fn stage_one_key_releases_emit_nothing() {
+        let application = InputMode::normal().with_cursor(CursorKeyMode::Application);
+        for key in [
+            Key::Delete,
+            Key::Insert,
+            Key::Home,
+            Key::End,
+            Key::PageUp,
+            Key::PageDown,
+        ] {
+            let released = KeyInput::new(key, KeyPhase::Released, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(released), Err(KeyDropReason::Released));
+            assert_eq!(
+                KeyEncoder::encode_with(released, application),
+                Err(KeyDropReason::Released)
+            );
+        }
+        for function_key in all_function_keys() {
+            let released = KeyInput::new(
+                Key::Function(function_key),
+                KeyPhase::Released,
+                Modifiers::empty(),
+            );
+            assert_eq!(KeyEncoder::encode(released), Err(KeyDropReason::Released));
+            assert_eq!(
+                KeyEncoder::encode_with(released, application),
+                Err(KeyDropReason::Released)
+            );
+        }
+    }
+
+    #[test]
+    fn stage_one_key_repeats_emit_exactly_one_sequence() {
+        let cases = [
+            (Key::Delete, b"\x1b[3~".as_slice()),
+            (Key::Insert, b"\x1b[2~"),
+            (Key::Home, b"\x1b[H"),
+            (Key::End, b"\x1b[F"),
+            (Key::PageUp, b"\x1b[5~"),
+            (Key::PageDown, b"\x1b[6~"),
+            (Key::Function(FunctionKey::F1), b"\x1bOP"),
+            (Key::Function(FunctionKey::F12), b"\x1b[24~"),
+        ];
+        for (key, expected) in cases {
+            let repeated = KeyInput::new(key, KeyPhase::Repeat, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(repeated).as_deref(), Ok(expected));
+            let pressed = KeyInput::new(key, KeyPhase::Pressed, Modifiers::empty());
+            assert_eq!(KeyEncoder::encode(repeated), KeyEncoder::encode(pressed));
+        }
+    }
+
+    #[test]
+    fn stage_one_ctrl_combinations_remain_dropped() {
+        for key in [
+            Key::Delete,
+            Key::Home,
+            Key::PageUp,
+            Key::Function(FunctionKey::F1),
+            Key::Function(FunctionKey::F12),
+        ] {
+            let input = KeyInput::new(key, KeyPhase::Pressed, Modifiers::empty().ctrl());
+            assert_eq!(
+                KeyEncoder::encode(input),
+                Err(KeyDropReason::UnsupportedControl)
+            );
+        }
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3,9 +3,9 @@
 mod renderer;
 
 use noren_app::{
-    Arrow, CursorKeyMode, GridGeometry, GridSize, InputMode, Key, KeyDropReason, KeyEncoder,
-    KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, Modifiers, PARSE_BUDGET_BYTES_PER_TURN,
-    Resize,
+    Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
+    KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, Modifiers,
+    PARSE_BUDGET_BYTES_PER_TURN, Resize,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
 use noren_terminal::{TerminalEngine, TerminalState};
@@ -411,6 +411,24 @@ fn translate_logical_key(
         WinitKey::Named(NamedKey::ArrowDown) => Key::Arrow(Arrow::Down),
         WinitKey::Named(NamedKey::ArrowLeft) => Key::Arrow(Arrow::Left),
         WinitKey::Named(NamedKey::ArrowRight) => Key::Arrow(Arrow::Right),
+        WinitKey::Named(NamedKey::Delete) => Key::Delete,
+        WinitKey::Named(NamedKey::Insert) => Key::Insert,
+        WinitKey::Named(NamedKey::Home) => Key::Home,
+        WinitKey::Named(NamedKey::End) => Key::End,
+        WinitKey::Named(NamedKey::PageUp) => Key::PageUp,
+        WinitKey::Named(NamedKey::PageDown) => Key::PageDown,
+        WinitKey::Named(NamedKey::F1) => Key::Function(FunctionKey::F1),
+        WinitKey::Named(NamedKey::F2) => Key::Function(FunctionKey::F2),
+        WinitKey::Named(NamedKey::F3) => Key::Function(FunctionKey::F3),
+        WinitKey::Named(NamedKey::F4) => Key::Function(FunctionKey::F4),
+        WinitKey::Named(NamedKey::F5) => Key::Function(FunctionKey::F5),
+        WinitKey::Named(NamedKey::F6) => Key::Function(FunctionKey::F6),
+        WinitKey::Named(NamedKey::F7) => Key::Function(FunctionKey::F7),
+        WinitKey::Named(NamedKey::F8) => Key::Function(FunctionKey::F8),
+        WinitKey::Named(NamedKey::F9) => Key::Function(FunctionKey::F9),
+        WinitKey::Named(NamedKey::F10) => Key::Function(FunctionKey::F10),
+        WinitKey::Named(NamedKey::F11) => Key::Function(FunctionKey::F11),
+        WinitKey::Named(NamedKey::F12) => Key::Function(FunctionKey::F12),
         WinitKey::Dead(_) => return Err(KeyDropReason::ImeOrDeadKey),
         _ => return Err(KeyDropReason::UnsupportedKey),
     };
@@ -495,6 +513,48 @@ mod tests {
             assert_eq!(keypad_key(PhysicalKey::Code(code)), Some(expected));
         }
         assert_eq!(keypad_key(PhysicalKey::Code(KeyCode::Digit1)), None);
+    }
+
+    #[test]
+    fn navigation_and_function_named_keys_translate_to_app_keys() {
+        let cases = [
+            (NamedKey::Delete, Key::Delete),
+            (NamedKey::Insert, Key::Insert),
+            (NamedKey::Home, Key::Home),
+            (NamedKey::End, Key::End),
+            (NamedKey::PageUp, Key::PageUp),
+            (NamedKey::PageDown, Key::PageDown),
+            (NamedKey::F1, Key::Function(FunctionKey::F1)),
+            (NamedKey::F2, Key::Function(FunctionKey::F2)),
+            (NamedKey::F3, Key::Function(FunctionKey::F3)),
+            (NamedKey::F4, Key::Function(FunctionKey::F4)),
+            (NamedKey::F5, Key::Function(FunctionKey::F5)),
+            (NamedKey::F6, Key::Function(FunctionKey::F6)),
+            (NamedKey::F7, Key::Function(FunctionKey::F7)),
+            (NamedKey::F8, Key::Function(FunctionKey::F8)),
+            (NamedKey::F9, Key::Function(FunctionKey::F9)),
+            (NamedKey::F10, Key::Function(FunctionKey::F10)),
+            (NamedKey::F11, Key::Function(FunctionKey::F11)),
+            (NamedKey::F12, Key::Function(FunctionKey::F12)),
+        ];
+        for (named, expected) in cases {
+            let logical_key = WinitKey::Named(named);
+            let input = translate_logical_key(&logical_key, KeyPhase::Pressed, Modifiers::empty())
+                .expect("stage one key is supported terminal input");
+            assert_eq!(input.key(), expected);
+            assert_eq!(input.phase(), KeyPhase::Pressed);
+        }
+    }
+
+    #[test]
+    fn untranslated_named_keys_still_report_a_drop() {
+        for named in [NamedKey::F13, NamedKey::ScrollLock, NamedKey::Pause] {
+            let logical_key = WinitKey::Named(named);
+            assert_eq!(
+                translate_logical_key(&logical_key, KeyPhase::Pressed, Modifiers::empty()),
+                Err(KeyDropReason::UnsupportedKey)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stage 1 of #36. Keeps that Issue open for stages 2-4.

## What this fixes

Eighteen everyday keys were silently dropped instead of sending the bytes a real
terminal sends. Against the project's stated first-class input-preservation
contract, that is a real defect: Delete, Home, End, PageUp/PageDown, Insert, and
F1-F12 are ordinary keys in vim, less, and zellij, and each previously emitted
nothing with no feedback.

| Key | Bytes |
| --- | --- |
| Delete | `CSI 3 ~` |
| Insert | `CSI 2 ~` |
| PageUp / PageDown | `CSI 5 ~` / `CSI 6 ~` |
| Home / End | `CSI H` / `CSI F`, or `SS3 H` / `SS3 F` under DECCKM |
| F1-F4 | `SS3 P`-`SS3 S` |
| F5-F12 | `CSI 15/17/18/19/20/21/23/24 ~` |

Two details worth reviewing rather than skimming:

- **F1-F4 use SS3 while F5-F12 use `CSI <n> ~`**, and the numbering deliberately
  skips 16 and 22. That asymmetry is real xterm behavior, not an oversight.
- **Home/End are DECCKM-dependent**, matching the terminfo `khome=\EOH` /
  `kend=\EOF` capabilities that apply between `smkx` and `rmkx`. The lane chose
  this over the unconditional `CSI H` / `CSI F` form and documented why; both
  exist in the wild, so this is the deliberate choice the Issue asked for.

## Scope held deliberately narrow

Alt-as-ESC-prefix, Ctrl with named keys, and Shift/modifier parameters are
**not** in this change. They are stages 2-4 of #36 and land separately, because a
byte-exact change is reviewable and a sweeping input rewrite is not.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **147 workspace tests pass** (was 135), 0
failures.

The coordinator independently verified all 18 encodings byte-for-byte against
xterm with a separate test, including the F-key asymmetry and that key releases
emit nothing while a press emits exactly one sequence.

## Provenance

Found by the Qwen application-layer review of the Terminal Core stack
(`docs/coordination/reviews/terminal-stack-qwen.md`) and fixed by the same lane.