### PR TITLE
feat(terminal): retain scrolled-off lines in bounded scrollback

### DIFF
--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -14,8 +14,8 @@ mod state;
 
 pub use attributes::{AnsiColor, CellAttributes, Color};
 pub use state::{
-    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, ScreenBuffer, ScrollRegion, TerminalError,
-    TerminalModes, TerminalSnapshot, TerminalState,
+    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES, ScreenBuffer, ScrollRegion,
+    TerminalError, TerminalModes, TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -2,10 +2,37 @@ use crate::{
     attributes::{AnsiColor, CellAttributes, Color},
     parser::{Action, EraseMode, Parser, PrivateMode},
 };
+use std::collections::VecDeque;
 use std::fmt;
 
 /// Hard allocation bound for a visible Terminal Core screen.
 pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
+
+/// Maximum number of lines retained in the primary screen's scrollback buffer.
+///
+/// Only lines that scroll off the top of the *primary* screen are retained; the
+/// alternate screen never contributes. The bound is enforced by evicting the
+/// oldest retained line when the cap is reached, so a hostile program emitting
+/// unbounded output cannot grow history without limit.
+///
+/// # Memory ceiling
+///
+/// Each retained line owns `cols` cells (the column count at the moment it
+/// scrolled off). `size_of::<Cell>() == 32` on this target (a 24-byte owned
+/// `String` handle, a width byte, and packed attributes); the single-character
+/// text also owns one small heap allocation per cell, so ~40 bytes/cell is a
+/// safe upper bound. The retained-line ceiling is therefore
+/// `MAX_SCROLLBACK_LINES * cols * sizeof(Cell)`:
+///
+/// - Typical 80-column terminal: `10_000 * 80 * 40 ≈ 32 MiB`.
+/// - Typical 256-column terminal: `10_000 * 256 * 40 ≈ 100 MiB`.
+///
+/// The line count is the hard bound: a hostile program cannot grow history past
+/// this many lines regardless of volume. Per-row width is bounded by the live
+/// grid, which is itself bounded by [`MAX_SCREEN_CELLS`]. Resize does **not**
+/// reflow retained lines (see the terminal-core-foundation design note), so each
+/// line keeps the width it had when it scrolled off.
+pub const MAX_SCROLLBACK_LINES: usize = 10_000;
 
 /// One basic terminal cell.
 ///
@@ -252,14 +279,29 @@ impl ScreenBuffer {
         Ok(())
     }
 
-    fn scroll_up(&mut self, region: ScrollRegion, count: u16) {
+    /// Scroll the region up by `count`, returning the rows that left the top of
+    /// the *visible screen* in top-to-bottom order.
+    ///
+    /// Only rows that leave the physical top of the screen (region top == 0) are
+    /// returned; scrolling within a non-screen-aligned margin returns an empty
+    /// vector because those rows never left the grid. The caller still decides
+    /// whether retained rows belong in scrollback (primary screen only).
+    fn scroll_up(&mut self, region: ScrollRegion, count: u16) -> Vec<Vec<Cell>> {
         let columns = usize::from(self.cols);
         let rows = usize::from(count.min(region.height()));
         let start = usize::from(region.top) * columns;
         let end = (usize::from(region.bottom) + 1) * columns;
         let shift = rows * columns;
+        let evicted = if region.top == 0 && rows > 0 {
+            (0..rows)
+                .map(|r| self.cells[start + r * columns..start + (r + 1) * columns].to_vec())
+                .collect()
+        } else {
+            Vec::new()
+        };
         self.cells[start..end].rotate_left(shift);
         self.cells[end - shift..end].fill(Cell::blank());
+        evicted
     }
 
     fn scroll_down(&mut self, region: ScrollRegion, count: u16) {
@@ -422,6 +464,9 @@ pub struct TerminalState {
     // captured when written, independently of screen-buffer selection.
     pen: CellAttributes,
     parser: Parser,
+    // Bounded history of lines that scrolled off the top of the primary screen.
+    // The alternate screen never contributes; see `push_scrollback_rows`.
+    scrollback: VecDeque<Vec<Cell>>,
 }
 
 impl TerminalState {
@@ -433,6 +478,7 @@ impl TerminalState {
             modes: TerminalModes::default(),
             pen: CellAttributes::default(),
             parser: Parser::default(),
+            scrollback: VecDeque::new(),
         })
     }
 
@@ -499,6 +545,16 @@ impl TerminalState {
     #[must_use]
     pub const fn attributes(&self) -> &CellAttributes {
         &self.pen
+    }
+
+    /// Number of primary-screen lines currently retained in scrollback.
+    ///
+    /// Always bounded by [`MAX_SCROLLBACK_LINES`]. Use
+    /// [`TerminalSnapshot::scrollback`] for the full ordered cell view and
+    /// [`TerminalSnapshot::scrollback_lines`] for renderer-ready text.
+    #[must_use]
+    pub fn scrollback_len(&self) -> usize {
+        self.scrollback.len()
     }
 
     /// Save the active screen's cursor position.
@@ -653,7 +709,7 @@ impl TerminalState {
     fn index(&mut self) {
         self.active.wrap_pending = false;
         if self.active.cursor.row == self.active.scroll_region.bottom {
-            self.active.screen.scroll_up(self.active.scroll_region, 1);
+            self.scroll_up_capturing(self.active.scroll_region, 1);
         } else if self.active.cursor.row < self.active.screen.rows - 1 {
             self.active.cursor.row += 1;
         }
@@ -675,9 +731,27 @@ impl TerminalState {
 
     fn scroll_up(&mut self, count: u16) {
         self.active.wrap_pending = false;
-        self.active
-            .screen
-            .scroll_up(self.active.scroll_region, count);
+        self.scroll_up_capturing(self.active.scroll_region, count);
+    }
+
+    /// Scroll the active screen's region up and, when rows actually leave the
+    /// visible primary screen, retain them in scrollback.
+    ///
+    /// Retention requires both: (1) the primary screen is active (the alternate
+    /// screen never contributes, matching `less`/`vim` behavior), and (2) the
+    /// region starts at row 0 so the evicted rows left the top of the screen
+    /// rather than just the top of a non-screen-aligned margin.
+    fn scroll_up_capturing(&mut self, region: ScrollRegion, count: u16) {
+        let evicted = self.active.screen.scroll_up(region, count);
+        if self.modes.alternate_screen || region.top != 0 || evicted.is_empty() {
+            return;
+        }
+        for row in evicted {
+            if self.scrollback.len() >= MAX_SCROLLBACK_LINES {
+                self.scrollback.pop_front();
+            }
+            self.scrollback.push_back(row);
+        }
     }
 
     fn scroll_down(&mut self, count: u16) {
@@ -740,7 +814,7 @@ impl TerminalState {
         let cursor_row = self.active.cursor.row;
         let region = self.active.scroll_region;
         if (region.top..=region.bottom).contains(&cursor_row) {
-            self.active.screen.scroll_up(
+            self.scroll_up_capturing(
                 ScrollRegion {
                     top: cursor_row,
                     bottom: region.bottom,
@@ -876,6 +950,7 @@ pub struct TerminalSnapshot {
     wrap_pending: bool,
     modes: TerminalModes,
     lines: Vec<String>,
+    scrollback: Vec<Vec<Cell>>,
 }
 
 impl TerminalSnapshot {
@@ -887,6 +962,7 @@ impl TerminalSnapshot {
             wrap_pending: state.active.wrap_pending,
             modes: state.modes,
             lines: visible_lines(&state.active.screen),
+            scrollback: state.scrollback.iter().cloned().collect(),
         }
     }
 
@@ -937,6 +1013,27 @@ impl TerminalSnapshot {
     pub fn lines(&self) -> &[String] {
         &self.lines
     }
+
+    /// Retained scrollback rows in eviction order (oldest first, newest last).
+    ///
+    /// Each row is the full cell content of a primary-screen line that scrolled
+    /// off the top of the visible grid, captured at the width it had when it
+    /// left. The alternate screen never contributes. The slice length is bounded
+    /// by [`MAX_SCROLLBACK_LINES`].
+    #[must_use]
+    pub fn scrollback(&self) -> &[Vec<Cell>] {
+        &self.scrollback
+    }
+
+    /// Renderer-ready text rendering of [`scrollback`](Self::scrollback) with
+    /// trailing blanks trimmed per line, parallel to [`lines`](Self::lines).
+    #[must_use]
+    pub fn scrollback_lines(&self) -> Vec<String> {
+        self.scrollback
+            .iter()
+            .map(|row| cells_to_line(row))
+            .collect()
+    }
 }
 
 fn checked_cell_count(rows: u16, cols: u16) -> Result<usize, TerminalError> {
@@ -961,21 +1058,27 @@ fn clamp_cursor(cursor: Cursor, rows: u16, cols: u16) -> Cursor {
 fn visible_lines(screen: &ScreenBuffer) -> Vec<String> {
     let mut lines = Vec::with_capacity(usize::from(screen.rows));
     for row in 0..screen.rows {
-        let mut line = String::new();
-        for column in 0..screen.cols {
-            if let Some(cell) = screen.cell(row, column) {
-                line.push_str(cell.text());
-            }
-        }
-        while line.ends_with(' ') {
-            line.pop();
-        }
-        lines.push(line);
+        let start = usize::from(row) * usize::from(screen.cols);
+        let end = start + usize::from(screen.cols);
+        lines.push(cells_to_line(&screen.cells[start..end]));
     }
     while lines.last().is_some_and(String::is_empty) {
         lines.pop();
     }
     lines
+}
+
+/// Render a cell row to text with trailing blanks removed. Shared by the
+/// visible-screen snapshot and scrollback so the trimming policy is identical.
+fn cells_to_line(cells: &[Cell]) -> String {
+    let mut line = String::with_capacity(cells.len());
+    for cell in cells {
+        line.push_str(cell.text());
+    }
+    while line.ends_with(' ') {
+        line.pop();
+    }
+    line
 }
 
 #[cfg(test)]

--- a/crates/noren-terminal/tests/scrollback.rs
+++ b/crates/noren-terminal/tests/scrollback.rs
@@ -1,0 +1,191 @@
+//! Scrollback retention: lines that scroll off the top of the primary screen
+//! are retained in a bounded buffer and exposed renderer-independently.
+//!
+//! These tests pin the design constraints from the terminal-core-foundation
+//! roadmap: bounded memory, primary-screen-only contribution, no contribution
+//! from non-screen-aligned scroll regions, deliberate (no-reflow) resize
+//! behavior, and hostile-output safety.
+//!
+//! Lines are separated with CRLF (`\r\n`): in this core, LF moves the cursor
+//! down (and scrolls) without returning to column 0, exactly like a real
+//! terminal, so CR is needed to start each label at the left margin.
+
+use noren_terminal::{Cell, MAX_SCROLLBACK_LINES, TerminalState};
+
+/// Text rendering of retained scrollback rows, oldest first.
+fn scrollback_lines(state: &TerminalState) -> Vec<String> {
+    state.snapshot().scrollback_lines()
+}
+
+/// Width (cell count) of each retained scrollback row, in order.
+fn scrollback_widths(state: &TerminalState) -> Vec<usize> {
+    state.snapshot().scrollback().iter().map(Vec::len).collect()
+}
+
+#[test]
+fn lines_scrolled_off_the_top_are_retained_in_order() {
+    // 3-row grid, full-screen margins. Each CRLF past the third evicts the top
+    // row into scrollback, oldest first.
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"AAAA\r\nBBBB\r\nCCCC\r\nDDDD\r\n");
+
+    // After CCCC's line feed the screen scrolled once (AAAA evicted); after
+    // DDDD's line feed it scrolled again (BBBB evicted). The visible screen
+    // holds the two freshest rows; scrollback holds the evicted rows in order.
+    assert_eq!(scrollback_lines(&state), ["AAAA", "BBBB"]);
+    assert_eq!(state.snapshot().lines(), ["CCCC", "DDDD"]);
+    assert_eq!(state.scrollback_len(), 2);
+    assert_eq!(state.snapshot().scrollback().len(), 2);
+
+    // The retained rows carry full cell fidelity, not just text.
+    let snapshot = state.snapshot();
+    let first_row = &snapshot.scrollback()[0];
+    assert_eq!(first_row.len(), 4);
+    assert_eq!(first_row[0].text(), "A");
+}
+
+#[test]
+fn the_bound_holds_and_evicts_the_oldest_lines() {
+    // One-row grid: every CRLF evicts the just-printed row. Emit well past the
+    // cap and assert the count clamps and the OLDEST (earliest emitted) are the
+    // ones dropped.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    let overflow = 200;
+    let total = MAX_SCROLLBACK_LINES + overflow;
+
+    let mut script = String::new();
+    for index in 0..total {
+        script.push_str(&format!("{index:05}\r\n"));
+    }
+    state.feed_bytes(script.as_bytes());
+
+    // The count is clamped exactly at the cap.
+    assert_eq!(state.scrollback_len(), MAX_SCROLLBACK_LINES);
+    assert_eq!(state.snapshot().scrollback().len(), MAX_SCROLLBACK_LINES);
+
+    // The oldest `overflow` lines were evicted; the retained window is the most
+    // recent `cap` labels: [overflow .. total).
+    let lines = scrollback_lines(&state);
+    assert_eq!(lines.len(), MAX_SCROLLBACK_LINES);
+    assert_eq!(lines.first().map(String::as_str), Some("00200"));
+    assert_eq!(
+        lines.last().map(String::as_str),
+        Some(format!("{:05}", total - 1).as_str())
+    );
+    // Monotonic increase proves in-order retention with no duplication/gaps.
+    let mut previous = 0u32;
+    for line in &lines {
+        let value = line.parse::<u32>().expect("numeric label");
+        assert!(value >= previous, "retention order broke at {line}");
+        previous = value;
+    }
+}
+
+#[test]
+fn alternate_screen_contributes_nothing_and_preserves_primary_scrollback() {
+    // Accumulate primary scrollback first.
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"A\r\nB\r\nC\r\n");
+    assert_eq!(scrollback_lines(&state), ["A", "B"]);
+
+    // Enter the alternate screen and thrash it with scrolling output. The final
+    // line has no CRLF so both Z and W stay visible on the 2-row grid.
+    state.feed_bytes(b"\x1b[?1049h");
+    assert!(state.modes().is_alternate_screen_active());
+    let alternate_scroll_before = state.scrollback_len();
+    state.feed_bytes(b"X\r\nY\r\nZ\r\nW");
+    assert_eq!(state.snapshot().lines(), ["Z", "W"]);
+    // The alternate screen added nothing to scrollback.
+    assert_eq!(state.scrollback_len(), alternate_scroll_before);
+    assert_eq!(scrollback_lines(&state), ["A", "B"]);
+
+    // Leaving the alternate screen leaves primary scrollback intact.
+    state.feed_bytes(b"\x1b[?1049l");
+    assert!(!state.modes().is_alternate_screen_active());
+    assert_eq!(scrollback_lines(&state), ["A", "B"]);
+    assert_eq!(state.snapshot().lines(), ["C"]);
+    assert_eq!(state.scrollback_len(), 2);
+
+    // And primary-screen scrolling after returning resumes appending.
+    state.feed_bytes(b"D\r\n");
+    assert_eq!(scrollback_lines(&state), ["A", "B", "C"]);
+}
+
+#[test]
+fn scroll_region_not_at_the_top_of_the_screen_does_not_push_to_scrollback() {
+    // 5-row grid. Set margins to rows 3..5 (1-based) so scrolling inside the
+    // region never reaches the top of the screen.
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    state.feed_bytes(b"\x1b[3;5r\x1b[5;1H\n");
+
+    // Rows above the margin (AAA, BBB) are untouched; the region scrolled
+    // internally but nothing left the visible screen, so scrollback is empty.
+    assert_eq!(state.scrollback_len(), 0);
+    assert!(state.snapshot().scrollback().is_empty());
+    assert_eq!(state.snapshot().lines(), ["AAA", "BBB", "DDD", "EEE"]);
+
+    // A full-screen scroll from the same state DOES push, proving the gate is
+    // region placement, not the scroll operation itself.
+    state.feed_bytes(b"\x1b[r\x1b[5;1H\n");
+    assert_eq!(scrollback_lines(&state), ["AAA"]);
+}
+
+#[test]
+fn resize_does_not_reflow_or_corrupt_retained_lines() {
+    // Known limitation, asserted explicitly: retained rows keep the column
+    // width they had when they scrolled off; resize neither reflows nor
+    // truncates them, and never panics.
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"AAAA\r\nBBBB\r\nCCCC\r\n");
+    assert_eq!(scrollback_lines(&state), ["AAAA", "BBBB"]);
+    assert_eq!(scrollback_widths(&state), [4, 4]);
+
+    // Grow: retained rows stay width-4 (not padded to the new width).
+    state.resize(4, 6).expect("grow");
+    assert_eq!(scrollback_lines(&state), ["AAAA", "BBBB"]);
+    assert_eq!(scrollback_widths(&state), [4, 4]);
+
+    // Shrink below the original width: retained rows stay width-4 (not
+    // truncated to the narrower grid).
+    state.resize(1, 2).expect("shrink");
+    assert_eq!(scrollback_lines(&state), ["AAAA", "BBBB"]);
+    assert_eq!(scrollback_widths(&state), [4, 4]);
+    assert_eq!(state.scrollback_len(), 2);
+
+    // Cell content survives the resize storm verbatim.
+    let snapshot = state.snapshot();
+    let row0 = &snapshot.scrollback()[0];
+    assert_eq!(row0.iter().map(Cell::text).collect::<String>(), "AAAA");
+}
+
+#[test]
+fn hostile_output_is_bounded_and_evicts_correctly() {
+    // 100k lines into a one-row grid: memory must stay bounded at the cap and
+    // the retained window must be exactly the most recent `cap` lines.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    let total = 100_000;
+
+    let mut script = String::with_capacity(total * 7);
+    for index in 0..total {
+        script.push_str(&format!("{index:05}\r\n"));
+    }
+    state.feed_bytes(script.as_bytes());
+
+    // Bounded: scrollback is exactly at the cap, never above.
+    assert_eq!(state.scrollback_len(), MAX_SCROLLBACK_LINES);
+    assert!(state.scrollback_len() <= MAX_SCROLLBACK_LINES);
+
+    // Correct eviction: oldest retained is the (total - cap)-th line, newest is
+    // the last line emitted.
+    let lines = scrollback_lines(&state);
+    assert_eq!(lines.first().map(String::as_str), Some("90000"));
+    assert_eq!(lines.last().map(String::as_str), Some("99999"));
+
+    // The visible grid itself never grew beyond rows*cols.
+    let (rows, cols) = state.size();
+    assert_eq!(
+        state.screen().cells().len(),
+        usize::from(rows) * usize::from(cols)
+    );
+}

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -81,10 +81,45 @@ Added by Draft PR #23 / Issue #22 (alternate screen, stacked on #21):
 This slice makes `?1049` round-trips reliable; it is not full xterm, vim,
 tmux, or zellij compatibility.
 
+## Scrollback
+
+Lines that scroll off the top of the *primary* screen are retained in a bounded
+scrollback buffer instead of being discarded, and are readable through the public
+renderer-independent API.
+
+- **Bounded.** `MAX_SCROLLBACK_LINES` (10,000) sits next to `MAX_SCREEN_CELLS`
+  and is the hard line-count cap. Each retained row owns `cols` cells (the column
+  count when it left), so the memory ceiling is
+  `MAX_SCROLLBACK_LINES * cols * sizeof(Cell)`. At ~40 bytes/cell that is ~32 MiB
+  for an 80-column terminal and ~100 MiB for 256 columns; the line count is the
+  hard bound so hostile unbounded output cannot grow history past it. The oldest
+  retained line is evicted when the cap is reached.
+- **Primary screen only.** Retention is gated on the primary screen being active
+  and on the scrolling region starting at row 0. The alternate screen never
+  contributes (so `less`/`vim` do not pollute history), and scrolling inside a
+  non-screen-aligned margin never reaches scrollback. Entering/leaving the
+  alternate screen leaves primary scrollback intact.
+- **Capture point.** `ScreenBuffer::scroll_up` returns the rows that left the top
+  of the region; `TerminalState::scroll_up_capturing` pushes them to the
+  `VecDeque` scrollback only when both gates hold. All three scroll-up paths
+  (explicit `CSI SU`, `LF`/`IND`/`NEL` at the bottom margin, and `CSI DL`) route
+  through this capture, so wrap-driven and explicit scrolling behave identically.
+- **Renderer-independent exposure.** `TerminalSnapshot::scrollback()` returns the
+  retained rows as `&[Vec<Cell>]` (oldest first) and `scrollback_lines()` gives a
+  trimmed text rendering parallel to `lines()`. `TerminalState::scrollback_len()`
+  reports the count cheaply. The renderer never reaches past the snapshot.
+- **Resize does not reflow (known limitation).** Reflowing retained history on a
+  column change is deliberately out of scope for this slice. Retained rows keep
+  the width they had when they scrolled off: growing the grid does not pad them,
+  shrinking it does not truncate them, and each row's cell count is the original
+  `cols`. This is asserted in the test suite. A future slice may reflow or
+  soft-wrap retained rows; until then renderers must tolerate mixed-width
+  scrollback rows (each row's `.len()` is its own width).
+
 ## Deferred
 
 SGR/erase/insert/delete, cell attributes, tabs, origin mode, and
 query/reply sequences remain deferred, along with other DEC private modes
 (such as 1047/1048, 25, and 2004), application cursor/keypad modes, OSC
-titles, alternate-screen scrollback, and saved-cursor state beyond
+titles, scrollback reflow on resize, and saved-cursor state beyond
 position. Unicode and IME remain later.


### PR DESCRIPTION
The largest remaining Milestone 2 gap in the terminal foundation. Lines that
scroll off the top of the primary screen are now retained instead of discarded.

## Design constraints, and how each is enforced

**Bounded** — capped at 10,000 lines, enforced by evicting the oldest. A hostile
program emitting endless output cannot grow memory without limit, which matters
because untrusted terminal input is an explicit Noren threat-model boundary.

**Primary screen only** — the alternate screen contributes nothing, which is how
real terminals behave and why `less`/`vim` don't pollute shell history.

**No reflow on resize** — deliberately chosen and **documented as a known
limitation** rather than silently truncating or corrupting history. Reflowing
scrollback across a column change is genuinely hard; doing it badly is worse than
not doing it, so the limitation is written into
`docs/architecture/terminal-core-foundation.md`.

**Renderer-independent** — exposed through the snapshot, so the renderer never
reaches into internals.

## Coordinator verification

Beyond the lane's own 6 tests, I independently verified the invariants that matter
most, because a scrollback bug is either a memory leak or silent data loss:

- **The bound actually holds.** After emitting 30,000 lines the buffer sat at
  exactly 10,000, with line `0` evicted and the newest lines present — so it
  evicts oldest-first rather than refusing new lines or growing.
- **The alternate screen truly contributes nothing.** 50 lines written to the
  alternate screen left the history length unchanged, and after leaving 1049 no
  `ALT` content had leaked into primary history.
- **Order is oldest-first** (`["L1","L2","L3"]` retained while `["L4","L5"]` stay
  visible).
- **Resize neither panics nor drops retained lines** across a grow-then-shrink
  sequence.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **177 workspace tests pass** (was 171), 0
failures. Rebased onto current `main`; the diff is additive and deletes no landed
test.