### PR TITLE
feat(terminal): model indexed and truecolor SGR colors

### DIFF
--- a/crates/noren-terminal/src/attributes.rs
+++ b/crates/noren-terminal/src/attributes.rs
@@ -54,12 +54,25 @@ impl AnsiColor {
 /// Renderer-independent color selection for a terminal cell.
 ///
 /// [`Default`](Self::Default) means the renderer's default foreground or
-/// background according to the field in which the value is used.
+/// background according to the field in which the value is used. [`Ansi`]
+/// selects one of the 16 ANSI palette colors; [`Indexed`] selects an entry of
+/// the xterm 256-color palette (the 16 ANSI colors, a 6×6×6 color cube, and a
+/// 24-step grayscale ramp); [`Rgb`] selects a direct 24-bit color. All three
+/// extended forms are modelled but left to the renderer to resolve against a
+/// palette or theme — the terminal state only records the selection.
+///
+/// [`Ansi`]: Self::Ansi
+/// [`Indexed`]: Self::Indexed
+/// [`Rgb`]: Self::Rgb
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Color {
     #[default]
     Default,
     Ansi(AnsiColor),
+    /// An xterm 256-color palette index (`0..=255`).
+    Indexed(u8),
+    /// A direct 24-bit color (red, green, blue), each channel `0..=255`.
+    Rgb(u8, u8, u8),
 }
 
 impl Color {
@@ -69,18 +82,48 @@ impl Color {
         Self::Ansi(color)
     }
 
+    /// Select an xterm 256-color palette index.
+    #[must_use]
+    pub const fn indexed(index: u8) -> Self {
+        Self::Indexed(index)
+    }
+
+    /// Select a direct 24-bit color.
+    #[must_use]
+    pub const fn rgb(red: u8, green: u8, blue: u8) -> Self {
+        Self::Rgb(red, green, blue)
+    }
+
     /// Whether this selection uses the renderer's contextual default color.
     #[must_use]
     pub const fn is_default(self) -> bool {
         matches!(self, Self::Default)
     }
 
-    /// The selected ANSI color, or `None` for the contextual default.
+    /// The selected ANSI color, or `None` for any other selection.
     #[must_use]
     pub const fn ansi_color(self) -> Option<AnsiColor> {
         match self {
-            Self::Default => None,
             Self::Ansi(color) => Some(color),
+            _ => None,
+        }
+    }
+
+    /// The selected 256-color palette index, or `None` for other selections.
+    #[must_use]
+    pub const fn indexed_value(self) -> Option<u8> {
+        match self {
+            Self::Indexed(index) => Some(index),
+            _ => None,
+        }
+    }
+
+    /// The selected direct color channels, or `None` for other selections.
+    #[must_use]
+    pub const fn rgb_channels(self) -> Option<(u8, u8, u8)> {
+        match self {
+            Self::Rgb(red, green, blue) => Some((red, green, blue)),
+            _ => None,
         }
     }
 }
@@ -91,12 +134,13 @@ const REVERSE: u8 = 1 << 2;
 
 /// Renderer-independent visual attributes for a terminal cell.
 ///
-/// The default uses contextual foreground and background colors with all
-/// style flags disabled.
+/// The default uses contextual foreground, background, and underline colors
+/// with all style flags disabled.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CellAttributes {
     foreground: Color,
     background: Color,
+    underline_color: Color,
     flags: u8,
 }
 
@@ -105,6 +149,7 @@ impl CellAttributes {
     pub const DEFAULT: Self = Self {
         foreground: Color::Default,
         background: Color::Default,
+        underline_color: Color::Default,
         flags: 0,
     };
 
@@ -124,6 +169,12 @@ impl CellAttributes {
     #[must_use]
     pub const fn background(self) -> Color {
         self.background
+    }
+
+    /// Underline color selection.
+    #[must_use]
+    pub const fn underline_color(self) -> Color {
+        self.underline_color
     }
 
     /// Whether bold intensity is enabled.
@@ -155,6 +206,13 @@ impl CellAttributes {
     #[must_use]
     pub const fn with_background(mut self, background: Color) -> Self {
         self.background = background;
+        self
+    }
+
+    /// Return these attributes with a different underline color selection.
+    #[must_use]
+    pub const fn with_underline_color(mut self, underline_color: Color) -> Self {
+        self.underline_color = underline_color;
         self
     }
 

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -2,7 +2,29 @@
 
 const ESC: u8 = 0x1b;
 const BEL: u8 = 0x07;
-const MAX_CSI_PARAMS: usize = 8;
+
+/// Maximum number of parameter slots collected for a single CSI sequence.
+///
+/// SGR is the parameter-hungriest supported final: the ordinary way to set
+/// foreground and background truecolor together (`38;2;R;G;B;48;2;R;G;B`)
+/// needs 10 slots, and adding underline truecolor (`58;2;R;G;B`) raises that
+/// to 15. The ITU-T T.416 colon form is wider still (`38:2::R:G:B` is six
+/// slots per color, 18 for all three), and a realistic emission surrounds the
+/// colors with style flags. 32 covers that ceiling with headroom while keeping
+/// the per-sequence `Csi` struct (and the copied SGR action payload) small.
+///
+/// The bound is the hard memory ceiling against a hostile
+/// `\x1b[1;1;…;1m` with thousands of parameters: `Csi::push_current` flips
+/// `overflowed` once `len` reaches it and `Csi::action` then drops the whole
+/// sequence, so the parser never allocates beyond these fixed arrays.
+const MAX_CSI_PARAMS: usize = 32;
+
+// Compile-time check that the cap covers the realistic SGR ceiling described
+// above (combined fg+bg+underline truecolor in colon form plus style flags).
+const _: () = assert!(
+    MAX_CSI_PARAMS >= 20,
+    "MAX_CSI_PARAMS must cover combined fg/bg/underline truecolor plus flags"
+);
 
 /// Separator marker recorded with each collected CSI parameter value.
 /// `0` marks a value that begins a new parameter (`;`-separated or the first

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -4,6 +4,18 @@ const ESC: u8 = 0x1b;
 const BEL: u8 = 0x07;
 const MAX_CSI_PARAMS: usize = 8;
 
+/// Separator marker recorded with each collected CSI parameter value.
+/// `0` marks a value that begins a new parameter (`;`-separated or the first
+/// value); `1` marks an ECMA-48 sub-parameter that followed a `:`. SGR is the
+/// only supported final that consumes sub-parameters, so any other CSI carrying
+/// a sub-parameter is dropped wholesale by `Csi::action`.
+pub(crate) const SEPARATOR_SUB: u8 = 1;
+
+/// Whether a recorded separator marks an ECMA-48 sub-parameter (`:` form).
+pub(crate) const fn is_sub_parameter(separator: &u8) -> bool {
+    *separator == SEPARATOR_SUB
+}
+
 /// Map a C0 control byte (0x00..=0x1f) to the same action Ground emits.
 ///
 /// Most C0 controls (NUL, CAN, SUB, ...) produce no action; the actionable
@@ -56,6 +68,7 @@ pub(crate) enum Action {
     DeleteLines(u16),
     SelectGraphicRendition {
         params: [u16; MAX_CSI_PARAMS],
+        separators: [u8; MAX_CSI_PARAMS],
         len: usize,
     },
     SaveCursor,
@@ -296,24 +309,30 @@ enum ParserState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Csi {
     params: [u16; MAX_CSI_PARAMS],
+    separators: [u8; MAX_CSI_PARAMS],
     len: usize,
     current: u16,
     has_current: bool,
     overflowed: bool,
     ignored: bool,
+    has_colon: bool,
     private_marker: Option<u8>,
+    pending_sep: u8,
 }
 
 impl Default for Csi {
     fn default() -> Self {
         Self {
             params: [0; MAX_CSI_PARAMS],
+            separators: [0; MAX_CSI_PARAMS],
             len: 0,
             current: 0,
             has_current: false,
             overflowed: false,
             ignored: false,
+            has_colon: false,
             private_marker: None,
+            pending_sep: 0,
         }
     }
 }
@@ -331,6 +350,18 @@ impl Csi {
             }
             b';' => {
                 self.push_current();
+                self.pending_sep = 0;
+                CsiAdvance::pending()
+            }
+            // ECMA-48 sub-parameter separator. It terminates the current value
+            // like `;` but marks the next value as belonging to the same
+            // parameter. SGR is the only supported final that reads
+            // sub-parameters (for `38:5:N` / `38:2::R:G:B` extended colors);
+            // any other final with a colon present is dropped in `action`.
+            b':' => {
+                self.push_current();
+                self.pending_sep = SEPARATOR_SUB;
+                self.has_colon = true;
                 CsiAdvance::pending()
             }
             // ECMA-48 private markers occupy 0x3c..=0x3f: `<`, `=`, `>`, `?`.
@@ -348,7 +379,7 @@ impl Csi {
                 self.ignored = true;
                 CsiAdvance::pending()
             }
-            b':' | 0x20..=0x2f => {
+            0x20..=0x2f => {
                 self.ignored = true;
                 CsiAdvance::pending()
             }
@@ -373,6 +404,7 @@ impl Csi {
     fn push_current(&mut self) {
         if self.len < MAX_CSI_PARAMS {
             self.params[self.len] = self.current;
+            self.separators[self.len] = self.pending_sep;
             self.len += 1;
         } else {
             self.overflowed = true;
@@ -382,6 +414,12 @@ impl Csi {
     }
 
     fn action(&self, final_byte: u8) -> Option<Action> {
+        // Sub-parameters (`:` colon form) are only meaningful for SGR in this
+        // slice. Any other final byte carrying a colon is dropped so a
+        // sub-parameter-shaped sequence never executes an unrelated command.
+        if self.has_colon && final_byte != b'm' {
+            return None;
+        }
         match self.private_marker {
             None => self.standard_action(final_byte),
             Some(b'?') => self.private_action(final_byte),
@@ -419,6 +457,7 @@ impl Csi {
             }),
             b'm' => Some(Action::SelectGraphicRendition {
                 params: self.params,
+                separators: self.separators,
                 len: self.len,
             }),
             b's' if self.is_default_only() => Some(Action::SaveCursor),

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     attributes::{AnsiColor, CellAttributes, Color},
-    parser::{Action, EraseMode, Parser, PrivateMode},
+    parser::{Action, EraseMode, Parser, PrivateMode, is_sub_parameter},
 };
 use std::collections::VecDeque;
 use std::fmt;
@@ -51,16 +51,17 @@ pub const MAX_COMBINING_MARKS_PER_CELL: usize = 7;
 /// # Memory ceiling
 ///
 /// Each retained line owns `cols` cells (the column count at the moment it
-/// scrolled off). `size_of::<Cell>() == 32` on this target (a 24-byte owned
-/// `String` handle, a width byte, and packed attributes). The owned text is
-/// bounded separately by [`MAX_COMBINING_MARKS_PER_CELL`]: at most one base
-/// `char` plus seven combining marks, i.e. at most `4 * 8 == 32` bytes of text,
-/// so a cell holds **64 bytes worst case** (single-character cells stay near 40).
-/// The retained-line ceiling is therefore
-/// `MAX_SCROLLBACK_LINES * cols * bytes_per_cell`:
+/// scrolled off). `size_of::<Cell>() == 40` on this target (a 24-byte owned
+/// `String` handle, a width byte, and a 13-byte `CellAttributes` made of three
+/// 4-byte `Color` selections plus a flag byte). The owned text is bounded
+/// separately by [`MAX_COMBINING_MARKS_PER_CELL`]: at most one base `char`
+/// plus seven combining marks, i.e. at most `4 * 8 == 32` bytes of text, so a
+/// cell holds **72 bytes worst case** (the 40-byte struct plus 32 bytes of
+/// capped text; single-character cells stay near 48). The retained-line
+/// ceiling is therefore `MAX_SCROLLBACK_LINES * cols * bytes_per_cell`:
 ///
-/// - Typical 80-column, single-character text: `10_000 * 80 * 40 ≈ 32 MiB`.
-/// - Worst-case 256-column, fully capped cells: `10_000 * 256 * 64 ≈ 164 MiB`.
+/// - Typical 80-column, single-character text: `10_000 * 80 * 48 ≈ 38 MiB`.
+/// - Worst-case 256-column, fully capped cells: `10_000 * 256 * 72 ≈ 184 MiB`.
 ///
 /// The line count is the hard bound: a hostile program cannot grow history past
 /// this many lines regardless of volume, and a stream of zero-width combining
@@ -854,9 +855,11 @@ impl TerminalState {
             Action::DeleteCharacters(count) => self.delete_characters(count),
             Action::InsertLines(count) => self.insert_lines(count),
             Action::DeleteLines(count) => self.delete_lines(count),
-            Action::SelectGraphicRendition { params, len } => {
-                self.select_graphic_rendition(&params[..len]);
-            }
+            Action::SelectGraphicRendition {
+                params,
+                separators,
+                len,
+            } => self.select_graphic_rendition(&params[..len], &separators[..len]),
             Action::SaveCursor => self.save_cursor(),
             Action::RestoreCursor => self.restore_cursor(),
             Action::SetKeypadApplication(enabled) => {
@@ -1077,7 +1080,7 @@ impl TerminalState {
         }
     }
 
-    fn select_graphic_rendition(&mut self, params: &[u16]) {
+    fn select_graphic_rendition(&mut self, params: &[u16], separators: &[u8]) {
         let mut index = 0;
         while index < params.len() {
             let param = params[index];
@@ -1111,12 +1114,29 @@ impl TerminalState {
                         .pen
                         .with_background(Color::Ansi(AnsiColor::ALL[usize::from(param - 100 + 8)]));
                 }
-                // Indexed, direct, and underline colors are deferred. Consume
-                // their semicolon-form arguments as one unsupported group so
-                // channel values such as 1, 4, or 7 are never reinterpreted as
-                // independent bold/underline/reverse controls.
-                38 | 48 | 58 => {
-                    index += extended_color_parameter_count(&params[index..]);
+                58 => {
+                    let (color, consumed) = parse_extended_color(params, separators, index);
+                    if let Some(color) = color {
+                        self.pen = self.pen.with_underline_color(color);
+                    }
+                    index += consumed;
+                    continue;
+                }
+                59 => self.pen = self.pen.with_underline_color(Color::Default),
+                38 => {
+                    let (color, consumed) = parse_extended_color(params, separators, index);
+                    if let Some(color) = color {
+                        self.pen = self.pen.with_foreground(color);
+                    }
+                    index += consumed;
+                    continue;
+                }
+                48 => {
+                    let (color, consumed) = parse_extended_color(params, separators, index);
+                    if let Some(color) = color {
+                        self.pen = self.pen.with_background(color);
+                    }
+                    index += consumed;
                     continue;
                 }
                 _ => {}
@@ -1174,12 +1194,101 @@ impl TerminalState {
     }
 }
 
-fn extended_color_parameter_count(params: &[u16]) -> usize {
-    match params.get(1) {
-        Some(5) => params.len().min(3),
-        Some(2) => params.len().min(5),
-        _ => 1,
+/// Parse an extended SGR color (`38`/`48`/`58`) starting at `start`.
+///
+/// Returns the parsed color (if the sequence is well-formed and in range) and
+/// the number of parameter slots consumed, *including* the selector. The
+/// consume count is chosen so a truncated or out-of-range sequence can never
+/// leak its channel values back into the caller as independent bold/underline/
+/// reverse codes: every channel slot the selector claimed is skipped over
+/// whether or not a color was produced.
+///
+/// Both ECMA-48 forms are handled:
+///
+/// - semicolon form: `38;5;N` and `38;2;R;G;B` (xterm);
+/// - colon sub-parameter form: `38:5:N` and `38:2::R:G:B` (ITU-T T.416). The
+///   RGB colon form carries an empty colour-space slot after the `2`; a
+///   non-empty slot (`38:2:Pi:R:G:B`) is accepted and ignored. The whole run
+///   of sub-parameters belongs to the selector's parameter, so all of it is
+///   consumed.
+fn parse_extended_color(params: &[u16], separators: &[u8], start: usize) -> (Option<Color>, usize) {
+    let Some(mode_index) = start.checked_add(1).filter(|&i| i < params.len()) else {
+        return (None, 1);
+    };
+    let remaining = params.len() - start;
+    let colon_form = separators.get(mode_index).is_some_and(is_sub_parameter);
+    if colon_form {
+        // The whole run of `:`-separated sub-parameters belongs to the
+        // selector's parameter, so all of it is consumed regardless of whether
+        // a color is produced.
+        let run_end = params.len().min(
+            (mode_index..)
+                .take_while(|&i| separators.get(i).is_some_and(is_sub_parameter))
+                .last()
+                .map_or(mode_index, |i| i + 1),
+        );
+        let run = &params[mode_index..run_end];
+        let consumed = 1 + run.len();
+        let body = run.get(1..).unwrap_or(&[]);
+        let color = parse_extended_color_body(*run.first().unwrap_or(&0), body);
+        (color, consumed)
+    } else {
+        let mode = params[mode_index];
+        match mode {
+            5 => {
+                let consumed = remaining.min(3);
+                let color = params
+                    .get(start + 2)
+                    .copied()
+                    .filter(|value| *value <= u16::from(u8::MAX))
+                    .map(|value| Color::Indexed(value as u8));
+                (color, consumed)
+            }
+            2 => {
+                let consumed = remaining.min(5);
+                let body = params.get(start + 2..start + 5).unwrap_or(&[]);
+                let color = parse_extended_color_body(mode, body);
+                (color, consumed)
+            }
+            _ => (None, remaining.min(2)),
+        }
     }
+}
+
+/// Resolve the body following an extended-color mode (`5` indexed, `2` direct).
+///
+/// `body` excludes the mode slot itself. For the colon RGB form the first body
+/// slot is the colour-space id (often empty) when four slots are present, and
+/// is ignored; the next three are red/green/blue. Indexed values above 255 are
+/// out of range and yield no color; direct channels are clamped to `u8`.
+fn parse_extended_color_body(mode: u16, body: &[u16]) -> Option<Color> {
+    match mode {
+        5 => body
+            .first()
+            .copied()
+            .filter(|value| *value <= u16::from(u8::MAX))
+            .map(|value| Color::Indexed(value as u8)),
+        2 => {
+            let channels = if body.len() >= 4 {
+                body.get(1..4)
+            } else if body.len() == 3 {
+                body.get(0..3)
+            } else {
+                None
+            }?;
+            Some(Color::Rgb(
+                clamp_channel(channels[0]),
+                clamp_channel(channels[1]),
+                clamp_channel(channels[2]),
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Clamp a direct-color channel to its eight-bit range, matching xterm.
+fn clamp_channel(value: u16) -> u8 {
+    u8::try_from(value).unwrap_or(u8::MAX)
 }
 
 impl fmt::Debug for TerminalState {

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1084,6 +1084,19 @@ impl TerminalState {
         let mut index = 0;
         while index < params.len() {
             let param = params[index];
+            // Extent of the current ECMA-48 parameter group: the leading value
+            // plus any trailing colon sub-parameters (`:`-separated). A lone
+            // `;`-separated value is a one-element group.
+            let group_end = sgr_group_end(separators, index);
+            // Outside the extended-color selectors (38/48/58), a multi-element
+            // colon group is an unsupported compound attribute (e.g. `4:0` and
+            // other modern underline styles). It must be skipped whole so its
+            // sub-parameters never touch the pen — `4:0` must not turn underline
+            // on and then let the trailing `0` reset every attribute.
+            if group_end > index + 1 && !matches!(param, 38 | 48 | 58) {
+                index = group_end;
+                continue;
+            }
             match param {
                 0 => self.pen = CellAttributes::default(),
                 1 => self.pen = self.pen.with_bold(true),
@@ -1192,6 +1205,21 @@ impl TerminalState {
         }
         self.modes.alternate_screen = false;
     }
+}
+
+/// End index (exclusive) of the ECMA-48 parameter group that begins at `start`.
+///
+/// A group is the leading value plus every trailing colon sub-parameter
+/// (separator `SEPARATOR_SUB`). A lone `;`-separated value is a one-element
+/// group, so this returns `start + 1` for it. Used by the SGR walker to treat a
+/// colon-bearing attribute as a single parameter and skip unsupported compound
+/// groups (e.g. `4:0`) whole instead of walking their sub-parameters.
+fn sgr_group_end(separators: &[u8], start: usize) -> usize {
+    let mut end = start + 1;
+    while end < separators.len() && is_sub_parameter(&separators[end]) {
+        end += 1;
+    }
+    end
 }
 
 /// Parse an extended SGR color (`38`/`48`/`58`) starting at `start`.

--- a/crates/noren-terminal/tests/adversarial.rs
+++ b/crates/noren-terminal/tests/adversarial.rs
@@ -73,8 +73,12 @@ fn degenerate_parameter_lists_do_not_panic() {
     assert_eq!((state.cursor().row(), state.cursor().column()), (0, 0));
     assert_invariants(&state, "many semicolons CUP");
 
-    // SGR with >8 params is dropped entirely (overflow), pen unchanged.
-    state.feed_bytes(b"\x1b[1;2;3;4;5;6;7;8;9m");
+    // SGR beyond the parameter cap is dropped entirely (overflow), pen
+    // unchanged. The cap is 32, so 40 bold-codes overflows and is discarded.
+    let mut hostile = b"\x1b[".to_vec();
+    hostile.extend(b"1;".repeat(40));
+    hostile.extend(b"m");
+    state.feed_bytes(&hostile);
     assert_eq!(*state.attributes(), CellAttributes::default());
 
     // Lone/default params resolve to defaults.

--- a/crates/noren-terminal/tests/sgr_attributes.rs
+++ b/crates/noren-terminal/tests/sgr_attributes.rs
@@ -273,23 +273,34 @@ fn unsupported_codes_are_ignored_and_parameter_overflow_drops_the_sgr() {
 }
 
 #[test]
-fn deferred_extended_colors_do_not_leak_channel_values_into_style_flags() {
+fn extended_colors_apply_without_leaking_channel_values_into_style_flags() {
     let mut state = TerminalState::new(1, 3).expect("valid terminal");
     state.feed_bytes(b"\x1b[38;5;1mI\x1b[48;2;1;4;7mR\x1b[1;38;5;123;4mS");
 
-    assert_eq!(
-        state
-            .screen()
-            .cell(0, 0)
-            .expect("indexed cell")
-            .attributes(),
-        &CellAttributes::default()
-    );
-    assert_eq!(
-        state.screen().cell(0, 1).expect("direct cell").attributes(),
-        &CellAttributes::default()
-    );
+    // `38;5;1` selects an indexed foreground; its `5` channel is consumed and
+    // never reinterpreted, so the cell keeps default flags.
+    let indexed = state
+        .screen()
+        .cell(0, 0)
+        .expect("indexed cell")
+        .attributes();
+    assert_eq!(indexed.foreground(), Color::Indexed(1));
+    assert_eq!(indexed.background(), Color::Default);
+    assert!(!indexed.is_bold());
+    assert!(!indexed.is_underlined());
+    assert!(!indexed.is_reversed());
 
+    // `48;2;1;4;7` is a direct RGB background; the `1`, `4`, `7` channels are
+    // RGB data, not bold/underline/reverse controls.
+    let direct = state.screen().cell(0, 1).expect("direct cell").attributes();
+    assert_eq!(direct.foreground(), Color::Indexed(1));
+    assert_eq!(direct.background(), Color::Rgb(1, 4, 7));
+    assert!(!direct.is_bold());
+    assert!(!direct.is_underlined());
+    assert!(!direct.is_reversed());
+
+    // Codes surrounding `38;5;123` apply to their own attributes; the indexed
+    // color applies instead of leaking `5` or `123` into other slots.
     let surrounded = state
         .screen()
         .cell(0, 2)
@@ -297,8 +308,249 @@ fn deferred_extended_colors_do_not_leak_channel_values_into_style_flags() {
         .attributes();
     assert!(surrounded.is_bold());
     assert!(surrounded.is_underlined());
-    assert_eq!(surrounded.foreground(), Color::Default);
-    assert_eq!(surrounded.background(), Color::Default);
+    assert!(!surrounded.is_reversed());
+    assert_eq!(surrounded.foreground(), Color::Indexed(123));
+    assert_eq!(surrounded.background(), Color::Rgb(1, 4, 7));
+}
+
+#[test]
+fn indexed_and_truecolor_sgr_colors_apply_to_all_three_color_targets() {
+    let mut state = TerminalState::new(1, 7).expect("valid terminal");
+    // Semicolon forms: indexed (`38;5;N` / `48;5;N` / `58;5;N`) and direct
+    // RGB (`38;2;R;G;B` / `48;2;R;G;B` / `58;2;R;G;B`).
+    state.feed_bytes(b"\x1b[38;5;10mF\x1b[48;5;20mG\x1b[58;5;30mU");
+    state.feed_bytes(b"\x1b[38;2;1;2;3mr\x1b[48;2;4;5;6mg\x1b[58;2;7;8;9mb");
+
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("indexed fg")
+            .attributes()
+            .foreground(),
+        Color::Indexed(10)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("indexed bg")
+            .attributes()
+            .background(),
+        Color::Indexed(20)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 2)
+            .expect("indexed underline")
+            .attributes()
+            .underline_color(),
+        Color::Indexed(30)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 3)
+            .expect("rgb fg")
+            .attributes()
+            .foreground(),
+        Color::Rgb(1, 2, 3)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 4)
+            .expect("rgb bg")
+            .attributes()
+            .background(),
+        Color::Rgb(4, 5, 6)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 5)
+            .expect("rgb underline")
+            .attributes()
+            .underline_color(),
+        Color::Rgb(7, 8, 9)
+    );
+}
+
+#[test]
+fn colon_sub_parameter_forms_parse_for_indexed_and_truecolor() {
+    let mut state = TerminalState::new(1, 7).expect("valid terminal");
+    // ITU-T T.416 colon forms: `38:5:N` indexed and `38:2::R:G:B` direct RGB.
+    // The empty slot after `2` is the colour-space id; it must not corrupt the
+    // following RGB channels.
+    state.feed_bytes(b"\x1b[38:5:10mF\x1b[48:5:20mG\x1b[58:5:30mU");
+    state.feed_bytes(b"\x1b[38:2::1:2:3mr\x1b[48:2::4:5:6mg\x1b[58:2::7:8:9mb");
+
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("colon idx fg")
+            .attributes()
+            .foreground(),
+        Color::Indexed(10)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 1)
+            .expect("colon idx bg")
+            .attributes()
+            .background(),
+        Color::Indexed(20)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 2)
+            .expect("colon idx ul")
+            .attributes()
+            .underline_color(),
+        Color::Indexed(30)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 3)
+            .expect("colon rgb fg")
+            .attributes()
+            .foreground(),
+        Color::Rgb(1, 2, 3)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 4)
+            .expect("colon rgb bg")
+            .attributes()
+            .background(),
+        Color::Rgb(4, 5, 6)
+    );
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 5)
+            .expect("colon rgb ul")
+            .attributes()
+            .underline_color(),
+        Color::Rgb(7, 8, 9)
+    );
+}
+
+#[test]
+fn colon_rgb_with_an_explicit_colour_space_slot_is_accepted() {
+    let mut state = TerminalState::new(1, 1).expect("valid terminal");
+    // A non-empty colour-space id (`38:2:Pi:R:G:B`) is accepted and skipped;
+    // the following three slots are still red/green/blue.
+    state.feed_bytes(b"\x1b[38:2:3:1:2:3mX");
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("cell")
+            .attributes()
+            .foreground(),
+        Color::Rgb(1, 2, 3)
+    );
+}
+
+#[test]
+fn truncated_and_out_of_range_extended_colors_leave_the_pen_unchanged() {
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    // A truncated RGB selector (`38;2;1` has one component) and an out-of-range
+    // index (`38;5;300`) drop the color and never reinterpret their channel
+    // values as bold/underline/reverse controls.
+    state.feed_bytes(b"\x1b[38;2;1mI\x1b[1;38;5;300;4mR");
+
+    let first = state
+        .screen()
+        .cell(0, 0)
+        .expect("truncated cell")
+        .attributes();
+    assert_eq!(first.foreground(), Color::Default);
+    assert!(!first.is_bold());
+    assert!(!first.is_underlined());
+    assert!(!first.is_reversed());
+
+    let second = state
+        .screen()
+        .cell(0, 1)
+        .expect("out-of-range cell")
+        .attributes();
+    assert!(
+        second.is_bold(),
+        "the `1` before the selector still applies"
+    );
+    assert!(
+        second.is_underlined(),
+        "the `4` after the dropped color still applies"
+    );
+    assert_eq!(
+        second.foreground(),
+        Color::Default,
+        "the out-of-range index is dropped, not set"
+    );
+}
+
+#[test]
+fn sgr_reset_and_default_selectors_clear_extended_colors() {
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    // Set extended colors on all three targets plus a style flag. Each SGR is
+    // sent separately so the combined parameter list stays under the CSI cap.
+    state.feed_bytes(b"\x1b[1;38;5;5m\x1b[48;5;6m\x1b[58;5;7mA");
+
+    let styled = state.screen().cell(0, 0).expect("styled cell").attributes();
+    assert!(styled.is_bold());
+    assert_eq!(styled.foreground(), Color::Indexed(5));
+    assert_eq!(styled.background(), Color::Indexed(6));
+    assert_eq!(styled.underline_color(), Color::Indexed(7));
+
+    // A full reset (`CSI m`) clears extended colors along with everything else.
+    state.feed_bytes(b"\x1b[mB");
+    assert_eq!(
+        state.screen().cell(0, 1).expect("reset cell").attributes(),
+        &CellAttributes::default()
+    );
+
+    // `39`/`49`/`59` restore only their target, leaving other colors and flags.
+    state.feed_bytes(b"\x1b[1;38;5;5m\x1b[48;5;6m\x1b[58;5;7mC\x1b[39;49;59mD");
+    let after = state
+        .screen()
+        .cell(0, 3)
+        .expect("selective reset cell")
+        .attributes();
+    assert!(after.is_bold(), "bold survives the color resets");
+    assert_eq!(after.foreground(), Color::Default);
+    assert_eq!(after.background(), Color::Default);
+    assert_eq!(after.underline_color(), Color::Default);
+}
+
+#[test]
+fn extended_colors_survive_an_alternate_screen_switch() {
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    // The SGR pen is terminal-global, so an extended color survives a screen
+    // switch exactly as ANSI SGR state does.
+    state.feed_bytes(b"\x1b[38;5;7m");
+    state.feed_bytes(b"\x1b[?1049h");
+    state.feed_bytes(b"\x1b[38:2::1:2:3mA");
+    state.feed_bytes(b"\x1b[?1049l");
+    state.feed_bytes(b"B");
+
+    assert_eq!(state.snapshot().lines(), ["B".to_owned()]);
+    assert_eq!(
+        state
+            .screen()
+            .cell(0, 0)
+            .expect("carried pen")
+            .attributes()
+            .foreground(),
+        Color::Rgb(1, 2, 3)
+    );
 }
 
 #[test]

--- a/crates/noren-terminal/tests/sgr_attributes.rs
+++ b/crates/noren-terminal/tests/sgr_attributes.rs
@@ -247,7 +247,13 @@ fn alternate_screen_cells_are_isolated_while_the_pen_is_preserved() {
 fn unsupported_codes_are_ignored_and_parameter_overflow_drops_the_sgr() {
     let mut state = TerminalState::new(1, 3).expect("valid terminal");
     state.feed_bytes(b"\x1b[31;1234;1mA");
-    state.feed_bytes(b"\x1b[0m\x1b[31;1;4;7;40;90;100;22;24mB");
+    // A hostile SGR exceeding the CSI parameter cap is dropped wholesale so the
+    // parser's memory stays bounded; the pen is left untouched. The cap is 32,
+    // so 40 bold-codes overflows and the whole sequence is discarded.
+    let mut hostile = b"\x1b[0m\x1b[".to_vec();
+    hostile.extend(b"1;".repeat(40));
+    hostile.extend(b"mB");
+    state.feed_bytes(&hostile);
     state.feed_bytes(b"\x1b[32mC");
 
     let first = state.screen().cell(0, 0).expect("first cell").attributes();
@@ -585,4 +591,147 @@ fn erase_and_inserted_blank_cells_use_default_attributes() {
             .all(|cell| cell.attributes() == &CellAttributes::default())
     );
     assert_eq!(state.attributes().foreground(), Color::Ansi(AnsiColor::Red));
+}
+
+#[test]
+fn combined_foreground_and_background_truecolor_in_one_sgr_sets_both() {
+    // The normal way to set fg and bg truecolor together needs 10 parameter
+    // slots (`38;2;R;G;B;48;2;R;G;B`). With the old cap of 8 the whole SGR was
+    // dropped and both colors were silently lost.
+    let mut state = TerminalState::new(1, 1).expect("valid terminal");
+    state.feed_bytes(b"\x1b[38;2;1;2;3;48;2;4;5;6mA");
+
+    let attributes = state
+        .screen()
+        .cell(0, 0)
+        .expect("printed cell")
+        .attributes();
+    assert_eq!(attributes.foreground(), Color::Rgb(1, 2, 3));
+    assert_eq!(attributes.background(), Color::Rgb(4, 5, 6));
+}
+
+#[test]
+fn combined_foreground_background_and_underline_truecolor_in_one_sgr() {
+    // All three extended-color targets in a single SGR run: 15 parameter slots,
+    // comfortably inside the new capacity.
+    let mut state = TerminalState::new(1, 1).expect("valid terminal");
+    state.feed_bytes(b"\x1b[38;2;1;2;3;48;2;4;5;6;58;2;7;8;9mA");
+
+    let attributes = state
+        .screen()
+        .cell(0, 0)
+        .expect("printed cell")
+        .attributes();
+    assert_eq!(attributes.foreground(), Color::Rgb(1, 2, 3));
+    assert_eq!(attributes.background(), Color::Rgb(4, 5, 6));
+    assert_eq!(attributes.underline_color(), Color::Rgb(7, 8, 9));
+}
+
+#[test]
+fn hostile_sgr_beyond_the_capacity_is_dropped_and_memory_stays_bounded() {
+    // A hostile `\x1b[1;1;…;1m` with thousands of parameters must be dropped
+    // safely: the parser never grows its fixed parameter arrays past the cap,
+    // and the pen is left untouched.
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    state.feed_bytes(b"\x1b[31mR");
+    let mut hostile = b"\x1b[".to_vec();
+    hostile.extend(b"1;".repeat(5000));
+    hostile.extend(b"mB");
+    state.feed_bytes(&hostile);
+
+    let red = state.screen().cell(0, 0).expect("red cell").attributes();
+    assert_eq!(red.foreground(), Color::Ansi(AnsiColor::Red));
+    // The hostile SGR was discarded wholesale, so the pen kept its red
+    // foreground; B was printed red, not reset.
+    let untouched = state
+        .screen()
+        .cell(0, 1)
+        .expect("post-hostile cell")
+        .attributes();
+    assert_eq!(untouched.foreground(), Color::Ansi(AnsiColor::Red));
+    assert!(!untouched.is_bold());
+}
+
+#[test]
+fn unsupported_colon_underline_styles_leave_flags_untouched() {
+    // `4:0`, `4:1`, `4:3` are modern (curly/dotted) underline styles this slice
+    // does not render. Each is one unsupported parameter group and must be
+    // skipped whole — the trailing sub-parameter must never reach the pen, so
+    // it must not turn underline on nor reset existing attributes.
+    for sequence in [b"\x1b[4:0m", b"\x1b[4:1m", b"\x1b[4:3m"] {
+        let mut state = TerminalState::new(1, 1).expect("valid terminal");
+        state.feed_bytes(b"\x1b[1m");
+        state.feed_bytes(sequence);
+        state.feed_bytes(b"A");
+
+        let attributes = state
+            .screen()
+            .cell(0, 0)
+            .expect("printed cell")
+            .attributes();
+        assert!(attributes.is_bold(), "bold survived {sequence:?}");
+        assert!(
+            !attributes.is_underlined(),
+            "underline not turned on by {sequence:?}"
+        );
+        assert!(
+            !attributes.is_reversed(),
+            "reverse not flipped by {sequence:?}"
+        );
+    }
+
+    // A compound colon attribute with several sub-parameters is skipped whole
+    // as well, leaving the pen exactly as it was.
+    let mut state = TerminalState::new(1, 1).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;31m");
+    state.feed_bytes(b"\x1b[21:0:1mA");
+    let attributes = state
+        .screen()
+        .cell(0, 0)
+        .expect("printed cell")
+        .attributes();
+    assert!(attributes.is_bold());
+    assert_eq!(attributes.foreground(), Color::Ansi(AnsiColor::Red));
+}
+
+#[test]
+fn itu_colon_truecolor_still_works_alongside_solidus_forms() {
+    // Regression guard: the ITU-T T.416 colon form (`38:2::R:G:B`) must keep
+    // working after the colon-group skipping change, and SGR reset plus the
+    // `39`/`49` default selectors still behave on the semicolon form.
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    state.feed_bytes(b"\x1b[38:2::1:2:3mA");
+
+    let cell = state
+        .screen()
+        .cell(0, 0)
+        .expect("colon rgb cell")
+        .attributes();
+    assert_eq!(cell.foreground(), Color::Rgb(1, 2, 3));
+
+    // Semicolon-form truecolor still works.
+    state.feed_bytes(b"\x1b[48;2;9;9;9mB");
+    let cell = state
+        .screen()
+        .cell(0, 1)
+        .expect("semicolon rgb cell")
+        .attributes();
+    assert_eq!(cell.foreground(), Color::Rgb(1, 2, 3));
+    assert_eq!(cell.background(), Color::Rgb(9, 9, 9));
+
+    // Full reset and selective `39`/`49` defaults still clear colors.
+    state.feed_bytes(b"\x1b[mC");
+    assert_eq!(
+        state.screen().cell(0, 2).expect("reset cell").attributes(),
+        &CellAttributes::default()
+    );
+
+    state.feed_bytes(b"\x1b[38;2;1;1;1;48;2;2;2;2mD\x1b[39;49mE");
+    let selective = state
+        .screen()
+        .cell(0, 4)
+        .expect("selective reset cell")
+        .attributes();
+    assert_eq!(selective.foreground(), Color::Default);
+    assert_eq!(selective.background(), Color::Default);
 }

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -175,6 +175,44 @@ as their per-character widths; resize blanks a wide pair whose continuation
 would be truncated rather than reflowing it; ambiguous-width and grapheme
 cluster work remain later.
 
+## Color model
+
+SGR colors are modelled in full but left to the renderer to resolve: the
+terminal state records the selection, it never draws it. `Color` carries four
+selections — `Default` (the renderer's contextual default), `Ansi(AnsiColor)`
+(one of the 16-name palette), `Indexed(u8)` (an xterm 256-color slot), and
+`Rgb(u8, u8, u8)` (direct 24-bit) — and `CellAttributes` holds one color per
+target: foreground, background, and underline.
+
+- **SGR codes.** The 16 ANSI colors (`30..=37`, `90..=97` and the `40..=47`,
+  `100..=107` background twins), the `39`/`49`/`59` default resets, and the
+  `38`/`48`/`58` extended selectors are all honored. `58` sets the underline
+  *color*, distinct from the `4` underline *flag*; `59` restores it to default.
+- **Extended forms.** Both ECMA-48 serializations parse: the xterm semicolon
+  form (`38;5;N`, `38;2;R;G;B`) and the ITU-T T.416 colon sub-parameter form
+  (`38:5:N`, `38:2::R:G:B`). The colon RGB form carries an empty colour-space
+  slot after the `2`; a non-empty slot (`38:2:Pi:R:G:B`) is accepted and
+  ignored. The whole run of colon sub-parameters belongs to one selector and is
+  consumed together.
+- **Sub-parameters are SGR-only.** The CSI parser records each parameter's
+  separator (`;` versus `:`) instead of dropping every colon-bearing sequence.
+  Sub-parameters are only meaningful for SGR, so any other CSI final byte that
+  carries a colon is still dropped wholesale — `CSI 1:2 A` does not become a
+  cursor move.
+- **Malformed sequences never corrupt the pen.** A truncated selector
+  (`38;2;1`) or an out-of-range index (`38;5;300`) consumes the slots it
+  claimed and sets no color, so channel values can never leak back into the
+  main loop as independent bold/underline/reverse codes. Direct-color channels
+  are clamped to `u8`, matching xterm. Parameter-count overflow still drops the
+  whole SGR rather than misparsing.
+- **Reset semantics.** `CSI m` / `CSI 0 m` clears extended colors along with
+  everything else; `39`/`49`/`59` restore only their target, leaving other
+  colors and flags intact. The SGR pen is terminal-global, so an extended color
+  survives an alternate-screen switch exactly as ANSI SGR state does.
+
+Wiring the modelled colors to actual drawing is renderer work in `noren-app`
+and is intentionally out of scope for this slice.
+
 ## Deferred
 
 SGR/erase/insert/delete, cell attributes, tabs, origin mode, and


### PR DESCRIPTION
Closes gap #4 of the Zellij gap analysis.

## The gap

Extended colors were consumed but discarded: `38`/`48`/`58` swallowed their
arguments as one unsupported group, and `Color` modelled only Default plus the 16
ANSI colors. Zellij styles its chrome from RGB hex theme values and runs with
`TERM=xterm-256color`, so indexed and RGB forms are its normal path — the status
bar, tab bar, and pane frames lost all theme color, and light/dark themes were
indistinguishable.

## What it does

`Color` now carries `Indexed(u8)` and `Rgb(u8,u8,u8)` alongside `Default` and
`Ansi`, and both SGR forms parse for foreground, background, and underline:
`38;5;N` / `38;2;R;G;B` and their `48`/`58` counterparts.

**Colon sub-parameter forms now work**, which is the part worth reviewing. The
parser previously set an `ignored` flag on colon forms and dropped the whole CSI —
safe but wrong, since modern applications emit them. Both `38:5:N` and the ITU
form `38:2::R:G:B` (with its empty colour-space slot) are handled.

The renderer is deliberately untouched: wiring colors to actual drawing is
separate work in `noren-app`. This models the color in terminal state.

## Coordinator verification

Five independent checks, all passing:

- `38;5;196` → `Indexed(196)`, `48;2;10;20;30` → `Rgb(10,20,30)`;
- `38:5:99` → `Indexed(99)`, and **`38:2::1:2:3` → `Rgb(1,2,3)`** — the empty
  colour-space slot is the easy thing to get wrong;
- a truncated `38;2;1` does **not** leak channel values into the
  reverse/underline flags, which is the failure mode a naive parameter walk would
  produce;
- SGR reset clears extended colors, and `39` restores the default foreground;
- the 16 ANSI colors and bold/underline/reverse do not regress.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **211 workspace tests pass** (was 205), 0
failures. Rebased onto current `main`; the diff deletes no test file.

Note per the newly merged rule in #55: this will not be merged until review has
had a chance to arrive, not merely on green CI.