### PR TITLE
feat(terminal): honor display width for wide and zero-width characters

### DIFF
--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -4,9 +4,10 @@
 //! PTY bytes enter through [`TerminalEngine::feed_bytes`]; renderers receive an
 //! immutable [`TerminalSnapshot`] and never depend on PTY or parser types.
 //!
-//! This foundation supports a bounded ASCII/CSI subset, basic SGR attributes,
-//! scrolling regions, cursor save/restore, and DEC private mode 1049 screen
-//! switching. It is not a VT100/xterm compatibility claim.
+//! This foundation supports a bounded printable-text subset (ASCII plus
+//! decoded UTF-8, placed by display width), a bounded CSI subset, basic SGR
+//! attributes, scrolling regions, cursor save/restore, and DEC private mode
+//! 1049 screen switching. It is not a VT100/xterm compatibility claim.
 
 mod attributes;
 mod parser;
@@ -56,10 +57,14 @@ impl TerminalEngine for TerminalState {
     }
 }
 
-/// Current Unicode column-width seed for future non-ASCII cell handling.
+/// Display column width used when placing a character into cells.
 ///
-/// Terminal Core v1 writes printable ASCII only. This policy remains public so
-/// later grapheme/ambiguous-width work can evolve behind the same boundary.
+/// Printable characters are one or two columns wide; combining and other
+/// zero-width characters are zero. Widths come from
+/// [`UnicodeWidthChar`](unicode_width::UnicodeWidthChar) — no hand-rolled
+/// tables — so ambiguous-width characters follow that crate's defaults. This
+/// policy remains public so later grapheme work can evolve behind the same
+/// boundary.
 #[must_use]
 pub fn cell_width(ch: char) -> usize {
     UnicodeWidthChar::width(ch).unwrap_or(0)

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -21,7 +21,7 @@ fn c0_action(byte: u8) -> Option<Action> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Action {
-    Print(u8),
+    Print(char),
     LineFeed,
     CarriageReturn,
     Backspace,
@@ -80,13 +80,87 @@ pub(crate) enum PrivateMode {
     ApplicationCursorKey,
 }
 
+/// Incremental UTF-8 decoder for printable text in the Ground state.
+///
+/// Rejects overlong forms, surrogates, and out-of-range code points so only
+/// well-formed characters reach [`Action::Print`]. Invalid lead bytes are
+/// dropped; an invalid continuation abandons the pending sequence and is
+/// re-examined as a new lead.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Utf8 {
+    value: u32,
+    remaining: u8,
+    min: u32,
+}
+
+impl Utf8 {
+    const fn idle() -> Self {
+        Self {
+            value: 0,
+            remaining: 0,
+            min: 0,
+        }
+    }
+
+    fn feed(&mut self, byte: u8) -> Option<char> {
+        if self.remaining > 0 {
+            if (0x80..=0xbf).contains(&byte) {
+                self.value = (self.value << 6) | u32::from(byte & 0x3f);
+                self.remaining -= 1;
+                if self.remaining > 0 {
+                    return None;
+                }
+                let (value, min) = (self.value, self.min);
+                *self = Self::idle();
+                return if value >= min {
+                    char::from_u32(value)
+                } else {
+                    None
+                };
+            }
+            self.value = 0;
+            self.remaining = 0;
+            self.min = 0;
+        }
+        *self = match byte {
+            // 0xc0/0xc1 leads can only encode overlong forms, so they are
+            // rejected outright; the `min` bounds reject overlong 3- and
+            // 4-byte forms, and `char::from_u32` rejects surrogates and
+            // values above U+10FFFF.
+            0xc2..=0xdf => Self {
+                value: u32::from(byte & 0x1f),
+                remaining: 1,
+                min: 0x80,
+            },
+            0xe0..=0xef => Self {
+                value: u32::from(byte & 0x0f),
+                remaining: 2,
+                min: 0x800,
+            },
+            0xf0..=0xf4 => Self {
+                value: u32::from(byte & 0x07),
+                remaining: 3,
+                min: 0x10_000,
+            },
+            _ => Self::idle(),
+        };
+        None
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct Parser {
     state: ParserState,
+    utf8: Utf8,
 }
 
 impl Parser {
     pub(crate) fn advance(&mut self, byte: u8) -> Option<Action> {
+        if self.state != ParserState::Ground {
+            // A pending multi-byte character never straddles an escape
+            // sequence or control-string payload.
+            self.utf8 = Utf8::idle();
+        }
         let state = self.state;
         match state {
             ParserState::Ground => self.advance_ground(byte),
@@ -146,10 +220,18 @@ impl Parser {
         match byte {
             ESC => {
                 self.state = ParserState::Escape;
+                self.utf8 = Utf8::idle();
                 None
             }
-            0x20..=0x7e => Some(Action::Print(byte)),
-            _ => c0_action(byte),
+            0x20..=0x7e => {
+                self.utf8 = Utf8::idle();
+                Some(Action::Print(char::from(byte)))
+            }
+            0x80..=0xff => self.utf8.feed(byte).map(Action::Print),
+            _ => {
+                self.utf8 = Utf8::idle();
+                c0_action(byte)
+            }
         }
     }
 
@@ -444,7 +526,7 @@ mod tests {
         assert_eq!(
             actions(b"A\n\x0b\x0c\r\x08\x1b[2A\x1b[3;4H"),
             [
-                Action::Print(b'A'),
+                Action::Print('A'),
                 Action::LineFeed,
                 Action::LineFeed,
                 Action::LineFeed,
@@ -457,14 +539,53 @@ mod tests {
     }
 
     #[test]
+    fn decodes_multibyte_utf8_into_print_actions() {
+        assert_eq!(actions("日".as_bytes()), [Action::Print('日')]);
+        assert_eq!(
+            actions("aé😀".as_bytes()),
+            [Action::Print('a'), Action::Print('é'), Action::Print('😀')]
+        );
+        // Zero-width combining characters decode like any other printable.
+        assert_eq!(actions("\u{0301}".as_bytes()), [Action::Print('\u{0301}')]);
+    }
+
+    #[test]
+    fn utf8_state_survives_chunk_boundaries_but_not_escapes() {
+        let bytes = "日".as_bytes();
+        let mut parser = Parser::default();
+        assert_eq!(parser.advance(bytes[0]), None);
+        assert_eq!(parser.advance(bytes[1]), None);
+        assert_eq!(parser.advance(bytes[2]), Some(Action::Print('日')));
+
+        // An escape sequence mid-character abandons the pending bytes.
+        let mut parser = Parser::default();
+        assert_eq!(parser.advance(bytes[0]), None);
+        assert_eq!(parser.advance(ESC), None);
+        assert_eq!(parser.advance(b'['), None);
+        assert_eq!(parser.advance(b'A'), Some(Action::MoveUp(1)));
+    }
+
+    #[test]
+    fn invalid_utf8_bytes_are_dropped_without_printing() {
+        assert!(actions(&[0xff, 0xfe]).is_empty());
+        assert!(actions(&[0xc0, 0x80]).is_empty()); // overlong NUL
+        assert!(actions(&[0xe0, 0x80, 0x80]).is_empty()); // overlong
+        // Truncated multi-byte sequences at end of input are dropped.
+        assert!(actions(&"日".as_bytes()[..2]).is_empty());
+        // An invalid continuation abandons the pending sequence; the ASCII
+        // byte that broke it still prints.
+        assert_eq!(actions(&[0xc3, b'a']), [Action::Print('a')]);
+    }
+
+    #[test]
     fn horizontal_tab_emits_a_tab_action() {
         assert_eq!(
             actions(b"\ta\tb"),
             [
                 Action::Tab,
-                Action::Print(b'a'),
+                Action::Print('a'),
                 Action::Tab,
-                Action::Print(b'b'),
+                Action::Print('b'),
             ]
         );
     }
@@ -491,7 +612,7 @@ mod tests {
             .iter()
             .filter_map(|byte| parser.advance(*byte))
             .collect();
-        assert_eq!(emitted, [Action::Print(b'X')]);
+        assert_eq!(emitted, [Action::Print('X')]);
     }
 
     #[test]

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -37,8 +37,11 @@ pub const MAX_SCROLLBACK_LINES: usize = 10_000;
 /// One basic terminal cell.
 ///
 /// Text remains an owned string so later grapheme work does not require a
-/// renderer-facing shape change. Terminal Core v1 writes one ASCII character
-/// with width one into each cell.
+/// renderer-facing shape change. Printing honors display width: a two-column
+/// character occupies a lead cell (`width == 2`, holding the character) and a
+/// zero-width continuation cell that renders as nothing and is never an
+/// independent character; zero-width combining characters are appended to the
+/// preceding cell's text without changing its width.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cell {
     text: String,
@@ -87,12 +90,33 @@ impl Cell {
         self.text == " "
     }
 
-    fn from_ascii(byte: u8, attributes: CellAttributes) -> Self {
+    /// Whether this is the second column placeholder of a wide character.
+    ///
+    /// A continuation cell renders as nothing and must always be preceded in
+    /// its row by its width-two lead cell.
+    #[must_use]
+    pub fn is_continuation(&self) -> bool {
+        self.text.is_empty() && self.width == 0
+    }
+
+    fn from_char(ch: char, width: u8, attributes: CellAttributes) -> Self {
         Self {
-            text: char::from(byte).to_string(),
-            width: 1,
+            text: ch.to_string(),
+            width,
             attributes,
         }
+    }
+
+    fn continuation(attributes: CellAttributes) -> Self {
+        Self {
+            text: String::new(),
+            width: 0,
+            attributes,
+        }
+    }
+
+    fn push_text(&mut self, ch: char) {
+        self.text.push(ch);
     }
 }
 
@@ -261,6 +285,66 @@ impl ScreenBuffer {
         }
     }
 
+    fn is_continuation(&self, row: u16, column: u16) -> bool {
+        self.cell(row, column).is_some_and(Cell::is_continuation)
+    }
+
+    fn push_text(&mut self, row: u16, column: u16, ch: char) {
+        if let Some(index) = self.index(row, column) {
+            self.cells[index].push_text(ch);
+        }
+    }
+
+    /// Enforce the wide-character invariant on one row: every continuation
+    /// cell directly follows its width-two lead, and every lead is directly
+    /// followed by its continuation. A half that lost its partner is blanked,
+    /// i.e. clearing either half of a wide character clears both.
+    fn repair_row(&mut self, row: u16) {
+        let Some(start) = self.index(row, 0) else {
+            return;
+        };
+        let end = start + usize::from(self.cols);
+        let mut index = start;
+        while index < end {
+            if self.cells[index].is_continuation() {
+                self.cells[index] = Cell::blank();
+                index += 1;
+            } else if self.cells[index].width() == 2 {
+                let paired = index + 1 < end && self.cells[index + 1].is_continuation();
+                if paired {
+                    index += 2;
+                } else {
+                    self.cells[index] = Cell::blank();
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    /// Whether every wide-character pair in the buffer is intact.
+    pub(crate) fn wide_cells_intact(&self) -> bool {
+        (0..self.rows).all(|row| {
+            let start = usize::from(row) * usize::from(self.cols);
+            let end = start + usize::from(self.cols);
+            let mut index = start;
+            while index < end {
+                if self.cells[index].width() == 2 {
+                    if index + 1 >= end || !self.cells[index + 1].is_continuation() {
+                        return false;
+                    }
+                    index += 2;
+                } else if self.cells[index].is_continuation() {
+                    return false;
+                } else {
+                    index += 1;
+                }
+            }
+            true
+        })
+    }
+
     fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
         let count = checked_cell_count(rows, cols)?;
         let mut next = vec![Cell::blank(); count];
@@ -276,6 +360,12 @@ impl ScreenBuffer {
         self.rows = rows;
         self.cols = cols;
         self.cells = next;
+        // Shrinking a row can truncate the continuation half of a wide
+        // character; blank the orphaned lead rather than leaving a pair
+        // split across the right edge.
+        for row in 0..retained_rows {
+            self.repair_row(row);
+        }
         Ok(())
     }
 
@@ -318,10 +408,19 @@ impl ScreenBuffer {
         let Some(cursor_index) = self.index(cursor.row, cursor.column) else {
             return;
         };
+        let repaired_rows = match mode {
+            EraseMode::ToEnd => cursor.row..self.rows,
+            EraseMode::ToBeginning => 0..cursor.row + 1,
+            EraseMode::All => 0..self.rows,
+        };
         match mode {
             EraseMode::ToEnd => self.cells[cursor_index..].fill(Cell::default()),
             EraseMode::ToBeginning => self.cells[..cursor_index + 1].fill(Cell::default()),
             EraseMode::All => self.cells.fill(Cell::default()),
+        }
+        // An erase boundary may cut a wide character; blank the orphaned half.
+        for row in repaired_rows {
+            self.repair_row(row);
         }
     }
 
@@ -338,6 +437,7 @@ impl ScreenBuffer {
             }
             EraseMode::All => self.cells[row_start..row_end].fill(Cell::default()),
         }
+        self.repair_row(cursor.row);
     }
 
     fn erase_characters(&mut self, cursor: Cursor, count: u16) {
@@ -347,6 +447,7 @@ impl ScreenBuffer {
         let row_end = (usize::from(cursor.row) + 1) * usize::from(self.cols);
         let count = usize::from(count).min(row_end - start);
         self.cells[start..start + count].fill(Cell::default());
+        self.repair_row(cursor.row);
     }
 
     fn insert_characters(&mut self, cursor: Cursor, count: u16) {
@@ -357,6 +458,7 @@ impl ScreenBuffer {
         let count = usize::from(count).min(row_end - start);
         self.cells[start..row_end].rotate_right(count);
         self.cells[start..start + count].fill(Cell::default());
+        self.repair_row(cursor.row);
     }
 
     fn delete_characters(&mut self, cursor: Cursor, count: u16) {
@@ -367,6 +469,7 @@ impl ScreenBuffer {
         let count = usize::from(count).min(row_end - start);
         self.cells[start..row_end].rotate_left(count);
         self.cells[row_end - count..row_end].fill(Cell::default());
+        self.repair_row(cursor.row);
     }
 
     fn index(&self, row: u16, column: u16) -> Option<usize> {
@@ -434,10 +537,10 @@ impl ScreenState {
 
     fn resize(&mut self, rows: u16, cols: u16) -> Result<(), TerminalError> {
         self.screen.resize(rows, cols)?;
-        self.cursor = clamp_cursor(self.cursor, rows, cols);
+        self.cursor = snap_to_lead(&self.screen, clamp_cursor(self.cursor, rows, cols));
         self.saved_cursor = self
             .saved_cursor
-            .map(|cursor| clamp_cursor(cursor, rows, cols));
+            .map(|cursor| snap_to_lead(&self.screen, clamp_cursor(cursor, rows, cols)));
         self.scroll_region = ScrollRegion::full_screen(rows);
         self.wrap_pending = false;
         Ok(())
@@ -449,10 +552,29 @@ impl ScreenState {
 
     fn restore_cursor(&mut self) {
         if let Some(cursor) = self.saved_cursor {
-            self.cursor = clamp_cursor(cursor, self.screen.rows, self.screen.cols);
+            let cursor = clamp_cursor(cursor, self.screen.rows, self.screen.cols);
+            self.cursor = snap_to_lead(&self.screen, cursor);
         }
         self.wrap_pending = false;
     }
+}
+
+/// Move a cursor off continuation cells onto the lead of its wide character.
+fn snap_to_lead(screen: &ScreenBuffer, mut cursor: Cursor) -> Cursor {
+    while cursor.column > 0 && screen.is_continuation(cursor.row, cursor.column) {
+        cursor.column -= 1;
+    }
+    cursor
+}
+
+/// Move a cursor forward past any continuation cell, resolving to the cell
+/// after the wide character when there is room and otherwise to its lead.
+fn snap_past_continuation(screen: &ScreenBuffer, mut cursor: Cursor) -> Cursor {
+    let last_column = screen.cols.saturating_sub(1);
+    while cursor.column < last_column && screen.is_continuation(cursor.row, cursor.column) {
+        cursor.column += 1;
+    }
+    snap_to_lead(screen, cursor)
 }
 
 /// Noren-owned mutable terminal state.
@@ -484,8 +606,9 @@ impl TerminalState {
 
     /// Apply PTY bytes in order.
     ///
-    /// Non-ASCII bytes and unsupported control sequences are ignored in this
-    /// foundation. They are never interpreted as authority or rendered as raw
+    /// Bytes are decoded as UTF-8; printable characters are placed by display
+    /// width, and invalid or unsupported bytes and sequences are ignored.
+    /// They are never interpreted as authority or rendered as raw
     /// escape-sequence payload.
     pub fn feed_bytes(&mut self, bytes: &[u8]) {
         for byte in bytes {
@@ -576,10 +699,15 @@ impl TerminalState {
     }
 
     /// Apply a clamped renderer-independent cursor operation.
+    ///
+    /// The result never rests on a continuation cell: relative forward motion
+    /// resolves past the wide character, and all other motion resolves onto
+    /// its lead cell.
     pub fn move_cursor(&mut self, movement: CursorMove) {
         self.active.wrap_pending = false;
         let last_row = self.active.screen.rows - 1;
         let last_column = self.active.screen.cols - 1;
+        let snap_forward = matches!(movement, CursorMove::Right(_));
         match movement {
             CursorMove::Up(count) => {
                 self.active.cursor.row = self.active.cursor.row.saturating_sub(count);
@@ -617,6 +745,11 @@ impl TerminalState {
                 self.active.cursor.row = row.min(last_row);
             }
         }
+        self.active.cursor = if snap_forward {
+            snap_past_continuation(&self.active.screen, self.active.cursor)
+        } else {
+            snap_to_lead(&self.active.screen, self.active.cursor)
+        };
     }
 
     /// Clone a bounded immutable renderer/test view.
@@ -627,14 +760,16 @@ impl TerminalState {
 
     fn apply(&mut self, action: Action) {
         match action {
-            Action::Print(byte) => self.print_ascii(byte),
+            Action::Print(ch) => self.print_char(ch),
             Action::LineFeed => self.line_feed(),
             Action::CarriageReturn => {
                 self.active.cursor.column = 0;
                 self.active.wrap_pending = false;
             }
             Action::Backspace => {
-                self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
+                let mut cursor = self.active.cursor;
+                cursor.column = cursor.column.saturating_sub(1);
+                self.active.cursor = snap_to_lead(&self.active.screen, cursor);
                 self.active.wrap_pending = false;
             }
             Action::Tab => self.tab(),
@@ -674,23 +809,79 @@ impl TerminalState {
             }
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
         }
+        debug_assert!(self.active.screen.wide_cells_intact());
+        if let Some(primary) = &self.primary_screen {
+            debug_assert!(primary.screen.wide_cells_intact());
+        }
     }
 
-    fn print_ascii(&mut self, byte: u8) {
+    /// Print one decoded character honoring its display width.
+    ///
+    /// A two-column character occupies a lead cell plus a zero-width
+    /// continuation cell; it wraps to the next line when the remaining
+    /// columns cannot fit both. Zero-width combining characters attach to the
+    /// preceding cell and never move the cursor. The cursor never lands on a
+    /// continuation cell: after writing a wide character flush against the
+    /// right edge it waits on the lead cell with autowrap pending, and a
+    /// character wider than the whole grid is dropped.
+    fn print_char(&mut self, ch: char) {
+        let width = match crate::cell_width(ch) {
+            0 => {
+                self.attach_zero_width(ch);
+                return;
+            }
+            width => u16::try_from(width).unwrap_or(1),
+        };
+        if width > self.active.screen.cols {
+            return;
+        }
         if self.active.wrap_pending {
             self.active.cursor.column = 0;
             self.index();
         }
-        self.active.screen.put(
-            self.active.cursor.row,
-            self.active.cursor.column,
-            Cell::from_ascii(byte, self.pen),
-        );
-        if self.active.cursor.column == self.active.screen.cols - 1 {
+        if self.active.cursor.column > self.active.screen.cols - width {
+            self.active.cursor.column = 0;
+            self.index();
+        }
+        let row = self.active.cursor.row;
+        let column = self.active.cursor.column;
+        self.active
+            .screen
+            .put(row, column, Cell::from_char(ch, width as u8, self.pen));
+        if width == 2 {
+            self.active
+                .screen
+                .put(row, column + 1, Cell::continuation(self.pen));
+        }
+        // Overwritten halves of pre-existing wide characters must not dangle.
+        self.active.screen.repair_row(row);
+        if column + width >= self.active.screen.cols {
             self.active.wrap_pending = true;
         } else {
-            self.active.cursor.column += 1;
+            self.active.cursor.column = column + width;
         }
+    }
+
+    /// Append a zero-width (combining) character to the preceding cell.
+    ///
+    /// Combining characters are attached rather than dropped: they extend the
+    /// preceding cell's text without changing its width, never advance the
+    /// cursor, and do not clear pending autowrap. With no preceding cell the
+    /// character is dropped.
+    fn attach_zero_width(&mut self, ch: char) {
+        let cursor = self.active.cursor;
+        let column = if self.active.wrap_pending {
+            Some(cursor.column)
+        } else {
+            cursor.column.checked_sub(1)
+        };
+        let Some(mut column) = column else {
+            return;
+        };
+        if self.active.screen.is_continuation(cursor.row, column) {
+            column = column.saturating_sub(1);
+        }
+        self.active.screen.push_text(cursor.row, column, ch);
     }
 
     fn line_feed(&mut self) {
@@ -704,6 +895,7 @@ impl TerminalState {
         let next_stop = (usize::from(self.active.cursor.column) / 8 + 1) * 8;
         self.active.cursor.column =
             last_column.min(u16::try_from(next_stop).unwrap_or(last_column));
+        self.active.cursor = snap_past_continuation(&self.active.screen, self.active.cursor);
     }
 
     fn index(&mut self) {
@@ -1128,6 +1320,207 @@ mod tests {
         state.feed_bytes(b"\rZ");
         assert_eq!(state.snapshot().lines(), ["Zbc"]);
         assert_eq!(state.cursor(), Cursor { row: 0, column: 1 });
+        assert!(!state.is_wrap_pending());
+    }
+
+    fn row_widths(state: &TerminalState, row: u16) -> Vec<u8> {
+        (0..state.screen().cols())
+            .map(|column| state.screen().cell(row, column).map_or(0, Cell::width))
+            .collect()
+    }
+
+    #[test]
+    fn ascii_lines_are_unchanged_by_the_width_model() {
+        let mut state = TerminalState::new(2, 8).expect("valid terminal");
+        state.feed_bytes(b"hello");
+
+        assert_eq!(state.snapshot().lines(), ["hello"]);
+        assert_eq!(row_widths(&state, 0), vec![1, 1, 1, 1, 1, 1, 1, 1]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 5 });
+        assert!(!state.is_wrap_pending());
+    }
+
+    #[test]
+    fn cjk_characters_occupy_two_cells_each() {
+        let mut state = TerminalState::new(2, 8).expect("valid terminal");
+        state.feed_bytes("日本語".as_bytes());
+
+        let screen = state.screen();
+        assert_eq!(
+            screen.cell(0, 0).map(|c| (c.text(), c.width())),
+            Some(("日", 2))
+        );
+        assert!(screen.cell(0, 1).is_some_and(Cell::is_continuation));
+        assert_eq!(
+            screen.cell(0, 2).map(|c| (c.text(), c.width())),
+            Some(("本", 2))
+        );
+        assert!(screen.cell(0, 3).is_some_and(Cell::is_continuation));
+        assert_eq!(
+            screen.cell(0, 4).map(|c| (c.text(), c.width())),
+            Some(("語", 2))
+        );
+        assert!(screen.cell(0, 5).is_some_and(Cell::is_continuation));
+        assert_eq!(state.snapshot().lines(), ["日本語"]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 6 });
+    }
+
+    #[test]
+    fn wide_character_at_the_last_column_wraps_instead_of_splitting() {
+        let mut state = TerminalState::new(3, 4).expect("valid terminal");
+        state.feed_bytes("abc日".as_bytes());
+
+        assert_eq!(state.snapshot().lines(), ["abc", "日"]);
+        // The lead never lands in the final column without its continuation.
+        assert_eq!(state.screen().cell(0, 3).map(Cell::text), Some(" "));
+        assert_eq!(
+            state.screen().cell(1, 0).map(|c| (c.text(), c.width())),
+            Some(("日", 2))
+        );
+        assert!(state.screen().cell(1, 1).is_some_and(Cell::is_continuation));
+        assert_eq!(state.cursor(), Cursor { row: 1, column: 2 });
+    }
+
+    #[test]
+    fn wide_character_fitting_at_the_right_edge_keeps_cursor_on_its_lead() {
+        let mut state = TerminalState::new(2, 5).expect("valid terminal");
+        state.feed_bytes("abc日".as_bytes());
+
+        assert_eq!(state.snapshot().lines(), ["abc日"]);
+        assert!(state.is_wrap_pending());
+        // Pending wrap parks the cursor on the lead, never the continuation.
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 3 });
+        assert!(!state.screen().cell(0, 3).is_some_and(Cell::is_continuation));
+    }
+
+    #[test]
+    fn overwriting_or_erasing_half_of_a_wide_character_leaves_no_continuation() {
+        // Overwrite the lead of a wide character with a narrow one.
+        let mut state = TerminalState::new(2, 6).expect("valid terminal");
+        state.feed_bytes("日a".as_bytes());
+        state.feed_bytes(b"\x1b[1;1HX");
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("X"));
+        assert_eq!(state.screen().cell(0, 1).map(Cell::text), Some(" "));
+        assert!(!state.screen().cell(0, 1).is_some_and(Cell::is_continuation));
+        assert_eq!(state.snapshot().lines(), ["X a"]);
+
+        // ECH over only the lead clears the orphaned continuation too.
+        let mut state = TerminalState::new(2, 6).expect("valid terminal");
+        state.feed_bytes("a日b".as_bytes());
+        state.feed_bytes(b"\x1b[1;2H\x1b[X");
+        assert_eq!(state.snapshot().lines(), ["a  b"]);
+
+        // EL to the beginning up to the lead clears the continuation after it.
+        let mut state = TerminalState::new(2, 6).expect("valid terminal");
+        state.feed_bytes("a日b".as_bytes());
+        state.feed_bytes(b"\x1b[1;2H\x1b[1K");
+        assert_eq!(state.snapshot().lines(), ["   b"]);
+
+        // DCH deleting the lead shifts the row and clears the continuation.
+        let mut state = TerminalState::new(2, 6).expect("valid terminal");
+        state.feed_bytes("a日b".as_bytes());
+        state.feed_bytes(b"\x1b[1;2H\x1b[P");
+        assert_eq!(state.snapshot().lines(), ["a b"]);
+        assert!(state.screen().wide_cells_intact());
+    }
+
+    #[test]
+    fn combining_mark_attaches_to_the_preceding_cell_and_does_not_advance() {
+        let mut state = TerminalState::new(2, 8).expect("valid terminal");
+        state.feed_bytes("e\u{0301}".as_bytes());
+
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("e\u{0301}"));
+        assert_eq!(state.screen().cell(0, 0).map(Cell::width), Some(1));
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 1 });
+        assert_eq!(state.snapshot().lines(), ["e\u{0301}"]);
+    }
+
+    #[test]
+    fn combining_mark_without_a_preceding_cell_is_dropped() {
+        let mut state = TerminalState::new(2, 8).expect("valid terminal");
+        state.feed_bytes("\u{0301}x".as_bytes());
+
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("x"));
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 1 });
+    }
+
+    #[test]
+    fn cursor_motion_never_rests_on_a_continuation_cell() {
+        let mut state = TerminalState::new(3, 8).expect("valid terminal");
+        state.feed_bytes("日a".as_bytes());
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 3 });
+
+        // Left onto the continuation snaps onto the lead, Right skips the pair.
+        state.move_cursor(CursorMove::Left(2));
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 0 });
+        state.move_cursor(CursorMove::Right(1));
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 2 });
+
+        // Absolute addressing onto the continuation column snaps to the lead.
+        state.move_cursor(CursorMove::To { row: 0, column: 1 });
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 0 });
+
+        // Backspace from just past the pair lands on the lead.
+        state.move_cursor(CursorMove::To { row: 0, column: 2 });
+        state.feed_bytes(b"\x08");
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 0 });
+
+        // Vertical/absolute motion into a row whose target column is a
+        // continuation resolves onto that row's lead.
+        state.feed_bytes(b"\r\n \xe6\x97\xa5");
+        state.move_cursor(CursorMove::To { row: 1, column: 2 });
+        assert_eq!(state.cursor(), Cursor { row: 1, column: 1 });
+        assert!(
+            !state
+                .screen()
+                .cell(state.cursor().row(), state.cursor().column())
+                .is_some_and(Cell::is_continuation)
+        );
+    }
+
+    #[test]
+    fn mixed_ascii_cjk_and_emoji_render_at_the_expected_columns() {
+        let mut state = TerminalState::new(2, 10).expect("valid terminal");
+        state.feed_bytes("a日😀b".as_bytes());
+
+        let texts: Vec<&str> = (0..6)
+            .map(|column| state.screen().cell(0, column).map_or("", Cell::text))
+            .collect();
+        assert_eq!(texts, ["a", "日", "", "\u{1F600}", "", "b"]);
+        assert_eq!(row_widths(&state, 0), vec![1, 2, 0, 2, 0, 1, 1, 1, 1, 1]);
+        assert_eq!(state.snapshot().lines(), ["a日😀b"]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 6 });
+    }
+
+    #[test]
+    fn utf8_split_across_feeds_still_decodes_and_invalid_bytes_are_dropped() {
+        let mut state = TerminalState::new(2, 8).expect("valid terminal");
+        state.feed_bytes(&[0xe6]);
+        state.feed_bytes(&[0x97, 0xa5]);
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("日"));
+
+        state.feed_bytes(&[0xff]);
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 2 });
+    }
+
+    #[test]
+    fn resize_truncating_a_wide_character_blanks_the_orphaned_lead() {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        state.feed_bytes("日".as_bytes());
+        state.resize(2, 1).expect("valid resize");
+
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some(" "));
+        assert_eq!(state.snapshot().lines(), [] as [String; 0]);
+        assert!(state.screen().wide_cells_intact());
+    }
+
+    #[test]
+    fn a_character_wider_than_the_grid_is_dropped() {
+        let mut state = TerminalState::new(2, 1).expect("valid terminal");
+        state.feed_bytes("日".as_bytes());
+
+        assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some(" "));
+        assert_eq!(state.cursor(), Cursor { row: 0, column: 0 });
         assert!(!state.is_wrap_pending());
     }
 }

--- a/crates/noren-terminal/tests/terminal_state.rs
+++ b/crates/noren-terminal/tests/terminal_state.rs
@@ -103,7 +103,9 @@ fn split_sequences_are_retained_and_unsupported_bytes_do_not_leak() {
 
     state.feed_bytes(b"\x1b[31m\xff\xc3\xa9");
     state.feed_bytes(b"Q");
-    assert_eq!(state.snapshot().lines(), ["", "  Q"]);
+    // 0xff is invalid UTF-8 and is dropped; é decodes and prints as a
+    // one-column character.
+    assert_eq!(state.snapshot().lines(), ["", "  éQ"]);
 }
 
 #[test]

--- a/crates/noren-terminal/tests/unicode_width.rs
+++ b/crates/noren-terminal/tests/unicode_width.rs
@@ -1,0 +1,277 @@
+//! Display-width behavior for wide, zero-width, and mixed-width printing.
+
+use noren_terminal::{Cell, CursorMove, TerminalState};
+
+fn cursor(state: &TerminalState) -> (u16, u16) {
+    (state.cursor().row(), state.cursor().column())
+}
+
+fn cell(state: &TerminalState, row: u16, column: u16) -> &Cell {
+    state.screen().cell(row, column).expect("cell is in bounds")
+}
+
+#[test]
+fn ascii_line_is_unchanged_and_every_cell_keeps_width_one() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"ab\rZ\nQ\x08R");
+
+    assert_eq!(state.snapshot().lines(), ["Zb", " R"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| cell.width() == 1 && !cell.is_continuation())
+    );
+}
+
+#[test]
+fn cjk_characters_occupy_two_cells_with_a_continuation() {
+    let mut state = TerminalState::new(2, 8).expect("valid terminal");
+    state.feed_bytes("你好".as_bytes());
+
+    assert_eq!(state.snapshot().lines(), ["你好"]);
+    assert_eq!(cell(&state, 0, 0).text(), "你");
+    assert_eq!(cell(&state, 0, 0).width(), 2);
+    assert!(cell(&state, 0, 1).is_continuation());
+    assert_eq!(cell(&state, 0, 1).text(), "");
+    assert_eq!(cell(&state, 0, 1).width(), 0);
+    assert_eq!(cell(&state, 0, 2).text(), "好");
+    assert_eq!(cell(&state, 0, 2).width(), 2);
+    assert!(cell(&state, 0, 3).is_continuation());
+    assert_eq!(cursor(&state), (0, 4));
+}
+
+#[test]
+fn wide_character_flush_against_the_right_edge_defers_wrap_on_its_lead() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"ab");
+    state.feed_bytes("你".as_bytes());
+
+    assert_eq!(state.snapshot().lines(), ["ab你"]);
+    // The cursor rests on the lead cell, never on the continuation.
+    assert_eq!(cursor(&state), (0, 2));
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"X");
+    assert_eq!(state.snapshot().lines(), ["ab你", "X"]);
+    assert_eq!(cursor(&state), (1, 1));
+}
+
+#[test]
+fn wide_character_that_does_not_fit_wraps_whole_instead_of_splitting() {
+    let mut state = TerminalState::new(2, 5).expect("valid terminal");
+    state.feed_bytes(b"abcd");
+    assert_eq!(cursor(&state), (0, 4));
+
+    state.feed_bytes("你".as_bytes());
+
+    assert_eq!(state.snapshot().lines(), ["abcd", "你"]);
+    assert_eq!(cursor(&state), (1, 2));
+    assert!(!state.is_wrap_pending());
+    assert!(cell(&state, 1, 0).text() == "你" && cell(&state, 1, 1).is_continuation());
+}
+
+#[test]
+fn overwriting_half_of_a_wide_character_clears_both_halves() {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("你A".as_bytes());
+
+    // Positioning onto the continuation column snaps to the lead cell, and
+    // overwriting the lead clears the continuation as well.
+    state.move_cursor(CursorMove::ToColumn(1));
+    assert_eq!(cursor(&state), (0, 0));
+    state.feed_bytes(b"X");
+
+    assert_eq!(state.snapshot().lines(), ["X A"]);
+    assert!(!cell(&state, 0, 0).is_continuation());
+    assert!(!cell(&state, 0, 1).is_continuation());
+    assert_eq!(cell(&state, 0, 1).text(), " ");
+}
+
+#[test]
+fn erasing_half_of_a_wide_character_clears_both_halves() {
+    // ECH covering only the lead leaves no dangling continuation.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("你A".as_bytes());
+    state.move_cursor(CursorMove::ToColumn(0));
+    state.feed_bytes(b"\x1b[1X");
+    // The erased lead and its orphaned continuation both blank in place;
+    // ECH never shifts the tail left.
+    assert_eq!(state.snapshot().lines(), ["  A"]);
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| !cell.is_continuation())
+    );
+
+    // EL to the end starting on the lead clears the whole pair.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("a你b".as_bytes());
+    state.move_cursor(CursorMove::ToColumn(1));
+    state.feed_bytes(b"\x1b[0K");
+    assert_eq!(state.snapshot().lines(), ["a"]);
+
+    // EL to the beginning ending on the lead clears the orphaned
+    // continuation as well.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("a你b".as_bytes());
+    state.move_cursor(CursorMove::ToColumn(1));
+    state.feed_bytes(b"\x1b[1K");
+    assert_eq!(state.snapshot().lines(), ["   b"]);
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| !cell.is_continuation())
+    );
+}
+
+#[test]
+fn deleting_and_inserting_characters_leave_no_dangling_continuation() {
+    // DCH 1 on the lead shifts the row; the orphaned continuation that
+    // lands in column zero must be blanked.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes("你AB".as_bytes());
+    state.move_cursor(CursorMove::ToColumn(0));
+    state.feed_bytes(b"\x1b[1P");
+    // Cell-based delete: the continuation shifted into column zero is
+    // blanked, leaving one blank ahead of the shifted tail.
+    assert_eq!(state.snapshot().lines(), [" AB"]);
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| !cell.is_continuation())
+    );
+
+    // ICH before the lead shifts the intact pair right without splitting it.
+    let mut state = TerminalState::new(1, 5).expect("valid terminal");
+    state.feed_bytes("A你".as_bytes());
+    state.move_cursor(CursorMove::ToColumn(2));
+    assert_eq!(cursor(&state), (0, 1));
+    state.feed_bytes(b"\x1b[1@");
+    assert_eq!(state.snapshot().lines(), ["A 你"]);
+    assert_eq!(cell(&state, 0, 2).text(), "你");
+    assert!(cell(&state, 0, 3).is_continuation());
+}
+
+#[test]
+fn combining_marks_attach_to_the_preceding_cell_without_moving_the_cursor() {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("e\u{0301}o".as_bytes());
+
+    assert_eq!(cell(&state, 0, 0).text(), "e\u{0301}");
+    assert_eq!(cell(&state, 0, 0).width(), 1);
+    assert_eq!(cell(&state, 0, 1).text(), "o");
+    assert_eq!(state.snapshot().lines(), ["e\u{0301}o"]);
+    assert_eq!(cursor(&state), (0, 2));
+
+    // A mark after a wide character skips the continuation cell and attaches
+    // to the lead.
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("你\u{0301}".as_bytes());
+    assert_eq!(cell(&state, 0, 0).text(), "你\u{0301}");
+    assert_eq!(cell(&state, 0, 0).width(), 2);
+    assert_eq!(cursor(&state), (0, 2));
+
+    // A mark while autowrap is pending attaches to the edge character and
+    // keeps the wrap pending.
+    let mut state = TerminalState::new(2, 3).expect("valid terminal");
+    state.feed_bytes("abc\u{0301}".as_bytes());
+    assert_eq!(cursor(&state), (0, 2));
+    assert!(state.is_wrap_pending());
+    state.feed_bytes(b"d");
+    assert_eq!(state.snapshot().lines(), ["abc\u{0301}", "d"]);
+}
+
+#[test]
+fn combining_mark_with_no_preceding_cell_is_dropped() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes("\u{0301}A".as_bytes());
+
+    assert_eq!(state.snapshot().lines(), ["A"]);
+    assert_eq!(cell(&state, 0, 0).text(), "A");
+    assert_eq!(cursor(&state), (0, 1));
+}
+
+#[test]
+fn cursor_never_reports_a_continuation_column() {
+    let mut state = TerminalState::new(2, 6).expect("valid terminal");
+    state.feed_bytes("你好".as_bytes());
+    assert_eq!(cursor(&state), (0, 4));
+
+    // Absolute positioning onto a continuation column snaps to the lead.
+    state.move_cursor(CursorMove::To { row: 0, column: 3 });
+    assert_eq!(cursor(&state), (0, 2));
+    state.feed_bytes(b"\x1b[1;4H");
+    assert_eq!(cursor(&state), (0, 2));
+
+    // Relative motion resolves onto character boundaries: forward motion
+    // skips the wide character, backward motion lands on its lead.
+    state.move_cursor(CursorMove::Right(1));
+    assert_eq!(cursor(&state), (0, 4));
+    state.feed_bytes(b"\x08");
+    assert_eq!(cursor(&state), (0, 2));
+    state.move_cursor(CursorMove::ToColumn(4));
+    state.move_cursor(CursorMove::Left(1));
+    assert_eq!(cursor(&state), (0, 2));
+
+    // A downward move onto another row's continuation snaps to its lead.
+    state.feed_bytes("\x1b[2;5H你".as_bytes());
+    state.move_cursor(CursorMove::To { row: 0, column: 5 });
+    state.move_cursor(CursorMove::Down(1));
+    assert_eq!(cursor(&state), (1, 4));
+}
+
+#[test]
+fn mixed_ascii_cjk_and_emoji_land_on_the_expected_columns() {
+    let mut state = TerminalState::new(1, 10).expect("valid terminal");
+    state.feed_bytes("a😀日b".as_bytes());
+
+    assert_eq!(state.snapshot().lines(), ["a😀日b"]);
+    assert_eq!(cell(&state, 0, 0).text(), "a");
+    assert_eq!(cell(&state, 0, 0).width(), 1);
+    assert_eq!(cell(&state, 0, 1).text(), "😀");
+    assert_eq!(cell(&state, 0, 1).width(), 2);
+    assert!(cell(&state, 0, 2).is_continuation());
+    assert_eq!(cell(&state, 0, 3).text(), "日");
+    assert_eq!(cell(&state, 0, 3).width(), 2);
+    assert!(cell(&state, 0, 4).is_continuation());
+    assert_eq!(cell(&state, 0, 5).text(), "b");
+    assert_eq!(cursor(&state), (0, 6));
+}
+
+#[test]
+fn multibyte_sequences_decode_across_feed_boundaries() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    for byte in "你".as_bytes() {
+        state.feed_bytes(std::slice::from_ref(byte));
+    }
+
+    assert_eq!(state.snapshot().lines(), ["你"]);
+    assert_eq!(cursor(&state), (0, 2));
+}
+
+#[test]
+fn resize_cutting_a_continuation_blanks_the_orphaned_lead() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes("ab你".as_bytes());
+
+    state.resize(1, 3).expect("valid resize");
+
+    assert_eq!(state.snapshot().lines(), ["ab"]);
+    assert!(
+        state
+            .screen()
+            .cells()
+            .iter()
+            .all(|cell| !cell.is_continuation())
+    );
+    assert_eq!(cell(&state, 0, 2).text(), " ");
+}

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -113,6 +113,61 @@ renderer-independent API.
   soft-wrap retained rows; until then renderers must tolerate mixed-width
   scrollback rows (each row's `.len()` is its own width).
 
+## Character width model
+
+Printing honors display width, so CJK output, wide emoji, and combining marks
+keep the cell grid aligned instead of drifting it one cell per wide character.
+
+- **Decoding.** The parser's Ground state decodes UTF-8 incrementally and emits
+  one `Action::Print(char)` per complete character; the decoder keeps no other
+  allocation, so split feeds across `feed_bytes` calls are fine. Overlong,
+  surrogate, and out-of-range sequences are rejected as a unit; a byte that
+  interrupts a pending sequence is re-examined as a new lead; and a pending
+  sequence never straddles an escape sequence or control-string payload.
+  Invalid bytes never print.
+- **Width policy.** `cell_width` delegates to `UnicodeWidthChar` from the pinned
+  `unicode-width` crate; no hand-rolled width tables. Characters are zero, one,
+  or two columns wide (ambiguous-width characters follow the crate's non-CJK
+  default of one).
+- **Wide characters.** A two-column character occupies a lead cell
+  (`width == 2`, holding the text) and a continuation cell (`width == 0`, empty
+  text) that renders as nothing and is never treated as an independent
+  character. The grid invariant is: every continuation directly follows its
+  lead, and every lead is directly followed by its continuation.
+- **Wrap rule.** Delayed autowrap is preserved. A wide character that does not
+  fit in the remaining columns wraps whole to the next line instead of being
+  split across the right edge. A wide character written flush against the right
+  edge leaves the cursor on the lead cell with autowrap pending. A character
+  wider than the entire grid is dropped.
+- **No dangling halves.** Erase (ED/EL/ECH), insert/delete characters (ICH/DCH),
+  overwriting, and resize all enforce the invariant: clearing either half of a
+  wide character clears both. `ScreenBuffer::repair_row` blanks any half that
+  lost its partner, runs after every grid edit, and `apply` debug-asserts the
+  invariant on both screens after every action.
+- **Cursor rule.** The cursor never rests on a continuation cell. Forward
+  relative motion moves past the whole wide character; absolute positioning,
+  backward motion, backspace, restore-cursor, and resize clamping snap onto the
+  lead cell.
+- **Zero-width characters.** Combining marks are *attached* to the preceding
+  cell in the row (skipping continuation cells): they extend that cell's text
+  without changing its width, never advance the cursor, and do not clear
+  pending autowrap. With no preceding cell (cursor at column zero with no
+  pending wrap) the mark is dropped. This is a documented simplification: the
+  grid stores per-cell text, not grapheme clusters.
+
+Known limitations of this slice: emoji ZWJ/variation sequences are only as wide
+as their per-character widths; resize blanks a wide pair whose continuation
+would be truncated rather than reflowing it; ambiguous-width and grapheme
+cluster work remain later.
+
+## Deferred
+
+SGR/erase/insert/delete, cell attributes, tabs, origin mode, and
+query/reply sequences remain deferred, along with other DEC private modes
+(such as 1047/1048, 25, and 2004), application cursor/keypad modes, OSC
+titles, scrollback reflow on resize, and saved-cursor state beyond
+position. IME, grapheme clusters, and ambiguous-width policy remain later.
+
 ## Also merged since this document was first written
 
 The sections above describe the foundation slices in the order they landed. These
@@ -133,10 +188,6 @@ capabilities are now on `main` as well and are no longer deferred:
 Origin mode and query/reply sequences remain deferred, along with other DEC
 private modes (1047/1048, 25, 2004), OSC titles, scrollback reflow on resize, and
 saved-cursor state beyond position.
-
-Unicode/CJK character width remains the largest outstanding gap: the parser still
-prints only `0x20..=0x7e`, so wide characters and combining marks are not yet
-modeled even though `Cell` carries a `width` field.
 
 Mouse support is unimplemented, but note the channel direction before treating any
 `CSI M` handling as a parser defect. `feed_bytes` parses PTY **output**, where


### PR DESCRIPTION
Closes the largest blocking gap in the [Zellij gap
analysis](../compatibility/zellij-gap-analysis.md) (gap #1).

## Why this was the top gap

The parser printed only `0x20..=0x7e` and dropped every other byte. Zellij draws
its pane frames with box-drawing characters and its status bar with non-ASCII
glyphs, so **its entire visible chrome disappeared**, and column addressing
drifted by one cell for every wide character in pane content.

## What it does

- A double-width character occupies **two** cells: a lead carrying the character
  with `width = 2`, plus a continuation cell that renders as nothing and is never
  treated as an independent character.
- A wide character that does not fit in the remaining columns **wraps** to the
  next line instead of being split across the right edge.
- Combining marks are **attached to the preceding cell** (`combining=attached`)
  and do not advance the cursor.
- The cursor never lands on a continuation cell.
- Erase/insert/delete cannot leave a dangling continuation without its lead.

`unicode-width` was already a pinned workspace dependency; this wires it to the
write path rather than hand-rolling width tables.

## Coordinator verification

Six independent checks, all passing:

- ASCII output is byte-identical (no regression);
- `日本` advances the cursor by 4 columns, i.e. 2 per character;
- a wide character at the last column **wraps** — asserted by checking it is
  *absent* from row 0 and *present* on row 1, so a split would fail;
- a combining acute after `e` leaves the cursor where it was;
- overwriting the lead half of a wide character leaves no stray glyph from its
  continuation;
- mixed `a日b` lands the cursor at column 4.

## One existing expectation changed, deliberately

`tests/terminal_state.rs` asserted that `\x1b[31m\xff\xc3\xa9Q` rendered `"  Q"`.
It now renders `"  éQ"`: `0xff` is still dropped as invalid UTF-8, but `é` now
decodes and prints as a one-column character — which is the point of the change.
The lane updated the expectation with that reasoning in a comment rather than
deleting the test.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **205 workspace tests pass** (was 177), 0
failures.

Rebased onto current `main`. One documentation conflict was resolved by keeping
both sections and dropping the now-false claim that Unicode width "remains the
largest outstanding gap".