### PR TITLE
docs(coordination): distinguish the two ways a lane stalls

### DIFF
--- a/docs/coordination/fleet.md
+++ b/docs/coordination/fleet.md
@@ -79,8 +79,30 @@ Three failure modes cost real time and are worth knowing:
   substitution — the run produces empty output with exit 0. Feed the prompt on
   stdin instead.
 
-A lane that stalls has usually still done useful work. Inspect its worktree and
-commits before discarding the run.
+- **A lane can die during `init`, before it ever reaches the model.** The
+  symptom is a log that stops at `message=init` and never grows past roughly
+  1.4 KB, with no session id recorded and no branch created. It appears when
+  several opencode instances start at once. Distinguish it from a slow start by
+  checking whether a branch exists and whether the log is still growing; a lane
+  killed this way has produced nothing, so relaunching it costs only time.
+
+Distinguishing the two stall modes matters:
+
+| Symptom | Meaning | Action |
+| --- | --- | --- |
+| Log frozen at `message=init`, ~1.4 KB, no branch | died before starting | relaunch, nothing lost |
+| Log frozen at `message=asking`, large, branch exists | blocked on a permission prompt | inspect the branch — the work is usually **already done** |
+| Log still growing | working, just slow | leave it alone |
+
+A lane that stalls after starting has usually still done useful work. Inspect its
+worktree and commits before discarding the run — that has been true every time so
+far, including for two lanes whose complete, correct fixes were sitting
+uncommitted or committed-but-unreported.
+
+Uncommitted changes are worth reading rather than discarding for a second reason:
+a lane fixing behavior often has to update a *sibling* test suite that asserted
+the old behavior, and may leave that edit unstaged. Deleting it silently
+reintroduces a failing gate.
 
 ## Failover and resumption
 

--- a/scripts/fleet/dispatch.sh
+++ b/scripts/fleet/dispatch.sh
@@ -28,6 +28,9 @@ case "$lane" in
   glm-*)   engine=glm;   account=glm-main;   model="zai-coding-plan/glm-5.2" ;;
   qwen-*)  engine=qwen;  account=qwen-main;  model="qwencloud/qwen3.8-max-preview" ;;
   kimi-*)  engine=kimi;  account=kimi-main;  model="" ;;
+  # Codex work goes through the codex-lab wrapper only (portal `codex-main`).
+  # The plain `codex` binary maps to `codex-tatu`, which is nearly exhausted and
+  # is deliberately not reachable from this script.
   lab-*)   engine=lab;   account=codex-main; model="" ;;
   *) echo "unknown lane: $lane" >&2; exit 2 ;;
 esac


### PR DESCRIPTION
Coordination-only; no crate code.

Four lanes stalled while running the fleet this session, from two different
causes that need opposite responses. Getting this wrong destroys work, so it is
worth writing down.

| Symptom | Meaning | Action |
| --- | --- | --- |
| Log frozen at `message=init`, ~1.4 KB, no branch created | died before reaching the model | relaunch; nothing lost |
| Log frozen at `message=asking`, large, branch exists | blocked on opencode's `external_directory` permission prompt | **inspect the branch — the work is usually already done** |
| Log still growing | working, just slow | leave it alone |

The init failure appears when several opencode instances start at once. The
permission-prompt stall is the dangerous one to misread: every lane that hit it
this session had already finished its real work, including two whose complete,
correct fixes were sitting committed-but-unreported or unstaged.

I misjudged this once and killed three working lanes. They happened to be
pre-commit so nothing was lost, but the rule now says to check for a branch and a
growing log before concluding a lane is dead.

Also records a second reason not to discard uncommitted changes: a lane fixing
behavior often has to update a **sibling** test suite that asserted the old
behavior, and may leave that edit unstaged. Deleting it silently reintroduces a
failing gate — which nearly happened with the DECSTBM clamp change, where
`adversarial.rs` needed updating alongside `scroll_regions.rs`.

Finally, pins the Codex rule in `dispatch.sh` as a comment: Codex work goes
through the `codex-lab` wrapper only (portal `codex-main`). The plain `codex`
binary maps to `codex-tatu`, which is nearly exhausted, and is deliberately not
reachable from the script.

Verified: `python3 scripts/check_docs.py` passes.