### PR TITLE
ci: add dependency audit, license policy, and MSRV verification

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,72 @@
+name: Audit
+
+# Supply-chain and toolchain-pin gates. This workflow is intentionally separate
+# from `rust.yml`: `rust.yml` owns build/lint/test, while this file owns the
+# dependency audit (advisories, licenses, bans, sources) and the Minimum
+# Supported Rust Version claim. Neither job duplicates a step in `rust.yml`.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deny:
+    name: Dependency audit (cargo-deny)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # No floating Rust setup action is used (matches rust.yml). rustup is
+      # preinstalled on the runner; rust-toolchain.toml pins the exact
+      # toolchain. cargo-deny only reads metadata and the lockfile, so it does
+      # not compile the workspace.
+      - name: Install cargo-deny (pinned)
+        run: cargo install cargo-deny --locked --version 0.20.2
+      - name: cargo-deny version
+        run: cargo deny --version
+      # Runs all four checks: advisories, bans, licenses, sources. Advisories,
+      # licenses, and sources fail the job; duplicate versions are surfaced as
+      # warnings (see deny.toml for the written policy).
+      - name: cargo deny check
+        run: cargo deny check
+
+  msrv:
+    name: Verify MSRV build (rust-version)
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The MSRV is declared once in the workspace `rust-version`. Read it from
+      # the manifest rather than hard-coding it here, so a bump in Cargo.toml is
+      # what drives this gate. `cargo +<msrv>` overrides rust-toolchain.toml, so
+      # the declared MSRV is what is actually tested even if the toolchain pin
+      # moves.
+      - name: Resolve declared MSRV
+        id: msrv
+        run: |
+          msrv="$(python3 -c 'import tomllib;print(tomllib.load(open("Cargo.toml","rb"))["workspace"]["package"]["rust-version"])')"
+          echo "msrv=${msrv}" >> "$GITHUB_OUTPUT"
+          echo "Declared MSRV: ${msrv}"
+      - name: Install the declared MSRV toolchain
+        run: rustup toolchain install "${MSRV}" --profile minimal
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}
+      - name: Build the workspace on the MSRV
+        run: cargo +"${MSRV}" check --workspace --all-targets
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,23 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
-Dependency audit and license policy checks remain intended additions; the
-repository will not claim these pass before CI actually runs them.
+Dependency audit, license policy, and MSRV verification run in CI via the
+`Audit` workflow (`.github/workflows/audit.yml`):
+
+- `cargo deny check` enforces advisories (security, yanked), license policy
+  (the allow-list in `deny.toml`, derived from the actual dependency tree and
+  limited to permissive licenses), and source policy (crates.io only).
+- A dedicated job builds the workspace with the toolchain named by the
+  workspace `rust-version` (currently `1.88`), so the MSRV claim is tested
+  rather than asserted.
+
+Reproduce locally before opening a supply-chain or MSRV change:
+
+```text
+cargo install cargo-deny --locked --version 0.20.2
+cargo deny check
+cargo +<rust-version> check --workspace --all-targets
+```
 
 Changes to `crates/noren-terminal/` additionally keep these conventions:
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,83 @@
+# cargo-deny configuration for the Noren workspace.
+#
+# The project is dual-licensed "MIT OR Apache-2.0" (see the root Cargo.toml and
+# LICENSE-MIT / LICENSE-APACHE). The `[licenses]` allow-list below is derived
+# from the resolved dependency tree, not guessed: every SPDX identifier it lists
+# was produced by enumerating `cargo metadata` over the lockfile. Only
+# permissive licenses are permitted.
+#
+# One weak-copyleft identifier, LGPL-2.1-or-later, appears in the tree, but only
+# inside the tri-licensed `r-efi` crate's expression `MIT OR Apache-2.0 OR
+# LGPL-2.1-or-later`. Because that is a disjunction, cargo-deny satisfies
+# `r-efi` via the MIT/Apache-2.0 terms, so the LGPL identifier is intentionally
+# NOT on the allow-list and no suppression is required.
+
+[graph]
+# Audit the full resolved lockfile graph (all target cfg branches), matching the
+# comprehensive `cargo metadata` the license list was derived from. Default
+# features only, since that is what `cargo build` / `cargo test` compile.
+all-features = false
+no-default-features = false
+
+[advisories]
+# Use the canonical RustSec advisory database.
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Fail the build on any yanked entry: the `=` version pins in Cargo.toml are
+# meant to be reproducible, and a yanked version breaks that guarantee.
+yanked = "deny"
+# Suppressions belong here with a written justification. There are none today,
+# so every advisory surfaces instead of being hidden.
+ignore = []
+
+[licenses]
+# Allow-list derived from `cargo metadata` for the resolved workspace. Each
+# identifier is actually present in the dependency tree; the comment above
+# explains why LGPL-2.1-or-later is excluded.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unlicense",
+]
+confidence-threshold = 0.93
+
+[licenses.private]
+# Workspace members are `publish = false`; skip them so the license check audits
+# only the real third-party dependency tree.
+ignore = true
+
+[bans]
+# The root Cargo.toml pins one exact version per external dependency. A second
+# copy of a crate entering the graph is worth noticing, so it is a warning
+# (transitive duplicates are common and not always actionable at the workspace
+# level) rather than a hard failure.
+multiple-versions = "warn"
+# `wildcards` is set to "warn" with this written justification, as the project's
+# suppression policy requires. cargo-deny 0.20.2 cannot evaluate the
+# `noren-pty.workspace = true` / `noren-terminal.workspace = true` inheritance
+# form: it logs `unresolved-workspace-dependency` and then treats those two
+# internal path members as `*` wildcards, even though they carry no version
+# requirement by design (their versions are pinned at the workspace root). The
+# real anti-wildcard rule — every *external* dependency uses an exact `=` pin in
+# the root `[workspace.dependencies]` table — is enforced structurally there and
+# reviewable in one place. "warn" keeps a real floating-version external
+# dependency visible in CI output without failing on that known false positive.
+# Switch this back to "deny" once cargo-deny resolves workspace-inherited path
+# dependencies correctly.
+wildcards = "warn"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+[sources]
+# All dependencies are version-pinned crates from crates.io; no git or custom
+# registry sources are used. Anything else is a failure.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Turns three documented intentions into gates that actually run.

`CONTRIBUTING.md` previously said: "Dependency audit and license policy checks
remain intended additions; the repository will not claim these pass before CI
actually runs them." This makes them run, and updates that sentence to describe
only what is really enforced.

## What runs

New `Audit` workflow (`.github/workflows/audit.yml`), actions pinned by commit
SHA like the existing workflow:

- **`cargo deny check`** — security advisories and yanked crates, license policy,
  bans, and source policy (crates.io only).
- **MSRV verification** — a dedicated job builds the workspace with the toolchain
  named by the workspace `rust-version`, so the 1.88 claim is tested rather than
  asserted. The job **reads the MSRV out of `Cargo.toml`** rather than hard-coding
  it, so a bump to the manifest is what drives the gate, and `cargo +<msrv>`
  overrides `rust-toolchain.toml` so the declared MSRV is what actually gets
  tested.

## License policy is an explicit allow-list, not permissive-by-default

`deny.toml` lists only identifiers actually present in the resolved tree: MIT,
Apache-2.0, Apache-2.0 WITH LLVM-exception, Unicode-3.0, BSD-2-Clause,
BSD-3-Clause, ISC, Zlib, Unlicense.

One weak-copyleft identifier (LGPL-2.1-or-later, via `r-efi`) appears in the tree
but only inside a disjunction with MIT/Apache-2.0, so cargo-deny satisfies it via
the permissive terms and the LGPL identifier is deliberately **not** added to the
allow-list. That reasoning is written into `deny.toml` rather than left implicit.

## Verification

The coordinator ran `cargo deny check` independently on this branch:

```
advisories ok, bans ok, licenses ok, sources ok
```

Zero findings — nothing was suppressed to reach that result. Also on this branch
after rebasing onto current `main`: `cargo fmt --all --check` clean, 153 workspace
tests pass, `python3 scripts/check_docs.py` passes. The diff is additive (172
insertions, 2 deletions, all in the CONTRIBUTING sentence being corrected) and
touches no crate source.