### PR TITLE
docs(contributing): green CI is not review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,11 @@ Work advances through parallel lanes under these rules:
   so the next lane starts from evidence instead of memory.
 - CI must pass on the exact head before review; documentation lanes run
   `python3 scripts/check_docs.py`.
+- **Green CI is not review.** Wait for review comments to arrive and be resolved
+  before merging, not merely for checks to pass. Automated reviewers post after
+  the checks finish, so a PR that looks mergeable may still have findings in
+  flight. Two merged changes needed follow-up Issues because they were landed on
+  green CI alone.
 
 Implemented in a Draft PR is not supported behavior and not a compatibility
 claim. Lane ownership and dispatch are described in


### PR DESCRIPTION
One rule, learned the hard way twice in one session.

Two changes were merged on green CI before review comments arrived, and both
needed follow-up Issues:

- **PR #52** claimed output-side `CSI M` was an X10 mouse-report misparse. A P1
  review finding showed `feed_bytes` parses PTY **output**, where parameterless
  `CSI M` is the valid Delete Line command — X10 reports travel the other way into
  PTY input and no mouse input path exists. The "fix" would have made a legitimate
  DL discard itself plus three output bytes. Issue #46 and PR #52 were closed.
- **PR #53** landed the character-width model. Review then found that `lines()`
  collapses the second column of every wide character while the renderer positions
  glyphs with `chars().enumerate()`, so wide output is misaligned on screen — the
  exact breakage that PR set out to fix. Reproduced against `main` and filed as
  Issue #54, with a fix lane already running.

Automated reviewers post *after* the checks finish, so a PR reporting
`mergeable`/`CLEAN` can still have findings in flight. Both were caught by review,
not by CI, and neither would have been caught by more tests — they were wrong
premises, not wrong code.

Adds one bullet to the parallel-development rules: wait for review to arrive and
resolve before merging, not merely for CI to go green.

Verified: `python3 scripts/check_docs.py` passes. No code touched.