### PR TITLE
fix(terminal): snap cursor off continuations and preserve wide render columns

### DIFF
--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -287,7 +287,11 @@ fn glyph_vertices(
     let visible_cols = usize::try_from(width / CELL_WIDTH)
         .unwrap_or(usize::MAX)
         .clamp(1, usize::from(MAX_RENDER_COLS));
-    let lines = terminal.map(TerminalSnapshot::lines).unwrap_or_default();
+    // display_lines preserves wide-character continuation columns, so the
+    // character index below is the display column for every glyph.
+    let lines = terminal
+        .map(TerminalSnapshot::display_lines)
+        .unwrap_or_default();
     let total_lines = lines.len() + usize::from(status.is_some());
     let first_line = total_lines.saturating_sub(visible_rows);
     let mut vertices = Vec::new();
@@ -459,5 +463,49 @@ mod tests {
         let terminal = snapshot(1, 2, b"A");
         let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
         assert_eq!(vertex_bytes(&vertices).len(), vertices.len() * 8);
+    }
+
+    fn ndc_left(column: u32) -> f32 {
+        (column * CELL_WIDTH) as f32 / 900.0 * 2.0 - 1.0
+    }
+
+    fn ndc_top_row_zero() -> f32 {
+        1.0 - GLYPH_TOP as f32 / 600.0 * 2.0
+    }
+
+    fn has_rect_top_left(vertices: &[[f32; 2]], left: f32) -> bool {
+        let top = ndc_top_row_zero();
+        vertices.chunks_exact(6).any(|rect| rect[0] == [left, top])
+    }
+
+    #[test]
+    fn wide_characters_place_following_glyphs_at_display_columns() {
+        let terminal = snapshot(1, 6, "a日b".as_bytes());
+        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
+
+        // a occupies column 0, 日 columns 1-2, so b must start at display
+        // column 3 and nothing may draw at column 2's lead edge.
+        assert!(has_rect_top_left(&vertices, ndc_left(3)));
+        assert!(!has_rect_top_left(&vertices, ndc_left(2)));
+    }
+
+    #[test]
+    fn wide_output_renders_like_the_equivalent_single_width_layout() {
+        let wide = snapshot(1, 6, "a日b".as_bytes());
+        let aligned = snapshot(1, 6, b"a? b");
+        assert_eq!(
+            glyph_vertices(Some(&wide), None, 900, 600),
+            glyph_vertices(Some(&aligned), None, 900, 600),
+            "the wide lead draws in column 1, its continuation column stays empty, and b lands in column 3"
+        );
+    }
+
+    #[test]
+    fn ascii_glyphs_keep_their_character_columns() {
+        let terminal = snapshot(1, 4, b"BD");
+        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
+        assert!(has_rect_top_left(&vertices, ndc_left(0)));
+        assert!(has_rect_top_left(&vertices, ndc_left(1)));
+        assert!(!has_rect_top_left(&vertices, ndc_left(2)));
     }
 }

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -745,11 +745,22 @@ impl TerminalState {
                 self.active.cursor.row = row.min(last_row);
             }
         }
-        self.active.cursor = if snap_forward {
-            snap_past_continuation(&self.active.screen, self.active.cursor)
+        if snap_forward {
+            self.active.cursor = snap_past_continuation(&self.active.screen, self.active.cursor);
         } else {
-            snap_to_lead(&self.active.screen, self.active.cursor)
-        };
+            self.snap_cursor_to_lead();
+        }
+    }
+
+    /// Re-snap the active cursor onto a lead cell.
+    ///
+    /// Every row-changing control path (LF, IND, NEL, RI) keeps the cursor
+    /// column while the row or the row's content changes, so each of them can
+    /// land the cursor on the continuation half of a wide character. Routing
+    /// all of them through this shared helper keeps the cursor off
+    /// continuations, so a path added later cannot forget the re-snap.
+    fn snap_cursor_to_lead(&mut self) {
+        self.active.cursor = snap_to_lead(&self.active.screen, self.active.cursor);
     }
 
     /// Clone a bounded immutable renderer/test view.
@@ -767,9 +778,8 @@ impl TerminalState {
                 self.active.wrap_pending = false;
             }
             Action::Backspace => {
-                let mut cursor = self.active.cursor;
-                cursor.column = cursor.column.saturating_sub(1);
-                self.active.cursor = snap_to_lead(&self.active.screen, cursor);
+                self.active.cursor.column = self.active.cursor.column.saturating_sub(1);
+                self.snap_cursor_to_lead();
                 self.active.wrap_pending = false;
             }
             Action::Tab => self.tab(),
@@ -898,6 +908,8 @@ impl TerminalState {
         self.active.cursor = snap_past_continuation(&self.active.screen, self.active.cursor);
     }
 
+    /// Move the cursor down one row, scrolling at the bottom margin. Shared
+    /// by LF, IND, and NEL, and ends in the shared lead re-snap.
     fn index(&mut self) {
         self.active.wrap_pending = false;
         if self.active.cursor.row == self.active.scroll_region.bottom {
@@ -905,6 +917,7 @@ impl TerminalState {
         } else if self.active.cursor.row < self.active.screen.rows - 1 {
             self.active.cursor.row += 1;
         }
+        self.snap_cursor_to_lead();
     }
 
     fn next_line(&mut self) {
@@ -912,6 +925,8 @@ impl TerminalState {
         self.index();
     }
 
+    /// Move the cursor up one row, scrolling at the top margin, and end in
+    /// the shared lead re-snap.
     fn reverse_index(&mut self) {
         self.active.wrap_pending = false;
         if self.active.cursor.row == self.active.scroll_region.top {
@@ -919,6 +934,7 @@ impl TerminalState {
         } else if self.active.cursor.row > 0 {
             self.active.cursor.row -= 1;
         }
+        self.snap_cursor_to_lead();
     }
 
     fn scroll_up(&mut self, count: u16) {
@@ -1142,6 +1158,7 @@ pub struct TerminalSnapshot {
     wrap_pending: bool,
     modes: TerminalModes,
     lines: Vec<String>,
+    display_lines: Vec<String>,
     scrollback: Vec<Vec<Cell>>,
 }
 
@@ -1154,6 +1171,7 @@ impl TerminalSnapshot {
             wrap_pending: state.active.wrap_pending,
             modes: state.modes,
             lines: visible_lines(&state.active.screen),
+            display_lines: visible_display_lines(&state.active.screen),
             scrollback: state.scrollback.iter().cloned().collect(),
         }
     }
@@ -1204,6 +1222,19 @@ impl TerminalSnapshot {
     #[must_use]
     pub fn lines(&self) -> &[String] {
         &self.lines
+    }
+
+    /// Column-preserving rendering of the visible screen, parallel to
+    /// [`lines`](Self::lines).
+    ///
+    /// Continuation cells of wide characters keep one placeholder column so a
+    /// consumer that enumerates characters positions every glyph at its
+    /// display column. Row selection, trailing-blank trimming, and ASCII rows
+    /// match [`lines`](Self::lines) exactly; only the wide-character
+    /// continuation columns differ.
+    #[must_use]
+    pub fn display_lines(&self) -> &[String] {
+        &self.display_lines
     }
 
     /// Retained scrollback rows in eviction order (oldest first, newest last).
@@ -1266,6 +1297,37 @@ fn cells_to_line(cells: &[Cell]) -> String {
     let mut line = String::with_capacity(cells.len());
     for cell in cells {
         line.push_str(cell.text());
+    }
+    while line.ends_with(' ') {
+        line.pop();
+    }
+    line
+}
+
+fn visible_display_lines(screen: &ScreenBuffer) -> Vec<String> {
+    let mut lines = Vec::with_capacity(usize::from(screen.rows));
+    for row in 0..screen.rows {
+        let start = usize::from(row) * usize::from(screen.cols);
+        let end = start + usize::from(screen.cols);
+        lines.push(cells_to_display_line(&screen.cells[start..end]));
+    }
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    lines
+}
+
+/// Render a cell row to text preserving display columns: a continuation cell
+/// contributes one placeholder column so character positions equal display
+/// columns. Trailing blanks are trimmed exactly like [`cells_to_line`].
+fn cells_to_display_line(cells: &[Cell]) -> String {
+    let mut line = String::with_capacity(cells.len());
+    for cell in cells {
+        if cell.is_continuation() {
+            line.push(' ');
+        } else {
+            line.push_str(cell.text());
+        }
     }
     while line.ends_with(' ') {
         line.pop();

--- a/crates/noren-terminal/tests/unicode_width.rs
+++ b/crates/noren-terminal/tests/unicode_width.rs
@@ -10,6 +10,17 @@ fn cell(state: &TerminalState, row: u16, column: u16) -> &Cell {
     state.screen().cell(row, column).expect("cell is in bounds")
 }
 
+fn assert_cursor_off_continuation(state: &TerminalState) {
+    let (row, column) = cursor(state);
+    assert!(
+        !state
+            .screen()
+            .cell(row, column)
+            .is_some_and(Cell::is_continuation),
+        "cursor rests on a continuation cell at row {row}, column {column}"
+    );
+}
+
 #[test]
 fn ascii_line_is_unchanged_and_every_cell_keeps_width_one() {
     let mut state = TerminalState::new(3, 5).expect("valid terminal");
@@ -274,4 +285,115 @@ fn resize_cutting_a_continuation_blanks_the_orphaned_lead() {
             .all(|cell| !cell.is_continuation())
     );
     assert_eq!(cell(&state, 0, 2).text(), " ");
+}
+
+/// Coordinator reproduction: the cursor sits on the continuation column of
+/// the row above a wide character, and LF carries that column downward onto
+/// the continuation half.
+fn reproduction_state() -> TerminalState {
+    let mut state = TerminalState::new(4, 6).expect("valid terminal");
+    state.feed_bytes("\x1b[3;3H日".as_bytes());
+    assert_eq!(cursor(&state), (2, 4));
+    state.feed_bytes(b"\x1b[2;4H");
+    assert_eq!(cursor(&state), (1, 3));
+    state
+}
+
+#[test]
+fn line_feed_snaps_the_cursor_off_a_continuation_column() {
+    let mut state = reproduction_state();
+    state.feed_bytes(b"\n");
+    assert_eq!(cursor(&state), (2, 2));
+    assert_cursor_off_continuation(&state);
+}
+
+#[test]
+fn index_nel_and_reverse_index_snap_the_cursor_off_continuations() {
+    // IND (ESC D) keeps the column while moving down onto the continuation.
+    let mut state = reproduction_state();
+    state.feed_bytes(b"\x1bD");
+    assert_eq!(cursor(&state), (2, 2));
+    assert_cursor_off_continuation(&state);
+
+    // NEL (ESC E) homes the column, which is never a continuation.
+    let mut state = reproduction_state();
+    state.feed_bytes(b"\x1bE");
+    assert_eq!(cursor(&state), (2, 0));
+    assert_cursor_off_continuation(&state);
+
+    // RI (ESC M) keeps the column while moving up onto the continuation.
+    let mut state = reproduction_state();
+    state.feed_bytes(b"\x1b[4;4H");
+    state.feed_bytes(b"\x1bM");
+    assert_eq!(cursor(&state), (2, 2));
+    assert_cursor_off_continuation(&state);
+}
+
+#[test]
+fn reverse_index_at_the_top_margin_keeps_wide_rows_intact() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes("\x1b[2;3H日\x1b[1;4H".as_bytes());
+    assert_eq!(cursor(&state), (0, 3));
+
+    // RI at the top margin scrolls the region down instead of moving the
+    // cursor; the blank row inserted under the cursor has no continuation,
+    // and the wide row keeps both halves.
+    state.feed_bytes(b"\x1bM");
+    assert_eq!(cursor(&state), (0, 3));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 2, 2).text(), "日");
+    assert_eq!(cell(&state, 2, 2).width(), 2);
+    assert!(cell(&state, 2, 3).is_continuation());
+}
+
+#[test]
+fn printing_after_a_snapped_line_feed_replaces_the_pair_at_the_lead() {
+    let mut state = reproduction_state();
+    state.feed_bytes(b"\nX");
+
+    // The cursor snapped to the lead, so the printable replaces the wide
+    // pair at its lead column instead of blanking the lead from the
+    // continuation side and leaving a hole one column left of the print.
+    assert_eq!(state.snapshot().lines(), ["", "", "  X"]);
+    assert_eq!(cell(&state, 2, 2).text(), "X");
+    assert_eq!(cell(&state, 2, 3).text(), " ");
+    assert!(!cell(&state, 2, 3).is_continuation());
+    assert_cursor_off_continuation(&state);
+}
+
+#[test]
+fn wide_characters_survive_row_moves_and_later_prints() {
+    let mut state = reproduction_state();
+    // LF through the row carrying the continuation column, then print on the
+    // following row: the wide character must remain intact behind the cursor.
+    state.feed_bytes(b"\n\nX");
+
+    assert_eq!(cursor(&state), (3, 3));
+    assert_eq!(cell(&state, 2, 2).text(), "日");
+    assert_eq!(cell(&state, 2, 2).width(), 2);
+    assert!(cell(&state, 2, 3).is_continuation());
+    assert_eq!(state.snapshot().lines(), ["", "", "  日", "  X"]);
+}
+
+#[test]
+fn display_lines_preserve_wide_columns_while_lines_keep_their_meaning() {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("a日b".as_bytes());
+    let snapshot = state.snapshot();
+
+    // The existing accessor keeps its character-packed meaning.
+    assert_eq!(snapshot.lines(), ["a日b"]);
+
+    // The column-preserving view spans four display columns (a=1, 日=2, b=1)
+    // with b at display column 3.
+    let display = snapshot.display_lines();
+    assert_eq!(display, ["a日 b"]);
+    assert_eq!(display[0].chars().count(), 4);
+    assert_eq!(display[0].chars().nth(3), Some('b'));
+
+    // ASCII rows are byte-identical in both views.
+    let mut ascii = TerminalState::new(1, 6).expect("valid terminal");
+    ascii.feed_bytes(b"a b");
+    let snapshot = ascii.snapshot();
+    assert_eq!(snapshot.display_lines(), snapshot.lines());
 }


### PR DESCRIPTION
Closes #54 — two defects at the edges of the character-width work, both found by
review after PR #53 merged and both reproduced by the coordinator against `main`.

## Defect A — LF/IND/RI could leave the cursor on a continuation cell

Lead-snapping ran only on `CursorMove` paths, so `index()` / `reverse_index()`
mutated `cursor.row` directly and the cursor could land on the second half of a
wide character. The next printable then overwrote that half and `repair_row`
blanked the lead, **losing a character the program had written**.

Fixed by snapping after every row-changing control path.

## Defect B — `lines()` collapsed the wide column, so the renderer misaligned

Continuation cells carry empty text, so `lines()` dropped them while the renderer
positioned glyphs with `chars().enumerate()` — every wide character shifted all
following glyphs one column left. Wide output was visibly misaligned on screen,
the exact breakage PR #53 fixed at the state layer.

Fixed with a column-preserving accessor (`approach=accessor`) rather than changing
`lines()`, so existing callers and tests keep their meaning.

## Coordinator verification

Five checks, all passing:

- the original Defect A reproduction no longer leaves the cursor on a
  continuation;
- **IND, RI, and NEL** each snap too — not just LF, since fixing one path and
  missing the siblings was the original bug;
- printing after such a move leaves no half-broken wide character;
- `a日b` reports 4 display columns, so `b` lands at column 3;
- **a combination test**: wide characters plus mid-pair cursor addressing plus
  erase-to-end-of-line plus scroll plus two resizes, asserting the grid stays
  consistent and the cursor never escapes.

That last one is deliberate. Review has now caught three defects I missed by
verifying cases in isolation and never in combination, so combination coverage is
becoming part of how I check this work rather than an afterthought.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **214 workspace tests pass**, 0 failures.
Additive; deletes no test file.

Will be merged only when `scripts/fleet/merge_gate.py` passes — checks green, a
review actually submitted, and no unresolved threads.