### PR TITLE
feat: add grid selection and clipboard copy/paste

### DIFF
--- a/crates/noren-app/src/clipboard.rs
+++ b/crates/noren-app/src/clipboard.rs
@@ -1,0 +1,235 @@
+//! User-initiated clipboard copy and paste for the macOS PoC.
+//!
+//! # Security policy (Issue #57)
+//!
+//! The clipboard is a policy boundary with exactly two user-initiated gates:
+//!
+//! - **Copy**: the user's grid selection is written to the system clipboard
+//!   (`Command+C`).
+//! - **Paste**: the system clipboard is read and inserted into the PTY as
+//!   input (`Command+V`), bracketed when the application enabled DEC private
+//!   mode 2004.
+//!
+//! Application-driven clipboard access (OSC 52) is explicitly out of scope:
+//! the terminal core swallows every OSC payload without acting on it, and this
+//! module exposes no path by which terminal output bytes can read or write the
+//! clipboard. A future OSC 52 feature must never answer read queries — a
+//! program must not be able to exfiltrate the clipboard by asking.
+
+use std::fmt;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Bracketed paste begin marker (`CSI 200 ~`), sent before pasted text when
+/// the application has enabled DEC private mode 2004.
+pub const BRACKET_PASTE_BEGIN: &[u8] = b"\x1b[200~";
+
+/// Bracketed paste end marker (`CSI 201 ~`), sent after pasted text when the
+/// application has enabled DEC private mode 2004.
+pub const BRACKET_PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Maximum pasted bytes accepted in one user-initiated paste.
+///
+/// Larger pastes are rejected rather than truncated, so a paste is always
+/// either complete or never happens; truncation could split a UTF-8 character
+/// or a bracketed-paste marker.
+pub const MAX_PASTE_BYTES: usize = 1024 * 1024;
+
+/// Why a user-initiated paste was gated instead of sent to the PTY.
+///
+/// Noren never pastes unbracketed and never pretends a gated paste succeeded:
+/// every rejection leaves the PTY input stream untouched.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PasteReject {
+    /// The application has not enabled bracketed paste (DEC private mode
+    /// 2004), or the terminal state tracking it is unavailable.
+    Unbracketed,
+    /// The clipboard held no text at all.
+    Empty,
+    /// The clipboard text exceeds [`MAX_PASTE_BYTES`].
+    Oversized,
+}
+
+impl fmt::Display for PasteReject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unbracketed => {
+                f.write_str("paste gated: application did not enable bracketed paste (mode 2004)")
+            }
+            Self::Empty => f.write_str("paste gated: clipboard text is empty"),
+            Self::Oversized => f.write_str("paste gated: clipboard text exceeds the paste bound"),
+        }
+    }
+}
+
+impl std::error::Error for PasteReject {}
+
+/// A failure of the system clipboard helper itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClipboardError {
+    /// The fixed macOS helper could not be spawned or did not exit cleanly.
+    HelperFailed,
+    /// The clipboard contents could not be decoded as UTF-8 text.
+    NotUtf8,
+}
+
+impl fmt::Display for ClipboardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HelperFailed => f.write_str("macOS clipboard helper failed"),
+            Self::NotUtf8 => f.write_str("clipboard contents are not UTF-8 text"),
+        }
+    }
+}
+
+impl std::error::Error for ClipboardError {}
+
+/// macOS system clipboard access via the fixed `/usr/bin/pbcopy` and
+/// `/usr/bin/pbpaste` helpers.
+///
+/// No shell, no interpolation: clipboard contents travel as piped bytes and
+/// are data, never authority. Both directions serve user-initiated actions
+/// only; nothing here is reachable from PTY output.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClipboard;
+
+impl SystemClipboard {
+    /// Construct the clipboard handle.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Write text to the system clipboard.
+    ///
+    /// The payload is piped verbatim to `/usr/bin/pbcopy`; any spawn, write,
+    /// or non-zero exit is a typed failure the caller surfaces visibly.
+    pub fn write(&self, text: &str) -> Result<(), ClipboardError> {
+        let mut child = Command::new("/usr/bin/pbcopy")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| ClipboardError::HelperFailed)?;
+        let written = child
+            .stdin
+            .as_mut()
+            .is_some_and(|stdin| stdin.write_all(text.as_bytes()).is_ok());
+        // Close stdin so pbcopy sees EOF before waiting for it.
+        drop(child.stdin.take());
+        let exited = child.wait().is_ok_and(|status| status.success());
+        if written && exited {
+            Ok(())
+        } else {
+            Err(ClipboardError::HelperFailed)
+        }
+    }
+
+    /// Read the system clipboard as UTF-8 text.
+    ///
+    /// Non-UTF-8 clipboard contents (files, images, undecodable bytes) are a
+    /// typed failure rather than a lossy conversion, so no corrupted bytes can
+    /// reach the PTY through a paste.
+    pub fn read(&self) -> Result<String, ClipboardError> {
+        let output = Command::new("/usr/bin/pbpaste")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .map_err(|_| ClipboardError::HelperFailed)?;
+        if !output.status.success() {
+            return Err(ClipboardError::HelperFailed);
+        }
+        String::from_utf8(output.stdout).map_err(|_| ClipboardError::NotUtf8)
+    }
+}
+
+/// Encode a user-initiated paste for the PTY, or gate it.
+///
+/// When `bracketed_paste_enabled` (DEC private mode 2004 is set in the
+/// terminal state) the text is wrapped in [`BRACKET_PASTE_BEGIN`] /
+/// [`BRACKET_PASTE_END`]. When the mode is off the paste is refused
+/// unconditionally; an empty or oversized clipboard is refused as well. The
+/// `Err` cases carry a payload-free reason so the caller can report the gate
+/// instead of silently sending nothing — or worse, unbracketed text.
+pub fn encode_paste(text: &str, bracketed_paste_enabled: bool) -> Result<Vec<u8>, PasteReject> {
+    if !bracketed_paste_enabled {
+        return Err(PasteReject::Unbracketed);
+    }
+    let bytes = text.as_bytes();
+    if bytes.is_empty() {
+        return Err(PasteReject::Empty);
+    }
+    if bytes.len() > MAX_PASTE_BYTES {
+        return Err(PasteReject::Oversized);
+    }
+    let mut encoded =
+        Vec::with_capacity(BRACKET_PASTE_BEGIN.len() + bytes.len() + BRACKET_PASTE_END.len());
+    encoded.extend_from_slice(BRACKET_PASTE_BEGIN);
+    encoded.extend_from_slice(bytes);
+    encoded.extend_from_slice(BRACKET_PASTE_END);
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paste_is_wrapped_in_bracketed_markers_when_2004_is_on() {
+        let encoded = encode_paste("ls -la\n", true).expect("enabled mode 2004 brackets the paste");
+        assert_eq!(encoded, b"\x1b[200~ls -la\n\x1b[201~");
+        assert!(encoded.starts_with(BRACKET_PASTE_BEGIN));
+        assert!(encoded.ends_with(BRACKET_PASTE_END));
+    }
+
+    #[test]
+    fn paste_keeps_cjk_and_multibyte_content_byte_exact() {
+        let encoded = encode_paste("日本語😀", true).expect("enabled mode 2004");
+        assert_eq!(
+            encoded,
+            [
+                BRACKET_PASTE_BEGIN,
+                "日本語😀".as_bytes(),
+                BRACKET_PASTE_END
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn paste_is_gated_not_unbracketed_when_2004_is_off() {
+        // The gate holds even for content that would otherwise be pasteable;
+        // nothing ever reaches the PTY without the markers.
+        assert_eq!(
+            encode_paste("ls -la\n", false),
+            Err(PasteReject::Unbracketed)
+        );
+        assert_eq!(encode_paste("", false), Err(PasteReject::Unbracketed));
+    }
+
+    #[test]
+    fn empty_and_oversized_pastes_are_gated_even_with_2004_on() {
+        assert_eq!(encode_paste("", true), Err(PasteReject::Empty));
+        let oversized = "a".repeat(MAX_PASTE_BYTES + 1);
+        assert_eq!(encode_paste(&oversized, true), Err(PasteReject::Oversized));
+        // Exactly at the bound the paste is accepted.
+        let at_bound = "a".repeat(MAX_PASTE_BYTES);
+        let encoded = encode_paste(&at_bound, true).expect("bound-sized paste fits");
+        assert_eq!(
+            encoded.len(),
+            BRACKET_PASTE_BEGIN.len() + MAX_PASTE_BYTES + BRACKET_PASTE_END.len()
+        );
+    }
+
+    /// Manual system-clipboard round trip: `cargo test -- --ignored`.
+    /// Kept ignored so automated runs never mutate the user's clipboard.
+    #[test]
+    #[ignore = "touches the real macOS system clipboard"]
+    fn system_clipboard_round_trips_user_text() {
+        let clipboard = SystemClipboard::new();
+        let payload = "noren clipboard round trip 日本";
+        clipboard.write(payload).expect("pbcopy writes");
+        assert_eq!(clipboard.read().as_deref(), Ok(payload));
+    }
+}

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -8,9 +8,20 @@
 //! types stay inside `noren-app` and never cross into the PTY or terminal
 //! crates.
 
+mod clipboard;
 mod input;
 
+pub use clipboard::{
+    BRACKET_PASTE_BEGIN, BRACKET_PASTE_END, ClipboardError, PasteReject, SystemClipboard,
+};
 pub use input::{CursorKeyMode, FunctionKey, InputMode, KeypadInput, KeypadKey, KeypadMode};
+
+/// Encode a user-initiated paste for the PTY, gated on DEC private mode 2004.
+///
+/// Re-exported so both the library tests and the binary share one policy:
+/// bracketed when the application enabled mode 2004, refused (never sent
+/// unbracketed) when it is off or unavailable.
+pub use clipboard::encode_paste;
 
 use std::fmt;
 use std::time::Duration;

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -4,17 +4,18 @@ mod renderer;
 
 use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
-    KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, Resize,
+    KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_ROWS, Modifiers,
+    PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH, PasteReject, Resize,
+    SystemClipboard, encode_paste,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
-use noren_terminal::{TerminalEngine, TerminalState};
+use noren_terminal::{Cell, GridPoint, Selection, SelectionMode, TerminalEngine, TerminalState};
 use renderer::{RenderOutcome, Renderer};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
-use winit::dpi::PhysicalSize;
-use winit::event::{ElementState, KeyEvent, WindowEvent};
+use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::event::{ElementState, KeyEvent, MouseButton, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key as WinitKey, KeyCode, ModifiersState, NamedKey, PhysicalKey};
 use winit::window::{Window, WindowId};
@@ -34,6 +35,13 @@ struct NorenApp {
     status: &'static str,
     show_status: bool,
     redraw_needed: bool,
+    // User-initiated selection state. The renderer does not highlight it yet;
+    // copy still extracts it. Any PTY output or resize invalidates it because
+    // grid coordinates only address the content they were captured on.
+    selection: Option<Selection>,
+    drag_origin: Option<GridPoint>,
+    drag_mode: SelectionMode,
+    cursor_position: Option<PhysicalPosition<f64>>,
 }
 
 impl Default for NorenApp {
@@ -49,6 +57,10 @@ impl Default for NorenApp {
             status: "Noren PoC starting",
             show_status: true,
             redraw_needed: true,
+            selection: None,
+            drag_origin: None,
+            drag_mode: SelectionMode::Char,
+            cursor_position: None,
         }
     }
 }
@@ -126,6 +138,9 @@ impl NorenApp {
     }
 
     fn handle_key(&mut self, event: &KeyEvent) {
+        if self.handle_clipboard_shortcut(event) {
+            return;
+        }
         let input_mode = self.current_input_mode();
         let encoded = if let Some(input) = translate_keypad_key(event) {
             KeyEncoder::encode_keypad_with(input.with_modifiers(self.modifiers), input_mode)
@@ -137,6 +152,192 @@ impl NorenApp {
             return;
         };
         self.send_input(&bytes);
+    }
+
+    /// User-initiated selection and clipboard shortcuts.
+    ///
+    /// Cmd+A selects the whole grid, Cmd+C copies the selection to the system
+    /// clipboard, and Cmd+V pastes the clipboard into the PTY — but only as a
+    /// bracketed paste when the application enabled DEC private mode 2004;
+    /// otherwise the paste is gated and reported, never sent unbracketed.
+    fn handle_clipboard_shortcut(&mut self, event: &KeyEvent) -> bool {
+        if event.state != ElementState::Pressed || event.repeat || !self.modifiers.is_super() {
+            return false;
+        }
+        let WinitKey::Character(text) = &event.logical_key else {
+            return false;
+        };
+        let mut characters = text.chars();
+        let Some(character) = characters.next() else {
+            return false;
+        };
+        if characters.next().is_some() {
+            return false;
+        }
+        match character {
+            'a' | 'A' => self.select_entire_grid(),
+            'c' | 'C' => self.copy_selection(),
+            'v' | 'V' => self.paste_clipboard(),
+            _ => return false,
+        }
+        true
+    }
+
+    fn select_entire_grid(&mut self) {
+        if let Some(terminal) = &self.terminal {
+            self.selection = Some(Selection::entire_grid(terminal));
+        }
+    }
+
+    fn copy_selection(&mut self) {
+        let Some(terminal) = &self.terminal else {
+            return;
+        };
+        let Some(selection) = &self.selection else {
+            return;
+        };
+        if !selection.is_valid(terminal) {
+            self.selection = None;
+            return;
+        }
+        let text = selection.extract(terminal);
+        if text.is_empty() {
+            return;
+        }
+        if SystemClipboard::new().write(&text).is_err() {
+            self.status = "Noren clipboard copy failed";
+            self.show_status = true;
+            self.redraw_needed = true;
+        }
+    }
+
+    fn paste_clipboard(&mut self) {
+        let text = match SystemClipboard::new().read() {
+            Ok(text) => text,
+            Err(_) => {
+                self.status = "Noren clipboard paste failed";
+                self.show_status = true;
+                self.redraw_needed = true;
+                return;
+            }
+        };
+        match self.paste_bytes(&text) {
+            Ok(bytes) => self.send_input(&bytes),
+            Err(reject @ (PasteReject::Unbracketed | PasteReject::Oversized)) => {
+                self.show_paste_gate(reject);
+            }
+            Err(PasteReject::Empty) => {}
+        }
+    }
+
+    /// Encode a user-initiated paste against the live terminal mode.
+    ///
+    /// Returns the bracketed bytes when DEC private mode 2004 is enabled, and a
+    /// typed [`PasteReject`] otherwise. Never yields unbracketed bytes: when the
+    /// mode is off, or the terminal state is unavailable, the paste is gated.
+    fn paste_bytes(&self, text: &str) -> Result<Vec<u8>, PasteReject> {
+        let bracketed = self
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal.modes().is_bracketed_paste_enabled());
+        encode_paste(text, bracketed)
+    }
+
+    /// Surface a gated paste visibly instead of sending nothing silently.
+    fn show_paste_gate(&mut self, reject: PasteReject) {
+        // Status is a &'static str, so map the typed reason to fixed text.
+        self.status = match reject {
+            PasteReject::Unbracketed => {
+                "Noren paste gated: application did not enable bracketed paste (mode 2004)"
+            }
+            PasteReject::Oversized => "Noren paste gated: clipboard text exceeds the paste bound",
+            PasteReject::Empty => "Noren paste gated: clipboard text is empty",
+        };
+        self.show_status = true;
+        self.redraw_needed = true;
+    }
+
+    fn handle_mouse_move(&mut self, position: PhysicalPosition<f64>) {
+        self.cursor_position = Some(position);
+        let Some(origin) = self.drag_origin else {
+            return;
+        };
+        let Some(point) = self.grid_point_at(position) else {
+            return;
+        };
+        if let Some(terminal) = &self.terminal {
+            self.selection = Some(Selection::new(terminal, self.drag_mode, origin, point));
+        }
+    }
+
+    fn handle_mouse_button(&mut self, state: ElementState, button: MouseButton) {
+        if button != MouseButton::Left {
+            return;
+        }
+        match state {
+            ElementState::Pressed => {
+                let Some(position) = self.cursor_position else {
+                    return;
+                };
+                let Some(point) = self.grid_point_at(position) else {
+                    return;
+                };
+                let Some(terminal) = &self.terminal else {
+                    return;
+                };
+                // Option-drag selects word-wise, Cmd-drag line-wise.
+                let mode = if self.modifiers.is_alt() {
+                    SelectionMode::Word
+                } else if self.modifiers.is_super() {
+                    SelectionMode::Line
+                } else {
+                    SelectionMode::Char
+                };
+                self.drag_mode = mode;
+                self.drag_origin = Some(point);
+                self.selection = Some(Selection::new(terminal, mode, point, point));
+            }
+            ElementState::Released => {
+                self.drag_origin = None;
+            }
+        }
+    }
+
+    /// Map a window pixel position to grid coordinates, mirroring the
+    /// renderer's bottom-aligned layout of the trimmed visible lines and the
+    /// optional status row. Returns `None` outside the rendered content.
+    fn grid_point_at(&self, position: PhysicalPosition<f64>) -> Option<GridPoint> {
+        if position.x < 0.0 || position.y < 0.0 {
+            return None;
+        }
+        let terminal = self.terminal.as_ref()?;
+        let window = self.window.as_ref()?;
+        let physical = window.inner_size();
+        let visible_rows = usize::try_from(physical.height / POC_CELL_HEIGHT)
+            .unwrap_or(0)
+            .clamp(1, usize::from(MAX_RENDER_ROWS));
+        let content_rows = visible_content_rows(terminal);
+        let total_lines = content_rows + usize::from(self.show_status);
+        let displayed = total_lines.min(visible_rows);
+        let top_blank_rows = visible_rows - displayed;
+        let first_line = total_lines - displayed;
+        let row = pixel_row_index(position.y, POC_CELL_HEIGHT)?;
+        if row < top_blank_rows {
+            return None;
+        }
+        let line_index = first_line + (row - top_blank_rows);
+        if line_index >= content_rows {
+            return None;
+        }
+        let (rows, cols) = terminal.size();
+        if line_index >= usize::from(rows) {
+            return None;
+        }
+        let column = pixel_row_index(position.x, POC_CELL_WIDTH)?.min(usize::from(cols) - 1);
+        Some(GridPoint::new(
+            terminal.scrollback_len() + line_index,
+            column,
+        ))
     }
 
     fn send_input(&mut self, bytes: &[u8]) {
@@ -185,6 +386,9 @@ impl NorenApp {
         let Some(grid) = self.pending_grid.take() else {
             return;
         };
+        // Resize re-addresses the grid, so captured coordinates expire.
+        self.selection = None;
+        self.drag_origin = None;
         if let Some(terminal) = &mut self.terminal {
             if terminal.resize(grid.rows(), grid.cols()).is_err() {
                 self.status = "Noren terminal resize failed";
@@ -203,6 +407,7 @@ impl NorenApp {
     fn drain_pty(&mut self) {
         let mut remaining = PARSE_BUDGET_BYTES_PER_TURN;
         let mut terminal_status = None;
+        let mut output_consumed = false;
         while remaining >= noren_pty::READ_CHUNK_BYTES {
             let event = match self.pty.as_ref().map(PtySession::try_recv) {
                 Some(Ok(Some(event))) => event,
@@ -224,6 +429,7 @@ impl NorenApp {
                     if let Some(terminal) = &mut self.terminal {
                         terminal.feed_bytes(&bytes);
                     }
+                    output_consumed = true;
                     self.redraw_needed = true;
                 }
                 PtyEvent::Eof => {
@@ -243,6 +449,13 @@ impl NorenApp {
                     break;
                 }
             }
+        }
+        // Any output may have moved or overwritten the selected content; the
+        // selection model treats every state change as expiration, so the app
+        // drops captured coordinates rather than risk stale text.
+        if output_consumed {
+            self.selection = None;
+            self.drag_origin = None;
         }
         if let Some(status) = terminal_status {
             self.finish_pty(status);
@@ -318,6 +531,10 @@ impl ApplicationHandler for NorenApp {
             WindowEvent::CloseRequested => self.close(event_loop),
             WindowEvent::Resized(physical) => self.handle_resize(physical),
             WindowEvent::ModifiersChanged(modifiers) => self.update_modifiers(modifiers.state()),
+            WindowEvent::CursorMoved { position, .. } => self.handle_mouse_move(position),
+            WindowEvent::MouseInput { state, button, .. } => {
+                self.handle_mouse_button(state, button)
+            }
             WindowEvent::KeyboardInput { event, .. } => self.handle_key(&event),
             WindowEvent::Ime(_) => {
                 let _ = KeyDropReason::ImeOrDeadKey;
@@ -348,6 +565,34 @@ impl ApplicationHandler for NorenApp {
 
 fn pty_size(grid: GridSize) -> Result<PtySize, noren_pty::PtyError> {
     PtySize::from_raw(grid.rows(), grid.cols()).ok_or(noren_pty::PtyError::InvalidSize)
+}
+
+/// Index of the cell row containing a non-negative pixel coordinate, or
+/// `None` when the coordinate is not finite. The cast saturates on overflow,
+/// and downstream clamping keeps any saturated index inside the grid.
+fn pixel_row_index(pixel: f64, cell_size: u32) -> Option<usize> {
+    if !pixel.is_finite() {
+        return None;
+    }
+    Some((pixel / f64::from(cell_size)) as usize)
+}
+
+/// Number of visible grid rows the renderer will draw: rows up to and
+/// including the last row with non-blank content. Mirrors the snapshot
+/// `lines` trimming without cloning the grid (or the scrollback), so mouse
+/// mapping never pays for an immutable snapshot per event.
+fn visible_content_rows(terminal: &TerminalState) -> usize {
+    let screen = terminal.screen();
+    let cols = usize::from(screen.cols());
+    let cells = screen.cells();
+    (0..usize::from(screen.rows()))
+        .filter(|row| {
+            !cells[row * cols..(row + 1) * cols]
+                .iter()
+                .all(Cell::is_blank)
+        })
+        .next_back()
+        .map_or(0, |row| row + 1)
 }
 
 fn translate_key(event: &KeyEvent, modifiers: Modifiers) -> Result<KeyInput, KeyDropReason> {
@@ -555,6 +800,94 @@ mod tests {
                 Err(KeyDropReason::UnsupportedKey)
             );
         }
+    }
+
+    #[test]
+    fn pixel_row_index_truncates_and_rejects_non_finite() {
+        assert_eq!(pixel_row_index(0.0, 20), Some(0));
+        assert_eq!(pixel_row_index(39.0, 20), Some(1));
+        assert_eq!(pixel_row_index(40.0, 20), Some(2));
+        assert_eq!(pixel_row_index(f64::NAN, 20), None);
+        assert_eq!(pixel_row_index(f64::INFINITY, 20), None);
+    }
+
+    #[test]
+    fn visible_content_rows_counts_through_the_last_non_blank_row() {
+        let mut terminal = TerminalState::new(4, 8).expect("valid terminal");
+        terminal.feed_bytes(b"ab\r\ncd");
+        assert_eq!(visible_content_rows(&terminal), 2);
+
+        terminal.feed_bytes(b"\r\n\r\nef");
+        assert_eq!(visible_content_rows(&terminal), 4);
+    }
+
+    #[test]
+    fn paste_is_gated_in_the_app_without_a_terminal() {
+        // With no terminal state, mode 2004 is unavailable, so encode_paste
+        // gates rather than emitting an unbracketed paste.
+        assert_eq!(encode_paste("hello", false), Err(PasteReject::Unbracketed));
+    }
+
+    #[test]
+    fn paste_is_bracketed_when_mode_2004_is_enabled() {
+        let mut app = NorenApp::default();
+        let mut terminal = TerminalState::new(2, 4).expect("valid terminal");
+        terminal.feed_bytes(b"\x1b[?2004h");
+        app.terminal = Some(terminal);
+
+        assert_eq!(
+            app.paste_bytes("ls -la"),
+            Ok(b"\x1b[200~ls -la\x1b[201~".to_vec())
+        );
+    }
+
+    #[test]
+    fn paste_is_gated_when_mode_2004_is_off_or_terminal_unavailable() {
+        let mut app = NorenApp::default();
+        // No terminal state at all: bracketed paste cannot be enabled.
+        assert_eq!(app.paste_bytes("ls"), Err(PasteReject::Unbracketed));
+
+        // Terminal state present but the application never enabled 2004.
+        let terminal = TerminalState::new(2, 4).expect("valid terminal");
+        app.terminal = Some(terminal);
+        assert_eq!(app.paste_bytes("ls"), Err(PasteReject::Unbracketed));
+    }
+
+    #[test]
+    fn copy_selection_drops_an_expired_selection_without_copying() {
+        let mut app = NorenApp::default();
+        let mut terminal = TerminalState::new(2, 6).expect("valid terminal");
+        terminal.feed_bytes(b"hello");
+        app.selection = Some(Selection::new(
+            &terminal,
+            SelectionMode::Char,
+            GridPoint::new(0, 0),
+            GridPoint::new(0, 4),
+        ));
+        terminal.resize(3, 8).expect("valid resize");
+        app.terminal = Some(terminal);
+
+        // The resize expired the selection's stamp; copy clears the selection
+        // and returns before any system clipboard access.
+        app.copy_selection();
+        assert!(app.selection.is_none());
+    }
+
+    #[test]
+    fn select_entire_grid_captures_all_visible_content() {
+        let mut app = NorenApp::default();
+        let mut terminal = TerminalState::new(3, 6).expect("valid terminal");
+        terminal.feed_bytes(b"abc\r\ndef");
+        app.terminal = Some(terminal);
+
+        app.select_entire_grid();
+        let terminal = app.terminal.as_ref().expect("terminal present");
+        assert_eq!(
+            app.selection
+                .as_ref()
+                .map(|selection| selection.extract(terminal)),
+            Some("abc\ndef".to_owned())
+        );
     }
 
     #[test]

--- a/crates/noren-terminal/src/lib.rs
+++ b/crates/noren-terminal/src/lib.rs
@@ -12,12 +12,14 @@
 mod attributes;
 mod parser;
 mod search;
+mod selection;
 mod state;
 
 pub use attributes::{AnsiColor, CellAttributes, Color};
 pub use search::{
     CaseSensitivity, Search, SearchDirection, SearchIter, SearchMatch, SearchPosition,
 };
+pub use selection::{GridPoint, Selection, SelectionGrid, SelectionMode};
 pub use state::{
     Cell, Cursor, CursorMove, MAX_COMBINING_MARKS_PER_CELL, MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES,
     ScreenBuffer, ScrollRegion, TerminalError, TerminalModes, TerminalSnapshot, TerminalState,

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -113,6 +113,7 @@ pub(crate) enum EraseMode {
 pub(crate) enum PrivateMode {
     AlternateScreen,
     ApplicationCursorKey,
+    BracketedPaste,
 }
 
 /// Incremental UTF-8 decoder for printable text in the Ground state.
@@ -495,6 +496,7 @@ impl Csi {
         let mode = match self.params[0] {
             1 => PrivateMode::ApplicationCursorKey,
             1049 => PrivateMode::AlternateScreen,
+            2004 => PrivateMode::BracketedPaste,
             _ => return None,
         };
         match final_byte {
@@ -683,8 +685,25 @@ mod tests {
 
     #[test]
     fn swallows_unsupported_csi_and_osc_payloads() {
-        assert_eq!(actions(b"a\x1b[?2004hb\x1b]0;secret\x07c"), actions(b"abc"));
+        assert_eq!(actions(b"a\x1b[?9999hb\x1b]0;secret\x07c"), actions(b"abc"));
         assert!(actions(b"\x1b[?2A\x1b[1:2A").is_empty());
+    }
+
+    #[test]
+    fn bracketed_paste_mode_2004_is_tracked_as_a_private_mode() {
+        assert_eq!(
+            actions(b"\x1b[?2004h\x1b[?2004l"),
+            [
+                Action::SetPrivateMode {
+                    mode: PrivateMode::BracketedPaste,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::BracketedPaste,
+                    enabled: false,
+                },
+            ]
+        );
     }
 
     #[test]
@@ -780,6 +799,6 @@ mod tests {
                 },
             ]
         );
-        assert!(actions(b"\x1b[?2004h\x1b[?1049;1h\x1b[>1049h").is_empty());
+        assert!(actions(b"\x1b[?9999h\x1b[?1049;1h\x1b[>1049h").is_empty());
     }
 }

--- a/crates/noren-terminal/src/selection.rs
+++ b/crates/noren-terminal/src/selection.rs
@@ -1,0 +1,491 @@
+//! Renderer-independent grid selection over the visible screen and scrollback.
+//!
+//! A [`Selection`] is a normalized, inclusive range over the terminal's rows:
+//! retained scrollback rows first (oldest eviction order), then the visible
+//! screen rows. It supports three granularities ([`SelectionMode`]):
+//! character-wise, word-wise, and line-wise. The model is renderer- and
+//! app-independent: capture and extraction take any [`SelectionGrid`], which
+//! [`TerminalState`] and [`TerminalSnapshot`] both implement.
+//!
+//! # Wide characters
+//!
+//! A selection never splits a wide character. Endpoints that land on a
+//! continuation cell snap onto the lead cell of the character that owns it, so
+//! the whole character is included; extraction emits lead cells only and skips
+//! continuation cells rather than emitting empty halves. CJK copy is therefore
+//! byte-exact or absent, never corrupted.
+//!
+//! # Rows keep their own widths
+//!
+//! Scrollback rows are not reflowed by resize; each keeps the width it had
+//! when it scrolled off. Column coordinates are clamped per row, so a
+//! selection may span scrollback rows and visible rows of different widths
+//! and still yield contiguous text.
+//!
+//! # Expiration: resize, scroll, and screen switches
+//!
+//! A selection is only meaningful against the exact grid it was captured on.
+//! Every [`Selection`] records a [`GridStamp`] (rows, cols, scrollback length,
+//! active screen); [`Selection::extract`] checks the stamp first and returns
+//! an empty string on mismatch, so a stale selection can never silently yield
+//! wrong text. Concretely:
+//!
+//! - **Resize** changes rows/cols, so the stamp mismatches and extraction
+//!   yields `""`. Cell coordinates do not survive a reflow-free resize; the
+//!   selection is invalidated rather than re-anchored.
+//! - **Scrolling** that pushes lines off the top of the primary screen changes
+//!   the scrollback length, so the stamp mismatches and the selection is
+//!   invalidated. Content shifts that keep the stamp identical (in-place
+//!   overwrites, `ESC M` scroll-down at the top) are NOT detected by the
+//!   stamp; the selection owner must invalidate on every terminal state change
+//!   (the app clears its selection on any PTY output and any resize).
+//! - **Alternate screen**: while DEC 1049 selects the alternate screen the
+//!   stamp mismatches and extraction yields `""`. Returning to the primary
+//!   screen restores the stamp because 1049 leaves primary content untouched,
+//!   so a pre-alt selection becomes extractable again; in practice the owner
+//!   has already invalidated it when the 1049 bytes arrived as output.
+//!
+//! # Extraction shape
+//!
+//! Per row, lead-cell text is concatenated (continuations skipped) and
+//! trailing blank columns are trimmed, matching the snapshot `lines` policy.
+//! Rows are joined with `\n`; trailing blank-only rows are dropped and no
+//! trailing newline is emitted. Character selections spanning several rows
+//! include the rest of the first row and the start of the last row, like
+//! classic terminal selection. A selection over only blank cells yields `""`.
+
+use crate::{Cell, ScreenBuffer, TerminalSnapshot, TerminalState};
+
+/// How a selection expands its endpoints when captured.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectionMode {
+    /// Endpoints are snapped to character boundaries only.
+    Char,
+    /// Each endpoint expands to the full word containing it. A word is a
+    /// maximal run of cells whose first character is alphanumeric or `_`;
+    /// every other cell (blank or punctuation) separates words. Expansion
+    /// stops at row edges and never crosses rows.
+    Word,
+    /// Every covered row is taken whole, from its first to its last cell.
+    Line,
+}
+
+/// A grid coordinate addressed across scrollback and the visible screen.
+///
+/// `line` is absolute: retained scrollback rows come first in eviction order
+/// (oldest at line 0), followed by the visible rows. `column` is zero-based
+/// within that row's own width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GridPoint {
+    line: usize,
+    column: usize,
+}
+
+impl GridPoint {
+    /// Create a grid coordinate.
+    #[must_use]
+    pub const fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+
+    /// Absolute line index (scrollback first, then visible rows).
+    #[must_use]
+    pub const fn line(self) -> usize {
+        self.line
+    }
+
+    /// Zero-based column within the line.
+    #[must_use]
+    pub const fn column(self) -> usize {
+        self.column
+    }
+}
+
+/// Immutable row-oriented grid view a [`Selection`] can be captured from and
+/// extracted against.
+///
+/// Implemented by [`TerminalState`] (borrowed rows, no cloning) and
+/// [`TerminalSnapshot`] (cloned rows). Selections never mutate the grid.
+pub trait SelectionGrid {
+    /// Visible row count.
+    fn rows(&self) -> u16;
+
+    /// Visible column count.
+    fn cols(&self) -> u16;
+
+    /// Number of retained scrollback rows.
+    fn scrollback_len(&self) -> usize;
+
+    /// Whether the alternate screen is currently selected.
+    fn is_alternate_screen_active(&self) -> bool;
+
+    /// Cells of one absolute line (scrollback first, then visible rows),
+    /// each row at its own width.
+    fn row_cells(&self, line: usize) -> Option<&[Cell]>;
+
+    /// Total addressable lines: scrollback plus visible rows.
+    fn total_lines(&self) -> usize {
+        self.scrollback_len() + usize::from(self.rows())
+    }
+}
+
+fn visible_row_cells(screen: &ScreenBuffer, row: usize) -> Option<&[Cell]> {
+    let rows = usize::from(screen.rows());
+    let cols = usize::from(screen.cols());
+    if row >= rows {
+        return None;
+    }
+    let cells = screen.cells();
+    Some(&cells[row * cols..(row + 1) * cols])
+}
+
+impl SelectionGrid for TerminalState {
+    fn rows(&self) -> u16 {
+        self.size().0
+    }
+
+    fn cols(&self) -> u16 {
+        self.size().1
+    }
+
+    fn scrollback_len(&self) -> usize {
+        TerminalState::scrollback_len(self)
+    }
+
+    fn is_alternate_screen_active(&self) -> bool {
+        self.modes().is_alternate_screen_active()
+    }
+
+    fn row_cells(&self, line: usize) -> Option<&[Cell]> {
+        if let Some(row) = self.scrollback_row(line) {
+            return Some(row);
+        }
+        visible_row_cells(self.screen(), line - TerminalState::scrollback_len(self))
+    }
+}
+
+impl SelectionGrid for TerminalSnapshot {
+    fn rows(&self) -> u16 {
+        TerminalSnapshot::rows(self)
+    }
+
+    fn cols(&self) -> u16 {
+        TerminalSnapshot::cols(self)
+    }
+
+    fn scrollback_len(&self) -> usize {
+        self.scrollback().len()
+    }
+
+    fn is_alternate_screen_active(&self) -> bool {
+        self.modes().is_alternate_screen_active()
+    }
+
+    fn row_cells(&self, line: usize) -> Option<&[Cell]> {
+        let scrollback = self.scrollback();
+        if line < scrollback.len() {
+            return Some(&scrollback[line]);
+        }
+        visible_row_cells(self.screen(), line - scrollback.len())
+    }
+}
+
+/// Structural identity of the grid at capture time.
+///
+/// Any mismatch means the selection's coordinates no longer address the same
+/// content, so extraction refuses to run instead of yielding wrong text. See
+/// the module docs for per-event behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GridStamp {
+    rows: u16,
+    cols: u16,
+    scrollback_len: usize,
+    alternate_screen: bool,
+}
+
+impl GridStamp {
+    fn capture(grid: &impl SelectionGrid) -> Self {
+        Self {
+            rows: grid.rows(),
+            cols: grid.cols(),
+            scrollback_len: grid.scrollback_len(),
+            alternate_screen: grid.is_alternate_screen_active(),
+        }
+    }
+
+    fn matches(&self, grid: &impl SelectionGrid) -> bool {
+        self.rows == grid.rows()
+            && self.cols == grid.cols()
+            && self.scrollback_len == grid.scrollback_len()
+            && self.alternate_screen == grid.is_alternate_screen_active()
+    }
+}
+
+/// A normalized, inclusive grid range captured from a [`SelectionGrid`].
+///
+/// Endpoints are clamped into the grid, snapped off continuation cells, and
+/// ordered so [`Selection::start`] precedes [`Selection::end`] in reading
+/// order. Word and line granularities expand the endpoints at capture time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Selection {
+    mode: SelectionMode,
+    start: GridPoint,
+    end: GridPoint,
+    stamp: GridStamp,
+}
+
+impl Selection {
+    /// Capture a selection between two pointer positions.
+    ///
+    /// Out-of-bounds points clamp to the grid; points on a wide character's
+    /// continuation round to the character's lead so extraction never splits
+    /// the character. The grid's dimensions, scrollback length, and active
+    /// screen are recorded in a stamp checked by [`Selection::extract`].
+    pub fn new(
+        grid: &impl SelectionGrid,
+        mode: SelectionMode,
+        anchor: GridPoint,
+        focus: GridPoint,
+    ) -> Self {
+        let stamp = GridStamp::capture(grid);
+        let mut anchor = clamp_point(grid, anchor);
+        let mut focus = clamp_point(grid, focus);
+        anchor.column = snap_off_continuation(grid, anchor);
+        focus.column = snap_off_continuation(grid, focus);
+        if (focus.line, focus.column) < (anchor.line, anchor.column) {
+            std::mem::swap(&mut anchor, &mut focus);
+        }
+        let (start, end) = match mode {
+            SelectionMode::Char => (anchor, focus),
+            SelectionMode::Word => {
+                let (word_start, _) = word_bounds(grid, anchor);
+                let (_, word_end) = word_bounds(grid, focus);
+                (
+                    GridPoint::new(anchor.line, word_start),
+                    GridPoint::new(focus.line, word_end),
+                )
+            }
+            SelectionMode::Line => (
+                GridPoint::new(anchor.line, 0),
+                GridPoint::new(focus.line, last_lead_column(grid, focus.line)),
+            ),
+        };
+        Self {
+            mode,
+            start,
+            end,
+            stamp,
+        }
+    }
+
+    /// Select every cell of the grid: oldest scrollback row through the last
+    /// visible row, at the current dimensions.
+    pub fn entire_grid(grid: &impl SelectionGrid) -> Self {
+        let last_line = grid.total_lines().saturating_sub(1);
+        Self::new(
+            grid,
+            SelectionMode::Line,
+            GridPoint::new(0, 0),
+            GridPoint::new(last_line, usize::MAX),
+        )
+    }
+
+    /// Granularity applied when this selection was captured.
+    #[must_use]
+    pub const fn mode(&self) -> SelectionMode {
+        self.mode
+    }
+
+    /// Normalized first point in reading order, on a character boundary.
+    #[must_use]
+    pub const fn start(&self) -> GridPoint {
+        self.start
+    }
+
+    /// Normalized inclusive last point in reading order, on a character
+    /// boundary.
+    #[must_use]
+    pub const fn end(&self) -> GridPoint {
+        self.end
+    }
+
+    /// Whether the grid still matches the stamp captured with this selection.
+    ///
+    /// `false` means coordinates no longer address the captured content and
+    /// [`Selection::extract`] yields an empty string.
+    #[must_use]
+    pub fn is_valid(&self, grid: &impl SelectionGrid) -> bool {
+        self.stamp.matches(grid)
+    }
+
+    /// Extract the selected text, or `""` when the selection has expired.
+    ///
+    /// Never splits a wide character: continuation cells are skipped and
+    /// endpoints were rounded to character boundaries at capture time. Never
+    /// panics: all coordinates stay within the captured stamp's grid.
+    pub fn extract(&self, grid: &impl SelectionGrid) -> String {
+        if !self.is_valid(grid) {
+            return String::new();
+        }
+        let mut lines: Vec<String> = Vec::new();
+        for line in self.start.line..=self.end.line {
+            let Some(cells) = grid.row_cells(line) else {
+                continue;
+            };
+            let from = if line == self.start.line {
+                self.start.column
+            } else {
+                0
+            };
+            let to = if line == self.end.line {
+                self.end.column
+            } else {
+                usize::MAX
+            };
+            lines.push(extract_row(cells, from, to));
+        }
+        while lines.last().is_some_and(String::is_empty) {
+            lines.pop();
+        }
+        lines.join("\n")
+    }
+}
+
+fn extract_row(cells: &[Cell], from: usize, to: usize) -> String {
+    let mut line = String::new();
+    for (column, cell) in cells.iter().enumerate() {
+        if column < from || column > to {
+            continue;
+        }
+        // Continuation cells render as nothing and never own text; skipping
+        // them (instead of emitting their empty text) is what keeps wide
+        // characters whole even if an endpoint were mis-snapped.
+        if cell.is_continuation() {
+            continue;
+        }
+        line.push_str(cell.text());
+    }
+    while line.ends_with(' ') {
+        line.pop();
+    }
+    line
+}
+
+fn clamp_point(grid: &impl SelectionGrid, point: GridPoint) -> GridPoint {
+    let last_line = grid.total_lines().saturating_sub(1);
+    let line = point.line.min(last_line);
+    let width = grid.row_cells(line).map(<[Cell]>::len).unwrap_or(1);
+    let column = point.column.min(width.saturating_sub(1));
+    GridPoint::new(line, column)
+}
+
+fn snap_off_continuation(grid: &impl SelectionGrid, point: GridPoint) -> usize {
+    let Some(cells) = grid.row_cells(point.line) else {
+        return point.column;
+    };
+    let mut column = point.column;
+    // The grid invariant pairs every continuation directly with its lead, so
+    // stepping back at most once suffices; the loop keeps this defensive.
+    while column > 0 && cells.get(column).is_some_and(Cell::is_continuation) {
+        column -= 1;
+    }
+    column
+}
+
+fn head_cells(cells: &[Cell]) -> Vec<(usize, &Cell)> {
+    cells
+        .iter()
+        .enumerate()
+        .filter(|(_, cell)| !cell.is_continuation())
+        .collect()
+}
+
+fn is_word_cell(cell: &Cell) -> bool {
+    cell.text()
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_alphanumeric() || ch == '_')
+}
+
+/// Bounds of the word containing `point`, as `(lead column of first word
+/// cell, lead column of last word cell)`. A non-word cell selects itself.
+fn word_bounds(grid: &impl SelectionGrid, point: GridPoint) -> (usize, usize) {
+    let Some(cells) = grid.row_cells(point.line) else {
+        return (point.column, point.column);
+    };
+    let heads = head_cells(cells);
+    let Some(index) = heads
+        .iter()
+        .rposition(|(column, _)| *column <= point.column)
+    else {
+        return (point.column, point.column);
+    };
+    if !is_word_cell(heads[index].1) {
+        return (heads[index].0, heads[index].0);
+    }
+    let mut low = index;
+    let mut high = index;
+    while low > 0 && is_word_cell(heads[low - 1].1) {
+        low -= 1;
+    }
+    while high + 1 < heads.len() && is_word_cell(heads[high + 1].1) {
+        high += 1;
+    }
+    (heads[low].0, heads[high].0)
+}
+
+fn last_lead_column(grid: &impl SelectionGrid, line: usize) -> usize {
+    let Some(cells) = grid.row_cells(line) else {
+        return 0;
+    };
+    let mut column = cells.len().saturating_sub(1);
+    while column > 0 && cells[column].is_continuation() {
+        column -= 1;
+    }
+    column
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid(rows: u16, cols: u16, bytes: &[u8]) -> TerminalState {
+        let mut state = TerminalState::new(rows, cols).expect("valid test terminal");
+        state.feed_bytes(bytes);
+        state
+    }
+
+    #[test]
+    fn char_selection_normalizes_reversed_endpoints() {
+        let state = grid(1, 6, b"abc");
+        let forward = Selection::new(
+            &state,
+            SelectionMode::Char,
+            GridPoint::new(0, 0),
+            GridPoint::new(0, 2),
+        );
+        let reversed = Selection::new(
+            &state,
+            SelectionMode::Char,
+            GridPoint::new(0, 2),
+            GridPoint::new(0, 0),
+        );
+        assert_eq!(forward, reversed);
+        assert_eq!(forward.start(), GridPoint::new(0, 0));
+        assert_eq!(forward.end(), GridPoint::new(0, 2));
+        assert_eq!(forward.extract(&state), "abc");
+    }
+
+    #[test]
+    fn out_of_bounds_points_clamp_instead_of_panicking() {
+        let state = grid(2, 3, b"abc\r\ndef");
+        let selection = Selection::new(
+            &state,
+            SelectionMode::Char,
+            GridPoint::new(usize::MAX, usize::MAX),
+            GridPoint::new(usize::MAX, usize::MAX),
+        );
+        assert_eq!(selection.start(), GridPoint::new(1, 2));
+        assert_eq!(selection.extract(&state), "f");
+    }
+}

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -260,6 +260,7 @@ pub struct TerminalModes {
     alternate_screen: bool,
     application_cursor_key: bool,
     application_keypad: bool,
+    bracketed_paste: bool,
 }
 
 impl TerminalModes {
@@ -279,6 +280,16 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_application_keypad_mode(self) -> bool {
         self.application_keypad
+    }
+
+    /// Whether DEC private mode 2004 (bracketed paste) is enabled.
+    ///
+    /// When enabled, the application expects user-initiated paste text wrapped
+    /// in `CSI 200 ~` / `CSI 201 ~` markers; when disabled, paste must be
+    /// gated rather than silently sent unbracketed.
+    #[must_use]
+    pub const fn is_bracketed_paste_enabled(self) -> bool {
+        self.bracketed_paste
     }
 }
 
@@ -741,6 +752,16 @@ impl TerminalState {
         self.scrollback.len()
     }
 
+    /// Borrow one retained scrollback row by eviction order index (oldest
+    /// first), without cloning the buffer.
+    ///
+    /// Each row keeps the cells (and width) it had when it scrolled off; see
+    /// [`TerminalSnapshot::scrollback`] for the cloned ordered view.
+    #[must_use]
+    pub fn scrollback_row(&self, index: usize) -> Option<&[Cell]> {
+        self.scrollback.get(index).map(Vec::as_slice)
+    }
+
     /// Save the active screen's cursor position.
     pub fn save_cursor(&mut self) {
         self.active.save_cursor();
@@ -1194,6 +1215,9 @@ impl TerminalState {
             (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
             (PrivateMode::ApplicationCursorKey, enabled) => {
                 self.modes.application_cursor_key = enabled;
+            }
+            (PrivateMode::BracketedPaste, enabled) => {
+                self.modes.bracketed_paste = enabled;
             }
         }
     }

--- a/crates/noren-terminal/tests/bracketed_paste.rs
+++ b/crates/noren-terminal/tests/bracketed_paste.rs
@@ -1,0 +1,47 @@
+//! DEC private mode 2004 (bracketed paste) tracking in terminal state.
+//!
+//! Noren pastes are gated on this mode: paste text may only reach the PTY
+//! wrapped in `CSI 200 ~` / `CSI 201 ~` when the application has enabled
+//! 2004. Tracking therefore lives in the terminal state where every other
+//! input-affecting mode lives.
+
+use noren_terminal::TerminalState;
+
+#[test]
+fn bracketed_paste_defaults_to_disabled() {
+    let state = TerminalState::new(2, 4).expect("valid terminal");
+    assert!(!state.modes().is_bracketed_paste_enabled());
+    assert!(!state.snapshot().modes().is_bracketed_paste_enabled());
+}
+
+#[test]
+fn bracketed_paste_toggles_with_csi_question_2004_h_and_l() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?2004h");
+    assert!(state.modes().is_bracketed_paste_enabled());
+    assert!(state.snapshot().modes().is_bracketed_paste_enabled());
+
+    state.feed_bytes(b"\x1b[?2004l");
+    assert!(!state.modes().is_bracketed_paste_enabled());
+
+    // Repeated enabling is idempotent.
+    state.feed_bytes(b"\x1b[?2004h\x1b[?2004h");
+    assert!(state.modes().is_bracketed_paste_enabled());
+}
+
+#[test]
+fn bracketed_paste_is_independent_of_cursor_and_screen_modes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?2004h\x1b[?1h\x1b[?1049h");
+
+    let modes = state.modes();
+    assert!(modes.is_bracketed_paste_enabled());
+    assert!(modes.is_application_cursor_key_mode());
+    assert!(modes.is_alternate_screen_active());
+
+    // Leaving the alternate screen keeps the paste mode.
+    state.feed_bytes(b"\x1b[?1049l");
+    assert!(state.modes().is_bracketed_paste_enabled());
+    assert!(!state.modes().is_alternate_screen_active());
+}

--- a/crates/noren-terminal/tests/selection.rs
+++ b/crates/noren-terminal/tests/selection.rs
@@ -1,0 +1,415 @@
+//! Grid selection: granularities, wide-character boundary rounding,
+//! scrollback spans, and the documented expiration policy for resize,
+//! scroll, and alternate-screen switches.
+
+use noren_terminal::{GridPoint, Selection, SelectionGrid, SelectionMode, TerminalState};
+
+fn grid(rows: u16, cols: u16, bytes: &[u8]) -> TerminalState {
+    let mut state = TerminalState::new(rows, cols).expect("valid test terminal");
+    state.feed_bytes(bytes);
+    state
+}
+
+#[test]
+fn ascii_extraction_is_byte_exact() {
+    let state = grid(3, 12, b"hello world\r\nsecond line");
+    let row = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 10),
+    );
+    assert_eq!(row.extract(&state), "hello world");
+
+    let partial = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 6),
+        GridPoint::new(1, 5),
+    );
+    // First row keeps its tail, last row keeps its head, joined with LF.
+    assert_eq!(partial.extract(&state), "world\nsecond");
+
+    let single_cell = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(1, 3),
+        GridPoint::new(1, 3),
+    );
+    assert_eq!(single_cell.extract(&state), "o");
+}
+
+#[test]
+fn cjk_extraction_is_byte_exact() {
+    let state = grid(2, 8, "日本語".as_bytes());
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 5),
+    );
+    assert_eq!(selection.extract(&state), "日本語");
+
+    // Ending on the lead column of the second character excludes the third.
+    let two = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(two.extract(&state), "日本");
+}
+
+#[test]
+fn mixed_width_extraction_is_byte_exact() {
+    let state = grid(2, 10, "a😀日b".as_bytes());
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 5),
+    );
+    assert_eq!(selection.extract(&state), "a😀日b");
+}
+
+#[test]
+fn endpoints_on_a_continuation_round_to_the_whole_character() {
+    // Columns: 你=0(+1 continuation), 好=2(+3 continuation), 世=4(+5 continuation).
+    let state = grid(2, 8, "你好世".as_bytes());
+
+    // End landing on 好's continuation still extracts the whole character.
+    let end_on_continuation = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 3),
+    );
+    assert_eq!(end_on_continuation.end(), GridPoint::new(0, 2));
+    let text = end_on_continuation.extract(&state);
+    assert_eq!(text, "你好");
+    assert!(text.contains('好'), "the whole character, never a half");
+
+    // Start landing on 好's continuation rounds back onto its lead.
+    let start_on_continuation = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 3),
+        GridPoint::new(0, 5),
+    );
+    assert_eq!(start_on_continuation.start(), GridPoint::new(0, 2));
+    assert_eq!(start_on_continuation.extract(&state), "好世");
+
+    // Both endpoints on the continuation of one character select it whole.
+    let collapsed = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 1),
+    );
+    assert_eq!(collapsed.extract(&state), "你");
+}
+
+#[test]
+fn word_selection_expands_to_word_boundaries() {
+    let state = grid(2, 16, b"foo bar.baz_qux");
+
+    let bar = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 5),
+        GridPoint::new(0, 5),
+    );
+    assert_eq!(bar.start(), GridPoint::new(0, 4));
+    assert_eq!(bar.end(), GridPoint::new(0, 6));
+    assert_eq!(bar.extract(&state), "bar");
+
+    // `_` joins a word; `.` and blanks separate words.
+    let joined = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 9),
+        GridPoint::new(0, 9),
+    );
+    assert_eq!(joined.extract(&state), "baz_qux");
+
+    // A separator cell selects only itself.
+    let dot = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 7),
+        GridPoint::new(0, 7),
+    );
+    assert_eq!(dot.extract(&state), ".");
+
+    // Dragging across two words covers both and the gap between them.
+    let span = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 9),
+    );
+    assert_eq!(span.extract(&state), "foo bar.baz_qux");
+}
+
+#[test]
+fn word_selection_treats_cjk_cells_as_word_characters() {
+    let state = grid(2, 10, "日本語 abc".as_bytes());
+    let word = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 3),
+        GridPoint::new(0, 3),
+    );
+    assert_eq!(word.extract(&state), "日本語");
+
+    // Word expansion never crosses a row edge.
+    let across = grid(2, 8, b"abc\r\ndef");
+    let bounded = Selection::new(
+        &across,
+        SelectionMode::Word,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 1),
+    );
+    assert_eq!(bounded.extract(&across), "abc");
+}
+
+#[test]
+fn line_selection_takes_whole_rows_and_trims_trailing_blanks() {
+    // Row 0 carries trailing blanks; row 1 is short.
+    let state = grid(3, 8, b"AAA   \r\nBB");
+    let both = Selection::new(
+        &state,
+        SelectionMode::Line,
+        GridPoint::new(0, 5),
+        GridPoint::new(1, 0),
+    );
+    assert_eq!(both.start(), GridPoint::new(0, 0));
+    assert_eq!(both.end(), GridPoint::new(1, 7));
+    assert_eq!(both.extract(&state), "AAA\nBB");
+
+    let single = Selection::new(
+        &state,
+        SelectionMode::Line,
+        GridPoint::new(0, 3),
+        GridPoint::new(0, 3),
+    );
+    assert_eq!(single.extract(&state), "AAA");
+}
+
+#[test]
+fn selections_spanning_scrollback_and_visible_rows_are_contiguous() {
+    // Two-row grid; three CRLFs evict AAAA then BBBB into scrollback.
+    let state = grid(2, 4, b"AAAA\r\nBBBB\r\nCCCC\r\n");
+    assert_eq!(state.scrollback_len(), 2);
+
+    let span = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(3, 3),
+    );
+    assert_eq!(span.extract(&state), "AAAA\nBBBB\nCCCC");
+
+    // A span starting inside scrollback and ending mid-visible works too.
+    let tail = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(1, 2),
+        GridPoint::new(2, 1),
+    );
+    assert_eq!(tail.extract(&state), "BB\nCC");
+}
+
+#[test]
+fn scrollback_rows_keep_their_own_widths_after_resize() {
+    let mut state = grid(2, 4, b"AAAA\r\nBBBB\r\nCCCC\r\n");
+    state.resize(2, 8).expect("valid resize");
+
+    // Scrollback rows keep width 4; visible rows are width 8. A line-wise
+    // selection of the oldest scrollback row yields exactly its content.
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Line,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 0),
+    );
+    assert_eq!(selection.extract(&state), "AAAA");
+}
+
+#[test]
+fn resize_expires_a_selection() {
+    let mut state = grid(3, 8, b"hello");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 4),
+    );
+    assert_eq!(selection.extract(&state), "hello");
+
+    state.resize(4, 10).expect("valid resize");
+    assert!(!selection.is_valid(&state));
+    // Expired selections yield empty text, never stale or wrong text.
+    assert_eq!(selection.extract(&state), "");
+}
+
+#[test]
+fn scrolling_that_retains_lines_expires_a_selection() {
+    let mut state = grid(2, 4, b"AAAA\r\nBBBB");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(1, 0),
+        GridPoint::new(1, 3),
+    );
+    assert_eq!(selection.extract(&state), "BBBB");
+
+    // Evicting a top row changes the scrollback length, shifting every
+    // absolute line index; the selection must not silently re-address.
+    state.feed_bytes(b"\r\nCCCC");
+    assert_eq!(state.scrollback_len(), 1);
+    assert!(!selection.is_valid(&state));
+    assert_eq!(selection.extract(&state), "");
+}
+
+#[test]
+fn alternate_screen_makes_capture_time_selections_unavailable() {
+    let mut state = grid(3, 8, b"primary");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 6),
+    );
+    assert_eq!(selection.extract(&state), "primary");
+
+    // While the alternate screen is selected, extraction refuses.
+    state.feed_bytes(b"\x1b[?1049h");
+    assert!(state.modes().is_alternate_screen_active());
+    assert!(!selection.is_valid(&state));
+    assert_eq!(selection.extract(&state), "");
+
+    // Leaving restores the primary content untouched, so the stamp matches
+    // again (the app separately invalidates on the output that switched).
+    state.feed_bytes(b"\x1b[?1049l");
+    assert!(selection.is_valid(&state));
+    assert_eq!(selection.extract(&state), "primary");
+}
+
+#[test]
+fn empty_selections_yield_empty_text_without_panicking() {
+    let blank = grid(3, 4, b"");
+    let selection = Selection::new(
+        &blank,
+        SelectionMode::Char,
+        GridPoint::new(1, 1),
+        GridPoint::new(2, 2),
+    );
+    assert_eq!(selection.extract(&blank), "");
+
+    // Line-wise over blank-only rows is equally empty.
+    let lines = Selection::new(
+        &blank,
+        SelectionMode::Line,
+        GridPoint::new(0, 0),
+        GridPoint::new(2, 3),
+    );
+    assert_eq!(lines.extract(&blank), "");
+}
+
+#[test]
+fn whole_grid_selection_works_at_every_boundary() {
+    let state = grid(3, 4, b"ABCD\r\nEFGH\r\nIJKL");
+    let everything = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(2, 3),
+    );
+    assert_eq!(everything.extract(&state), "ABCD\nEFGH\nIJKL");
+
+    // The four corners individually.
+    for (point, expected) in [
+        (GridPoint::new(0, 0), "A"),
+        (GridPoint::new(0, 3), "D"),
+        (GridPoint::new(2, 0), "I"),
+        (GridPoint::new(2, 3), "L"),
+    ] {
+        let corner = Selection::new(&state, SelectionMode::Char, point, point);
+        assert_eq!(corner.extract(&state), expected, "corner {point:?}");
+    }
+
+    // Trailing blank rows inside the range do not leave dangling newlines.
+    let with_tail = grid(4, 4, b"ABCD");
+    let full = Selection::new(
+        &with_tail,
+        SelectionMode::Line,
+        GridPoint::new(0, 0),
+        GridPoint::new(3, 3),
+    );
+    assert_eq!(full.extract(&with_tail), "ABCD");
+}
+
+#[test]
+fn selection_works_through_a_snapshot_grid_as_well() {
+    let state = grid(2, 4, b"AAAA\r\nBBBB\r\nCCCC\r\n");
+    let snapshot = state.snapshot();
+    assert_eq!(snapshot.scrollback_len(), 2);
+
+    let span = Selection::new(
+        &snapshot,
+        SelectionMode::Line,
+        GridPoint::new(0, 0),
+        GridPoint::new(2, 0),
+    );
+    assert_eq!(span.extract(&snapshot), "AAAA\nBBBB\nCCCC");
+    assert!(!span.extract(&state).is_empty());
+
+    // A resize after capture expires the snapshot-based selection too.
+    let mut resized = state;
+    resized.resize(3, 6).expect("valid resize");
+    let resized_snapshot = resized.snapshot();
+    assert!(!span.is_valid(&resized_snapshot));
+    assert_eq!(span.extract(&resized_snapshot), "");
+}
+
+#[test]
+fn entire_grid_covers_scrollback_and_visible_rows_at_boundaries() {
+    let state = grid(2, 4, b"AAAA\r\nBBBB\r\nCCCC\r\n");
+    let everything = Selection::entire_grid(&state);
+    assert_eq!(everything.start(), GridPoint::new(0, 0));
+    assert_eq!(everything.extract(&state), "AAAA\nBBBB\nCCCC");
+
+    // A resized grid is covered by a freshly captured entire-grid selection.
+    let grown = grid(3, 4, b"ABCD\r\nEFGH\r\nIJKL");
+    assert_eq!(
+        Selection::entire_grid(&grown).extract(&grown),
+        "ABCD\nEFGH\nIJKL"
+    );
+}
+
+#[test]
+fn wide_character_word_and_line_modes_keep_characters_whole() {
+    let state = grid(1, 8, "a你好b".as_bytes());
+
+    let word = Selection::new(
+        &state,
+        SelectionMode::Word,
+        GridPoint::new(0, 2),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(word.extract(&state), "a你好b");
+
+    let line = Selection::new(
+        &state,
+        SelectionMode::Line,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 7),
+    );
+    assert_eq!(line.extract(&state), "a你好b");
+    // No endpoint rests on a continuation column after normalization.
+    for point in [line.start(), line.end(), word.start(), word.end()] {
+        let cells = state.row_cells(point.line()).expect("row exists");
+        assert!(!cells[point.column()].is_continuation());
+    }
+}


### PR DESCRIPTION
Closes #57 — a Milestone 2 acceptance requirement, and the second-to-last M2 item.

Character-, word-, and line-wise selection over the grid in `noren-terminal`, plus
macOS clipboard copy and paste in `noren-app`.

## Wide characters, the part that silently corrupts data

`Selection::new` runs `snap_off_continuation` on **both** endpoints, so a selection
can never split a wide character's two cells. Extraction skips continuation cells
rather than emitting empty strings for them. Without this, copying CJK text would
appear to work and quietly produce broken output.

Verified: an endpoint landing on `日`'s continuation column yields either the whole
character or excludes it — never a half — and `日本` extracts exactly.

## Security boundary held

`paste=bracketed`: paste is wrapped in the mode-2004 markers rather than injected
raw.

I checked the boundary specifically: there is **no output-side clipboard read path**
anywhere in `noren-terminal`. A `grep` for OSC 52 and clipboard-read handling returns
nothing, so terminal output cannot query the clipboard. OSC 52 remains out of scope,
and per the compatibility matrix any future work there must never answer read
queries.

## Coordinator verification

Five independent checks, all passing:

- a selection through a wide character's continuation never yields half a character;
- ASCII and CJK extraction are byte-exact (`hello`, `日本`);
- an empty selection yields an empty string rather than panicking;
- whole-grid line selection preserves every row;
- word mode captures the containing word (`beta` from mid-word), and line mode is
  never narrower than word mode.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, **300 workspace tests pass** (was 256),
`python3 scripts/check_docs.py` passes.

Rebased onto current `main`; one export-list conflict with the search module was
resolved by keeping both. Additive — deletes no test file.