### PR TITLE
fix(terminal): cap combining marks attached to one cell

### DIFF
--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -15,8 +15,8 @@ mod state;
 
 pub use attributes::{AnsiColor, CellAttributes, Color};
 pub use state::{
-    Cell, Cursor, CursorMove, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES, ScreenBuffer, ScrollRegion,
-    TerminalError, TerminalModes, TerminalSnapshot, TerminalState,
+    Cell, Cursor, CursorMove, MAX_COMBINING_MARKS_PER_CELL, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES,
+    ScreenBuffer, ScrollRegion, TerminalError, TerminalModes, TerminalSnapshot, TerminalState,
 };
 
 use unicode_width::UnicodeWidthChar;

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -8,6 +8,39 @@ use std::fmt;
 /// Hard allocation bound for a visible Terminal Core screen.
 pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
 
+/// Maximum number of zero-width combining characters that may be attached to a
+/// single cell's base character.
+///
+/// `attach_zero_width` previously appended every combining mark to the target
+/// cell's owned `String` with no cap, so a hostile PTY stream of `a` followed
+/// by arbitrarily many `U+0301` marks grew one cell linearly in the input
+/// volume while every other documented ceiling — cell count (`rows * cols` ≤
+/// [`MAX_SCREEN_CELLS`]), scrollback lines (≤ [`MAX_SCROLLBACK_LINES`]) — still
+/// held. The inflated cells are also copied verbatim into scrollback and every
+/// snapshot, multiplying the cost. Marks beyond this budget are now dropped
+/// instead of appended (KBUG-01).
+///
+/// # Why this value
+///
+/// Real text rarely stacks more than three or four combining marks on one base:
+/// fully pointed Hebrew carries up to three (dagesh + vowel point + cantillation),
+/// decomposed Vietnamese two, and Devanagari/Thai conjuncts two to three. A
+/// budget of **seven** leaves roughly 2× headroom over the heaviest real script
+/// while keeping the per-cell text bound small and exact. Legitimate accented
+/// and Indic text (base + two to three marks) renders unchanged.
+///
+/// # Resulting per-cell bound
+///
+/// A cell holds at most one base character plus [`MAX_COMBINING_MARKS_PER_CELL`]
+/// marks, i.e. at most eight `char`s. The longest UTF-8 encoding of any `char`
+/// is four bytes, so a cell's owned text is bounded by
+/// `4 * (MAX_COMBINING_MARKS_PER_CELL + 1) == 32` bytes. Adding
+/// `size_of::<Cell>() == 32` gives a hard **64 bytes per cell** in the inflated
+/// worst case (single-character cells stay near 40 bytes). That bound propagates
+/// for free to every retained scrollback row and every snapshot, which simply
+/// borrow the already-capped cells.
+pub const MAX_COMBINING_MARKS_PER_CELL: usize = 7;
+
 /// Maximum number of lines retained in the primary screen's scrollback buffer.
 ///
 /// Only lines that scroll off the top of the *primary* screen are retained; the
@@ -19,19 +52,22 @@ pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
 ///
 /// Each retained line owns `cols` cells (the column count at the moment it
 /// scrolled off). `size_of::<Cell>() == 32` on this target (a 24-byte owned
-/// `String` handle, a width byte, and packed attributes); the single-character
-/// text also owns one small heap allocation per cell, so ~40 bytes/cell is a
-/// safe upper bound. The retained-line ceiling is therefore
-/// `MAX_SCROLLBACK_LINES * cols * sizeof(Cell)`:
+/// `String` handle, a width byte, and packed attributes). The owned text is
+/// bounded separately by [`MAX_COMBINING_MARKS_PER_CELL`]: at most one base
+/// `char` plus seven combining marks, i.e. at most `4 * 8 == 32` bytes of text,
+/// so a cell holds **64 bytes worst case** (single-character cells stay near 40).
+/// The retained-line ceiling is therefore
+/// `MAX_SCROLLBACK_LINES * cols * bytes_per_cell`:
 ///
-/// - Typical 80-column terminal: `10_000 * 80 * 40 ≈ 32 MiB`.
-/// - Typical 256-column terminal: `10_000 * 256 * 40 ≈ 100 MiB`.
+/// - Typical 80-column, single-character text: `10_000 * 80 * 40 ≈ 32 MiB`.
+/// - Worst-case 256-column, fully capped cells: `10_000 * 256 * 64 ≈ 164 MiB`.
 ///
 /// The line count is the hard bound: a hostile program cannot grow history past
-/// this many lines regardless of volume. Per-row width is bounded by the live
-/// grid, which is itself bounded by [`MAX_SCREEN_CELLS`]. Resize does **not**
-/// reflow retained lines (see the terminal-core-foundation design note), so each
-/// line keeps the width it had when it scrolled off.
+/// this many lines regardless of volume, and a stream of zero-width combining
+/// marks cannot grow one cell past the per-cell cap. Per-row width is bounded by
+/// the live grid, which is itself bounded by [`MAX_SCREEN_CELLS`]. Resize does
+/// **not** reflow retained lines (see the terminal-core-foundation design note),
+/// so each line keeps the width it had when it scrolled off.
 pub const MAX_SCROLLBACK_LINES: usize = 10_000;
 
 /// One basic terminal cell.
@@ -116,7 +152,16 @@ impl Cell {
     }
 
     fn push_text(&mut self, ch: char) {
-        self.text.push(ch);
+        if self.combining_marks() < MAX_COMBINING_MARKS_PER_CELL {
+            self.text.push(ch);
+        }
+    }
+
+    /// Number of zero-width combining marks attached to the base character
+    /// (every `char` past the first). Bounded by
+    /// [`MAX_COMBINING_MARKS_PER_CELL`]: `push_text` drops the excess.
+    fn combining_marks(&self) -> usize {
+        self.text.chars().count().saturating_sub(1)
     }
 }
 

--- a/crates/noren-terminal/tests/adversarial_kimi.rs
+++ b/crates/noren-terminal/tests/adversarial_kimi.rs
@@ -539,7 +539,6 @@ fn public_api_edge_inputs_are_rejected_or_clamped() {
 /// cells, not the text inside them). The wrap-pending path (`attach` targets
 /// the last column while a wrap is armed) has the same hole.
 #[test]
-#[ignore = "reproduces KBUG-01"]
 fn combining_marks_grow_a_single_cell_without_bound() {
     const REASONABLE_GRAPHEME_CAP: usize = 32;
 

--- a/crates/noren-terminal/tests/adversarial_kimi.rs
+++ b/crates/noren-terminal/tests/adversarial_kimi.rs
@@ -1,0 +1,570 @@
+//! Independent adversarial sweep for the Terminal Core state machine (Kimi
+//! lane). This suite deliberately avoids re-running the attacks in
+//! `tests/adversarial.rs` (GLM lane); see
+//! `docs/coordination/reviews/terminal-adversarial-kimi.md` for the coverage
+//! split. Focus areas GLM did not attack:
+//!
+//! - scrollback under feature *combinations* (alt-screen + DECSC/DECRC thrash,
+//!   wide-character lines, resize storms between scroll batches)
+//! - exhaustive `EscapeIntermediate` final-byte handling (the code added in
+//!   `5e266d4`): every intermediate x every final, plus ESC/C0 abuse inside it
+//! - determinism of a compound hostile script across *every* feed chunking
+//! - wide-character pairs vs. tab stops, scroll storms, and edit ops
+//! - `wrap_pending` combined with edit ops, scroll regions, and screen switches
+//! - idempotence/round-trip properties checked by full snapshot equality
+//! - unbounded-growth hunting in per-cell text (zero-width combining marks)
+
+use noren_terminal::{
+    AnsiColor, Cell, Color, CursorMove, MAX_SCROLLBACK_LINES, ScreenBuffer, TerminalError,
+    TerminalState,
+};
+
+/// Public invariants that must hold after any sequence of public calls.
+fn assert_invariants(state: &TerminalState, context: &str) {
+    let (rows, cols) = state.size();
+    assert!(rows > 0 && cols > 0, "{context}: non-zero size");
+    assert_eq!(
+        state.screen().cells().len(),
+        usize::from(rows) * usize::from(cols),
+        "{context}: cell count matches grid"
+    );
+    let cursor = state.cursor();
+    assert!(cursor.row() < rows, "{context}: cursor row in bounds");
+    assert!(cursor.column() < cols, "{context}: cursor column in bounds");
+    let region = state.scroll_region();
+    assert!(region.top() <= region.bottom(), "{context}: region ordered");
+    assert!(region.bottom() < rows, "{context}: region within screen");
+    assert!(
+        state.scrollback_len() <= MAX_SCROLLBACK_LINES,
+        "{context}: scrollback cap"
+    );
+}
+
+/// The wide-character invariant, checked through the public cell view: every
+/// width-2 lead is immediately followed by its continuation cell, and no
+/// continuation cell exists without its lead. `apply()` only checks this with
+/// `debug_assert!`; here it is asserted for real.
+fn assert_wide_pairs_intact(screen: &ScreenBuffer, context: &str) {
+    for row in 0..screen.rows() {
+        let mut column = 0;
+        while column < screen.cols() {
+            let cell = screen.cell(row, column).expect("in-bounds cell");
+            if cell.width() == 2 {
+                assert!(
+                    column + 1 < screen.cols(),
+                    "{context}: wide lead on the last column at r{row}c{column}"
+                );
+                assert!(
+                    screen
+                        .cell(row, column + 1)
+                        .is_some_and(Cell::is_continuation),
+                    "{context}: wide lead without continuation at r{row}c{column}"
+                );
+                column += 2;
+            } else {
+                assert!(
+                    !cell.is_continuation(),
+                    "{context}: orphaned continuation at r{row}c{column}"
+                );
+                column += 1;
+            }
+        }
+    }
+}
+
+// ===== Scrollback under feature combinations (GLM never fed scrollback) =====
+
+#[test]
+fn scrollback_is_byte_identical_after_alt_screen_decsc_decrc_thrash() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    // Accumulate primary scrollback with recognizable content.
+    state.feed_bytes(b"HIST01\r\nHIST02\r\nHIST03\r\nLIVE01");
+    let baseline = state.snapshot();
+
+    for iteration in 0..50_u16 {
+        state.feed_bytes(b"\x1b[?1049h");
+        // Thrash the alternate screen: scrolling output, DECSC/DECRC around a
+        // cursor move, and a scroll-region-local scroll.
+        state.feed_bytes(b"aaaaaa\r\nbbbbbb\r\ncccccc\r\n");
+        state.feed_bytes(b"\x1b[2;2H\x1b7\x1b[1;1H\x1b8");
+        state.feed_bytes(b"\x1b[2;3r\x1b[3;1H\x1bD\x1b[r");
+        state.feed_bytes(b"\x1b[?1049l");
+        assert!(
+            !state.modes().is_alternate_screen_active(),
+            "iteration {iteration}: back on primary"
+        );
+    }
+
+    let after = state.snapshot();
+    assert_eq!(
+        after.scrollback(),
+        baseline.scrollback(),
+        "scrollback cells drifted across alternate-screen thrash"
+    );
+    assert_eq!(
+        after.lines(),
+        baseline.lines(),
+        "visible primary content drifted across alternate-screen thrash"
+    );
+    assert_invariants(&state, "alt-screen scrollback thrash");
+}
+
+#[test]
+fn scrollback_stays_capped_with_wide_character_lines_and_keeps_pairs() {
+    // One-row grid: every CRLF evicts the just-printed line of wide chars.
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    let total = MAX_SCROLLBACK_LINES + 100;
+    let mut script = String::new();
+    for _ in 0..total {
+        script.push_str("日日日日\r\n");
+    }
+    state.feed_bytes(script.as_bytes());
+
+    assert_eq!(state.scrollback_len(), MAX_SCROLLBACK_LINES);
+    let snapshot = state.snapshot();
+    let newest = &snapshot.scrollback()[MAX_SCROLLBACK_LINES - 1];
+    // The retained rows kept full cell fidelity: 4 leads + 4 continuations.
+    assert_eq!(newest.len(), 8);
+    assert_eq!(newest[0].text(), "日");
+    assert_eq!(newest[0].width(), 2);
+    assert!(newest[1].is_continuation());
+    assert_eq!(
+        snapshot.scrollback_lines().last().map(String::as_str),
+        Some("日日日日")
+    );
+}
+
+#[test]
+fn scrollback_of_mixed_widths_survives_a_resize_storm_between_batches() {
+    let mut state = TerminalState::new(2, 8).expect("valid terminal");
+    let sizes = [(3u16, 8u16), (2, 3), (4, 11), (1, 2), (2, 8)];
+    for (batch, &(rows, cols)) in sizes.iter().enumerate() {
+        state.resize(rows, cols).expect("valid storm resize");
+        for line in 0..40_u32 {
+            state.feed_bytes(format!("B{batch}L{line:02}\r\n").as_bytes());
+        }
+        assert_invariants(&state, "resize-storm scrollback batch");
+    }
+
+    // The append-only order is preserved up to line truncation: retained
+    // rows were captured at different historical widths, so labels may be
+    // cut short, but the newest retained row is exactly the second-to-last
+    // line printed in the final batch.
+    let lines = state.snapshot().scrollback_lines();
+    assert!(lines.len() <= MAX_SCROLLBACK_LINES);
+    assert_eq!(lines.last().map(String::as_str), Some("B4L38"));
+    // Rows retained their original widths (no reflow): witnessed widths are
+    // drawn only from the historical column counts.
+    for row in state.snapshot().scrollback() {
+        assert!(
+            [8, 3, 11, 2].contains(&row.len()),
+            "unexpected retained row width {}",
+            row.len()
+        );
+    }
+}
+
+// ===== EscapeIntermediate: the state added in 5e266d4, attacked exhaustively =====
+
+#[test]
+fn every_escape_intermediate_final_byte_is_consumed_without_leaking() {
+    // Every intermediate byte (0x20..=0x2f) x every possible final byte
+    // (0x30..=0x7e): the final must terminate the sequence and vanish; only
+    // the trailing X may print, at column 1.
+    for intermediate in 0x20..=0x2f_u8 {
+        for final_byte in 0x30..=0x7e_u8 {
+            let mut state = TerminalState::new(1, 4).expect("valid terminal");
+            state.feed_bytes(&[0x1b, intermediate, final_byte, b'X']);
+            assert_eq!(
+                state.snapshot().lines(),
+                ["X".to_owned()],
+                "ESC {intermediate:#04x} {final_byte:#04x} leaked"
+            );
+            assert_eq!(
+                (state.cursor().row(), state.cursor().column()),
+                (0, 1),
+                "ESC {intermediate:#04x} {final_byte:#04x} moved the cursor"
+            );
+        }
+    }
+}
+
+#[test]
+fn stacked_intermediates_and_esc_restarts_never_leak() {
+    // Multiple intermediates before one final: everything is swallowed.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b()# \x1b(BX");
+    // The second ESC restarts; its `(` re-enters EscapeIntermediate; `B` is
+    // the consumed final. Only X prints.
+    assert_eq!(state.snapshot().lines(), ["X".to_owned()]);
+
+    // DEL and NUL inside EscapeIntermediate do not terminate it; the eventual
+    // final byte is still consumed.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b(\x7f\x00\x7f\x00BY");
+    assert_eq!(state.snapshot().lines(), ["Y".to_owned()]);
+    assert_invariants(&state, "stacked intermediates");
+}
+
+#[test]
+fn escape_aborting_csi_then_intermediate_sequence_keeps_later_csi_working() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    // Partial CSI 2;3... aborted by ESC; an SCS-like sequence follows; then a
+    // real CUP must still land exactly.
+    state.feed_bytes(b"\x1b[2;3\x1b(B\x1b[2;2HZ");
+    assert_eq!(state.screen().cell(1, 1).map(Cell::text), Some("Z"));
+    assert_eq!((state.cursor().row(), state.cursor().column()), (1, 2));
+    assert_invariants(&state, "esc-aborted csi then intermediate");
+}
+
+#[test]
+fn mid_osc_resize_does_not_corrupt_the_string_state() {
+    let mut state = TerminalState::new(2, 6).expect("valid terminal");
+    state.feed_bytes(b"\x1b]0;part");
+    state.resize(3, 9).expect("valid resize mid-OSC");
+    state.feed_bytes(b"ial\x07Z");
+    // The OSC swallowed everything up to BEL despite the resize; Z prints on
+    // the resized grid.
+    assert_eq!(state.screen().cell(0, 0).map(Cell::text), Some("Z"));
+    assert_eq!(state.size(), (3, 9));
+    assert_invariants(&state, "mid-OSC resize");
+}
+
+// ===== Determinism: compound hostile script across EVERY feed chunking =====
+
+#[test]
+fn compound_hostile_script_is_deterministic_across_all_chunkings() {
+    // Individually valid but collectively awkward: regions, alt screen, SGR,
+    // OSC, tabs at the edge, wide chars, combining marks, invalid UTF-8,
+    // DECSC/DECRC, aborted sequences.
+    let script: &[u8] = b"\x1b[31;1mab\xe6\x97\xa5\x1b[2;4r\x1b[4;1H\x1bD\tZ\
+        \x1b]8;;payload\x07\x1b[?1049hW\xe6\x97\xa5\x1b[?1049l\
+        \x1b7\x1b[1;1HQ\x1b8e\xcc\x81\xff\xc0\xaf\x1b[9\x1b[2G\\\x1b[r\x1b[mR";
+
+    let mut whole = TerminalState::new(5, 9).expect("valid terminal");
+    whole.feed_bytes(script);
+    let reference = whole.snapshot();
+
+    for chunk in 1..=script.len() {
+        let mut split = TerminalState::new(5, 9).expect("valid terminal");
+        for piece in script.chunks(chunk) {
+            split.feed_bytes(piece);
+        }
+        assert_eq!(
+            split.snapshot(),
+            reference,
+            "chunk size {chunk} diverged from the whole-feed result"
+        );
+    }
+    assert_invariants(&whole, "compound script");
+    assert_wide_pairs_intact(whole.screen(), "compound script");
+}
+
+// ===== Wide characters vs. tab stops, scroll storms, and edit ops =====
+
+#[test]
+fn tab_landing_on_a_continuation_cell_snaps_forward_off_the_pair() {
+    let mut state = TerminalState::new(2, 10).expect("valid terminal");
+    // 日 leads at 0,2,4; 'a' at 6; 日 lead at 7 with continuation at 8.
+    state.feed_bytes("日日日a日".as_bytes());
+    assert_eq!((state.cursor().row(), state.cursor().column()), (0, 9));
+
+    state.feed_bytes(b"\r\t");
+    // Tab stop 8 is the continuation half: the cursor must move past the pair
+    // to column 9, never rest on the continuation.
+    assert_eq!(state.cursor().column(), 9);
+    assert!(
+        !state
+            .screen()
+            .cell(0, state.cursor().column())
+            .is_some_and(Cell::is_continuation)
+    );
+
+    // Printing there fills the last column and arms the wrap; pairs stay whole.
+    state.feed_bytes(b"X");
+    assert!(state.is_wrap_pending());
+    assert_wide_pairs_intact(state.screen(), "tab onto continuation");
+}
+
+#[test]
+fn scroll_and_edit_storm_never_splits_a_wide_pair() {
+    let mut state = TerminalState::new(6, 10).expect("valid terminal");
+    state.feed_bytes(
+        "\x1b[1;1H日a日b\x1b[2;1Hc日d日\x1b[3;1H日日日日日\
+         \x1b[4;1He日f日g\x1b[5;1Hh日日i日\x1b[6;1H日日日日日"
+            .as_bytes(),
+    );
+    state.feed_bytes(b"\x1b[2;5r\x1b[1;1H");
+
+    let ops: &[&[u8]] = &[
+        b"\x1b[2S", // scroll region up
+        b"\x1b[T",  // scroll region down
+        b"\x1bD",   // index
+        b"\x1bM",   // reverse index
+        b"\x1b[2L", // insert lines
+        b"\x1b[M",  // delete lines
+        b"\x1b[3@", // insert characters
+        b"\x1b[2P", // delete characters
+        b"\x1b[4X", // erase characters
+        b"\x1b[1K", // erase line to beginning
+        b"\x1b[2K", // erase whole line
+        b"\x1b[2C", // move within the row
+        b"\x1b[B",  // move down a row
+    ];
+    for round in 0..40 {
+        for op in ops {
+            state.feed_bytes(op);
+            assert_wide_pairs_intact(state.screen(), &format!("round {round} op {op:?}"));
+        }
+        assert_invariants(&state, &format!("storm round {round}"));
+    }
+}
+
+#[test]
+fn erase_in_display_at_every_wide_boundary_leaves_no_dangling_half() {
+    // ED0/ED1/ED2 with the cursor on every column of a row of wide chars:
+    // an erase boundary that cuts a pair must blank the orphaned half.
+    for mode in 0..=2_u8 {
+        for column in 1..=8_u16 {
+            let mut state = TerminalState::new(3, 8).expect("valid terminal");
+            state.feed_bytes("日日日日\x1b[2;1H日日日日".as_bytes());
+            state.feed_bytes(format!("\x1b[1;{column}H\x1b[{mode}J").as_bytes());
+            assert_wide_pairs_intact(state.screen(), &format!("ED{mode} at column {column}"));
+        }
+    }
+}
+
+// ===== wrap_pending combined with edit ops, regions, and screen switches =====
+
+#[test]
+fn edit_and_erase_ops_cancel_a_pending_wrap_before_the_next_print() {
+    // Each op clears wrap_pending; the following printable must land at the
+    // cursor WITHOUT triggering the deferred wrap/scroll.
+    let ops: &[&[u8]] = &[b"\x1b[K", b"\x1b[1P", b"\x1b[1X", b"\x1b[1@", b"\x1b[J"];
+    for op in ops {
+        let mut state = TerminalState::new(2, 4).expect("valid terminal");
+        state.feed_bytes(b"abcd");
+        assert!(state.is_wrap_pending(), "{op:?}: precondition");
+        state.feed_bytes(op);
+        assert!(!state.is_wrap_pending(), "{op:?}: wrap not cancelled");
+        state.feed_bytes(b"Z");
+        assert_eq!(
+            (state.cursor().row(), state.cursor().column()),
+            (0, 3),
+            "{op:?}: print after the op wrapped unexpectedly"
+        );
+        assert!(state.is_wrap_pending(), "{op:?}: wrap re-armed at the edge");
+        assert_invariants(&state, "edit op cancels wrap");
+    }
+}
+
+#[test]
+fn alternate_screen_round_trip_restores_content_but_clears_pending_wrap() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"abcd"); // fills row 0, wrap pending on primary
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"\x1b[?1049h");
+    assert!(
+        !state.is_wrap_pending(),
+        "alternate starts without a pending wrap"
+    );
+    state.feed_bytes(b"WXYZ"); // wrap pending on the alternate instead
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"\x1b[?1049l");
+    // Leaving runs DECRC on the restored primary, and this core's
+    // restore_cursor unconditionally clears wrap_pending. The cursor position
+    // and cells round-trip exactly; the deferred wrap does NOT. Whether xterm
+    // preserves do_wrap across mode 1049 is a compat question, not a crash:
+    // pinned here as the current behavior (see the review report).
+    assert!(!state.is_wrap_pending());
+    assert_eq!((state.cursor().row(), state.cursor().column()), (0, 3));
+    assert_eq!(state.screen().cell(0, 3).map(Cell::text), Some("d"));
+    state.feed_bytes(b"Q");
+    // With the wrap cleared, Q overwrites the last column instead of wrapping.
+    assert_eq!(state.screen().cell(0, 3).map(Cell::text), Some("Q"));
+    assert!(state.is_wrap_pending());
+    assert_invariants(&state, "wrap pending screen round trip");
+}
+
+#[test]
+fn wrap_at_a_region_bottom_scrolls_only_the_region() {
+    let mut state = TerminalState::new(5, 3).expect("valid terminal");
+    state.feed_bytes(b"AAA\x1b[2;1HBBB\x1b[3;1HCCC\x1b[4;1HDDD\x1b[5;1HEEE");
+    // Region rows 2..=4 (1-based); park on the region's bottom row and fill it
+    // to the right edge so the next printable wraps and indexes at the bottom.
+    state.feed_bytes(b"\x1b[3;4r\x1b[4;1Hddd");
+    assert!(state.is_wrap_pending());
+
+    state.feed_bytes(b"Z");
+    // The wrap moved to region-bottom column 0 and scrolled the region (rows
+    // 2..=3 zero-based) up by one: CCC rotated out of the region, ddd moved
+    // up. Rows outside the region (AAA, BBB, EEE) are untouched.
+    assert_eq!(state.snapshot().lines(), ["AAA", "BBB", "ddd", "Z", "EEE"]);
+    assert_eq!((state.cursor().row(), state.cursor().column()), (3, 1));
+    // The region top is not row 0, so nothing entered scrollback.
+    assert_eq!(state.scrollback_len(), 0);
+    assert_invariants(&state, "wrap at region bottom");
+}
+
+// ===== Idempotence and round-trip properties via full snapshot equality =====
+
+#[test]
+fn alternate_screen_round_trip_restores_the_exact_snapshot() {
+    let mut state = TerminalState::new(3, 6).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;31mRED\x1b[2;4r\x1b[3;2H\x1b7mid");
+    let baseline = state.snapshot();
+
+    for round in 0..2 {
+        state.feed_bytes(b"\x1b[?1049h");
+        state.feed_bytes(b"junk junk junk\x1b[2J\x1b[3;3H!!");
+        state.feed_bytes(b"\x1b[?1049l");
+        assert_eq!(
+            state.snapshot(),
+            baseline,
+            "round trip {round} did not restore the exact primary state"
+        );
+    }
+}
+
+#[test]
+fn double_enter_single_leave_restores_the_exact_snapshot() {
+    let mut state = TerminalState::new(2, 5).expect("valid terminal");
+    state.feed_bytes(b"prim\x1b[2;2H");
+    let baseline = state.snapshot();
+
+    state.feed_bytes(b"\x1b[?1049h\x1b[?1049h"); // second enter is a no-op
+    assert!(state.modes().is_alternate_screen_active());
+    state.feed_bytes(b"XXXXX\r\nYYYYY");
+    state.feed_bytes(b"\x1b[?1049l"); // one leave must suffice
+
+    assert!(!state.modes().is_alternate_screen_active());
+    assert_eq!(state.snapshot(), baseline);
+}
+
+#[test]
+fn rejected_operations_leave_the_full_snapshot_unchanged() {
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    state.feed_bytes(b"\x1b[33;4mgreen\x1b[2;2H\x1b7");
+    let baseline = state.snapshot();
+
+    // Rejected resizes: over the cell cap, and zero dimensions.
+    assert_eq!(state.resize(1025, 1024), Err(TerminalError::ScreenTooLarge));
+    assert_eq!(state.resize(0, 5), Err(TerminalError::InvalidSize));
+    assert_eq!(state.resize(3, 0), Err(TerminalError::InvalidSize));
+    assert_eq!(state.snapshot(), baseline, "rejected resize mutated state");
+
+    // Rejected scroll regions, via CSI and via the public API.
+    state.feed_bytes(b"\x1b[4;2r"); // inverted after clamping -> rejected
+    assert_eq!(state.snapshot(), baseline, "rejected DECSTBM mutated state");
+    assert_eq!(
+        state.set_scroll_region(2, 1),
+        Err(TerminalError::InvalidScrollRegion)
+    );
+    assert_eq!(
+        state.snapshot(),
+        baseline,
+        "rejected public region mutated state"
+    );
+}
+
+#[test]
+fn sgr_pen_is_terminal_global_across_screen_switches_and_resets_cleanly() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[1;31m");
+    let armed = *state.attributes();
+    assert!(armed.is_bold());
+    assert_eq!(armed.foreground(), Color::ansi(AnsiColor::Red));
+
+    // The pen follows into the alternate screen: cells written there carry it.
+    state.feed_bytes(b"\x1b[?1049hZ");
+    let alt_cell = state.screen().cell(0, 0).expect("alt cell");
+    assert_eq!(*alt_cell.attributes(), armed);
+
+    // Reset on the alternate screen; the default pen persists after leaving.
+    state.feed_bytes(b"\x1b[m\x1b[?1049lQ");
+    let primary_cell = state.screen().cell(0, 0).expect("primary cell");
+    assert_eq!(*state.attributes(), Default::default());
+    assert_eq!(*primary_cell.attributes(), Default::default());
+}
+
+// ===== Public API surface the suites never call =====
+
+#[test]
+fn public_api_edge_inputs_are_rejected_or_clamped() {
+    assert_eq!(
+        TerminalState::new(0, 5).unwrap_err(),
+        TerminalError::InvalidSize
+    );
+    assert_eq!(
+        TerminalState::new(5, 0).unwrap_err(),
+        TerminalError::InvalidSize
+    );
+
+    let mut state = TerminalState::new(3, 5).expect("valid terminal");
+    // Out-of-bounds cell access yields None, never a panic.
+    assert!(state.screen().cell(3, 0).is_none());
+    assert!(state.screen().cell(0, 5).is_none());
+    assert!(state.screen().cell(u16::MAX, u16::MAX).is_none());
+
+    // Saturating public cursor moves clamp to the grid.
+    state.move_cursor(CursorMove::Down(u16::MAX));
+    state.move_cursor(CursorMove::Right(u16::MAX));
+    assert_eq!((state.cursor().row(), state.cursor().column()), (2, 4));
+    state.move_cursor(CursorMove::Up(u16::MAX));
+    state.move_cursor(CursorMove::Left(u16::MAX));
+    assert_eq!((state.cursor().row(), state.cursor().column()), (0, 0));
+
+    // Public save/restore round trip returns to the saved position exactly.
+    state.move_cursor(CursorMove::To { row: 1, column: 3 });
+    state.save_cursor();
+    state.move_cursor(CursorMove::To { row: 2, column: 4 });
+    state.restore_cursor();
+    assert_eq!((state.cursor().row(), state.cursor().column()), (1, 3));
+
+    // A fresh terminal exposes empty scrollback through the snapshot.
+    assert!(state.snapshot().scrollback().is_empty());
+    assert!(state.snapshot().scrollback_lines().is_empty());
+    assert_invariants(&state, "public api edges");
+}
+
+// ===== Unbounded growth hunting: per-cell text has no size bound =====
+
+/// A hostile program can append an unlimited number of zero-width combining
+/// characters to a single cell: `attach_zero_width` pushes onto the cell's
+/// `String` with no cap, so memory grows linearly with input volume on a grid
+/// whose cell COUNT never changes. This violates the bounded-memory contract
+/// documented on `MAX_SCROLLBACK_LINES`/`MAX_SCREEN_CELLS` (the bounds cover
+/// cells, not the text inside them). The wrap-pending path (`attach` targets
+/// the last column while a wrap is armed) has the same hole.
+#[test]
+#[ignore = "reproduces KBUG-01"]
+fn combining_marks_grow_a_single_cell_without_bound() {
+    const REASONABLE_GRAPHEME_CAP: usize = 32;
+
+    let mut state = TerminalState::new(2, 8).expect("valid terminal");
+    state.feed_bytes(b"a");
+    let marks = "\u{0301}".repeat(200_000);
+    state.feed_bytes(marks.as_bytes());
+    let text_len = state
+        .screen()
+        .cell(0, 0)
+        .map_or(0, |cell| cell.text().len());
+    assert!(
+        text_len <= REASONABLE_GRAPHEME_CAP,
+        "KBUG-01: one cell holds {text_len} bytes after a combining-mark flood"
+    );
+
+    let mut state = TerminalState::new(2, 2).expect("valid terminal");
+    state.feed_bytes(b"ab"); // arm wrap_pending on the last column
+    state.feed_bytes(marks.as_bytes());
+    let text_len = state
+        .screen()
+        .cell(0, 1)
+        .map_or(0, |cell| cell.text().len());
+    assert!(
+        text_len <= REASONABLE_GRAPHEME_CAP,
+        "KBUG-01: wrap-pending cell holds {text_len} bytes after a combining-mark flood"
+    );
+}

--- a/crates/noren-terminal/tests/unicode_width.rs
+++ b/crates/noren-terminal/tests/unicode_width.rs
@@ -1,6 +1,6 @@
 //! Display-width behavior for wide, zero-width, and mixed-width printing.
 
-use noren_terminal::{Cell, CursorMove, TerminalState};
+use noren_terminal::{Cell, CursorMove, MAX_COMBINING_MARKS_PER_CELL, TerminalState};
 
 fn cursor(state: &TerminalState) -> (u16, u16) {
     (state.cursor().row(), state.cursor().column())
@@ -396,4 +396,116 @@ fn display_lines_preserve_wide_columns_while_lines_keep_their_meaning() {
     ascii.feed_bytes(b"a b");
     let snapshot = ascii.snapshot();
     assert_eq!(snapshot.display_lines(), snapshot.lines());
+}
+
+// ===== KBUG-01 fix: combining-mark budget must not break legitimate text =====
+
+/// The grapheme-cluster cap must leave realistic combining sequences — the
+/// regression risk for this fix — exactly intact. Every script that stacks
+/// marks in real text stays well under [`MAX_COMBINING_MARKS_PER_CELL`], so the
+/// cell's text round-trips byte-for-byte.
+#[test]
+fn realistic_combining_sequences_render_exactly_within_the_cap() {
+    // Latin: 'e' with macron and acute (e + U+0304 + U+0301).
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    state.feed_bytes("e\u{0304}\u{0301}".as_bytes());
+    assert_eq!(cell(&state, 0, 0).text(), "e\u{0304}\u{0301}");
+    assert_eq!(cell(&state, 0, 0).width(), 1);
+
+    // Devanagari: consonant + nukta + candrabindu (क + U+093C + U+0901).
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    state.feed_bytes("\u{0915}\u{093C}\u{0901}".as_bytes());
+    assert_eq!(cell(&state, 0, 0).text(), "\u{0915}\u{093C}\u{0901}");
+
+    // Thai: consonant + below vowel + above tone mark (ก + U+0E38 + U+0E48).
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    state.feed_bytes("\u{0E01}\u{0E38}\u{0E48}".as_bytes());
+    assert_eq!(cell(&state, 0, 0).text(), "\u{0E01}\u{0E38}\u{0E48}");
+
+    // Fully pointed Hebrew: bet + dagesh + qamats + etnahta (3 marks).
+    let pointed = "\u{05D1}\u{05BC}\u{05B8}\u{05A0}";
+    let mut state = TerminalState::new(1, 8).expect("valid terminal");
+    state.feed_bytes(pointed.as_bytes());
+    assert_eq!(cell(&state, 0, 0).text(), pointed);
+
+    // The renderer-facing line keeps every mark of the Hebrew cluster.
+    assert_eq!(state.snapshot().lines(), [pointed]);
+}
+
+/// A hostile flood of combining marks is capped to exactly
+/// [`MAX_COMBINING_MARKS_PER_CELL`] on both attach paths: the normal cursor
+/// path (preceding cell one column left) and the wrap-pending path (cursor
+/// resting on the armed right-edge cell). Kimi demonstrated the same flood
+/// reaches both.
+#[test]
+fn a_combining_mark_flood_is_capped_on_both_attach_paths() {
+    let flood = "\u{0301}".repeat(2_000);
+
+    // Normal cursor path.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"a");
+    state.feed_bytes(flood.as_bytes());
+    let normal_marks = cell(&state, 0, 0).text().chars().count().saturating_sub(1);
+    assert_eq!(
+        normal_marks, MAX_COMBINING_MARKS_PER_CELL,
+        "normal cursor path did not stop at the cap"
+    );
+
+    // Wrap-pending path: filling the last column arms autowrap, so attach
+    // targets that right-edge cell.
+    let mut state = TerminalState::new(1, 2).expect("valid terminal");
+    state.feed_bytes(b"ab");
+    assert!(state.is_wrap_pending());
+    state.feed_bytes(flood.as_bytes());
+    let wrap_marks = cell(&state, 0, 1).text().chars().count().saturating_sub(1);
+    assert_eq!(
+        wrap_marks, MAX_COMBINING_MARKS_PER_CELL,
+        "wrap-pending attach path did not stop at the cap"
+    );
+}
+
+/// Once a cell is capped the bound propagates for free to retained scrollback
+/// rows and to every snapshot, since both simply observe the already-capped
+/// cells. The documented per-cell text ceiling is `4 * (cap + 1)` bytes.
+#[test]
+fn a_capped_cell_stays_capped_through_scrollback_and_snapshots() {
+    let bytes_per_cell = 4 * (MAX_COMBINING_MARKS_PER_CELL + 1);
+    let flood = "\u{0301}".repeat(5_000);
+
+    // One-row grid: the capped row is the one that will scroll off.
+    let mut state = TerminalState::new(1, 4).expect("valid terminal");
+    state.feed_bytes(b"a");
+    state.feed_bytes(flood.as_bytes());
+    let live_text = cell(&state, 0, 0).text().to_owned();
+    assert!(
+        live_text.len() <= bytes_per_cell,
+        "live cell text {} exceeds the {}-byte per-cell ceiling",
+        live_text.len(),
+        bytes_per_cell
+    );
+
+    // Scroll the capped row off into scrollback.
+    state.feed_bytes(b"\r\nb");
+    assert_eq!(state.scrollback_len(), 1);
+
+    // The retained scrollback cell (via the snapshot) is the same capped cell.
+    let snapshot = state.snapshot();
+    let retained = &snapshot.scrollback()[0][0];
+    assert_eq!(
+        retained.text(),
+        live_text,
+        "scrollback inherited a different cell"
+    );
+    assert!(
+        retained.text().len() <= bytes_per_cell,
+        "scrollback cell exceeds the per-cell ceiling"
+    );
+
+    // The renderer-facing rendering of that retained row is bounded too.
+    let scrollback_lines = snapshot.scrollback_lines();
+    let row_text = scrollback_lines[0].as_str();
+    assert!(
+        row_text.len() <= bytes_per_cell,
+        "scrollback line {row_text:?} exceeds the per-cell ceiling"
+    );
 }

--- a/docs/architecture/terminal-core-foundation.md
+++ b/docs/architecture/terminal-core-foundation.md
@@ -87,10 +87,19 @@ renderer-independent API.
 - **Bounded.** `MAX_SCROLLBACK_LINES` (10,000) sits next to `MAX_SCREEN_CELLS`
   and is the hard line-count cap. Each retained row owns `cols` cells (the column
   count when it left), so the memory ceiling is
-  `MAX_SCROLLBACK_LINES * cols * sizeof(Cell)`. At ~40 bytes/cell that is ~32 MiB
-  for an 80-column terminal and ~100 MiB for 256 columns; the line count is the
-  hard bound so hostile unbounded output cannot grow history past it. The oldest
-  retained line is evicted when the cap is reached.
+  `MAX_SCROLLBACK_LINES * cols * bytes_per_cell`. `sizeof(Cell) == 32` (a 24-byte
+  owned `String` handle, a width byte, and packed attributes) plus the owned text:
+  combining marks attached to one cell are capped at
+  `MAX_COMBINING_MARKS_PER_CELL` (7), so the text is at most
+  `4 * (7 + 1) == 32` bytes (one base `char` plus seven marks, four bytes each in
+  the worst UTF-8 case). The inflated worst case is therefore **64 bytes/cell**
+  (single-character cells stay near 40). That is ~51 MiB for an 80-column
+  terminal and ~164 MiB for 256 columns at the cap; typical single-character text
+  is ~32 MiB and ~100 MiB respectively. The line count is the hard bound so
+  hostile unbounded output — including a stream of zero-width combining marks,
+  which used to grow one cell without bound and now stops at the cap — cannot
+  grow history past it. The oldest retained line is evicted when the cap is
+  reached.
 - **Primary screen only.** Retention is gated on the primary screen being active
   and on the scrolling region starting at row 0. The alternate screen never
   contributes (so `less`/`vim` do not pollute history), and scrolling inside a
@@ -152,8 +161,14 @@ keep the cell grid aligned instead of drifting it one cell per wide character.
   cell in the row (skipping continuation cells): they extend that cell's text
   without changing its width, never advance the cursor, and do not clear
   pending autowrap. With no preceding cell (cursor at column zero with no
-  pending wrap) the mark is dropped. This is a documented simplification: the
-  grid stores per-cell text, not grapheme clusters.
+  pending wrap) the mark is dropped. A hostile stream of marks is bounded by
+  `MAX_COMBINING_MARKS_PER_CELL` (7): once a cell carries that many, further
+  marks are dropped instead of appended, so the per-cell text cannot be grown
+  without bound (KBUG-01). This covers both attach paths — the normal cursor
+  path and the wrap-pending path — and the cap propagates to scrollback rows
+  and snapshots, which simply observe the already-capped cells. This is a
+  documented simplification: the grid stores capped per-cell text, not
+  grapheme clusters.
 
 Known limitations of this slice: emoji ZWJ/variation sequences are only as wide
 as their per-character widths; resize blanks a wide pair whose continuation

--- a/docs/coordination/reviews/terminal-adversarial-kimi.md
+++ b/docs/coordination/reviews/terminal-adversarial-kimi.md
@@ -1,0 +1,149 @@
+# Terminal adversarial sweep — Kimi (independent second attacker)
+
+Reviewed at: `kimi-adversarial` off `origin/main` @ `e83d8ed`.
+Independence note: I did not write the parser code under attack (the
+`EscapeIntermediate` state in `5e266d4` is GLM's). I read GLM's report
+(`terminal-adversarial-glm.md`) first and deliberately went elsewhere; no GLM
+attack was re-run.
+
+Test command and result:
+`cargo test -p noren-terminal` → **167 passed, 0 failed, 1 ignored**
+(suite `tests/adversarial_kimi.rs` contributes 19 passed + 1 ignored;
+pre-existing baseline was 148). `cargo clippy -p noren-terminal --all-targets
+-- -D warnings` clean. `cargo fmt --all` clean.
+`cargo test --workspace` cannot run on this Linux host because the
+winit/wgpu `noren-app` crate is macOS-first — expected, not a finding.
+
+The ignored test is the KBUG-01 reproducer. It was executed explicitly with
+`cargo test -p noren-terminal --test adversarial_kimi -- --ignored` and
+**fails** (i.e. the bug is real): 0 passed, 1 failed.
+
+## Bugs found
+
+### KBUG-01 — unbounded per-cell memory growth via zero-width combining marks
+
+`TerminalState::attach_zero_width` (`src/state.rs`) appends every zero-width
+character to the target cell's owned `String` with **no length cap**. A
+hostile PTY stream of `a` followed by N × U+0301 grows a single cell's text
+linearly in N while every documented bound holds: cell count stays
+`rows*cols`, grid ≤ `MAX_SCREEN_CELLS`, scrollback ≤ `MAX_SCROLLBACK_LINES`.
+The memory ceilings documented on `MAX_SCROLLBACK_LINES` ("a hostile program
+emitting unbounded output cannot grow history without limit", "~40 bytes/cell
+is a safe upper bound") are defeated: bytes/cell is in fact unlimited.
+
+Measured (executed, not extrapolated): `a` + 200 000 × U+0301 leaves
+`cell(0,0).text().len() == 400_001` bytes; on a 2×2 grid with wrap pending,
+the same flood lands on the armed last-column cell (`cell(0,1)` = 400 001
+bytes). The vector is reachable both in normal cursor flow and via the
+wrap-pending attach path, and the inflated cells are also copied into
+scrollback and snapshots, multiplying the cost.
+
+Reproducer: `tests/adversarial_kimi.rs`,
+`combining_marks_grow_a_single_cell_without_bound`,
+marked `#[ignore = "reproduces KBUG-01"]`. Not fixed — reported only, per
+lane rules. Suggested direction: cap the number of combining characters
+attached to one cell (a grapheme-cluster budget), dropping the excess.
+
+## Behavioral observations (not robustness bugs; for the compat lane)
+
+Both verified by execution in a scratch probe (since removed):
+
+- **DL/SU at row 0 feed scrollback.** On a 3-row primary with a full-screen
+  region, cursor home, `ESC[M` pushed the top row into scrollback, and a
+  following `ESC[S` pushed the next one. Deleted lines thus enter history,
+  and DL/IL are asymmetric (IL cannot push). Whether this matches xterm is a
+  compatibility question, not a crash.
+- **Leaving the alternate screen clears a pending wrap on the primary.**
+  `leave_alternate_screen` runs `restore_cursor`, which unconditionally sets
+  `wrap_pending = false`, so `print-to-right-edge → 1049h → 1049l → print`
+  overwrites the last column instead of wrapping. If xterm preserves
+  `do_wrap` across mode 1049 this is a rendering divergence; it is pinned as
+  current behavior in
+  `alternate_screen_round_trip_restores_content_but_clears_pending_wrap`.
+
+## Attacks that did NOT break it (all novel vs. GLM's sweep)
+
+**Scrollback under feature combinations — GLM never fed scrollback at all**
+- 50 rounds of 1049 enter → scrolling output + DECSC/DECRC + region-local
+  scroll → leave: scrollback and visible primary are **byte-identical** to
+  the pre-thrash snapshot.
+  (`scrollback_is_byte_identical_after_alt_screen_decsc_decrc_thrash`)
+- `MAX_SCROLLBACK_LINES + 100` lines of wide characters evicted through a
+  1-row grid: count clamps exactly at the cap and the newest retained row
+  keeps full lead/continuation fidelity.
+  (`scrollback_stays_capped_with_wide_character_lines_and_keeps_pairs`)
+- Resize storm (3×8 → 2×3 → 4×11 → 1×2 → 2×8) between scroll batches:
+  mixed retained widths render without panic, stay append-ordered, and keep
+  their historical widths (no reflow).
+  (`scrollback_of_mixed_widths_survives_a_resize_storm_between_batches`)
+
+**`EscapeIntermediate` (GLM's own freshest code), attacked exhaustively**
+- All 16 intermediates (0x20..=0x2f) × all 79 possible finals (0x30..=0x7e) —
+  1264 sequences — every final is consumed; only a trailing `X` prints, at
+  column 1. (`every_escape_intermediate_final_byte_is_consumed_without_leaking`)
+- Stacked intermediates (`ESC ( ) # SP`), ESC-restarts mid-intermediate, and
+  DEL/NUL bytes inside the state never leak a final byte.
+  (`stacked_intermediates_and_esc_restarts_never_leak`)
+- `ESC` aborting a partial CSI followed by an SCS-like sequence, then a real
+  CUP, lands exactly. (`escape_aborting_csi_then_intermediate_sequence_keeps_later_csi_working`)
+- OSC split by a `resize()` (GLM split only a CSI): the string state is
+  independent of the screen; BEL terminates and the next byte prints on the
+  resized grid. (`mid_osc_resize_does_not_corrupt_the_string_state`)
+
+**Determinism beyond byte-at-a-time**
+- A compound script (SGR + wide chars + region + index + tab-at-edge + OSC +
+  1049 round trip + DECSC/DECRC + combining mark + invalid UTF-8 + aborted
+  CSI) fed whole vs. in chunks of size k for **every** k in 1..=len: all
+  snapshots identical. GLM checked byte-at-a-time on 13 simple sequences;
+  this checks all partitions of one interacting script.
+  (`compound_hostile_script_is_deterministic_across_all_chunkings`)
+
+**Wide characters × controls (combinations, not single ops)**
+- A tab stop that lands exactly on a continuation cell snaps forward off the
+  pair; the next print arms the wrap with all pairs intact.
+  (`tab_landing_on_a_continuation_cell_snaps_forward_off_the_pair`)
+- 40 rounds × 13 ops (SU/SD/IND/RI/IL/DL/ICH/DCH/ECH/EL0/EL2/CUF/CUD) over a
+  wide-char grid inside a narrow scroll region: the lead/continuation
+  invariant (asserted through the public cell view, not `debug_assert`) holds
+  after every single op. (`scroll_and_edit_storm_never_splits_a_wide_pair`)
+- ED 0/1/2 with the cursor on **every** column boundary of wide-char rows:
+  no dangling halves. (`erase_in_display_at_every_wide_boundary_leaves_no_dangling_half`)
+
+**`wrap_pending` interactions GLM did not combine**
+- EL/DCH/ECH/ICH/ED each cancel a pending wrap; the next printable lands at
+  the cursor without wrapping. (`edit_and_erase_ops_cancel_a_pending_wrap_before_the_next_print`)
+- Wrap armed on a region's bottom row: the next print scrolls only the
+  region, rows outside are untouched, and (region top ≠ 0) nothing enters
+  scrollback. (`wrap_at_a_region_bottom_scrolls_only_the_region`)
+- Wrap across an alternate-screen round trip: content and cursor position
+  round-trip exactly; the pending wrap is cleared (see observations above).
+
+**Idempotence / round-trip via full snapshot equality (stronger than GLM's
+size-only checks)**
+- Two consecutive alt-screen round trips restore the exact snapshot, SGR pen
+  and scroll region included. (`alternate_screen_round_trip_restores_the_exact_snapshot`)
+- Double-enter / single-leave of mode 1049 restores the exact snapshot (the
+  second enter is a true no-op). (`double_enter_single_leave_restores_the_exact_snapshot`)
+- Rejected resize (over-cap, zero-dimension) and rejected DECSTBM (CSI and
+  public API) leave the **full snapshot** bit-identical, not just the size.
+  (`rejected_operations_leave_the_full_snapshot_unchanged`)
+
+**SGR pen across screens (pinning the documented design)**
+- The pen set on the primary writes attributed cells on the alternate screen;
+  `ESC[m` on the alternate persists as default after leaving.
+  (`sgr_pen_is_terminal_global_across_screen_switches_and_resets_cleanly`)
+
+**Public API surface the suites never call**
+- `TerminalState::new` with zero dimensions errors; `cell()` out of bounds
+  returns `None` (including `u16::MAX`); public `move_cursor` with `u16::MAX`
+  counts clamps; public `save_cursor`/`restore_cursor` round-trips exactly.
+  (`public_api_edge_inputs_are_rejected_or_clamped`)
+
+## Note on three initially-failing assertions
+
+First run had three failures; two were wrong expectations in my own tests
+(off-by-one in which row a regional scroll evicts; lexicographic ordering
+broken by truncation of retained labels after a shrink — both test bugs, the
+state machine was right). The third was the wrap-pending-across-1049
+deviation, reclassified as a compat observation and pinned as current
+behavior (above). No state-machine defect was found in any of the three.


### PR DESCRIPTION
Closes #63. Also lands the independent adversarial suite that found it, as a
separate commit so provenance stays with the Kimi lane that wrote it.

## The defect

`attach_zero_width` appended every zero-width character to a cell's owned `String`
with no cap, so a hostile stream grew one cell linearly.

Coordinator reproduction on `main`: `"a"` then 50,000 × U+0301 left
`cell(0,0).text().len() == 100_001` bytes. Kimi measured 400,001 bytes at 200,000
marks and showed the flood also reaches the **wrap-pending attach path**.

## Why this was a threat-model failure, not a nit

Every documented bound held while it happened — cell count stayed `rows*cols`, the
grid stayed under `MAX_SCREEN_CELLS`, scrollback under `MAX_SCROLLBACK_LINES`. So
the memory ceiling written into the architecture doc ("hostile unbounded output
cannot grow history past it", at "~40 bytes/cell") was **false as stated**: bytes
per cell was unlimited, and inflated cells were copied into scrollback and every
snapshot.

## The fix

A grapheme-cluster budget of **7 combining marks per cell**, giving a real bound of
**64 bytes/cell**. The architecture doc's memory-ceiling paragraph is corrected to
state the true bound instead of the false one.

## Coordinator verification

Four checks, all passing:

- 50,000 combining marks leave the cell at or under 64 bytes;
- the **wrap-pending path** is capped too, not just the normal cursor path — the
  original bug was reachable both ways;
- **legitimate text still renders**: `e` + combining acute, and a Devanagari
  cluster `क्षि` with multiple marks. This is the real regression risk, since a
  careless cap breaks accented and Indic writing;
- a capped cell scrolled into scrollback stays capped.

## Kimi's suite, landed with attribution

The first commit adds `tests/adversarial_kimi.rs` (20 tests) and the sweep report,
unmodified from the Kimi lane's branch. Those attacks were **all novel** against
the earlier GLM sweep: scrollback under feature combinations, 1264
escape-intermediate combinations, determinism across every chunking of a compound
hostile script, snapshot-equality idempotence. This was the only defect they found,
and the lane also reported honestly that three of its initial failures were its own
test expectations rather than state-machine bugs.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **228 workspace tests pass** (was 205),
`python3 scripts/check_docs.py` passes.

Will merge only when `scripts/fleet/merge_gate.py` passes.