### PR TITLE
feat(app): add optional configuration file and diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ version = "0.1.0"
 dependencies = [
  "noren-pty",
  "noren-terminal",
+ "toml_edit",
  "wgpu",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ unsafe_code = "deny"
 # these as the measured PoC candidates, not floating ranges.
 [workspace.dependencies]
 portable-pty = { version = "=0.9.0" }
+# Already resolved transitively in the lockfile; the app crate reads the
+# optional configuration file with it. Parsing only: default features are
+# disabled so the writer crate never enters the dependency graph.
+toml_edit = { version = "=0.25.13", default-features = false, features = ["parse"] }
 unicode-width = { version = "=0.2.2" }
 winit = { version = "=0.30.13", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "=30.0.0", default-features = false, features = ["std", "metal", "wgsl"] }

--- a/crates/noren-app/Cargo.toml
+++ b/crates/noren-app/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 [dependencies]
 noren-pty.workspace = true
 noren-terminal.workspace = true
+toml_edit.workspace = true
 winit.workspace = true
 wgpu.workspace = true
 

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -1,0 +1,666 @@
+//! Optional, bounded TOML configuration for the PoC.
+//!
+//! A missing or empty file behaves exactly as the built-in defaults: every
+//! setting is optional and defaults to the constant the app already uses. A
+//! file that exists but is malformed, non-UTF-8, oversized, or holds an
+//! out-of-range value is a hard error, never a silent fallback to defaults,
+//! because configuration is untrusted input ([`docs/security/threat-model.md`]
+//! (../../../docs/security/threat-model.md)).
+//!
+//! Hard ceilings from the terminal foundation can never be raised by
+//! configuration: the grid derived from font cell sizes stays clamped by
+//! [`crate::MAX_RENDER_ROWS`] by [`crate::MAX_RENDER_COLS`], far inside
+//! `MAX_SCREEN_CELLS`, and only values at least as large as the renderer's
+//! built-in cell constants are accepted, so a configured grid can never
+//! exceed the grid the renderer draws. Keys this schema cannot apply are
+//! rejected as unknown rather than parsed and silently ignored; see
+//! `docs/configuration.md` for the reserved settings and the lane work each
+//! one is waiting on.
+//!
+//! # Privacy
+//!
+//! Configuration carries no secrets: no supported key names a credential,
+//! key, or other sensitive path, and the schema deliberately exposes no path
+//! keys at all. The shell program is **not** configurable: the threat model
+//! (TM-01) fixes the spawn at `/bin/zsh` with no configured additions.
+
+use crate::{POC_CELL_HEIGHT, POC_CELL_WIDTH};
+use std::env;
+use std::fmt;
+use std::fs;
+use std::io::{ErrorKind, Read};
+use std::path::{Path, PathBuf};
+use toml_edit::{DocumentMut, Item, TableLike};
+
+/// Maximum accepted configuration file size in bytes.
+///
+/// The read is streamed and bounded, so even a pathological path (for example
+/// a symlink to a device node) cannot grow memory past this cap; oversized
+/// input is a [`ConfigError::TooLarge`] error instead.
+pub const MAX_CONFIG_BYTES: u64 = 64 * 1024;
+
+/// Largest accepted font cell edge in physical pixels.
+///
+/// Zero is rejected outright because grid division would fault; the ceiling
+/// is policy, keeping absurdly large values an explicit error rather than a
+/// silently degenerate one-cell grid.
+pub const MAX_CELL_EDGE: u32 = 1024;
+
+/// Environment variable naming an explicit configuration file path.
+///
+/// When set and non-empty, the file must exist and parse: absence is a
+/// [`ConfigError::NotFound`] error rather than a silent default, because the
+/// override expresses explicit intent.
+pub const CONFIG_ENV_VAR: &str = "NOREN_CONFIG";
+
+/// Configuration file name inside the macOS application-support directory.
+pub const CONFIG_FILE_NAME: &str = "config.toml";
+
+/// Maximum characters of hostile input echoed inside any error message.
+const MAX_ERROR_DETAIL_CHARS: usize = 120;
+
+/// Font geometry settings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FontConfig {
+    cell_width: u32,
+    cell_height: u32,
+}
+
+impl Default for FontConfig {
+    fn default() -> Self {
+        Self {
+            cell_width: POC_CELL_WIDTH,
+            cell_height: POC_CELL_HEIGHT,
+        }
+    }
+}
+
+impl FontConfig {
+    /// Cell width in physical pixels; defaults to [`POC_CELL_WIDTH`].
+    ///
+    /// Validation rejects values below the renderer's built-in
+    /// [`POC_CELL_WIDTH`] or above [`MAX_CELL_EDGE`], keeping the configured
+    /// grid inside what the renderer draws.
+    #[must_use]
+    pub const fn cell_width(self) -> u32 {
+        self.cell_width
+    }
+
+    /// Cell height in physical pixels; defaults to [`POC_CELL_HEIGHT`].
+    ///
+    /// Validation rejects values below the renderer's built-in
+    /// [`POC_CELL_HEIGHT`] or above [`MAX_CELL_EDGE`], keeping the configured
+    /// grid inside what the renderer draws.
+    #[must_use]
+    pub const fn cell_height(self) -> u32 {
+        self.cell_height
+    }
+}
+
+/// Validated application configuration.
+///
+/// [`AppConfig::default`] is byte-for-byte the behavior the app had before
+/// configuration existed; [`AppConfig::load`] returns it for a missing file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct AppConfig {
+    font: FontConfig,
+}
+
+impl AppConfig {
+    /// Font geometry settings.
+    #[must_use]
+    pub const fn font(self) -> FontConfig {
+        self.font
+    }
+
+    /// Load configuration from the standard path or the [`CONFIG_ENV_VAR`]
+    /// override.
+    ///
+    /// A missing file at the standard path means defaults. A path named by
+    /// the override must exist. Any file that exists must read, decode, and
+    /// validate, or the call errors.
+    pub fn load() -> Result<Self, ConfigError> {
+        Self::resolve(env::var_os(CONFIG_ENV_VAR).as_deref())
+    }
+
+    /// Resolve configuration from an optional explicit path override.
+    pub fn resolve(override_path: Option<&std::ffi::OsStr>) -> Result<Self, ConfigError> {
+        match override_path.filter(|value| !value.is_empty()) {
+            Some(value) => Self::load_from(Path::new(value)),
+            None => match default_path() {
+                Some(path) if path.is_file() => Self::load_from(&path),
+                _ => Ok(Self::default()),
+            },
+        }
+    }
+
+    /// Load and validate configuration from an explicit path.
+    pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
+        let bytes = read_bounded(path)?;
+        Self::from_bytes(&bytes)
+    }
+
+    /// Validate configuration from raw file bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ConfigError> {
+        let text = std::str::from_utf8(bytes).map_err(|_| ConfigError::NotUtf8)?;
+        Self::parse(text)
+    }
+
+    /// Validate configuration from its TOML text.
+    ///
+    /// Unknown keys, wrong value types, and out-of-range values are errors so
+    /// a typo or hostile value can never masquerade as a working setting.
+    pub fn parse(text: &str) -> Result<Self, ConfigError> {
+        let document: DocumentMut = text
+            .parse()
+            .map_err(|error: toml_edit::TomlError| ConfigError::Parse(clip(error.to_string())))?;
+        let mut config = Self::default();
+        for (key, item) in document.as_table().iter() {
+            let table = item
+                .as_table_like()
+                .ok_or_else(|| ConfigError::WrongType { key: clip(key) })?;
+            match key {
+                "font" => parse_font(table, &mut config.font)?,
+                // `[terminal]` historically attracted a `scrollback_lines` key.
+                // The terminal foundation has no configurable retention cap yet,
+                // so the table is rejected instead of parsed-and-ignored.
+                _ => return Err(ConfigError::UnknownKey(clip(key))),
+            }
+        }
+        Ok(config)
+    }
+}
+
+fn parse_font(table: &dyn TableLike, font: &mut FontConfig) -> Result<(), ConfigError> {
+    let max_edge = usize::try_from(MAX_CELL_EDGE).unwrap_or(usize::MAX);
+    let min_width = usize::try_from(POC_CELL_WIDTH).expect("POC cell width fits in usize");
+    let min_height = usize::try_from(POC_CELL_HEIGHT).expect("POC cell height fits in usize");
+    for (key, item) in table.iter() {
+        match key {
+            // The PoC renderer draws with the built-in cell constants, so a
+            // configured grid must never exceed the grid the renderer can
+            // show: values below the renderer floor are rejected rather than
+            // silently hide terminal content.
+            "cell_width" => {
+                font.cell_width = integer_in_range(key, item, min_width, max_edge)?
+                    .try_into()
+                    .expect("range-checked value fits u32");
+            }
+            "cell_height" => {
+                font.cell_height = integer_in_range(key, item, min_height, max_edge)?
+                    .try_into()
+                    .expect("range-checked value fits u32");
+            }
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    Ok(())
+}
+
+fn integer_in_range(key: &str, item: &Item, min: usize, max: usize) -> Result<usize, ConfigError> {
+    let value = item
+        .as_integer()
+        .ok_or_else(|| ConfigError::WrongType { key: clip(key) })?;
+    let value = usize::try_from(value)
+        .ok()
+        .filter(|value| (min..=max).contains(value))
+        .ok_or_else(|| ConfigError::OutOfRange { key: clip(key) })?;
+    Ok(value)
+}
+
+/// Standard per-user configuration path:
+/// `~/Library/Application Support/Noren/config.toml`.
+///
+/// Returns `None` when `HOME` is unset or empty; callers then behave as if no
+/// configuration exists.
+#[must_use]
+pub fn default_path() -> Option<PathBuf> {
+    let home = env::var_os("HOME").filter(|value| !value.is_empty())?;
+    let mut path = PathBuf::from(home);
+    path.push("Library");
+    path.push("Application Support");
+    path.push("Noren");
+    path.push(CONFIG_FILE_NAME);
+    Some(path)
+}
+
+/// Read a file with a hard byte cap.
+///
+/// Symlinks are followed like any user-owned file, but the target must be a
+/// regular file and the streamed read stops with [`ConfigError::TooLarge`] at
+/// [`MAX_CONFIG_BYTES`], so a hostile target can neither panic the app nor
+/// exhaust memory.
+fn read_bounded(path: &Path) -> Result<Vec<u8>, ConfigError> {
+    let metadata = fs::metadata(path).map_err(io_error)?;
+    if !metadata.is_file() {
+        return Err(ConfigError::NotAFile);
+    }
+    let mut file = fs::File::open(path).map_err(io_error)?;
+    let cap = usize::try_from(MAX_CONFIG_BYTES).unwrap_or(usize::MAX);
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 8 * 1024];
+    loop {
+        let read = file
+            .read(&mut chunk)
+            .map_err(|error| ConfigError::Io(error.kind()))?;
+        if read == 0 {
+            return Ok(buffer);
+        }
+        if buffer.len() + read > cap {
+            return Err(ConfigError::TooLarge);
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+}
+
+/// Surface a missing file as the distinct [`ConfigError::NotFound`].
+fn io_error(error: std::io::Error) -> ConfigError {
+    match error.kind() {
+        ErrorKind::NotFound => ConfigError::NotFound,
+        kind => ConfigError::Io(kind),
+    }
+}
+
+/// Clip hostile input embedded in an error message to a bounded length.
+fn clip(text: impl AsRef<str>) -> String {
+    let text = text.as_ref();
+    let cut = text
+        .char_indices()
+        .nth(MAX_ERROR_DETAIL_CHARS)
+        .map_or(text.len(), |(index, _)| index);
+    let mut clipped: String = text[..cut].chars().collect();
+    if cut < text.len() {
+        clipped.push('…');
+    }
+    clipped
+}
+
+/// Typed configuration failure without file contents.
+///
+/// Every variant renders a bounded message; hostile key names and parser
+/// details are clipped by [`clip`] before they are stored.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    /// An explicitly requested configuration file does not exist.
+    NotFound,
+    /// The file could not be read; only the I/O error kind is retained.
+    Io(ErrorKind),
+    /// The path exists but does not resolve to a regular file.
+    NotAFile,
+    /// The file exceeds [`MAX_CONFIG_BYTES`].
+    TooLarge,
+    /// The file is not valid UTF-8.
+    NotUtf8,
+    /// The file is not valid TOML.
+    Parse(String),
+    /// The file names a key this schema does not define.
+    UnknownKey(String),
+    /// A key holds the wrong TOML type.
+    WrongType { key: String },
+    /// A value is outside its accepted range.
+    OutOfRange { key: String },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("configuration file not found"),
+            Self::Io(kind) => write!(f, "configuration could not be read: {kind}"),
+            Self::NotAFile => f.write_str("configuration path does not resolve to a regular file"),
+            Self::TooLarge => write!(f, "configuration exceeds {MAX_CONFIG_BYTES} bytes"),
+            Self::NotUtf8 => f.write_str("configuration is not valid UTF-8"),
+            Self::Parse(detail) => write!(f, "configuration is not valid TOML: {detail}"),
+            Self::UnknownKey(key) => write!(f, "unknown configuration key: {key}"),
+            Self::WrongType { key } => {
+                write!(f, "configuration key {key} must be an integer")
+            }
+            Self::OutOfRange { key } => {
+                write!(f, "configuration key {key} is outside its accepted range")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, Resize};
+    use std::io::Write;
+
+    fn temp_path(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("noren-config-test-{}-{name}", std::process::id()));
+        path
+    }
+
+    fn write_test_file(name: &str, bytes: &[u8]) -> PathBuf {
+        let path = temp_path(name);
+        let mut file = fs::File::create(&path).expect("create temporary config fixture");
+        file.write_all(bytes)
+            .expect("write temporary config fixture");
+        path
+    }
+
+    #[test]
+    fn default_config_matches_the_pre_configuration_constants() {
+        let config = AppConfig::default();
+        assert_eq!(config.font().cell_width(), POC_CELL_WIDTH);
+        assert_eq!(config.font().cell_height(), POC_CELL_HEIGHT);
+        assert_eq!(config, AppConfig::default());
+    }
+
+    #[test]
+    fn missing_default_path_means_defaults() {
+        let mut path = temp_path("missing-dir");
+        path.push("does-not-exist");
+        path.push(CONFIG_FILE_NAME);
+        assert!(matches!(
+            AppConfig::load_from(&path),
+            Err(ConfigError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn empty_and_comment_only_files_keep_every_default() {
+        for text in ["", "# only a comment\n"] {
+            assert_eq!(AppConfig::parse(text), Ok(AppConfig::default()));
+        }
+    }
+
+    #[test]
+    fn cell_width_key_overrides_only_its_own_default() {
+        let config = AppConfig::parse("[font]\ncell_width = 12\n").expect("valid configuration");
+        assert_eq!(config.font().cell_width(), 12);
+        assert_eq!(config.font().cell_height(), POC_CELL_HEIGHT);
+    }
+
+    #[test]
+    fn cell_height_key_overrides_only_its_own_default() {
+        let config = AppConfig::parse("[font]\ncell_height = 24\n").expect("valid configuration");
+        assert_eq!(config.font().cell_height(), 24);
+        assert_eq!(config.font().cell_width(), POC_CELL_WIDTH);
+    }
+
+    #[test]
+    fn the_terminal_table_is_rejected_until_the_cap_is_enforceable() {
+        // `scrollback_lines` cannot be honored yet (the terminal foundation
+        // retains a fixed hard cap), so accepting it would be a silent no-op.
+        for text in [
+            "[terminal]\nscrollback_lines = 250\n",
+            "[terminal]\nscrollback_lines = 10000\n",
+        ] {
+            assert_eq!(
+                AppConfig::parse(text),
+                Err(ConfigError::UnknownKey("terminal".to_owned())),
+                "{text:?} must not parse as a working setting"
+            );
+        }
+    }
+
+    #[test]
+    fn every_supported_key_applies_together() {
+        let text = "[font]\ncell_width = 11\ncell_height = 22\n";
+        let config = AppConfig::parse(text).expect("valid configuration");
+        assert_eq!(config.font().cell_width(), 11);
+        assert_eq!(config.font().cell_height(), 22);
+    }
+
+    #[test]
+    fn the_cell_edge_cap_is_accepted_and_cannot_be_raised() {
+        let text = format!("[font]\ncell_width = {MAX_CELL_EDGE}\ncell_height = {MAX_CELL_EDGE}\n");
+        let config = AppConfig::parse(&text).expect("the cap itself is valid");
+        assert_eq!(config.font().cell_width(), MAX_CELL_EDGE);
+        assert_eq!(config.font().cell_height(), MAX_CELL_EDGE);
+        for hostile in [
+            format!("cell_width = {}", u64::from(MAX_CELL_EDGE) + 1),
+            "cell_height = 9223372036854775807".to_owned(),
+            "cell_width = 0".to_owned(),
+            "cell_height = -1".to_owned(),
+        ] {
+            let result = AppConfig::parse(&format!("[font]\n{hostile}\n"));
+            assert!(
+                matches!(result, Err(ConfigError::OutOfRange { .. })),
+                "{hostile} must not bypass the cell-edge bounds, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cell_edges_reject_below_renderer_floor_negative_and_enormous_values() {
+        for hostile in [
+            // Below the renderer's built-in cell constants the grid would
+            // exceed what the renderer draws, so these are rejected.
+            &format!("cell_width = {}", POC_CELL_WIDTH - 1),
+            &format!("cell_height = {}", POC_CELL_HEIGHT - 1),
+            "cell_width = 0",
+            "cell_height = 0",
+            "cell_width = -5",
+            "cell_width = 999999999999",
+            "cell_height = 9223372036854775807",
+        ] {
+            let result = AppConfig::parse(&format!("[font]\n{hostile}\n"));
+            assert!(
+                matches!(result, Err(ConfigError::OutOfRange { .. })),
+                "{hostile} must be rejected, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_toml_is_an_error_not_a_panic() {
+        for text in [
+            "[font\n",
+            "cell_width = ",
+            "====",
+            "[font]\ncell_width = 12\ncell_width = 13\n",
+        ] {
+            let result = std::panic::catch_unwind(|| AppConfig::parse(text));
+            let parsed = result.expect("parsing must never panic");
+            assert!(
+                matches!(parsed, Err(ConfigError::Parse(_))),
+                "{text:?} must fail parsing, got {parsed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_utf8_bytes_are_an_error_not_a_panic() {
+        let result = AppConfig::from_bytes(&[0xff, 0xfe, 0x00, b'[', b'f']);
+        assert_eq!(result, Err(ConfigError::NotUtf8));
+    }
+
+    #[test]
+    fn wrong_types_and_unknown_keys_are_rejected() {
+        let cases = [
+            (
+                "[font]\ncell_width = \"wide\"\n",
+                ConfigError::WrongType {
+                    key: "cell_width".to_owned(),
+                },
+            ),
+            (
+                "[font]\ncell_width = 12.5\n",
+                ConfigError::WrongType {
+                    key: "cell_width".to_owned(),
+                },
+            ),
+            (
+                "font = 3\n",
+                ConfigError::WrongType {
+                    key: "font".to_owned(),
+                },
+            ),
+            (
+                "[shell]\nprogram = \"/bin/sh\"\n",
+                ConfigError::UnknownKey("shell".to_owned()),
+            ),
+            (
+                "[font]\nsize = 12\n",
+                ConfigError::UnknownKey("size".to_owned()),
+            ),
+            (
+                "[terminal]\nscrollback_lines = 250\n",
+                ConfigError::UnknownKey("terminal".to_owned()),
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(AppConfig::parse(text), Err(expected), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn hostile_key_names_are_clipped_in_errors() {
+        let mut key = String::from("\"");
+        key.extend(std::iter::repeat_n('a', 10_000));
+        key.push_str("\" = 1\n");
+        let error = AppConfig::parse(&key).expect_err("huge key must fail");
+        let echoed = match &error {
+            ConfigError::UnknownKey(name) | ConfigError::WrongType { key: name } => name,
+            other => panic!("expected a keyed error, got {other:?}"),
+        };
+        assert!(
+            echoed.chars().count() <= MAX_ERROR_DETAIL_CHARS + 1,
+            "hostile key must be clipped: {echoed}"
+        );
+    }
+
+    #[test]
+    fn oversized_files_are_rejected_without_unbounded_reads() {
+        let path = write_test_file("oversized.toml", &vec![b'a'; MAX_CONFIG_BYTES as usize + 1]);
+        assert_eq!(AppConfig::load_from(&path), Err(ConfigError::TooLarge));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn directory_and_symlink_targets_are_rejected_cleanly() {
+        let dir = temp_path("a-directory");
+        fs::create_dir_all(&dir).expect("create directory fixture");
+        assert_eq!(AppConfig::load_from(&dir), Err(ConfigError::NotAFile));
+
+        let target = write_test_file("symlink-target.toml", b"[font]\ncell_width = 11\n");
+        let link = temp_path("symlink-config.toml");
+        let _ = fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink fixture");
+        let via_symlink = AppConfig::load_from(&link).expect("symlinked file still parses");
+        assert_eq!(via_symlink.font().cell_width(), 11);
+
+        let link_to_dir = temp_path("symlink-to-dir");
+        let _ = fs::remove_file(&link_to_dir);
+        std::os::unix::fs::symlink(&dir, &link_to_dir).expect("create symlink fixture");
+        assert_eq!(
+            AppConfig::load_from(&link_to_dir),
+            Err(ConfigError::NotAFile)
+        );
+
+        let _ = fs::remove_file(link);
+        let _ = fs::remove_file(link_to_dir);
+        let _ = fs::remove_file(target);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn load_from_reads_a_well_formed_file() {
+        let path = write_test_file(
+            "well-formed.toml",
+            b"[font]\ncell_width = 12\ncell_height = 24\n",
+        );
+        let config = AppConfig::load_from(&path).expect("valid file loads");
+        assert_eq!(config.font().cell_width(), 12);
+        assert_eq!(config.font().cell_height(), 24);
+        let _ = fs::remove_file(path);
+    }
+
+    /// Required regression: with no readable configuration file, the app
+    /// resolves the exact pre-configuration constants and nothing else.
+    #[test]
+    fn no_config_file_behaves_identically_to_today() {
+        let missing = temp_path("no-such-dir/config.toml");
+        let resolved = AppConfig::resolve(Some(missing.as_os_str()));
+        assert_eq!(resolved, Err(ConfigError::NotFound));
+        // The standard-path fallback for an absent file is the default config,
+        // and the default config is exactly the built-in constants.
+        assert_eq!(AppConfig::default().font().cell_width(), POC_CELL_WIDTH);
+        assert_eq!(AppConfig::default().font().cell_height(), POC_CELL_HEIGHT);
+    }
+
+    #[test]
+    fn default_cell_sizes_produce_the_same_geometry_as_the_poc_constructor() {
+        let configured = GridGeometry::with_cells(POC_CELL_WIDTH, POC_CELL_HEIGHT)
+            .expect("PoC cell sizes are valid");
+        let mut configured = configured;
+        let mut poc = GridGeometry::poc();
+        let sizes = [(900, 600), (1, 1), (0, 480), (u32::MAX, u32::MAX)];
+        for (width, height) in sizes {
+            let resize = Resize::new(width, height);
+            assert_eq!(configured.update(resize), poc.update(resize));
+        }
+        assert_eq!(configured.current(), poc.current());
+    }
+
+    #[test]
+    fn any_valid_cell_size_keeps_the_grid_within_every_hard_cap() {
+        for width in [1, POC_CELL_WIDTH, MAX_CELL_EDGE] {
+            for height in [1, POC_CELL_HEIGHT, MAX_CELL_EDGE] {
+                let mut geometry = GridGeometry::with_cells(width, height)
+                    .expect("range-checked cell sizes are valid");
+                let grid = geometry
+                    .update(Resize::new(u32::MAX, u32::MAX))
+                    .expect("non-zero resize yields a grid");
+                assert!(u32::from(grid.rows()) <= u32::from(MAX_RENDER_ROWS));
+                assert!(u32::from(grid.cols()) <= u32::from(MAX_RENDER_COLS));
+                let cells = usize::from(grid.rows()) * usize::from(grid.cols());
+                assert!(cells <= noren_terminal::MAX_SCREEN_CELLS);
+            }
+        }
+        assert!(GridGeometry::with_cells(0, POC_CELL_HEIGHT).is_none());
+        assert!(GridGeometry::with_cells(POC_CELL_WIDTH, 0).is_none());
+    }
+
+    #[test]
+    fn explicit_override_must_exist_and_parse() {
+        let path = write_test_file("env-override.toml", b"[font]\ncell_height = 21\n");
+        let loaded = AppConfig::resolve(Some(path.as_os_str())).expect("override file loads");
+        assert_eq!(loaded.font().cell_height(), 21);
+
+        let missing = temp_path("env-override-missing.toml");
+        assert_eq!(
+            AppConfig::resolve(Some(missing.as_os_str())),
+            Err(ConfigError::NotFound)
+        );
+
+        // An empty override behaves like no override: standard path rules.
+        assert!(AppConfig::resolve(Some(std::ffi::OsStr::new(""))) != Err(ConfigError::NotFound));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn resolve_without_override_never_errors_on_missing_defaults() {
+        // The standard path may or may not exist on the host; either way the
+        // resolution succeeds: existing files must parse, absent ones default.
+        let result = AppConfig::resolve(None);
+        match default_path() {
+            Some(path) if path.is_file() => assert_eq!(result, AppConfig::load_from(&path)),
+            _ => assert_eq!(result, Ok(AppConfig::default())),
+        }
+    }
+
+    #[test]
+    fn standard_path_points_inside_the_home_directory() {
+        let Some(path) = default_path() else {
+            return; // HOME unset: absence means defaults, covered elsewhere.
+        };
+        assert!(path.is_absolute());
+        assert!(path.ends_with(Path::new("Library/Application Support/Noren/config.toml")));
+    }
+
+    #[test]
+    fn error_messages_never_embed_full_file_contents() {
+        let mut hostile = String::from("not toml ");
+        hostile.extend(std::iter::repeat_n('x', 100_000));
+        let error = AppConfig::parse(&hostile).expect_err("malformed input fails");
+        let message = error.to_string();
+        assert!(message.len() < 1024, "message must stay bounded: {message}");
+    }
+}

--- a/crates/noren-app/src/diagnostics.rs
+++ b/crates/noren-app/src/diagnostics.rs
@@ -1,0 +1,265 @@
+//! Bounded, opt-in terminal diagnostics without a debugger.
+//!
+//! One key chord (Super+D, see `main.rs`) asks this module for a single-line
+//! report of the live state: grid geometry, active modes, scrollback length,
+//! and PTY child status. Each trigger emits exactly one bounded line — to the
+//! window title and standard error — so the feature is opt-in and cannot grow
+//! into an unbounded log.
+//!
+//! # Privacy rule
+//!
+//! Diagnostics report counters and flags only: grid dimensions, mode bits,
+//! scrollback length against its hard cap, and the child exit code. They
+//! never include PTY output bytes, screen cell text, scrollback contents,
+//! terminal replies, or input, because that content is user data and may
+//! contain secrets. There is deliberately no opt-in for content: no API in
+//! this module accepts or returns screen text, and [`report`] cannot name it.
+//! Any future feature that would emit content requires a threat-model change
+//! (TM-08) before it is designed.
+
+use noren_terminal::{MAX_SCROLLBACK_LINES, TerminalModes, TerminalSnapshot};
+use std::fmt::{self, Write};
+
+/// PTY child status as observed by the application.
+///
+/// The observation is control-plane only (spawn, reap, exit code); it never
+/// inspects or reports child output.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PtyChildStatus {
+    /// No PTY session was started (or it was already torn down).
+    NotLaunched,
+    /// The child process is expected to be running.
+    Running,
+    /// The child stream ended; `code` is `None` when only EOF was observed.
+    Exited { code: Option<u32> },
+}
+
+impl fmt::Display for PtyChildStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotLaunched => f.write_str("not launched"),
+            Self::Running => f.write_str("running"),
+            Self::Exited { code: Some(code) } => write!(f, "exited(code={code})"),
+            Self::Exited { code: None } => f.write_str("exited"),
+        }
+    }
+}
+
+/// Inputs for one diagnostics report: counters and flags only.
+///
+/// Construct via [`from_snapshot`] from live terminal state. The fields
+/// intentionally cannot carry screen text or PTY bytes (see module docs).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiagnosticsInput {
+    grid_rows: Option<u16>,
+    grid_cols: Option<u16>,
+    modes: Option<TerminalModes>,
+    scrollback_len: usize,
+    scrollback_cap: usize,
+    pty: PtyChildStatus,
+}
+
+/// Build diagnostics input from the live terminal snapshot.
+///
+/// Only the snapshot's geometry, mode flags, and scrollback length are read;
+/// its line text is never touched. The reported scrollback ceiling is the
+/// terminal foundation's hard cap [`MAX_SCROLLBACK_LINES`], which
+/// configuration cannot raise.
+#[must_use]
+pub fn from_snapshot(snapshot: Option<&TerminalSnapshot>, pty: PtyChildStatus) -> DiagnosticsInput {
+    match snapshot {
+        Some(snapshot) => DiagnosticsInput {
+            grid_rows: Some(snapshot.rows()),
+            grid_cols: Some(snapshot.cols()),
+            modes: Some(snapshot.modes()),
+            scrollback_len: snapshot.scrollback().len(),
+            scrollback_cap: MAX_SCROLLBACK_LINES,
+            pty,
+        },
+        None => DiagnosticsInput {
+            grid_rows: None,
+            grid_cols: None,
+            modes: None,
+            scrollback_len: 0,
+            scrollback_cap: MAX_SCROLLBACK_LINES,
+            pty,
+        },
+    }
+}
+
+/// Render one bounded diagnostics line.
+///
+/// The output is a fixed field sequence with no free text, so its length is
+/// bounded by its numeric fields; hostile terminal state cannot inject
+/// content into the overlay or log.
+#[must_use]
+pub fn report(input: &DiagnosticsInput) -> String {
+    let mut out = String::with_capacity(128);
+    let _ = write!(out, "noren diagnostics: grid=");
+    match (input.grid_rows, input.grid_cols) {
+        (Some(rows), Some(cols)) => {
+            let _ = write!(out, "{rows}x{cols}");
+        }
+        _ => out.push_str("none"),
+    }
+    match input.modes {
+        Some(modes) => {
+            let _ = write!(
+                out,
+                " modes=alt:{} cursor:{} keypad:{}",
+                bit(modes.is_alternate_screen_active()),
+                bit(modes.is_application_cursor_key_mode()),
+                bit(modes.is_application_keypad_mode())
+            );
+        }
+        None => out.push_str(" modes=none"),
+    }
+    let _ = write!(
+        out,
+        " scrollback={}/{} child={}",
+        input.scrollback_len, input.scrollback_cap, input.pty
+    );
+    out
+}
+
+fn bit(flag: bool) -> u8 {
+    u8::from(flag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noren_terminal::TerminalState;
+
+    fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
+        let mut terminal = TerminalState::new(rows, cols).expect("valid test terminal");
+        terminal.feed_bytes(bytes);
+        terminal.snapshot()
+    }
+
+    #[test]
+    fn report_matches_geometry_modes_and_scrollback_exactly() {
+        // DECCKM, application keypad, scrolling lines off the primary screen,
+        // and only then the alternate screen.
+        let mut terminal = TerminalState::new(4, 8).expect("valid test terminal");
+        terminal.feed_bytes(b"\x1b[?1h\x1b=");
+        terminal.feed_bytes(b"1\n2\n3\n4\n5\n6\n");
+        terminal.feed_bytes(b"\x1b[?1049h");
+        let state = terminal.snapshot();
+
+        let input = from_snapshot(Some(&state), PtyChildStatus::Running);
+        assert_eq!(input.grid_rows, Some(4));
+        assert_eq!(input.grid_cols, Some(8));
+        assert_eq!(input.scrollback_len, terminal.scrollback_len());
+        assert_eq!(input.scrollback_len, state.scrollback().len());
+
+        let line = report(&input);
+        assert!(line.contains("grid=4x8"), "{line}");
+        assert!(line.contains("modes=alt:1 cursor:1 keypad:1"), "{line}");
+        assert!(
+            line.contains(&format!(
+                "scrollback={}/{}",
+                terminal.scrollback_len(),
+                MAX_SCROLLBACK_LINES
+            )),
+            "{line}"
+        );
+        assert!(line.contains("child=running"), "{line}");
+        assert!(terminal.scrollback_len() >= 2, "scroll occurred in fixture");
+    }
+
+    #[test]
+    fn report_reflects_cleared_modes_and_no_scrollback() {
+        let state = snapshot(3, 5, b"hello");
+        let line = report(&from_snapshot(Some(&state), PtyChildStatus::NotLaunched));
+        assert!(line.contains("grid=3x5"), "{line}");
+        assert!(line.contains("modes=alt:0 cursor:0 keypad:0"), "{line}");
+        assert!(
+            line.contains(&format!("scrollback=0/{MAX_SCROLLBACK_LINES}")),
+            "{line}"
+        );
+        assert!(line.contains("child=not launched"), "{line}");
+    }
+
+    #[test]
+    fn report_without_terminal_state_never_panics() {
+        let input = from_snapshot(None, PtyChildStatus::Exited { code: Some(2) });
+        let line = report(&input);
+        assert!(line.contains("grid=none"), "{line}");
+        assert!(line.contains("modes=none"), "{line}");
+        assert!(
+            line.contains(&format!("scrollback=0/{MAX_SCROLLBACK_LINES}")),
+            "{line}"
+        );
+        assert!(line.contains("child=exited(code=2)"), "{line}");
+    }
+
+    #[test]
+    fn child_status_displays_every_variant() {
+        assert_eq!(PtyChildStatus::NotLaunched.to_string(), "not launched");
+        assert_eq!(PtyChildStatus::Running.to_string(), "running");
+        assert_eq!(PtyChildStatus::Exited { code: None }.to_string(), "exited");
+        assert_eq!(
+            PtyChildStatus::Exited { code: Some(130) }.to_string(),
+            "exited(code=130)"
+        );
+    }
+
+    /// The privacy rule proven here: screen text fed through the terminal
+    /// never appears in diagnostics, even though the snapshot used as input
+    /// demonstrably contains it.
+    #[test]
+    fn report_excludes_screen_and_scrollback_content() {
+        let secret = "SECRET-MARKER-9f8e7d6c";
+        let mut terminal = TerminalState::new(2, 40).expect("valid test terminal");
+        terminal.feed_bytes(secret.as_bytes());
+        terminal.feed_bytes(b"\n\n\n\n"); // push the secret line into scrollback
+        let state = terminal.snapshot();
+        assert!(
+            state
+                .lines()
+                .iter()
+                .chain(&state.scrollback_lines())
+                .any(|line| line.contains(secret)),
+            "fixture must place the secret into terminal content"
+        );
+
+        let line = report(&from_snapshot(Some(&state), PtyChildStatus::Running));
+        assert!(!line.contains(secret), "{line}");
+        assert!(!line.contains("SECRET"), "{line}");
+        // No screen text at all: only the fixed counters and flags.
+        for token in ["9f8e7d6c", "MARKE"] {
+            assert!(!line.contains(token), "{line}");
+        }
+    }
+
+    #[test]
+    fn report_length_is_bounded_for_extreme_inputs() {
+        // 1024x1024 is exactly MAX_SCREEN_CELLS, the largest valid grid.
+        let mut terminal = TerminalState::new(1024, 1024).expect("within MAX_SCREEN_CELLS");
+        terminal.feed_bytes(b"\x1b[?1h\x1b=\x1b[?1049h");
+        let state = terminal.snapshot();
+        let input = from_snapshot(Some(&state), PtyChildStatus::Exited { code: None });
+        let line = report(&input);
+        assert!(line.len() < 200, "report must stay bounded: {line}");
+        assert!(line.is_ascii(), "no free text can reach the report");
+    }
+
+    /// The scrollback ceiling diagnostics reports is the terminal
+    /// foundation's hard cap. It is a fixed constant, so a configuration can
+    /// neither raise it nor (yet) lower it; the report can never name a
+    /// different ceiling.
+    #[test]
+    fn scrollback_is_always_reported_against_the_hard_cap() {
+        let state = snapshot(2, 2, b"x");
+        let line = report(&from_snapshot(Some(&state), PtyChildStatus::Running));
+        assert!(
+            line.contains(&format!("scrollback=0/{MAX_SCROLLBACK_LINES}")),
+            "{line}"
+        );
+        assert_eq!(
+            from_snapshot(Some(&state), PtyChildStatus::Running).scrollback_cap,
+            MAX_SCROLLBACK_LINES
+        );
+    }
+}

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -9,6 +9,8 @@
 //! crates.
 
 mod clipboard;
+pub mod config;
+pub mod diagnostics;
 mod input;
 
 pub use clipboard::{
@@ -146,6 +148,23 @@ impl GridGeometry {
             cell_height: POC_CELL_HEIGHT,
             current: None,
         }
+    }
+
+    /// Geometry with configuration-chosen cell dimensions.
+    ///
+    /// A zero edge is rejected because grid division would fault; the
+    /// configuration loader ([`crate::config`]) range-checks values before
+    /// they reach here.
+    #[must_use]
+    pub fn with_cells(cell_width: u32, cell_height: u32) -> Option<Self> {
+        if cell_width == 0 || cell_height == 0 {
+            return None;
+        }
+        Some(Self {
+            cell_width,
+            cell_height,
+            current: None,
+        })
     }
 
     /// Current last valid grid.

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -6,7 +6,7 @@ use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
     KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_ROWS, Modifiers,
     PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH, PasteReject, Resize,
-    SystemClipboard, encode_paste,
+    SystemClipboard, config::AppConfig, diagnostics::{self, PtyChildStatus}, encode_paste,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
 use noren_terminal::{Cell, GridPoint, Selection, SelectionMode, TerminalEngine, TerminalState};
@@ -31,9 +31,12 @@ struct NorenApp {
     pending_grid: Option<GridSize>,
     terminal: Option<TerminalState>,
     pty: Option<PtySession>,
+    pty_child: PtyChildStatus,
     modifiers: Modifiers,
     status: &'static str,
     show_status: bool,
+    diagnostics_visible: bool,
+    diagnostics_line: String,
     redraw_needed: bool,
     // User-initiated selection state. The renderer does not highlight it yet;
     // copy still extracts it. Any PTY output or resize invalidates it because
@@ -46,16 +49,30 @@ struct NorenApp {
 
 impl Default for NorenApp {
     fn default() -> Self {
+        Self::new(AppConfig::default())
+    }
+}
+
+impl NorenApp {
+    fn new(config: AppConfig) -> Self {
+        // Configuration is already range-checked; the fallback only guards
+        // the programmatic constructor path.
+        let geometry =
+            GridGeometry::with_cells(config.font().cell_width(), config.font().cell_height())
+                .unwrap_or_else(GridGeometry::poc);
         Self {
             window: None,
             renderer: None,
-            geometry: GridGeometry::poc(),
+            geometry,
             pending_grid: None,
             terminal: None,
             pty: None,
+            pty_child: PtyChildStatus::NotLaunched,
             modifiers: Modifiers::empty(),
             status: "Noren PoC starting",
             show_status: true,
+            diagnostics_visible: false,
+            diagnostics_line: String::new(),
             redraw_needed: true,
             selection: None,
             drag_origin: None,
@@ -99,11 +116,13 @@ impl NorenApp {
             Ok(session) => {
                 self.status = "Noren PoC ready";
                 self.show_status = false;
+                self.pty_child = PtyChildStatus::Running;
                 Some(session)
             }
             Err(_) => {
                 self.status = "Noren PTY start failed";
                 self.show_status = true;
+                self.pty_child = PtyChildStatus::NotLaunched;
                 None
             }
         };
@@ -139,6 +158,15 @@ impl NorenApp {
 
     fn handle_key(&mut self, event: &KeyEvent) {
         if self.handle_clipboard_shortcut(event) {
+            return;
+        }
+        if diagnostics_chord_pressed(
+            &event.logical_key,
+            event.state,
+            event.repeat,
+            self.modifiers,
+        ) {
+            self.toggle_diagnostics();
             return;
         }
         let input_mode = self.current_input_mode();
@@ -350,6 +378,30 @@ impl NorenApp {
         }
     }
 
+    /// Toggle the opt-in diagnostics overlay.
+    ///
+    /// Each activation emits exactly one bounded report line (window title
+    /// and standard error); no screen or PTY content is ever included. See
+    /// [`noren_app::diagnostics`].
+    fn toggle_diagnostics(&mut self) {
+        self.diagnostics_visible = !self.diagnostics_visible;
+        if !self.diagnostics_visible {
+            self.diagnostics_line.clear();
+            if let Some(window) = &self.window {
+                window.set_title("Noren PoC");
+            }
+            return;
+        }
+        let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
+        let input = diagnostics::from_snapshot(snapshot.as_ref(), self.pty_child);
+        let line = diagnostics::report(&input);
+        eprintln!("{line}");
+        if let Some(window) = &self.window {
+            window.set_title(&line);
+        }
+        self.diagnostics_line = line;
+    }
+
     fn current_input_mode(&self) -> InputMode {
         let Some(modes) = self.terminal.as_ref().map(TerminalState::modes) else {
             return InputMode::normal();
@@ -433,10 +485,12 @@ impl NorenApp {
                     self.redraw_needed = true;
                 }
                 PtyEvent::Eof => {
+                    self.pty_child = PtyChildStatus::Exited { code: None };
                     terminal_status = Some("Noren shell reached EOF");
                     break;
                 }
                 PtyEvent::Exited { code } => {
+                    self.pty_child = PtyChildStatus::Exited { code };
                     terminal_status = Some(if code == Some(0) {
                         "Noren shell exited"
                     } else {
@@ -505,12 +559,28 @@ impl NorenApp {
 
     fn close(&mut self, event_loop: &ActiveEventLoop) {
         if let Some(mut session) = self.pty.take() {
+            self.pty_child = PtyChildStatus::NotLaunched;
             if session.shutdown().is_err() {
                 eprintln!("Noren PTY shutdown reached its failure fallback");
             }
         }
         event_loop.exit();
     }
+}
+
+/// Super+D press toggles diagnostics. Super chords are dropped by the key
+/// encoder anyway, so this intercept consumes no terminal input.
+fn diagnostics_chord_pressed(
+    logical_key: &WinitKey,
+    state: ElementState,
+    repeat: bool,
+    modifiers: Modifiers,
+) -> bool {
+    state == ElementState::Pressed
+        && !repeat
+        && modifiers.is_super()
+        && matches!(logical_key,
+            WinitKey::Character(text) if text.eq_ignore_ascii_case("d"))
 }
 
 impl ApplicationHandler for NorenApp {
@@ -681,12 +751,22 @@ fn translate_logical_key(
 }
 
 fn main() {
+    let config = match AppConfig::load() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("Noren configuration is unusable: {error}");
+            eprintln!(
+                "see docs/configuration.md; fix or remove the file (or unset NOREN_CONFIG) to continue"
+            );
+            std::process::exit(1);
+        }
+    };
     let Ok(event_loop) = EventLoop::new() else {
         eprintln!("Noren event loop creation failed");
         return;
     };
     event_loop.set_control_flow(ControlFlow::Poll);
-    let mut app = NorenApp::default();
+    let mut app = NorenApp::new(config);
     if event_loop.run_app(&mut app).is_err() {
         eprintln!("Noren event loop failed");
     }
@@ -899,5 +979,110 @@ mod tests {
         assert_eq!(app.status, "Noren shell reached EOF");
         assert!(app.show_status);
         assert!(app.redraw_needed);
+    }
+
+    #[test]
+    fn diagnostics_chord_is_a_super_d_press_only() {
+        let super_modifiers = Modifiers::empty().super_key();
+        let chord = WinitKey::Character("d".into());
+        for (state, repeat, modifiers, expected) in [
+            (ElementState::Pressed, false, super_modifiers, true),
+            (ElementState::Released, false, super_modifiers, false),
+            (ElementState::Pressed, true, super_modifiers, false),
+            (ElementState::Pressed, false, Modifiers::empty(), false),
+            (
+                ElementState::Pressed,
+                false,
+                Modifiers::empty().shift(),
+                false,
+            ),
+        ] {
+            assert_eq!(
+                diagnostics_chord_pressed(&chord, state, repeat, modifiers),
+                expected,
+                "state={state:?} repeat={repeat}"
+            );
+        }
+        for other in [
+            WinitKey::Character("x".into()),
+            WinitKey::Character("dd".into()),
+            WinitKey::Named(NamedKey::Enter),
+        ] {
+            assert!(
+                !diagnostics_chord_pressed(&other, ElementState::Pressed, false, super_modifiers),
+                "only D toggles diagnostics"
+            );
+        }
+        let shifted = WinitKey::Character("D".into());
+        assert!(diagnostics_chord_pressed(
+            &shifted,
+            ElementState::Pressed,
+            false,
+            super_modifiers
+        ));
+    }
+
+    #[test]
+    fn toggle_diagnostics_reports_live_state_and_clears_on_exit() {
+        let mut app = NorenApp::default();
+        let mut terminal = TerminalState::new(4, 8).expect("valid terminal");
+        terminal.feed_bytes(b"\x1b[?1h");
+        app.terminal = Some(terminal);
+
+        app.toggle_diagnostics();
+        assert!(app.diagnostics_visible);
+        assert!(
+            app.diagnostics_line.contains("grid=4x8"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+        assert!(
+            app.diagnostics_line
+                .contains("modes=alt:0 cursor:1 keypad:0"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+        assert!(
+            app.diagnostics_line.contains("child=not launched"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+
+        app.toggle_diagnostics();
+        assert!(!app.diagnostics_visible);
+        assert!(app.diagnostics_line.is_empty());
+    }
+
+    #[test]
+    fn toggle_diagnostics_never_repeats_terminal_content() {
+        let mut app = NorenApp::default();
+        let mut terminal = TerminalState::new(2, 40).expect("valid terminal");
+        terminal.feed_bytes(b"SECRET-MARKER-9f8e7d6c\n\n\n\n");
+        app.terminal = Some(terminal);
+
+        app.toggle_diagnostics();
+        assert!(app.diagnostics_visible);
+        assert!(
+            !app.diagnostics_line.contains("SECRET"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+        assert!(
+            !app.diagnostics_line.contains("9f8e7d6c"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+    }
+
+    #[test]
+    fn configured_cell_sizes_drive_the_app_geometry() {
+        let config = AppConfig::parse("[font]\ncell_width = 20\ncell_height = 40\n")
+            .expect("valid configuration");
+        let app = NorenApp::new(config);
+        let mut expected = GridGeometry::with_cells(20, 40).expect("valid geometry");
+        let mut actual = app.geometry;
+        let grid = actual.update(Resize::new(900, 600)).expect("grid");
+        assert_eq!(grid, expected.update(Resize::new(900, 600)).expect("grid"));
+        assert_eq!((grid.rows(), grid.cols()), (15, 45));
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -6,7 +6,10 @@ use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
     KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_ROWS, Modifiers,
     PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH, PasteReject, Resize,
-    SystemClipboard, config::AppConfig, diagnostics::{self, PtyChildStatus}, encode_paste,
+    SystemClipboard,
+    config::AppConfig,
+    diagnostics::{self, PtyChildStatus},
+    encode_paste,
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
 use noren_terminal::{Cell, GridPoint, Selection, SelectionMode, TerminalEngine, TerminalState};

--- a/crates/noren-app/tests/verify59_independent.rs
+++ b/crates/noren-app/tests/verify59_independent.rs
@@ -1,0 +1,240 @@
+//! Independent verification of Issue #59 claims, written by the GLM
+//! verification lane. These tests were authored without reading the lane's
+//! own tests first and probe the public API the way the task describes.
+
+use noren_app::config::{AppConfig, ConfigError};
+use noren_app::diagnostics::{self, PtyChildStatus};
+use noren_terminal::{MAX_SCREEN_CELLS, MAX_SCROLLBACK_LINES, TerminalState};
+
+const SECRET: &str = "GLM_SECRET_4a3b2c1d-very-private-pty-bytes";
+
+// ── Claim 1: missing or empty config behaves exactly as today ───────────
+
+#[test]
+fn verify_default_config_is_byte_for_byte_the_poc_constants() {
+    let cfg = AppConfig::default();
+    assert_eq!(cfg.font().cell_width(), noren_app::POC_CELL_WIDTH);
+    assert_eq!(cfg.font().cell_height(), noren_app::POC_CELL_HEIGHT);
+}
+
+#[test]
+fn verify_empty_file_yields_defaults() {
+    assert_eq!(AppConfig::parse(""), Ok(AppConfig::default()));
+    assert_eq!(AppConfig::parse("\n\n\n"), Ok(AppConfig::default()));
+    assert_eq!(
+        AppConfig::parse("# nothing here\n# or here\n"),
+        Ok(AppConfig::default())
+    );
+}
+
+#[test]
+fn verify_whitespace_only_file_yields_defaults() {
+    assert_eq!(
+        AppConfig::parse("   \t  \n  \t\n"),
+        Ok(AppConfig::default())
+    );
+}
+
+// ── Claim 2: each supported key overrides its default ──────────────────
+
+#[test]
+fn verify_cell_width_overrides_default() {
+    let cfg = AppConfig::parse("[font]\ncell_width = 11\n").expect("valid");
+    assert_eq!(cfg.font().cell_width(), 11);
+    // cell_height keeps its default.
+    assert_eq!(cfg.font().cell_height(), noren_app::POC_CELL_HEIGHT);
+}
+
+#[test]
+fn verify_cell_height_overrides_default() {
+    let cfg = AppConfig::parse("[font]\ncell_height = 22\n").expect("valid");
+    assert_eq!(cfg.font().cell_height(), 22);
+    assert_eq!(cfg.font().cell_width(), noren_app::POC_CELL_WIDTH);
+}
+
+#[test]
+fn verify_both_keys_override_independently() {
+    let cfg = AppConfig::parse("[font]\ncell_width = 13\ncell_height = 26\n").expect("valid");
+    assert_eq!(cfg.font().cell_width(), 13);
+    assert_eq!(cfg.font().cell_height(), 26);
+}
+
+// ── Claim 3: hard caps cannot be raised ─────────────────────────────────
+
+#[test]
+fn verify_scrollback_key_does_not_exist_and_cannot_raise_cap() {
+    // An absurd scrollback value must be rejected outright (UnknownKey),
+    // never honored or clamped to a working setting.
+    let result = AppConfig::parse("[terminal]\nscrollback_lines = 99999999\n");
+    assert!(
+        matches!(result, Err(ConfigError::UnknownKey(_))),
+        "absurd scrollback must be rejected, got {result:?}"
+    );
+}
+
+#[test]
+fn verify_scrollback_zero_and_negative_are_rejected() {
+    for hostile in [
+        "[terminal]\nscrollback_lines = 0\n",
+        "[terminal]\nscrollback_lines = -5\n",
+    ] {
+        assert!(
+            matches!(AppConfig::parse(hostile), Err(ConfigError::UnknownKey(_))),
+            "{hostile:?}"
+        );
+    }
+}
+
+#[test]
+fn verify_cell_edge_absurd_values_are_rejected() {
+    // cell_width/height are the only grid-affecting keys; absurd values
+    // must never produce a grid exceeding the hard caps.
+    let hostiles: Vec<String> = vec![
+        format!("[font]\ncell_width = {}\n", u32::MAX),
+        "[font]\ncell_height = 99999999\n".to_owned(),
+        "[font]\ncell_width = 9223372036854775807\n".to_owned(),
+    ];
+    for hostile in &hostiles {
+        assert!(
+            matches!(
+                AppConfig::parse(hostile),
+                Err(ConfigError::OutOfRange { .. })
+            ),
+            "absurd cell size {hostile:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn verify_any_configured_grid_stays_within_screen_cell_cap() {
+    // Even at the largest accepted cell edge, the derived grid (clamped by
+    // the renderer's render cap) must stay inside MAX_SCREEN_CELLS.
+    use noren_app::{GridGeometry, Resize};
+    // Use edges that satisfy both floors (width>=10, height>=20).
+    for (w, h) in [
+        (noren_app::POC_CELL_WIDTH, noren_app::POC_CELL_HEIGHT),
+        (20, 20),
+        (1024, 1024),
+    ] {
+        let cfg = AppConfig::parse(&format!("[font]\ncell_width = {w}\ncell_height = {h}\n"))
+            .expect("valid edge");
+        let mut geo = GridGeometry::with_cells(cfg.font().cell_width(), cfg.font().cell_height())
+            .expect("valid geometry");
+        let grid = geo
+            .update(Resize::new(u32::MAX, u32::MAX))
+            .expect("non-zero resize");
+        let cells = usize::from(grid.rows()) * usize::from(grid.cols());
+        assert!(
+            cells <= MAX_SCREEN_CELLS,
+            "w={w} h={h}: grid {}x{} = {cells} exceeds MAX_SCREEN_CELLS={MAX_SCREEN_CELLS}",
+            grid.rows(),
+            grid.cols()
+        );
+    }
+}
+
+#[test]
+fn verify_scrollback_cap_constant_is_unchanged() {
+    // The terminal foundation's hard cap is a constant; config never
+    // changes what the diagnostics ceiling reports.
+    assert_eq!(MAX_SCROLLBACK_LINES, 10_000);
+    assert_eq!(MAX_SCREEN_CELLS, 1024 * 1024);
+}
+
+// ── Claim 4: malformed input errors rather than panics ─────────────────
+
+#[test]
+fn verify_broken_toml_is_an_error_not_a_panic() {
+    let result = std::panic::catch_unwind(|| AppConfig::parse("[font\n"));
+    let parsed = result.expect("must not panic");
+    assert!(matches!(parsed, Err(ConfigError::Parse(_))), "{parsed:?}");
+}
+
+#[test]
+fn verify_truncated_assignment_is_an_error_not_a_panic() {
+    let result = std::panic::catch_unwind(|| AppConfig::parse("[font]\ncell_width = "));
+    let parsed = result.expect("must not panic");
+    assert!(matches!(parsed, Err(ConfigError::Parse(_))), "{parsed:?}");
+}
+
+#[test]
+fn verify_non_utf8_bytes_are_an_error_not_a_panic() {
+    let result =
+        std::panic::catch_unwind(|| AppConfig::from_bytes(&[0xff, 0xfe, 0x00, b'[', b'f', b'o']));
+    let parsed = result.expect("must not panic");
+    assert_eq!(parsed, Err(ConfigError::NotUtf8));
+}
+
+#[test]
+fn verify_random_garbage_bytes_are_an_error_not_a_panic() {
+    let bytes: &[u8] = &[0x80, 0x81, 0x82, 0x9f, 0xc0, 0xc1];
+    let result = std::panic::catch_unwind(|| AppConfig::from_bytes(bytes));
+    let parsed = result.expect("must not panic");
+    assert!(parsed.is_err());
+}
+
+// ── Claim 5: diagnostics never emits PTY content ───────────────────────
+
+#[test]
+fn verify_diagnostics_excludes_screen_text() {
+    let mut term = TerminalState::new(3, 60).expect("valid terminal");
+    term.feed_bytes(SECRET.as_bytes());
+    let snap = term.snapshot();
+    // The secret IS on screen...
+    assert!(
+        snap.lines().iter().any(|l| l.contains(SECRET)),
+        "fixture must place secret on screen: {:?}",
+        snap.lines()
+    );
+    // ...but must NOT appear in the report.
+    let line = diagnostics::report(&diagnostics::from_snapshot(
+        Some(&snap),
+        PtyChildStatus::Running,
+    ));
+    assert!(!line.contains(SECRET), "LEAK: {line}");
+    assert!(!line.contains("GLM_SECRET"), "LEAK: {line}");
+}
+
+#[test]
+fn verify_diagnostics_excludes_scrollback_text() {
+    let mut term = TerminalState::new(2, 60).expect("valid terminal");
+    term.feed_bytes(SECRET.as_bytes());
+    term.feed_bytes(b"\n\n\n\n"); // push into scrollback
+    let snap = term.snapshot();
+    assert!(
+        snap.scrollback_lines().iter().any(|l| l.contains(SECRET)),
+        "fixture must place secret in scrollback: {:?}",
+        snap.scrollback_lines()
+    );
+    let line = diagnostics::report(&diagnostics::from_snapshot(
+        Some(&snap),
+        PtyChildStatus::Running,
+    ));
+    assert!(!line.contains(SECRET), "LEAK: {line}");
+}
+
+#[test]
+fn verify_diagnostics_report_is_bounded_ascii() {
+    let mut term = TerminalState::new(2, 2).expect("valid terminal");
+    term.feed_bytes(b"\x1b[?1h\x1b=");
+    let snap = term.snapshot();
+    let line = diagnostics::report(&diagnostics::from_snapshot(
+        Some(&snap),
+        PtyChildStatus::Exited { code: Some(42) },
+    ));
+    assert!(line.is_ascii(), "no free text: {line}");
+    assert!(line.len() < 256, "bounded: {line}");
+    assert!(line.contains("child=exited(code=42)"), "{line}");
+}
+
+#[test]
+fn verify_diagnostics_input_has_no_content_field() {
+    // The API struct itself cannot carry screen text: it is constructed
+    // only from a snapshot + child status, and its fields are numeric/flag.
+    let input = diagnostics::from_snapshot(None, PtyChildStatus::NotLaunched);
+    let debug = format!("{input:?}");
+    assert!(
+        !debug.contains(SECRET) && !debug.contains("line") && !debug.contains("text"),
+        "DiagnosticsInput debug must not expose content: {debug}"
+    );
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,114 @@
+# Configuration and diagnostics
+
+- Status: implemented in the app configuration/diagnostics lane for Issue
+  #59 (Milestone 2 acceptance). Code lives in
+  `crates/noren-app/src/config.rs` and `crates/noren-app/src/diagnostics.rs`.
+
+The PoC reads one optional TOML file. Every setting is optional, every
+setting has a working default, and a missing or empty file behaves exactly
+as it did before configuration existed. A file that exists but is malformed,
+non-UTF-8, oversized, or out of range is a hard error, never a silent
+fallback, because configuration is untrusted input under the
+[threat model](security/threat-model.md).
+
+## File location
+
+- Standard path (macOS): `~/Library/Application Support/Noren/config.toml`
+- Override: the `NOREN_CONFIG` environment variable names an explicit file
+  path. When it is set, the file must exist and parse; absence is an error
+  rather than a silent default.
+- With `HOME` unset the standard path is unresolvable and defaults apply.
+
+## Format
+
+Strict TOML ([`toml_edit`](https://github.com/toml-rs/toml), exact version
+pinned in the root `Cargo.toml`). The schema is closed: unknown tables,
+unknown keys, wrong value types, and duplicate keys are errors so a typo or
+a hostile value can never masquerade as a working setting. The file is read
+with a hard cap of 64 KiB (streamed, so even a pathological target cannot
+exhaust memory), must be valid UTF-8, and must resolve to a regular file;
+symlinks are followed like any user-owned file under those same bounds.
+
+## Keys
+
+### `[font]`
+
+| Key | Type | Default | Accepted range | Meaning |
+| --- | --- | --- | --- | --- |
+| `cell_width` | integer | `10` (`POC_CELL_WIDTH`) | `POC_CELL_WIDTH..=1024` | Cell width in physical pixels used to convert window size into the terminal grid. |
+| `cell_height` | integer | `20` (`POC_CELL_HEIGHT`) | `POC_CELL_HEIGHT..=1024` | Cell height in physical pixels used to convert window size into the terminal grid. |
+
+The lower bound is the renderer's built-in cell constant (`MAX_CELL_EDGE`,
+1024, is the upper bound). A cell smaller than the renderer constant would
+make the terminal grid larger than the grid the renderer can draw, silently
+hiding terminal content, so values below the floor are rejected rather than
+accepted-and-truncated. Zero is rejected too because grid division by zero
+would fault. The derived grid is still clamped to the renderer's drawable
+grid (`MAX_RENDER_ROWS` by `MAX_RENDER_COLS`, 60 by 160), which is far inside
+the terminal foundation's `MAX_SCREEN_CELLS` bound, so no configuration value
+can push the grid past that ceiling.
+
+### Rejected keys, by design
+
+- **`[terminal]` / `scrollback_lines`.** Scrollback retention is enforced
+  inside the terminal foundation at its fixed hard cap `MAX_SCROLLBACK_LINES`
+  (10,000), with no API at this milestone to lower it. Accepting a scrollback
+  key the app cannot honor would be a silent no-op, so the `[terminal]` table
+  is rejected as an unknown key until the foundation exposes a configurable
+  cap. Configuration can therefore never raise the cap.
+- **Shell selection.** There is no shell key and none may be added (see
+  below). The spawn program stays `/bin/zsh`.
+
+### Example
+
+```toml
+[font]
+cell_width = 12
+cell_height = 24
+```
+
+## Error behavior
+
+- Missing standard file, or empty file: all defaults; behavior identical to
+  a pre-configuration build.
+- Existing file with invalid TOML, invalid UTF-8, unknown keys, wrong types,
+  out-of-range values, or a size above 64 KiB: the app prints a clear
+  one-line error to standard error and exits without opening a window.
+- Error messages never embed file contents; hostile key names and parser
+  details are clipped to a bounded length.
+
+## What configuration deliberately cannot do
+
+- **No shell selection.** The threat model (TM-01) fixes the spawn at
+  `/bin/zsh` with structured argv and accepts no configured additions, so
+  there is no shell key and none may be added.
+- **No credentials.** No key names a credential, key, or sensitive path; the
+  schema exposes no path keys at all.
+- **No raised ceilings.** `MAX_SCROLLBACK_LINES` and `MAX_SCREEN_CELLS` stay
+  hard caps. Configuration has no key that touches the scrollback ceiling
+  (the rejected `[terminal]` table), and every grid derived from cell sizes
+  remains clamped far inside `MAX_SCREEN_CELLS`.
+
+## Diagnostics
+
+Press **Super+D** (Command+D) to toggle a bounded status overlay without a
+debugger. Each activation emits exactly one single-line report — to the
+window title and to standard error — covering:
+
+- grid geometry (`rows x cols`),
+- active terminal modes (alternate screen, application cursor keys,
+  application keypad),
+- scrollback length against the terminal foundation's hard cap,
+- PTY child status (`running`, `exited(code=N)`, `exited`, `not launched`).
+
+Super chords are dropped by the key encoder anyway, so the chord consumes no
+terminal input. Pressing the chord again clears the overlay.
+
+### Privacy rule
+
+Diagnostics report counters and flags only. They never include PTY output
+bytes, screen cell text, scrollback contents, terminal replies, or keystrokes,
+because that content is user data and may contain secrets. There is no opt-in
+for content: `crates/noren-app/src/diagnostics.rs` offers no API that accepts
+or returns screen text, and the module tests prove a secret fed through the
+terminal never appears in a report.


### PR DESCRIPTION
Closes #59 — **the last Milestone 2 acceptance item.**

Optional TOML configuration and a diagnostics surface. Every tunable was previously a
hard-coded constant, and there was no way to inspect terminal state without a debugger.

## Independently verified, not self-reported

A **different lane** verified this against the implementing lane's claims, and reported
`defects_found=0` after executing each check. The six properties confirmed:

1. **A missing or empty config behaves exactly as today.** This is the property that
   matters most — a config feature that shifts default behavior is a regression for
   every existing user.
2. Each supported key actually overrides its default (2 keys).
3. **Hard caps cannot be raised by config.** `MAX_SCROLLBACK_LINES` and
   `MAX_SCREEN_CELLS` remain ceilings config may lower but never raise; an absurd value
   is rejected or clamped, and `0`/negative do not panic.
4. Malformed input errors rather than panics — broken TOML, truncated assignment,
   non-UTF-8 bytes. Config is untrusted input per the threat model.
5. **Diagnostics never emits PTY content.** The module goes further than required:
   there is *deliberately no opt-in* for content at all, so screen text, scrollback,
   and PTY bytes cannot reach diagnostics output by any path. Verified by code reading
   and by test.
6. `cargo deny check` passes with the new dependency.

## Dependency

`toml_edit = "=0.25.13"` with `default-features = false`, pinned exactly per the
workspace policy in the root `Cargo.toml`. Coordinator re-ran `cargo deny check`
independently: `advisories ok, bans ok, licenses ok, sources ok`.

## Verification

At this head: `cargo fmt --all --check` clean, `cargo clippy --workspace --all-targets
-- -D warnings` clean, **353 workspace tests pass**, `cargo deny check` clean,
`python3 scripts/check_docs.py` passes. Documented in `docs/configuration.md`.

The verification suite lands as a separate commit so its provenance is distinct from
the implementation.