### PR TITLE
fix(terminal): clamp DECSTBM margins and execute C0 inside CSI

### DIFF
--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -4,6 +4,21 @@ const ESC: u8 = 0x1b;
 const BEL: u8 = 0x07;
 const MAX_CSI_PARAMS: usize = 8;
 
+/// Map a C0 control byte (0x00..=0x1f) to the same action Ground emits.
+///
+/// Most C0 controls (NUL, CAN, SUB, ...) produce no action; the actionable
+/// ones are shared between Ground and an in-progress CSI so that a control
+/// embedded in a sequence executes without aborting it.
+fn c0_action(byte: u8) -> Option<Action> {
+    match byte {
+        b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
+        b'\r' => Some(Action::CarriageReturn),
+        b'\t' => Some(Action::Tab),
+        0x08 => Some(Action::Backspace),
+        _ => None,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Action {
     Print(u8),
@@ -133,12 +148,8 @@ impl Parser {
                 self.state = ParserState::Escape;
                 None
             }
-            b'\n' | 0x0b | 0x0c => Some(Action::LineFeed),
-            b'\r' => Some(Action::CarriageReturn),
-            b'\t' => Some(Action::Tab),
-            0x08 => Some(Action::Backspace),
             0x20..=0x7e => Some(Action::Print(byte)),
-            _ => None,
+            _ => c0_action(byte),
         }
     }
 
@@ -267,6 +278,12 @@ impl Csi {
                     self.action(byte)
                 })
             }
+            // C0 controls embedded in a control sequence execute immediately
+            // via the Ground action WITHOUT aborting the sequence (DEC VT and
+            // xterm). ESC never reaches here: Parser::advance intercepts it
+            // first and restarts the escape. CAN/SUB yield no action via
+            // c0_action, preserving the prior swallow-and-continue behavior.
+            0x00..=0x1f => CsiAdvance::embedded(c0_action(byte)),
             _ => CsiAdvance::pending(),
         }
     }
@@ -401,6 +418,13 @@ impl CsiAdvance {
             finished: true,
         }
     }
+
+    const fn embedded(action: Option<Action>) -> Self {
+        Self {
+            action,
+            finished: false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -484,6 +508,41 @@ mod tests {
     #[test]
     fn escape_restarts_an_incomplete_csi_sequence() {
         assert_eq!(actions(b"\x1b[9\x1b[2A"), [Action::MoveUp(2)]);
+    }
+
+    #[test]
+    fn embedded_c0_in_csi_executes_without_aborting() {
+        // A C0 control inside a CSI executes its Ground action immediately and
+        // the sequence keeps collecting parameters (DEC VT / xterm). The LF
+        // is no longer swallowed mid-sequence.
+        assert_eq!(actions(b"\x1b[\n2A"), [Action::LineFeed, Action::MoveUp(2)]);
+        // CR and BS likewise execute mid-sequence without aborting.
+        assert_eq!(
+            actions(b"\x1b[2\rA"),
+            [Action::CarriageReturn, Action::MoveUp(2)]
+        );
+        // Digits on both sides of an embedded C0 concatenate into one
+        // parameter: the execute action does not commit the current param.
+        assert_eq!(
+            actions(b"\x1b[1\n2A"),
+            [Action::LineFeed, Action::MoveUp(12)]
+        );
+    }
+
+    #[test]
+    fn embedded_esc_still_aborts_the_csi() {
+        // ESC inside a CSI restarts the escape; the partial sequence is
+        // dropped. (ESC is intercepted by Parser::advance before Csi::advance.)
+        assert_eq!(actions(b"\x1b[1\x1b[2A"), [Action::MoveUp(2)]);
+    }
+
+    #[test]
+    fn embedded_can_and_sub_are_unchanged() {
+        // CAN (0x18) and SUB (0x1a) emit no action and do not abort the CSI;
+        // the sequence runs to completion with its parameters intact, exactly
+        // as before the embedded-C0 fix.
+        assert_eq!(actions(b"\x1b[2\x18A"), [Action::MoveUp(2)]);
+        assert_eq!(actions(b"\x1b[2\x1aA"), [Action::MoveUp(2)]);
     }
 
     #[test]

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -126,7 +126,13 @@ impl ScrollRegion {
     }
 
     fn checked(rows: u16, top: u16, bottom: u16) -> Result<Self, TerminalError> {
-        if top >= bottom || bottom >= rows {
+        // xterm clamps both margins to the screen before the validity check,
+        // so ESC[1;6r on a 5-row terminal yields (0, 4) instead of being
+        // dropped. DECSTBM is ignored only when top >= bottom AFTER clamping.
+        let last_row = rows - 1;
+        let top = top.min(last_row);
+        let bottom = bottom.min(last_row);
+        if top >= bottom {
             return Err(TerminalError::InvalidScrollRegion);
         }
         Ok(Self { top, bottom })

--- a/crates/noren-terminal/tests/adversarial.rs
+++ b/crates/noren-terminal/tests/adversarial.rs
@@ -200,40 +200,44 @@ fn high_bytes_interleaved_with_ascii_are_individually_dropped() {
 // ===== Degenerate scroll regions =====
 
 #[test]
-fn inverted_and_degenerate_scroll_regions_are_rejected_and_preserve_state() {
+fn degenerate_scroll_regions_reject_and_out_of_range_clamps() {
     let mut state = TerminalState::new(5, 3).expect("valid terminal");
     let (top0, bottom0) = (state.scroll_region().top(), state.scroll_region().bottom());
 
-    // inverted (top > bottom)
-    state.feed_bytes(b"\x1b[4;2r");
-    assert_eq!(
-        (state.scroll_region().top(), state.scroll_region().bottom()),
-        (top0, bottom0)
-    );
-    // single-row (top == bottom)
-    state.feed_bytes(b"\x1b[3;3r");
-    assert_eq!(
-        (state.scroll_region().top(), state.scroll_region().bottom()),
-        (top0, bottom0)
-    );
-    // bottom past the last screen line
-    state.feed_bytes(b"\x1b[1;99r");
+    // Ranges that stay inverted or degenerate after clamping are rejected and
+    // leave the current region untouched (DECSTBM clamps before validating).
+    state.feed_bytes(b"\x1b[4;2r"); // top=3, bottom=1 -> inverted after clamping
+    state.feed_bytes(b"\x1b[3;3r"); // top==bottom==2 after clamping
     assert_eq!(
         (state.scroll_region().top(), state.scroll_region().bottom()),
         (top0, bottom0)
     );
 
-    // The public API must agree and return Err without mutating.
+    // Out-of-range bottom CLAMPS to the last screen line and is accepted, not
+    // rejected. On this 5-row terminal ESC[2;99r clamps bottom 98 -> 4.
+    state.feed_bytes(b"\x1b[2;99r");
+    assert_eq!(
+        (state.scroll_region().top(), state.scroll_region().bottom()),
+        (1, 4)
+    );
+
+    // The public API agrees with the CSI path on both rejection and clamping.
     assert_eq!(
         state.set_scroll_region(3, 1),
-        Err(TerminalError::InvalidScrollRegion)
+        Err(TerminalError::InvalidScrollRegion),
+        "inverted range rejected by the public API"
+    );
+    assert_eq!(
+        state.set_scroll_region(0, 99),
+        Ok(()),
+        "out-of-range bottom clamped by the public API"
     );
     assert_eq!(
         (state.scroll_region().top(), state.scroll_region().bottom()),
-        (top0, bottom0)
+        (0, 4)
     );
 
-    assert_invariants(&state, "degenerate regions rejected");
+    assert_invariants(&state, "degenerate regions reject, out-of-range clamps");
 }
 
 #[test]

--- a/crates/noren-terminal/tests/embedded_c0.rs
+++ b/crates/noren-terminal/tests/embedded_c0.rs
@@ -1,0 +1,111 @@
+//! DEC VT / xterm conformance for C0 controls embedded in a control sequence.
+
+use noren_terminal::TerminalState;
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+/// `ESC [ <LF> 2 A` executes the embedded LF (cursor down one) and then runs
+/// `CSI 2 A` (cursor up two) without aborting. From row 3 on a 5-row terminal
+/// the cursor moves 3 -> 4 (LF) -> 2 (CUU 2). Pre-fix the LF was lost and the
+/// cursor would have ended at row 1.
+#[test]
+fn embedded_lf_in_csi_moves_down_then_up() {
+    let mut state = TerminalState::new(5, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[4;1H");
+    assert_eq!(cursor(&state), (3, 0));
+
+    state.feed_bytes(b"\x1b[\n2A");
+    assert_eq!(cursor(&state), (2, 0));
+}
+
+/// The literal task sequence `ESC [ 1 <LF> 2 A` no longer drops the LF. The
+/// digits concatenate across the embedded C0 (the execute action does not
+/// commit the parameter), so this is `CSI 12 A` after the LF.
+#[test]
+fn embedded_lf_with_digits_on_both_sides_is_not_lost() {
+    let mut state = TerminalState::new(5, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[2;1H");
+    assert_eq!(cursor(&state), (1, 0));
+
+    state.feed_bytes(b"\x1b[1\n2A");
+    // LF moves 1 -> 2, then CSI 12 A clamps back to row 0. The point is that
+    // the LF executed (pre-fix the cursor would have moved 1 -> 0 directly).
+    assert_eq!(cursor(&state), (0, 0));
+
+    // Discriminating check: an embedded LF alone inside a CSI moves the cursor
+    // down, proving it executes rather than vanishing.
+    let mut state = TerminalState::new(5, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[2;1H\x1b[\n");
+    assert_eq!(cursor(&state), (2, 0));
+}
+
+/// A C0 inside a CSI does not abort the sequence: the final byte still
+/// dispatches after the embedded control runs.
+#[test]
+fn embedded_c0_does_not_abort_the_csi() {
+    let mut state = TerminalState::new(5, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[4;1H\x1b[\r2A");
+    // CR runs (column -> 0, already 0), then CSI 2 A moves up two: 3 -> 1.
+    assert_eq!(cursor(&state), (1, 0));
+}
+
+/// `ESC` inside a CSI still aborts it and starts a fresh escape.
+#[test]
+fn embedded_esc_still_aborts_the_csi() {
+    let mut state = TerminalState::new(5, 5).expect("valid terminal");
+    // ESC[2 is aborted by the second ESC; ESC[3;1H moves to row 2, then Z.
+    state.feed_bytes(b"\x1b[2\x1b[3;1HZ");
+    assert_eq!(cursor(&state), (2, 1));
+    assert_eq!(state.screen().cell(2, 0).map(|c| c.text()), Some("Z"));
+}
+
+/// CAN (0x18) and SUB (0x1a) inside a CSI behave as before: no action, no
+/// abort. The surrounding sequence still completes.
+#[test]
+fn embedded_can_and_sub_do_not_abort_or_act() {
+    for control in [0x18_u8, 0x1a] {
+        let mut state = TerminalState::new(5, 5).expect("valid terminal");
+        state.feed_bytes(b"\x1b[4;1H");
+        let before = cursor(&state);
+        // The control itself does not move the cursor.
+        state.feed_bytes(&[0x1b, b'[', b'2', control]);
+        assert_eq!(
+            cursor(&state),
+            before,
+            "control {control:#04x} moved cursor"
+        );
+        // The CSI still completes: the final A moves the cursor up two.
+        state.feed_bytes(b"A");
+        assert_eq!(cursor(&state), (1, 0), "control {control:#04x} aborted");
+    }
+}
+
+/// Split-sequence robustness: feeding the bytes one at a time must produce the
+/// same result as a single chunk. This is where the parser has been fragile.
+#[test]
+fn embedded_c0_survives_byte_at_a_time_feeding() {
+    let sequence: &[&[u8]] = &[
+        b"\x1b[4;1H",
+        b"\x1b[\n2A",
+        b"\x1b[2\x1b[3;1H",
+        b"\x1b[2\x18A",
+        b"\x1b[2\x1aA",
+    ];
+
+    let mut chunked = TerminalState::new(5, 5).expect("valid terminal");
+    for bytes in sequence {
+        chunked.feed_bytes(bytes);
+    }
+
+    let mut bytewise = TerminalState::new(5, 5).expect("valid terminal");
+    for bytes in sequence {
+        for byte in *bytes {
+            bytewise.feed_bytes(std::slice::from_ref(byte));
+        }
+    }
+
+    assert_eq!(chunked.cursor(), bytewise.cursor());
+    assert_eq!(chunked.snapshot(), bytewise.snapshot());
+}

--- a/crates/noren-terminal/tests/scroll_regions.rs
+++ b/crates/noren-terminal/tests/scroll_regions.rs
@@ -31,7 +31,7 @@ fn labeled_rows() -> TerminalState {
 }
 
 #[test]
-fn decstbm_defaults_reset_invalid_ranges_and_preserves_outside_rows() {
+fn decstbm_clamps_out_of_range_and_rejects_inverted_regions() {
     let mut state = labeled_rows();
 
     state.feed_bytes(b"\x1b[;4r");
@@ -42,16 +42,38 @@ fn decstbm_defaults_reset_invalid_ranges_and_preserves_outside_rows() {
     assert_eq!(region(&state), (1, 4));
     assert_eq!(cursor(&state), (0, 0));
 
-    state.feed_bytes(b"\x1b[3;3r\x1b[5;2r\x1b[2;99r");
+    // Genuine rejections: top >= bottom (even after clamping) leave the
+    // current region and cursor untouched. ESC[3;3r, ESC[5;2r, and ESC[4;2r
+    // all collapse to top >= bottom and are dropped, so the cursor stays.
+    state.feed_bytes(b"\x1b[4;1H");
+    assert_eq!(cursor(&state), (3, 0));
+    state.feed_bytes(b"\x1b[3;3r\x1b[5;2r\x1b[4;2r");
     assert_eq!(region(&state), (1, 4));
-    assert_eq!(cursor(&state), (0, 0));
+    assert_eq!(cursor(&state), (3, 0));
     assert_eq!(rows(&state), ["AAA", "BBB", "CCC", "DDD", "EEE"]);
 
+    // Out-of-range margins now clamp to the last row instead of rejecting.
+    // ESC[1;6r on a 5-row terminal clamps bottom 5 -> 4, accepting (0, 4).
+    state.feed_bytes(b"\x1b[1;6r");
+    assert_eq!(region(&state), (0, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    // ESC[2;99r clamps bottom 98 -> 4 and accepts (1, 4).
+    state.feed_bytes(b"\x1b[2;99r");
+    assert_eq!(region(&state), (1, 4));
+    assert_eq!(cursor(&state), (0, 0));
+
+    // The public set_scroll_region API rejects top >= bottom just like CSI.
     assert_eq!(
         state.set_scroll_region(3, 3),
         Err(TerminalError::InvalidScrollRegion)
     );
     assert_eq!(region(&state), (1, 4));
+
+    // The public API clamps identically to the CSI path: out-of-range bottom
+    // is accepted after clamping rather than erroring.
+    assert_eq!(state.set_scroll_region(0, 99), Ok(()));
+    assert_eq!(region(&state), (0, 4));
 
     state.feed_bytes(b"\x1b[r");
     assert_eq!(region(&state), (0, 4));
@@ -191,4 +213,36 @@ fn printable_ascii_and_ignored_controls_remain_stable() {
     assert_eq!(rows(&state), ["ABCD ", "     "]);
     assert_eq!(cursor(&state), (0, 4));
     assert!(!state.is_wrap_pending());
+}
+
+/// DECSTBM clamping must hold when the sequence is split across feed
+/// boundaries, where this parser has historically been fragile. Feeding the
+/// whole script one byte at a time must match feeding it as a single chunk.
+#[test]
+fn decstbm_clamp_survives_byte_at_a_time_feeding() {
+    let script: &[&[u8]] = &[
+        // Out-of-range bottom clamps to the last row.
+        b"\x1b[1;6r",
+        // Region valid only after clamping is accepted.
+        b"\x1b[2;99r",
+        // top >= bottom after clamping is rejected; prior region preserved.
+        b"\x1b[4;2r",
+    ];
+
+    let mut chunked = labeled_rows();
+    for bytes in script {
+        chunked.feed_bytes(bytes);
+    }
+
+    let mut bytewise = labeled_rows();
+    for bytes in script {
+        for byte in *bytes {
+            bytewise.feed_bytes(std::slice::from_ref(byte));
+        }
+    }
+
+    assert_eq!(region(&chunked), (1, 4));
+    assert_eq!(region(&bytewise), (1, 4));
+    assert_eq!(cursor(&chunked), cursor(&bytewise));
+    assert_eq!(chunked.snapshot(), bytewise.snapshot());
 }


### PR DESCRIPTION
Closes #37. Both were found by the GLM core review of the Terminal Core stack and
deliberately excluded from the BLOCKER fix so that merge-gating change stayed
narrow.

## DECSTBM now clamps instead of rejecting

On a 5-row terminal, `ESC [ 1 ; 6 r` was dropped entirely and the previous region
retained. xterm clamps the bottom margin to the last line, giving `(0, 4)`, and
ignores DECSTBM only when `top >= bottom` **after** clamping.

A program that computes its margin one row past the actual size — an off-by-one
against `TIOCGWINSZ` — silently failed to set the region it intended.

Verified: `ESC [ 1 ; 6 r` → `(0, 4)`, `ESC [ 2 ; 99 r` → `(1, 4)`, while
`ESC [ 4 ; 2 r` and `ESC [ 3 ; 3 r` are still rejected with the prior region and
cursor untouched. The `set_scroll_region` API and the CSI path were confirmed to
agree.

## C0 controls inside a CSI now execute instead of vanishing

`ESC [ 1 <LF> 2 A` lost the LF; only the CUU ran. Per DEC VT and xterm an
embedded C0 executes immediately without aborting the sequence.

One behavior worth understanding before reviewing: **the digits concatenate
across the embedded C0**, because the execute action does not commit the pending
parameter. So `ESC [ 1 <LF> 2 A` is `CSI 12 A` after the LF, not `CSI 2 A`. The
unambiguous case `ESC [ <LF> 2 A` moves down one then up two. Both are asserted,
and the lane documented the concatenation rather than leaving it implicit.

`ESC` still aborts an in-progress CSI, and CAN/SUB behavior is unchanged.

## Two test suites were deliberately updated, not deleted

`tests/scroll_regions.rs` and `tests/adversarial.rs` both asserted the old
reject-don't-clamp behavior, so their expectations had to change with the fix.
In both cases the genuine-rejection coverage was **kept** (inverted and
single-row regions still asserted as rejected) and the test renamed to match the
new semantics — rather than dropping the cases that no longer held.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **163 workspace tests pass** (was 153), 0
failures.

The coordinator independently verified all five behaviors above. One
coordinator test initially failed on the digit-concatenation case; investigation
showed the **coordinator's expectation** was wrong and the implementation
correct, so the lane's behavior stands.