### PR TITLE
fix(terminal): track mouse modes and consume X10 reports

### DIFF
--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -14,8 +14,8 @@ mod state;
 
 pub use attributes::{AnsiColor, CellAttributes, Color};
 pub use state::{
-    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES, ScreenBuffer, ScrollRegion,
-    TerminalError, TerminalModes, TerminalSnapshot, TerminalState,
+    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES, MouseModes, ScreenBuffer,
+    ScrollRegion, TerminalError, TerminalModes, TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -74,10 +74,23 @@ pub(crate) enum EraseMode {
     All,
 }
 
+/// DEC private modes (`CSI ? ... h/l`) recognised by the parser.
+///
+/// Mouse modes are tracked as state so the disambiguation between
+/// `DeleteLines` and an X10 mouse report can happen at the `CSI M` final byte;
+/// see [`Parser::advance`]. The encoding-only modes (1005/1006/1015) do not
+/// trigger report consumption on their own — a tracking mode must also be on —
+/// but are recorded so a future input path can read the active encoding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PrivateMode {
     AlternateScreen,
     ApplicationCursorKey,
+    MouseNormalTracking,
+    MouseButtonEvent,
+    MouseAnyEvent,
+    MouseUtf8,
+    MouseSgr,
+    MouseUrxvt,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -86,7 +99,17 @@ pub(crate) struct Parser {
 }
 
 impl Parser {
-    pub(crate) fn advance(&mut self, byte: u8) -> Option<Action> {
+    /// Advance the machine by one byte.
+    ///
+    /// `mouse_tracking` reports whether any mouse *tracking* mode (DEC 1000,
+    /// 1002, or 1003) is currently enabled. It is the sole disambiguator for
+    /// the genuinely ambiguous `CSI M`: with tracking on, a parameter-less
+    /// `CSI M` is the X10 mouse-report introducer and the next three bytes are
+    /// consumed as its binary payload; with tracking off, `CSI M` keeps its
+    /// ECMA-48 `DeleteLines(1)` meaning. The flag is supplied per byte by the
+    /// caller so a mode change inside one `feed_bytes` call takes effect at the
+    /// next byte.
+    pub(crate) fn advance(&mut self, byte: u8, mouse_tracking: bool) -> Option<Action> {
         let state = self.state;
         match state {
             ParserState::Ground => self.advance_ground(byte),
@@ -104,13 +127,31 @@ impl Parser {
                     self.state = ParserState::Escape;
                     return None;
                 }
-                let action = csi.advance(byte);
-                self.state = if action.finished {
-                    ParserState::Ground
+                let advance = csi.advance(byte, mouse_tracking);
+                self.state = if advance.finished {
+                    if advance.enter_mouse_report {
+                        ParserState::MouseReport { remaining: 3 }
+                    } else {
+                        ParserState::Ground
+                    }
                 } else {
                     ParserState::Csi(csi)
                 };
-                action.action
+                advance.action
+            }
+            // Fixed-length X10 mouse-report payload (Cb, Cx, Cy) introduced by a
+            // tracking-mode `CSI M`. Every byte is swallowed unconditionally —
+            // including ESC, BEL, and C0 controls — because the payload is raw
+            // binary coordinates, not text or control codes. Letting an ESC
+            // here restart the escape machine would desync the parser for the
+            // rest of the stream; treating it as data keeps the consumption
+            // count exact so the parser resynchronises on the byte after Cy.
+            ParserState::MouseReport { remaining } => {
+                match remaining.checked_sub(1) {
+                    Some(0) | None => self.state = ParserState::Ground,
+                    Some(next) => self.state = ParserState::MouseReport { remaining: next },
+                }
+                None
             }
             // Control-string payload swallowing. Entered by OSC (`ESC ]`),
             // DCS (`ESC P`), SOS (`ESC X`), PM (`ESC ^`), and APC (`ESC _`).
@@ -207,6 +248,11 @@ enum ParserState {
     Escape,
     EscapeIntermediate,
     Csi(Csi),
+    // Swallows the fixed-length three-byte payload of an X10 mouse report
+    // (`CSI M` + Cb/Cx/Cy) introduced while a mouse tracking mode is enabled.
+    MouseReport {
+        remaining: u8,
+    },
     ControlString,
     ControlStringEscape,
 }
@@ -237,7 +283,7 @@ impl Default for Csi {
 }
 
 impl Csi {
-    fn advance(&mut self, byte: u8) -> CsiAdvance {
+    fn advance(&mut self, byte: u8, mouse_tracking: bool) -> CsiAdvance {
         match byte {
             b'0'..=b'9' => {
                 self.has_current = true;
@@ -271,12 +317,27 @@ impl Csi {
                 CsiAdvance::pending()
             }
             0x40..=0x7e => {
+                // `CSI M` is ambiguous between DeleteLines (ECMA-48) and the X10
+                // mouse-report introducer. Only the *parameter-less* form is a
+                // report shape — real reports are bare `CSI M`; an explicit
+                // parameter such as `CSI 2 M` is DL. The disambiguator is mode
+                // state: with a mouse tracking mode on, bare `CSI M` becomes a
+                // report and the parser consumes the next three bytes as data
+                // instead of executing DL. Capture the bare shape before
+                // push_current commits the implicit zero parameter.
+                let bare_csi_m = mouse_tracking
+                    && byte == b'M'
+                    && self.private_marker.is_none()
+                    && self.len == 0
+                    && !self.has_current;
                 self.push_current();
-                CsiAdvance::finished(if self.overflowed || self.ignored {
-                    None
-                } else {
-                    self.action(byte)
-                })
+                if self.overflowed || self.ignored {
+                    return CsiAdvance::finished(None);
+                }
+                if bare_csi_m {
+                    return CsiAdvance::mouse_report();
+                }
+                CsiAdvance::finished(self.action(byte))
             }
             // C0 controls embedded in a control sequence execute immediately
             // via the Ground action WITHOUT aborting the sequence (DEC VT and
@@ -352,6 +413,16 @@ impl Csi {
         let mode = match self.params[0] {
             1 => PrivateMode::ApplicationCursorKey,
             1049 => PrivateMode::AlternateScreen,
+            // Mouse tracking modes: their presence flips `CSI M` from
+            // DeleteLines into the X10 report introducer.
+            1000 => PrivateMode::MouseNormalTracking,
+            1002 => PrivateMode::MouseButtonEvent,
+            1003 => PrivateMode::MouseAnyEvent,
+            // Mouse coordinate-encoding modes: recorded for a future input
+            // path but they do not, on their own, make `CSI M` a report.
+            1005 => PrivateMode::MouseUtf8,
+            1006 => PrivateMode::MouseSgr,
+            1015 => PrivateMode::MouseUrxvt,
             _ => return None,
         };
         match final_byte {
@@ -402,6 +473,7 @@ impl Csi {
 struct CsiAdvance {
     action: Option<Action>,
     finished: bool,
+    enter_mouse_report: bool,
 }
 
 impl CsiAdvance {
@@ -409,6 +481,7 @@ impl CsiAdvance {
         Self {
             action: None,
             finished: false,
+            enter_mouse_report: false,
         }
     }
 
@@ -416,6 +489,7 @@ impl CsiAdvance {
         Self {
             action,
             finished: true,
+            enter_mouse_report: false,
         }
     }
 
@@ -423,6 +497,18 @@ impl CsiAdvance {
         Self {
             action,
             finished: false,
+            enter_mouse_report: false,
+        }
+    }
+
+    /// Signals that a tracking-mode `CSI M` was seen and the parser must enter
+    /// the fixed-length mouse-report swallow state instead of returning to
+    /// Ground. No action is emitted: a report introduces no screen mutation.
+    const fn mouse_report() -> Self {
+        Self {
+            action: None,
+            finished: true,
+            enter_mouse_report: true,
         }
     }
 }
@@ -432,10 +518,14 @@ mod tests {
     use super::*;
 
     fn actions(bytes: &[u8]) -> Vec<Action> {
+        actions_with(bytes, false)
+    }
+
+    fn actions_with(bytes: &[u8], mouse_tracking: bool) -> Vec<Action> {
         let mut parser = Parser::default();
         bytes
             .iter()
-            .filter_map(|byte| parser.advance(*byte))
+            .filter_map(|byte| parser.advance(*byte, mouse_tracking))
             .collect()
     }
 
@@ -489,7 +579,7 @@ mod tests {
         let mut parser = Parser::default();
         let emitted: Vec<Action> = b"\x1b(BX"
             .iter()
-            .filter_map(|byte| parser.advance(*byte))
+            .filter_map(|byte| parser.advance(*byte, false))
             .collect();
         assert_eq!(emitted, [Action::Print(b'X')]);
     }
@@ -599,5 +689,103 @@ mod tests {
             ]
         );
         assert!(actions(b"\x1b[?2004h\x1b[?1049;1h\x1b[>1049h").is_empty());
+    }
+
+    #[test]
+    fn csi_m_is_delete_lines_without_a_mouse_mode() {
+        // With no mouse tracking mode enabled, the ECMA-48 reading of `CSI M`
+        // wins: it is DeleteLines(1). An explicit parameter stays DL too.
+        assert_eq!(actions(b"\x1b[M"), [Action::DeleteLines(1)]);
+        assert_eq!(actions(b"\x1b[2M"), [Action::DeleteLines(2)]);
+    }
+
+    #[test]
+    fn csi_m_with_mouse_tracking_consumes_three_payload_bytes() {
+        // The issue #46 repro: with tracking on, `CSI M` introduces the X10
+        // report and the three coordinate bytes are swallowed as data, never
+        // printed and never executed. No action leaves the parser at all.
+        assert!(actions_with(b"\x1b[M\x20\x25\x27", true).is_empty());
+        // A bare `CSI M` with tracking on emits nothing (no DL) and the
+        // following printable text resumes normally after the three bytes.
+        assert_eq!(
+            actions_with(b"\x1b[M\x20\x25\x27X", true),
+            [Action::Print(b'X')]
+        );
+    }
+
+    #[test]
+    fn csi_m_with_explicit_param_is_still_delete_lines_under_tracking() {
+        // Real reports are bare `CSI M`; a parameterised form is DL even while
+        // a mouse mode is on, so it cannot be used to smuggle a payload swallow.
+        assert_eq!(actions_with(b"\x1b[2M", true), [Action::DeleteLines(2)]);
+        assert_eq!(actions_with(b"\x1b[0M", true), [Action::DeleteLines(1)]);
+    }
+
+    #[test]
+    fn csi_m_mouse_report_swallows_esc_and_controls_without_desync() {
+        // Rule: the three report bytes are raw binary coordinates, so they are
+        // consumed unconditionally. ESC, BEL, and LF inside the payload must
+        // NOT restart the escape machine or execute their C0 actions — that
+        // would desync the parser for the rest of the stream. After three
+        // bytes the parser is back in Ground and printable text prints.
+        assert!(actions_with(b"\x1b[M\x1b\n\x07", true).is_empty());
+        assert_eq!(
+            actions_with(b"\x1b[M\x1b\n\x07X", true),
+            [Action::Print(b'X')]
+        );
+    }
+
+    #[test]
+    fn csi_m_mouse_report_survives_byte_at_a_time_feeds() {
+        // The parser state persists between advance calls, so a report split
+        // one byte at a time across feed boundaries behaves the same as a
+        // single feed.
+        let mut parser = Parser::default();
+        let mut emitted = Vec::new();
+        for byte in b"\x1b[M\x20\x25\x27X" {
+            emitted.extend(parser.advance(*byte, true));
+        }
+        assert_eq!(emitted, [Action::Print(b'X')]);
+    }
+
+    #[test]
+    fn private_mouse_modes_round_trip_at_the_action_level() {
+        let expected = [
+            (1000, PrivateMode::MouseNormalTracking),
+            (1002, PrivateMode::MouseButtonEvent),
+            (1003, PrivateMode::MouseAnyEvent),
+            (1005, PrivateMode::MouseUtf8),
+            (1006, PrivateMode::MouseSgr),
+            (1015, PrivateMode::MouseUrxvt),
+        ];
+        for (num, mode) in expected {
+            let enable = format!("\x1b[?{num}h");
+            let disable = format!("\x1b[?{num}l");
+            assert_eq!(
+                actions(enable.as_bytes()),
+                [Action::SetPrivateMode {
+                    mode,
+                    enabled: true,
+                }]
+            );
+            assert_eq!(
+                actions(disable.as_bytes()),
+                [Action::SetPrivateMode {
+                    mode,
+                    enabled: false,
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn sgr_mouse_report_marker_stays_poisoned() {
+        // Regression for issue #41: the `<` private marker poisons the CSI so a
+        // SGR-form mouse report (`CSI < Cb ; Cx ; Cy M/m`) is never executed as
+        // DeleteLines or printed as text — under mouse tracking or not.
+        assert!(actions(b"\x1b[<0;5;7M").is_empty());
+        assert!(actions(b"\x1b[<0;5;7m").is_empty());
+        assert!(actions_with(b"\x1b[<0;5;7M", true).is_empty());
+        assert!(actions_with(b"\x1b[<0;5;7m", true).is_empty());
     }
 }

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -184,12 +184,78 @@ impl ScrollRegion {
     }
 }
 
+/// DEC private mouse reporting modes (DECSET/DECRST 1000-1015).
+///
+/// These track the six modes Zellij's client enables on attach. The tracking
+/// modes (1000/1002/1003) decide whether a click produces a report at all and
+/// select the bare `CSI M` report introducer. The encoding modes (1005/1006/
+/// 1015) only change how a report is *formatted* by a future input path; they
+/// are recorded here so enabling/disabling them round-trips in the snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MouseModes {
+    normal_click_tracking: bool,
+    button_event_tracking: bool,
+    any_event_tracking: bool,
+    utf8_coordinate_encoding: bool,
+    sgr_encoding: bool,
+    urxvt_encoding: bool,
+}
+
+impl MouseModes {
+    /// Whether any mouse *tracking* mode (1000/1002/1003) is currently enabled.
+    ///
+    /// Only a tracking mode causes the terminal to emit a report, and a bare
+    /// `CSI M` is the X10-form introducer for that report. The encoding modes
+    /// alone never produce a report, so they do not flip this flag.
+    #[must_use]
+    pub const fn is_tracking_enabled(self) -> bool {
+        self.normal_click_tracking || self.button_event_tracking || self.any_event_tracking
+    }
+
+    /// DECSET/DECRST 1000: normal (X10/VT200 click) mouse tracking.
+    #[must_use]
+    pub const fn is_normal_click_tracking(self) -> bool {
+        self.normal_click_tracking
+    }
+
+    /// DECSET/DECRST 1002: button-event mouse tracking (press/release/drag).
+    #[must_use]
+    pub const fn is_button_event_tracking(self) -> bool {
+        self.button_event_tracking
+    }
+
+    /// DECSET/DECRST 1003: any-event mouse tracking (including motion).
+    #[must_use]
+    pub const fn is_any_event_tracking(self) -> bool {
+        self.any_event_tracking
+    }
+
+    /// DECSET/DECRST 1005: UTF-8 coordinate encoding.
+    #[must_use]
+    pub const fn is_utf8_coordinate_encoding(self) -> bool {
+        self.utf8_coordinate_encoding
+    }
+
+    /// DECSET/DECRST 1006: SGR mouse encoding (`CSI < Cb ; Cx ; Cy M`).
+    #[must_use]
+    pub const fn is_sgr_encoding(self) -> bool {
+        self.sgr_encoding
+    }
+
+    /// DECSET/DECRST 1015: urxvt mouse encoding.
+    #[must_use]
+    pub const fn is_urxvt_encoding(self) -> bool {
+        self.urxvt_encoding
+    }
+}
+
 /// Renderer-independent modes that affect screen selection or encoded input.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TerminalModes {
     alternate_screen: bool,
     application_cursor_key: bool,
     application_keypad: bool,
+    mouse: MouseModes,
 }
 
 impl TerminalModes {
@@ -209,6 +275,19 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_application_keypad_mode(self) -> bool {
         self.application_keypad
+    }
+
+    /// Mouse reporting mode state (DECSET/DECRST 1000-1015).
+    #[must_use]
+    pub const fn mouse(self) -> MouseModes {
+        self.mouse
+    }
+
+    /// Whether any mouse tracking mode is enabled, i.e. whether a bare `CSI M`
+    /// must be read as the X10 mouse-report introducer rather than DeleteLines.
+    #[must_use]
+    pub const fn is_mouse_tracking_enabled(self) -> bool {
+        self.mouse.is_tracking_enabled()
     }
 }
 
@@ -489,7 +568,11 @@ impl TerminalState {
     /// escape-sequence payload.
     pub fn feed_bytes(&mut self, bytes: &[u8]) {
         for byte in bytes {
-            if let Some(action) = self.parser.advance(*byte) {
+            // The mouse-tracking flag is read fresh on every byte so a DECSET
+            // that enables tracking mid-feed takes effect before the following
+            // `CSI M` report in the same feed_bytes call.
+            let mouse_tracking = self.modes.is_mouse_tracking_enabled();
+            if let Some(action) = self.parser.advance(*byte, mouse_tracking) {
                 self.apply(action);
             }
         }
@@ -893,6 +976,24 @@ impl TerminalState {
             (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
             (PrivateMode::ApplicationCursorKey, enabled) => {
                 self.modes.application_cursor_key = enabled;
+            }
+            (PrivateMode::MouseNormalTracking, enabled) => {
+                self.modes.mouse.normal_click_tracking = enabled;
+            }
+            (PrivateMode::MouseButtonEvent, enabled) => {
+                self.modes.mouse.button_event_tracking = enabled;
+            }
+            (PrivateMode::MouseAnyEvent, enabled) => {
+                self.modes.mouse.any_event_tracking = enabled;
+            }
+            (PrivateMode::MouseUtf8, enabled) => {
+                self.modes.mouse.utf8_coordinate_encoding = enabled;
+            }
+            (PrivateMode::MouseSgr, enabled) => {
+                self.modes.mouse.sgr_encoding = enabled;
+            }
+            (PrivateMode::MouseUrxvt, enabled) => {
+                self.modes.mouse.urxvt_encoding = enabled;
             }
         }
     }

--- a/crates/noren-terminal/tests/mouse_modes.rs
+++ b/crates/noren-terminal/tests/mouse_modes.rs
@@ -1,0 +1,217 @@
+//! Issue #46: the legacy X10 mouse report `CSI M` corrupts the screen.
+//!
+//! These are state-level regressions through `TerminalState`: a `DECSET` that
+//! enables a mouse tracking mode updates live mode state, the per-byte flag in
+//! `feed_bytes` reads that state, and a following `CSI M` is then consumed as a
+//! report introducer instead of executing as DeleteLines. The parser-unit
+//! behaviour is covered in `parser::tests`; this file proves the wiring and the
+//! observable screen/mode contract.
+
+use noren_terminal::{MouseModes, TerminalState};
+
+/// Read the six mouse-mode flags as a fixed-order array for indexed checks.
+fn mouse_flags(m: MouseModes) -> [bool; 6] {
+    [
+        m.is_normal_click_tracking(),
+        m.is_button_event_tracking(),
+        m.is_any_event_tracking(),
+        m.is_utf8_coordinate_encoding(),
+        m.is_sgr_encoding(),
+        m.is_urxvt_encoding(),
+    ]
+}
+
+fn feed_bytewise(state: &mut TerminalState, bytes: &[u8]) {
+    for byte in bytes {
+        state.feed_bytes(std::slice::from_ref(byte));
+    }
+}
+
+// ===== The issue #46 reproduction: screen unchanged under a tracking mode =====
+
+#[test]
+fn csi_m_report_leaves_the_screen_unchanged_under_each_tracking_mode() {
+    for enable in [b"\x1b[?1000h".as_slice(), b"\x1b[?1002h", b"\x1b[?1003h"] {
+        let mut state = TerminalState::new(3, 3).expect("valid terminal");
+        state.feed_bytes(b"AAA\r\nBBB\r\nCCC");
+        let before = state.snapshot().lines().to_vec();
+        let cursor_before = state.cursor();
+
+        state.feed_bytes(enable);
+        // The exact coordinator reproduction: CSI M + three coordinate bytes.
+        // (\x20 \x25 \x27 are space, %, ' — previously printed as text after a
+        // DeleteLines(1) corrupted the last row.)
+        state.feed_bytes(b"\x1b[M\x20\x25\x27");
+
+        assert_eq!(
+            state.snapshot().lines(),
+            before.as_slice(),
+            "screen must be untouched under {enable:?}"
+        );
+        assert_eq!(
+            state.cursor(),
+            cursor_before,
+            "a report introduces no cursor movement"
+        );
+    }
+}
+
+#[test]
+fn csi_m_report_data_bytes_are_never_printed_as_text() {
+    // Position the cursor over existing text and feed a report whose payload
+    // bytes would overwrite that text if they were printed. They must not be.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"XXXX");
+    state.feed_bytes(b"\x1b[?1000h");
+    state.feed_bytes(b"\x1b[1;1H");
+    state.feed_bytes(b"\x1b[M!\"#");
+
+    assert_eq!(state.snapshot().lines(), ["XXXX"]);
+}
+
+// ===== No mouse mode: CSI M keeps its ECMA-48 DeleteLines meaning =====
+
+#[test]
+fn csi_m_deletes_a_line_with_no_mouse_mode_enabled() {
+    let mut state = TerminalState::new(3, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\r\nBBB\r\nCCC");
+    // Cursor at row 0; bare CSI M is DeleteLines(1): row 0 drops, rows shift up.
+    state.feed_bytes(b"\x1b[1;1H\x1b[M");
+    assert_eq!(state.snapshot().lines(), ["BBB", "CCC"]);
+}
+
+#[test]
+fn csi_m_data_bytes_print_as_text_with_no_mouse_mode_enabled() {
+    // The corruption the fix prevents: without a mouse mode the three bytes
+    // after CSI M are ordinary printable text (CSI M itself is DeleteLines).
+    let mut state = TerminalState::new(2, 6).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;1H\x1b[M %'");
+    // CSI M deletes row 0 (blanking via scroll-up of the single-line region's
+    // top), then " %'" prints at the start of row 0.
+    assert_eq!(state.snapshot().lines(), [" %'"]);
+}
+
+// ===== Payload control bytes / ESC never desync the parser =====
+
+#[test]
+fn report_payload_with_esc_and_controls_does_not_desync() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?1000hAB");
+    let before = state.snapshot().lines().to_vec();
+
+    // Payload bytes ESC, LF, BEL are raw binary coordinates: none may start an
+    // escape, scroll, or ring — they are swallowed and the count stays exact.
+    state.feed_bytes(b"\x1b[M\x1b\n\x07");
+    assert_eq!(state.snapshot().lines(), before.as_slice());
+
+    // The parser resynchronises on the byte after Cy: text prints in place.
+    state.feed_bytes(b"CD");
+    assert_eq!(state.snapshot().lines(), ["ABCD"]);
+}
+
+// ===== A report split one byte at a time matches a single feed =====
+
+#[test]
+fn report_split_one_byte_at_a_time_matches_a_single_feed() {
+    let stream = b"\x1b[?1000h\x1b[M\x20\x25\x27X";
+
+    let mut whole = TerminalState::new(2, 4).expect("valid terminal");
+    whole.feed_bytes(stream);
+
+    let mut split = TerminalState::new(2, 4).expect("valid terminal");
+    feed_bytewise(&mut split, stream);
+
+    assert_eq!(whole.snapshot(), split.snapshot());
+    // The three report bytes were consumed; X is the first printable after.
+    assert_eq!(split.snapshot().lines(), ["X"]);
+}
+
+// ===== Mouse mode enable/disable round-trips in the snapshot =====
+
+#[test]
+fn each_mouse_mode_round_trips_in_the_snapshot() {
+    // (DEC private mode number, index into mouse_flags()).
+    let cases = [
+        (1000, 0),
+        (1002, 1),
+        (1003, 2),
+        (1005, 3),
+        (1006, 4),
+        (1015, 5),
+    ];
+
+    for (num, idx) in cases {
+        let mut state = TerminalState::new(1, 2).expect("valid terminal");
+
+        // Default: every mouse flag is off.
+        assert!(
+            mouse_flags(state.snapshot().modes().mouse())
+                .iter()
+                .all(|flag| !flag),
+            "mode {num}: all flags start off"
+        );
+
+        // Enable: only the targeted flag flips on; siblings stay off.
+        state.feed_bytes(format!("\x1b[?{num}h").as_bytes());
+        let flags = mouse_flags(state.snapshot().modes().mouse());
+        for (i, &flag) in flags.iter().enumerate() {
+            assert_eq!(flag, i == idx, "mode {num}: enable flag[{i}]");
+        }
+
+        // Disable: back to all off.
+        state.feed_bytes(format!("\x1b[?{num}l").as_bytes());
+        assert!(
+            mouse_flags(state.snapshot().modes().mouse())
+                .iter()
+                .all(|flag| !flag),
+            "mode {num}: disable clears the flag"
+        );
+    }
+}
+
+#[test]
+fn only_tracking_modes_enable_the_csi_m_disambiguation() {
+    // The encoding-only modes (1005/1006/1015) never produce a report on their
+    // own, so they must not flip the tracking flag that reclassifies CSI M.
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    for enc in [1005, 1006, 1015] {
+        state.feed_bytes(format!("\x1b[?{enc}h").as_bytes());
+        assert!(
+            !state.modes().is_mouse_tracking_enabled(),
+            "encoding mode {enc} must not enable tracking"
+        );
+        state.feed_bytes(format!("\x1b[?{enc}l").as_bytes());
+    }
+
+    // Each tracking mode alone is sufficient to arm the CSI M disambiguation.
+    for track in [1000, 1002, 1003] {
+        state.feed_bytes(format!("\x1b[?{track}h").as_bytes());
+        assert!(
+            state.modes().is_mouse_tracking_enabled(),
+            "tracking mode {track} arms disambiguation"
+        );
+        state.feed_bytes(format!("\x1b[?{track}l").as_bytes());
+        assert!(
+            !state.modes().is_mouse_tracking_enabled(),
+            "disabling {track} disarms disambiguation"
+        );
+    }
+}
+
+// ===== SGR-form reports stay harmless (issue #41 regression) =====
+
+#[test]
+fn sgr_form_mouse_reports_are_harmless_under_tracking() {
+    // Issue #41 fixed the `<` private marker so a SGR-mouse-shaped CSI is
+    // poisoned and never executes. Re-assert it under a tracking mode so a
+    // future change to the marker handling cannot regress #46 alongside it.
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"AB\r\nCD");
+    let before = state.snapshot().lines().to_vec();
+
+    state.feed_bytes(b"\x1b[?1006h\x1b[?1000h");
+    // Press (`...M`) and release (`...m`) SGR reports.
+    state.feed_bytes(b"\x1b[<0;5;7M\x1b[<0;5;7m");
+
+    assert_eq!(state.snapshot().lines(), before.as_slice());
+}


### PR DESCRIPTION
Closes #46.

## The defect

On `main` before this change:

```
screen before: ["AAA", "BBB", "CCC"]
feed: \x1b[M\x20\x25\x27          (CSI M + three data bytes)
screen after:  ["AAA", "BBB", "    %'"]
```

`CSI M` executed as DL and the coordinate bytes printed as text. Zellij enables
mouse mode by default, so **moving the mouse was enough to corrupt the screen** —
which is why this was the blocking defect behind any mouse work rather than a
cosmetic gap.

## Why mode state is the fix

`CSI M` is genuinely ambiguous: it is both DL and the X10 report introducer. The
disambiguation is mode state, so this tracks the six DEC private mouse modes
Zellij's client enables on attach and reads `CSI M` as an X10 introducer — quietly
consuming exactly three following bytes — only while tracking is on.

The design draws a distinction worth reviewing rather than skimming: **1000/1002/
1003 are tracking modes** and enable the X10 reading, while **1005/1006/1015 are
encoding-only** — they change how a report is formatted, not whether one is
produced, so they must leave `CSI M` as DL. That matches xterm and is documented
on `MouseModes`.

Mouse input *generation* is deliberately out of scope; this change is about not
corrupting the screen when reports arrive.

## Coordinator verification

Six independent checks, all passing:

- the original reproduction leaves the screen unchanged with tracking on;
- `CSI M` **still performs DL** with no mouse mode enabled (`["AAA","BBB","CCC"]`
  → `["BBB","CCC"]`);
- each of 1000/1002/1003 consumes the report with no data bytes leaking as text;
- each of 1005/1006/1015 leaves `CSI M` as DL, confirming the encoding-only
  distinction is real and not accidental;
- the whole report fed one byte at a time gives an identical screen;
- SGR-form reports (`CSI < 0;5;7 M/m`) stay harmless, so #41's fix does not
  regress.

One coordinator test initially failed on mode 1005; investigation showed the
**coordinator's assumption** was wrong — 1005 is encoding-only — and the
implementation correct.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **193 workspace tests pass** (was 177).

Rebased onto current `main`. One genuine conflict was resolved: PR #50 added
`MAX_SCROLLBACK_LINES` to the same export list this adds `MouseModes` to — both
are kept.

Found by the Zellij gap analysis (#47) after #41 had fixed only the `<`/`=`
markers, and reproduced by the coordinator before this fix was authorized.