### PR TITLE
feat(fleet): gate merges on review, not just green CI

### DIFF
--- a/docs/coordination/fleet.md
+++ b/docs/coordination/fleet.md
@@ -62,6 +62,27 @@ an account is unauthenticated, erroring, or below `FLOOR_PERCENT` remaining.
 `.fleet/` is runtime state and is gitignored; only this contract and the lane
 prompts under `.fleet/prompts/` describe intent.
 
+### The merge gate
+
+`scripts/fleet/merge_gate.py <pr>` exits 0 only when every required check passed,
+**a review has actually been submitted**, and no review thread is unresolved. Run
+it before every merge.
+
+The review condition is the one that matters. Automated reviewers post *after* the
+checks finish, so a PR can report `CLEAN` while findings are still in flight.
+Three PRs in one session needed follow-up Issues because they were merged, or
+nearly merged, on green CI alone:
+
+| PR | What review caught that CI could not |
+| --- | --- |
+| #52 | The premise was wrong — output-side `CSI M` is Delete Line, not a mouse report. The "fix" would have broken legitimate DL. |
+| #53 | `lines()` collapsed the second column of every wide character, so the renderer misaligned — the exact breakage the PR fixed at the state layer. |
+| #56 | Combined `fg;bg` truecolor needs 10 parameter slots against a cap of 8, so both colors were silently lost — the ordinary emission pattern. |
+
+None would have been caught by more tests. They were wrong premises and untested
+*combinations*, not wrong code. The recurring coordinator failure was verifying
+each case in isolation and never the combination.
+
 ### Dispatch pitfalls
 
 Three failure modes cost real time and are worth knowing:

--- a/scripts/fleet/merge_gate.py
+++ b/scripts/fleet/merge_gate.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Check whether a PR is genuinely ready to merge.
+
+`gh pr view` reporting CLEAN is not enough: automated reviewers post *after* the
+checks finish, so a PR can look mergeable while findings are still in flight.
+Three PRs in one session needed follow-up Issues because of exactly that.
+
+Exit 0 only when every required check passed, a review has actually been
+submitted, and no review thread is unresolved.
+
+    merge_gate.py <pr-number>
+"""
+import json
+import subprocess
+import sys
+
+QUERY = """
+{repository(owner:"ta-061",name:"noren"){pullRequest(number:%d){
+  mergeStateStatus
+  reviews(first:20){nodes{submittedAt}}
+  reviewThreads(first:50){nodes{isResolved}}
+  statusCheckRollup: commits(last:1){nodes{commit{statusCheckRollup{
+    contexts(first:20){nodes{__typename
+      ... on CheckRun{name conclusion status}
+      ... on StatusContext{context state}}}}}}}
+}}}
+"""
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: merge_gate.py <pr-number>", file=sys.stderr)
+        return 2
+    pr = int(sys.argv[1])
+    out = subprocess.run(
+        ["gh", "api", "graphql", "-f", "query=" + QUERY % pr],
+        capture_output=True, text=True, check=True).stdout
+    p = json.loads(out)["data"]["repository"]["pullRequest"]
+
+    reviews = len(p["reviews"]["nodes"])
+    unresolved = sum(1 for t in p["reviewThreads"]["nodes"] if not t["isResolved"])
+    state = p["mergeStateStatus"]
+
+    checks = []
+    for node in p["statusCheckRollup"]["nodes"]:
+        rollup = node["commit"]["statusCheckRollup"]
+        if rollup:
+            checks = rollup["contexts"]["nodes"]
+    pending = [c for c in checks
+               if c.get("status") in ("IN_PROGRESS", "QUEUED")]
+    failed = [c for c in checks
+              if c.get("conclusion") not in (None, "SUCCESS", "NEUTRAL", "SKIPPED")
+              or c.get("state") in ("FAILURE", "ERROR")]
+
+    problems = []
+    if pending:
+        problems.append("%d check(s) still running" % len(pending))
+    if failed:
+        problems.append("%d check(s) not successful" % len(failed))
+    if reviews == 0:
+        problems.append("NO REVIEW SUBMITTED YET — wait for it")
+    if unresolved:
+        problems.append("%d unresolved review thread(s)" % unresolved)
+    if state not in ("CLEAN", "UNSTABLE", "HAS_HOOKS"):
+        problems.append("mergeStateStatus=%s" % state)
+
+    if problems:
+        print("NOT READY (PR #%d): %s" % (pr, "; ".join(problems)))
+        return 1
+    print("READY (PR #%d): checks green, %d review(s) submitted, 0 unresolved"
+          % (pr, reviews))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fleet/merge_gate.py
+++ b/scripts/fleet/merge_gate.py
@@ -5,8 +5,17 @@
 checks finish, so a PR can look mergeable while findings are still in flight.
 Three PRs in one session needed follow-up Issues because of exactly that.
 
-Exit 0 only when every required check passed, a review has actually been
-submitted, and no review thread is unresolved.
+Exit 0 only when every required check passed, a review covering the CURRENT head
+has been submitted, and no review thread is unresolved.
+
+Two subtleties this deliberately handles:
+
+* A review of an older head does not count. If the author pushes more commits,
+  earlier reviews say nothing about the new code, and the checks for the new head
+  can finish before its review arrives — the exact race this script exists to
+  prevent.
+* Review threads are paged. A partial page can hide an unresolved finding, so
+  every page is fetched before deciding.
 
     merge_gate.py <pr-number>
 """
@@ -14,17 +23,43 @@ import json
 import subprocess
 import sys
 
-QUERY = """
+HEAD_QUERY = """
 {repository(owner:"ta-061",name:"noren"){pullRequest(number:%d){
   mergeStateStatus
-  reviews(first:20){nodes{submittedAt}}
-  reviewThreads(first:50){nodes{isResolved}}
-  statusCheckRollup: commits(last:1){nodes{commit{statusCheckRollup{
-    contexts(first:20){nodes{__typename
-      ... on CheckRun{name conclusion status}
-      ... on StatusContext{context state}}}}}}}
+  headRefOid
+  reviews(first:50){nodes{submittedAt commit{oid}}}
+  commits(last:1){nodes{commit{statusCheckRollup{contexts(first:50){nodes{
+    __typename
+    ... on CheckRun{name conclusion status}
+    ... on StatusContext{context state}}}}}}}
 }}}
 """
+
+THREADS_QUERY = """
+{repository(owner:"ta-061",name:"noren"){pullRequest(number:%d){
+  reviewThreads(first:100%s){
+    pageInfo{hasNextPage endCursor}
+    nodes{isResolved}
+}}}}
+"""
+
+
+def graphql(query):
+    out = subprocess.run(["gh", "api", "graphql", "-f", "query=" + query],
+                         capture_output=True, text=True, check=True).stdout
+    return json.loads(out)["data"]["repository"]["pullRequest"]
+
+
+def all_threads(pr):
+    """Every review thread, following pagination to the end."""
+    threads, cursor = [], ""
+    while True:
+        page = graphql(THREADS_QUERY % (pr, cursor))["reviewThreads"]
+        threads.extend(page["nodes"])
+        info = page["pageInfo"]
+        if not info["hasNextPage"]:
+            return threads
+        cursor = ', after: "%s"' % info["endCursor"]
 
 
 def main():
@@ -32,43 +67,49 @@ def main():
         print("usage: merge_gate.py <pr-number>", file=sys.stderr)
         return 2
     pr = int(sys.argv[1])
-    out = subprocess.run(
-        ["gh", "api", "graphql", "-f", "query=" + QUERY % pr],
-        capture_output=True, text=True, check=True).stdout
-    p = json.loads(out)["data"]["repository"]["pullRequest"]
+    p = graphql(HEAD_QUERY % pr)
 
-    reviews = len(p["reviews"]["nodes"])
-    unresolved = sum(1 for t in p["reviewThreads"]["nodes"] if not t["isResolved"])
-    state = p["mergeStateStatus"]
+    head = p["headRefOid"]
+    # Only reviews of the current head say anything about the code being merged.
+    on_head = [r for r in p["reviews"]["nodes"]
+               if (r.get("commit") or {}).get("oid") == head]
+    stale = len(p["reviews"]["nodes"]) - len(on_head)
+
+    threads = all_threads(pr)
+    unresolved = sum(1 for t in threads if not t["isResolved"])
 
     checks = []
-    for node in p["statusCheckRollup"]["nodes"]:
+    for node in p["commits"]["nodes"]:
         rollup = node["commit"]["statusCheckRollup"]
         if rollup:
             checks = rollup["contexts"]["nodes"]
-    pending = [c for c in checks
-               if c.get("status") in ("IN_PROGRESS", "QUEUED")]
+    pending = [c for c in checks if c.get("status") in ("IN_PROGRESS", "QUEUED")]
     failed = [c for c in checks
               if c.get("conclusion") not in (None, "SUCCESS", "NEUTRAL", "SKIPPED")
               or c.get("state") in ("FAILURE", "ERROR")]
 
     problems = []
+    if not checks:
+        problems.append("no checks reported yet")
     if pending:
         problems.append("%d check(s) still running" % len(pending))
     if failed:
         problems.append("%d check(s) not successful" % len(failed))
-    if reviews == 0:
-        problems.append("NO REVIEW SUBMITTED YET — wait for it")
+    if not on_head:
+        problems.append("NO REVIEW OF THE CURRENT HEAD (%s)%s — wait for it"
+                        % (head[:7],
+                           "; %d review(s) cover older heads" % stale if stale else ""))
     if unresolved:
-        problems.append("%d unresolved review thread(s)" % unresolved)
-    if state not in ("CLEAN", "UNSTABLE", "HAS_HOOKS"):
-        problems.append("mergeStateStatus=%s" % state)
+        problems.append("%d unresolved review thread(s) of %d"
+                        % (unresolved, len(threads)))
+    if p["mergeStateStatus"] not in ("CLEAN", "UNSTABLE", "HAS_HOOKS"):
+        problems.append("mergeStateStatus=%s" % p["mergeStateStatus"])
 
     if problems:
         print("NOT READY (PR #%d): %s" % (pr, "; ".join(problems)))
         return 1
-    print("READY (PR #%d): checks green, %d review(s) submitted, 0 unresolved"
-          % (pr, reviews))
+    print("READY (PR #%d): checks green, %d review(s) on head %s, 0 unresolved of %d"
+          % (pr, len(on_head), head[:7], len(threads)))
     return 0
 
 


### PR DESCRIPTION
Makes the rule from #55 executable instead of advisory.

`scripts/fleet/merge_gate.py <pr>` exits 0 only when:
- every required check passed and none is still running,
- **a review has actually been submitted**, and
- no review thread is unresolved.

## Why the review condition is the point

Automated reviewers post *after* the checks finish, so a PR can report `CLEAN`
while findings are still in flight. Three PRs in one session needed follow-up
Issues from exactly that:

| PR | What review caught that CI could not |
| --- | --- |
| #52 | The premise was wrong — output-side `CSI M` is Delete Line, not a mouse report. The "fix" would have made legitimate DL discard itself plus three output bytes. |
| #53 | `lines()` collapsed the second column of every wide character, so the renderer misaligned — the exact breakage the PR fixed at the state layer. |
| #56 | Combined `fg;bg` truecolor needs 10 parameter slots against a cap of 8, so **both colors were silently lost** — and that is the ordinary emission pattern. |

**None would have been caught by more tests.** They were wrong premises and
untested *combinations*, not wrong code. The recurring coordinator failure was
verifying each case in isolation and never the combination — I checked fg and bg
truecolor in separate sequences, never together.

Notably, `gh pr merge` on #56 was refused by branch protection seconds before those
two findings landed. The protection held where my judgment had already moved on.

## Verified against live PRs

```
$ merge_gate.py 60
NOT READY (PR #60): NO REVIEW SUBMITTED YET — wait for it
$ merge_gate.py 56
NOT READY (PR #56): 2 unresolved review thread(s); mergeStateStatus=BLOCKED
```

`python3 scripts/check_docs.py` passes. No crate code touched.