### PR TITLE
feat(fleet): repo-backed task state and an event-driven orchestrator

### DIFF
--- a/docs/coordination/decisions/D-M3-001-session-api.md
+++ b/docs/coordination/decisions/D-M3-001-session-api.md
@@ -1,0 +1,120 @@
+# D-M3-001: Milestone 3 session API contract
+
+- Status: Accepted (coordinator decision; reversible internal API)
+- Date: 2026-08-07
+- Scope: the minimum shared vocabulary M3-1 lanes code against
+- Governed by: ADR 0003 (Noren/Zellij responsibility boundary), landing in PR #68
+
+## Why this exists
+
+Five M3 lanes run in parallel against a session model none of them owns alone.
+Without a fixed contract they would each invent an incompatible shape and the
+integration commit would be a rewrite. This records the contract so lanes can
+start now.
+
+This is an **internal, reversible** API. It is not a persistence format, not a
+wire protocol, and not a public interface — those need their own decisions, and
+per the standing stop conditions a persistence format is an owner decision.
+
+## The boundary this contract must respect
+
+ADR 0003: Noren manages the workspace **outside** the terminal; Zellij manages
+it **inside**. Therefore:
+
+- there is no `Pane`, no `Tab`, no `Layout`, and no split anywhere in this model;
+- a session is opaque — Noren knows it exists, its kind, and whether it is
+  alive, and **nothing about what is displayed inside it**;
+- exactly **one** session is selected and visible at a time.
+
+Any lane that finds itself wanting a pane or layout type has hit the boundary and
+must stop and escalate rather than add one.
+
+## Contract
+
+```rust
+/// Opaque, stable within one run. Not a persistence key.
+pub struct SessionId(u64);
+
+/// What external context a session belongs to. Zellij's own tabs and panes
+/// live *inside* one of these and are not represented here.
+pub enum SessionKind {
+    Local,                 // a shell on this machine
+    Project { .. },        // a shell rooted in a project directory
+    Worktree { .. },       // a shell rooted in a git worktree
+    Ssh { .. },            // reserved shape; M3-1 does not implement SSH
+    Agent { .. },          // reserved shape; M3-1 does not launch agents
+}
+
+pub enum SessionStatus {
+    Starting,
+    Running,
+    Exited { code: Option<i32> },
+    Failed { reason: String },
+}
+
+/// Everything the sidebar needs to render one entry. Renderer-independent:
+/// no colors, no geometry, no widget types.
+pub struct SessionDescriptor {
+    id: SessionId,
+    kind: SessionKind,
+    status: SessionStatus,
+    title: String,
+}
+
+/// Requests *into* the domain. The dispatch seam speaks these so the sidebar,
+/// keybindings, and palette never call the registry directly.
+pub enum SessionAction {
+    Create { kind: SessionKind },
+    Select { id: SessionId },
+    Close { id: SessionId },
+}
+
+/// Facts *out of* the domain, for observers to react to.
+pub enum SessionEvent {
+    Created(SessionId),
+    Selected(Option<SessionId>),
+    StatusChanged { id: SessionId, status: SessionStatus },
+    Closed(SessionId),
+}
+
+/// Owns the set of sessions and the single selection. Holds no process handles:
+/// the lifecycle supervisor owns those, so the domain stays unit-testable
+/// without spawning anything.
+pub struct SessionRegistry { .. }
+
+/// Zero or one. Never more.
+pub type SelectedSession = Option<SessionId>;
+```
+
+## Invariants the lanes must uphold
+
+1. **At most one selected session.** `SelectedSession` is `Option`, and closing
+   the selected session must leave the selection either empty or on another
+   existing session — never dangling.
+2. **No session count cap is implied**, but the registry must not grow without
+   bound from repeated create/close cycles; ids may be reused only if that
+   cannot alias a live session.
+3. **`SessionRegistry` spawns nothing.** It is pure state, so the domain tests
+   run without processes. Process ownership belongs to the supervisor.
+4. **Status is reported, never inferred.** A session is `Running` because the
+   supervisor observed it, not because creation returned.
+5. **Nothing in this model describes terminal content or layout.**
+
+## Deliberately not fixed here
+
+- Persistence format and schema — owner decision, and M3-7's problem.
+- SSH connection semantics — `Ssh` is a reserved shape only; FR-010 governs.
+- Agent launch semantics — `Agent` is a reserved shape only; FR-011 governs.
+- Whether selecting a project entry auto-creates a session or offers a choice.
+- Whether a restored session re-spawns a shell or reattaches by Zellij name.
+
+The last two are open questions in the M3 breakdown. Lanes must not silently
+settle them.
+
+## Ownership
+
+`SessionId`, `SessionKind`, `SessionStatus`, `SessionDescriptor`,
+`SessionRegistry`, `SessionAction`, and `SessionEvent` are defined **once**, by
+the session-domain lane (M3-1a), in a new module. Every other lane imports them
+and may not redefine or shadow them. A lane needing a change to the contract
+escalates instead of forking it.

--- a/docs/coordination/handoffs/TEMPLATE.md
+++ b/docs/coordination/handoffs/TEMPLATE.md
@@ -1,0 +1,46 @@
+# Handoff <lane-id>
+
+Written so another model can resume from this file plus Git history alone, with
+no conversation context.
+
+- Task:
+- Branch:
+- Exact commit SHA:
+- Base main SHA:
+
+## Changed files
+
+-
+
+## Commands actually executed
+
+Real invocations and real results. Never record a command that was not run.
+
+```text
+```
+
+## Test results
+
+-
+
+## Unresolved findings
+
+-
+
+## Assumptions made
+
+-
+
+## Self-review limitations
+
+What this lane could not judge about its own work.
+
+-
+
+## Did this lane also author the code under review?
+
+(yes/no — if yes, an independent verifier is mandatory)
+
+## Next action
+
+-

--- a/docs/coordination/tasks/M3-1a.md
+++ b/docs/coordination/tasks/M3-1a.md
@@ -1,0 +1,54 @@
+# Task M3-1a
+
+- Issue / task ID: M3-1a (Milestone 3)
+- Goal: Session domain model: SessionId/Kind/Status/Descriptor/Registry, state transitions, invariants.
+- Base main SHA: `1d329a5`
+- Depends on: none
+- Assigned engine / lane: GLM / `glm-a`
+- Independent verifier: Qwen or Kimi
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `crates/noren-app/src/session.rs`
+- `crates/noren-app/tests/session_domain.rs`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Owns and defines every type in D-M3-001. Others import.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- Registry holds sessions with at most one selection, never dangling after close.
+- Registry spawns no process; domain tests run without any child.
+- Status is only set from a reported observation, never inferred.
+- No pane, tab, or layout type exists anywhere in the module.
+
+## Required tests
+
+- create/select/close transitions including closing the selected session
+- selection is None or an existing id after every operation
+- repeated create/close does not grow state without bound
+- invalid actions (unknown id, double close) are rejected without panic
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/M3-1b.md
+++ b/docs/coordination/tasks/M3-1b.md
@@ -1,0 +1,54 @@
+# Task M3-1b
+
+- Issue / task ID: M3-1b (Milestone 3)
+- Goal: Lifecycle supervisor: spawn/terminate/select, process ownership, child reap, stale/dead handling.
+- Base main SHA: `1d329a5`
+- Depends on: M3-1a
+- Assigned engine / lane: GLM / `glm-b`
+- Independent verifier: Kimi
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `crates/noren-app/src/session_supervisor.rs`
+- `crates/noren-app/tests/session_supervisor.rs`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Imports D-M3-001 types; owns process handles. Registry must stay process-free.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- Supervisor owns child handles; the registry never does.
+- A dead child produces Exited/Failed status rather than a stuck Running.
+- Termination reaps the child and is idempotent.
+- Until M3-1a lands, only a fake process model and a failure matrix exist.
+
+## Required tests
+
+- spawn then observe Running via a fake supervisor
+- child crash surfaces as Failed/Exited, not Running
+- double terminate is idempotent and reaps once
+- stale session (child gone, status not updated) is detected
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/M3-3.md
+++ b/docs/coordination/tasks/M3-3.md
@@ -1,0 +1,55 @@
+# Task M3-3
+
+- Issue / task ID: M3-3 (Milestone 3)
+- Goal: Sidebar view model and visual skeleton: entry kinds, selected session, empty state, single viewport.
+- Base main SHA: `1d329a5`
+- Depends on: none
+- Assigned engine / lane: Qwen / `qwen-a`
+- Independent verifier: GLM
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `crates/noren-app/src/sidebar.rs`
+- `crates/noren-app/tests/sidebar_view.rs`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Imports SessionDescriptor from D-M3-001; must not redefine it. Fixtures only, no real SSH/agent.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- View model is renderer-independent: no colors, geometry, or widget types.
+- Entry kinds render distinguishably for project/worktree/SSH/agent/session.
+- Empty state is representable.
+- Exactly one selected session is shown; hidden sessions are not rendered.
+- No native tabs, panes, or layout appear.
+
+## Required tests
+
+- each entry kind maps to a distinct view row
+- empty sidebar yields an empty-state view, not a panic
+- with N sessions and one selected, exactly one viewport is described
+- a session that is not selected produces no viewport
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/M3-4.md
+++ b/docs/coordination/tasks/M3-4.md
@@ -1,0 +1,55 @@
+# Task M3-4
+
+- Issue / task ID: M3-4 (Milestone 3)
+- Goal: Action dispatch seam and Zellij-collision-aware keybinding layer, plus command IDs for a palette.
+- Base main SHA: `1d329a5`
+- Depends on: none
+- Assigned engine / lane: Qwen / `qwen-b`
+- Independent verifier: GLM
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `crates/noren-app/src/actions.rs`
+- `crates/noren-app/tests/actions_dispatch.rs`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Speaks SessionAction/SessionEvent from D-M3-001. Must not redefine the session model.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- Sidebar/keybindings/palette all go through the seam, never the registry directly.
+- Noren bindings do not collide with Zellij default bindings; collisions are asserted absent.
+- Unbound chords pass through to the terminal unchanged.
+- A keyboard recovery path exists so a user cannot get stuck.
+- No pane or tab commands exist.
+
+## Required tests
+
+- each SessionAction round-trips through the seam
+- a Zellij default chord is not claimed by Noren
+- an unbound chord is forwarded as bytes, not swallowed
+- the recovery binding always returns control
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/M3-ADV-session.md
+++ b/docs/coordination/tasks/M3-ADV-session.md
@@ -1,0 +1,52 @@
+# Task M3-ADV-session
+
+- Issue / task ID: M3-ADV-session (Milestone 3)
+- Goal: Adversarial session lifecycle: mass create/close, rapid switching, crashes, stale selection, races.
+- Base main SHA: `1d329a5`
+- Depends on: M3-1a
+- Assigned engine / lane: Kimi / `kimi-a`
+- Independent verifier: GLM or Qwen
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `crates/noren-app/tests/session_adversarial.rs`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Attack the public API or a fake supervisor only. Do not couple to lane internals.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- Attacks target public API surface, not private functions.
+- Unbounded growth from repeated create/close is checked explicitly.
+- A found defect keeps its reproducer, marked ignored, and is reported not fixed.
+
+## Required tests
+
+- thousands of create/close cycles stay bounded
+- rapid selection switching never leaves two or zero-when-nonempty selections
+- duplicate or invalid ids are rejected without panic
+- shutdown race does not leak or double-reap
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/M3-EXP-zellij.md
+++ b/docs/coordination/tasks/M3-EXP-zellij.md
@@ -1,0 +1,50 @@
+# Task M3-EXP-zellij
+
+- Issue / task ID: M3-EXP-zellij (Milestone 3)
+- Goal: Zellij session lifecycle experiment: detect, new, list, attach, exit, stale, attach failure, fallback.
+- Base main SHA: `1d329a5`
+- Depends on: none
+- Assigned engine / lane: Fugu / `fugu-a`
+- Independent verifier: GLM
+
+## Exact file lease
+
+Only these paths may be created or edited.
+
+- `docs/experiments/zellij-session-lifecycle.md`
+
+## Forbidden files
+
+- `crates/*/src/lib.rs` — export wiring is a separate serial integration commit
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+- any file leased by another task
+
+## Public API contract
+
+Experiment only. No production code, no parser/state, no credentials.
+
+Contract source: `docs/coordination/decisions/D-M3-001-session-api.md`. A lane
+needing a contract change escalates instead of forking it.
+
+## Acceptance criteria
+
+- Every claim carries an exact command and its exit status.
+- Behavior when zellij is absent is recorded as a fallback path.
+- A failure matrix distinguishes attach-failure from stale-session.
+- No SSH key or credential is created, read, or stored.
+
+## Required tests
+
+- executed command transcripts with exit statuses, recorded in the doc
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a pane, tab, or layout type — that is the ADR 0003 boundary;
+- it needs a persistence format (owner decision);
+- it needs a change to a contract type owned by another task;
+- a required file falls outside this lease;
+- a verifier reports a BLOCKER.

--- a/docs/coordination/tasks/TEMPLATE.md
+++ b/docs/coordination/tasks/TEMPLATE.md
@@ -1,0 +1,47 @@
+# Task <task-id>
+
+- Issue / task ID:
+- Goal:
+- Base main SHA:
+- Depends on:
+- Assigned engine / lane:
+- Independent verifier:
+
+## Exact file lease
+
+Files this task may create or edit. Anything not listed is forbidden.
+
+-
+
+## Forbidden files
+
+Never edit these here, even incidentally.
+
+- `crates/*/src/lib.rs` (export wiring is a separate integration commit)
+- `crates/noren-app/src/main.rs`
+- `Cargo.toml`, `Cargo.lock`
+- `docs/coordination/status.md`
+
+## Public API contract
+
+The types and signatures this task must match. See
+`docs/coordination/decisions/D-M3-001-session-api.md` where applicable. A task may not
+redefine a contract type it does not own.
+
+## Acceptance criteria
+
+-
+
+## Required tests
+
+-
+
+## Stop conditions
+
+Stop and escalate rather than deciding, if:
+
+- the work needs a change to a public API contract owned elsewhere;
+- it needs a pane, tab, or layout type (that is the ADR 0003 boundary);
+- it needs a persistence format;
+- a required file is outside the lease;
+- a verifier reports a BLOCKER.

--- a/scripts/fleet/dispatch.sh
+++ b/scripts/fleet/dispatch.sh
@@ -28,6 +28,10 @@ case "$lane" in
   glm-*)   engine=glm;   account=glm-main;   model="zai-coding-plan/glm-5.2" ;;
   qwen-*)  engine=qwen;  account=qwen-main;  model="qwencloud/qwen3.8-max-preview" ;;
   kimi-*)  engine=kimi;  account=kimi-main;  model="" ;;
+  # Fugu owns Zellij, OpenSSH, and remote process-boundary work. It runs through
+  # the same opencode binary as GLM/Qwen, so it is gated on the GLM account.
+  # Adding this lane does NOT mean SSH implementation has started.
+  fugu-*)  engine=glm;   account=glm-main;   model="sakana/fugu-ultra" ;;
   # Codex work goes through the codex-lab wrapper only (portal `codex-main`).
   # The plain `codex` binary maps to `codex-tatu`, which is nearly exhausted and
   # is deliberately not reachable from this script.

--- a/scripts/fleet/orchestrator.py
+++ b/scripts/fleet/orchestrator.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Event-driven Noren fleet orchestrator.
+
+A plain Python process — not a model. It reads the task queue, resolves
+dependencies, checks quota, assigns worktrees and file leases, dispatches lanes,
+watches for real state changes, and runs the merge gate. It escalates to Claude
+Code only for decisions, never for waiting.
+
+What it deliberately does NOT do: architecture decisions, ignoring a BLOCKER,
+merging with unresolved threads or without review, pushing to main, touching
+credentials, assigning two writers to one file, or believing a lane's
+self-report as proof of completion.
+
+    orchestrator.py start        run the loop (foreground; use nohup for bg)
+    orchestrator.py status       print queue, lanes, leases, escalations
+    orchestrator.py stop         request a graceful stop
+    orchestrator.py once         one reconcile pass, then exit (for testing)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+FLEET = REPO / ".fleet"
+QUEUE = FLEET / "queue.json"
+EVENTS = FLEET / "events"
+LOCKS = FLEET / "locks"
+LOGS = FLEET / "logs"
+PACKETS = FLEET / "decision-packets"
+SESSIONS = FLEET / "sessions"
+PIDFILE = FLEET / "orchestrator.pid"
+STOPFILE = FLEET / "orchestrator.stop"
+SEEN = FLEET / "seen-events.json"
+TASKS_DIR = REPO / "docs" / "coordination" / "tasks"
+HANDOFF_DIR = REPO / "docs" / "coordination" / "handoffs"
+
+# Concurrency policy: target 6, floor 4, ceiling 8. Never invent duplicate work
+# just to reach the target.
+TARGET_LANES = 6
+MAX_LANES = 8
+
+# Files where two concurrent writers reliably conflict. Only a lane holding the
+# integration lease may edit these, and only one such lane runs at a time.
+INTEGRATION_PATHS = {
+    "crates/noren-terminal/src/lib.rs",
+    "crates/noren-app/src/lib.rs",
+    "crates/noren-pty/src/lib.rs",
+    "crates/noren-app/src/main.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+}
+
+POLL_SECONDS = 60
+# A lane whose log has not grown in this long and which produced no branch is
+# treated as an init stall (died before reaching the model), not a slow start.
+INIT_STALL_SECONDS = 240
+INIT_STALL_MAX_BYTES = 4096
+
+
+def log(msg: str) -> None:
+    print("[%s] %s" % (time.strftime("%Y-%m-%dT%H:%M:%S"), msg), flush=True)
+
+
+def sh(args, cwd=None, timeout=180):
+    """Run a command, returning (rc, stdout). Never raises on non-zero."""
+    try:
+        p = subprocess.run(args, cwd=cwd or REPO, capture_output=True,
+                           text=True, timeout=timeout)
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except subprocess.TimeoutExpired:
+        return 124, "timeout"
+    except FileNotFoundError as exc:
+        return 127, str(exc)
+
+
+def load_json(path: Path, default):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return default
+
+
+def save_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(value, indent=2, ensure_ascii=False))
+    tmp.replace(path)
+
+
+# --------------------------------------------------------------------------
+# Leases: the mechanism that makes parallel lanes safe.
+# --------------------------------------------------------------------------
+
+def held_leases() -> dict:
+    """path -> lane, for every currently held file lease."""
+    out = {}
+    for f in LOCKS.glob("*.json"):
+        rec = load_json(f, {})
+        for path in rec.get("paths", []):
+            out[path] = rec.get("lane")
+    return out
+
+
+def lease_conflict(task: dict) -> str | None:
+    """Return a human reason if this task cannot take its lease right now."""
+    want = set(task.get("file_lease", []))
+    if not want:
+        return "task declares no file lease"
+    held = held_leases()
+    for path in want:
+        owner = held.get(path)
+        if owner and owner != task["lane"]:
+            return "lease on %s held by %s" % (path, owner)
+    integration = want & INTEGRATION_PATHS
+    if integration:
+        # Only one integration-lease lane at a time, and only if the task says
+        # it holds that lease.
+        if not task.get("integration_lease"):
+            return "touches integration path %s without integration_lease" % sorted(integration)
+        for f in LOCKS.glob("*.json"):
+            rec = load_json(f, {})
+            if rec.get("integration_lease") and rec.get("lane") != task["lane"]:
+                return "integration lease held by %s" % rec.get("lane")
+    return None
+
+
+def take_lease(task: dict) -> None:
+    save_json(LOCKS / ("%s.json" % task["lane"]), {
+        "lane": task["lane"],
+        "task": task["id"],
+        "paths": task.get("file_lease", []),
+        "integration_lease": bool(task.get("integration_lease")),
+        "taken_at": time.time(),
+    })
+
+
+def release_lease(lane: str) -> None:
+    f = LOCKS / ("%s.json" % lane)
+    if f.exists():
+        f.unlink()
+
+
+# --------------------------------------------------------------------------
+# Events: emitted once each, deduplicated by hash.
+# --------------------------------------------------------------------------
+
+def emit(kind: str, task_id: str, detail: dict, needs_claude: bool) -> bool:
+    """Record an event. Returns True if it is new (not already emitted)."""
+    key = hashlib.sha256(
+        json.dumps([kind, task_id, detail.get("hash_key", detail)],
+                   sort_keys=True, default=str).encode()).hexdigest()[:16]
+    seen = load_json(SEEN, {})
+    if key in seen:
+        return False
+    seen[key] = {"kind": kind, "task": task_id, "at": time.time()}
+    save_json(SEEN, seen)
+    rec = {"kind": kind, "task": task_id, "needs_claude": needs_claude,
+           "at": time.time(), "detail": detail}
+    EVENTS.mkdir(parents=True, exist_ok=True)
+    (EVENTS / ("%s-%s.json" % (int(time.time()), key))).write_text(
+        json.dumps(rec, indent=2, ensure_ascii=False, default=str))
+    log("event %s task=%s needs_claude=%s" % (kind, task_id, needs_claude))
+    if needs_claude:
+        write_packet(kind, task_id, detail)
+    return True
+
+
+def write_packet(kind: str, task_id: str, detail: dict) -> None:
+    """A decision packet: the minimum a coordinator needs to decide."""
+    PACKETS.mkdir(parents=True, exist_ok=True)
+    p = PACKETS / ("%s-%s.md" % (task_id, kind))
+    lines = [
+        "# Decision packet: %s" % kind,
+        "",
+        "- Task: `%s`" % task_id,
+        "- Raised: %s" % time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "",
+        "## Why this needs a decision",
+        detail.get("why", "(unstated)"),
+        "",
+        "## State",
+    ]
+    for k in ("base_sha", "head_sha", "branch", "pr", "diff_summary",
+              "ci_summary", "review_findings", "gate"):
+        if detail.get(k):
+            lines.append("- %s: %s" % (k, detail[k]))
+    if detail.get("options"):
+        lines += ["", "## Options"] + ["- %s" % o for o in detail["options"]]
+    if detail.get("recommended"):
+        lines += ["", "## Recommended", detail["recommended"]]
+    if detail.get("evidence"):
+        lines += ["", "## Evidence paths"] + ["- `%s`" % e for e in detail["evidence"]]
+    p.write_text("\n".join(lines) + "\n")
+
+
+# --------------------------------------------------------------------------
+# Lane execution
+# --------------------------------------------------------------------------
+
+def quota_ok(account: str) -> bool:
+    rc, _ = sh(["python3", str(REPO / "scripts/fleet/quota.py"), "--gate", account])
+    return rc == 0
+
+
+def lane_running(lane: str) -> bool:
+    rc, out = sh(["ps", "ax", "-o", "command="])
+    return ("dispatch.sh %s " % lane) in out
+
+
+def newest_log(lane: str) -> Path | None:
+    files = sorted(LOGS.glob("%s.*.log" % lane), key=lambda f: f.stat().st_mtime)
+    return files[-1] if files else None
+
+
+def branch_exists(branch: str) -> bool:
+    rc, _ = sh(["git", "rev-parse", "--verify", "--quiet", "refs/heads/%s" % branch])
+    return rc == 0
+
+
+def dispatch(task: dict) -> None:
+    lane = task["lane"]
+    wt = task["worktree"]
+    prompt = REPO / task["prompt"]
+    if not Path(wt).exists():
+        rc, out = sh(["git", "worktree", "add", "-q", "-b",
+                      "pool/%s" % lane, wt, "origin/main"])
+        if rc != 0:
+            log("worktree add failed for %s: %s" % (lane, out.strip()[:200]))
+    take_lease(task)
+    # Absolute paths only: a relative prompt path silently resolves to nothing
+    # when the dispatcher is invoked from a worktree.
+    cmd = [str(REPO / "scripts/fleet/dispatch.sh"), lane, wt, str(prompt)]
+    logf = open(LOGS / ("%s.orchestrator.log" % lane), "a")
+    subprocess.Popen(cmd, cwd=str(REPO), stdout=logf, stderr=logf,
+                     start_new_session=True)
+    task["state"] = "running"
+    task["dispatched_at"] = time.time()
+    log("dispatched %s task=%s worktree=%s" % (lane, task["id"], wt))
+
+
+def classify_stall(task: dict) -> str | None:
+    """Distinguish an init stall from a permission stall from healthy work.
+
+    An init stall means the lane died before reaching the model: tiny log, no
+    branch, no growth. Relaunching costs nothing. A permission stall means the
+    lane is blocked on an interactive prompt but has usually already finished
+    its work, so its branch must be inspected before discarding anything.
+    """
+    lf = newest_log(task["lane"])
+    if lf is None:
+        return None
+    size = lf.stat().st_size
+    age = time.time() - lf.stat().st_mtime
+    if age < INIT_STALL_SECONDS:
+        return None
+    has_branch = branch_exists(task.get("branch", ""))
+    text = ""
+    try:
+        text = lf.read_text(errors="replace")[-4000:]
+    except Exception:
+        pass
+    if "message=asking" in text or "permission=" in text:
+        return "permission_stall"
+    if size <= INIT_STALL_MAX_BYTES and not has_branch:
+        return "init_stall"
+    return None
+
+
+def verdict_of(task: dict) -> str | None:
+    lf = newest_log(task["lane"])
+    if lf is None or not task.get("verdict_token"):
+        return None
+    try:
+        text = lf.read_text(errors="replace")
+    except Exception:
+        return None
+    for line in reversed(text.splitlines()):
+        if task["verdict_token"] in line:
+            return line.strip()
+    return None
+
+
+# --------------------------------------------------------------------------
+# PR gating
+# --------------------------------------------------------------------------
+
+def gate(pr: int) -> tuple[bool, str]:
+    rc, out = sh(["python3", str(REPO / "scripts/fleet/merge_gate.py"), str(pr)])
+    return rc == 0, out.strip()
+
+
+def reconcile(state: dict) -> None:
+    tasks = state["tasks"]
+    running = [t for t in tasks if t.get("state") == "running"]
+
+    # 1. Lanes that finished, stalled, or produced a verdict.
+    for t in list(running):
+        if lane_running(t["lane"]):
+            kind = classify_stall(t)
+            if kind == "init_stall":
+                log("%s init-stalled; relaunching (nothing produced)" % t["lane"])
+                sh(["pkill", "-f", "dispatch.sh %s " % t["lane"]])
+                release_lease(t["lane"])
+                t["state"] = "queued"
+                t["relaunches"] = t.get("relaunches", 0) + 1
+                emit("lane_init_stall", t["id"], {
+                    "why": "Lane died during init; relaunching.",
+                    "hash_key": "%s-%s" % (t["lane"], t.get("relaunches")),
+                }, needs_claude=False)
+            elif kind == "permission_stall":
+                emit("lane_permission_stall", t["id"], {
+                    "why": ("Lane is blocked on an interactive permission prompt. "
+                            "Its branch usually already holds finished work — "
+                            "inspect before discarding."),
+                    "branch": t.get("branch"),
+                    "evidence": [str(newest_log(t["lane"]))],
+                }, needs_claude=True)
+            continue
+        # Lane process is gone.
+        v = verdict_of(t)
+        release_lease(t["lane"])
+        if v:
+            t["state"] = "lane_done"
+            t["verdict"] = v
+            emit("lane_done", t["id"], {
+                "why": "Lane reported a verdict; needs independent verification.",
+                "verdict": v, "branch": t.get("branch"),
+                "hash_key": v,
+            }, needs_claude=False)
+        else:
+            t["state"] = "lane_ended_no_verdict"
+            emit("lane_no_verdict", t["id"], {
+                "why": ("Lane exited without printing its verdict line. Check "
+                        "whether it committed work before concluding it failed."),
+                "branch": t.get("branch"),
+                "evidence": [str(newest_log(t["lane"]) or "")],
+                "hash_key": "%s-%s" % (t["lane"], t.get("dispatched_at")),
+            }, needs_claude=True)
+
+    # 2. PR gating for tasks that have one.
+    for t in tasks:
+        pr = t.get("pr")
+        if not pr or t.get("state") in ("merged", "closed"):
+            continue
+        ok, detail = gate(int(pr))
+        if ok:
+            emit("ready_to_merge", t["id"], {
+                "why": "merge_gate.py PASS — checks green, review on head, 0 unresolved.",
+                "pr": pr, "gate": detail, "hash_key": detail,
+            }, needs_claude=True)
+        elif "not successful" in detail:
+            emit("ci_failed", t["id"], {
+                "why": ("A required check failed. Read the job log before assuming "
+                        "a code defect — infrastructure errors look identical here."),
+                "pr": pr, "ci_summary": detail, "hash_key": detail,
+            }, needs_claude=True)
+
+    # 3. Dispatch queued tasks whose dependencies and leases allow it.
+    active = sum(1 for t in tasks if t.get("state") == "running")
+    done_ids = {t["id"] for t in tasks
+                if t.get("state") in ("lane_done", "verified", "merged")}
+    for t in tasks:
+        if active >= min(TARGET_LANES, MAX_LANES):
+            break
+        if t.get("state") != "queued":
+            continue
+        missing = [d for d in t.get("depends_on", []) if d not in done_ids]
+        if missing:
+            continue
+        if not quota_ok(t["account"]):
+            emit("quota_blocked", t["id"], {
+                "why": "Engine has no headroom; will retry when it recovers.",
+                "hash_key": "%s-%s" % (t["account"], time.strftime("%Y%m%d%H")),
+            }, needs_claude=False)
+            continue
+        reason = lease_conflict(t)
+        if reason:
+            emit("lease_conflict", t["id"], {
+                "why": "Cannot dispatch: %s" % reason,
+                "hash_key": "%s-%s" % (t["id"], reason),
+                "options": ["re-scope the lease", "sequence behind the holder"],
+            }, needs_claude=True)
+            continue
+        dispatch(t)
+        active += 1
+
+    save_json(QUEUE, state)
+
+
+def cmd_status() -> int:
+    state = load_json(QUEUE, {"tasks": []})
+    pid = PIDFILE.read_text().strip() if PIDFILE.exists() else "-"
+    alive = "no"
+    if pid.isdigit():
+        rc, _ = sh(["kill", "-0", pid])
+        alive = "yes" if rc == 0 else "no"
+    print("orchestrator pid=%s alive=%s" % (pid, alive))
+    by = {}
+    for t in state["tasks"]:
+        by.setdefault(t.get("state", "?"), []).append(t["id"])
+    for k in sorted(by):
+        print("  %-22s %s" % (k, ", ".join(sorted(by[k]))))
+    leases = held_leases()
+    if leases:
+        print("file leases:")
+        for path, lane in sorted(leases.items()):
+            print("  %-52s %s" % (path, lane))
+    pend = sorted(PACKETS.glob("*.md"))
+    print("decision packets awaiting coordinator: %d" % len(pend))
+    for p in pend:
+        print("  %s" % p.name)
+    return 0
+
+
+def cmd_start(once: bool = False) -> int:
+    if PIDFILE.exists():
+        old = PIDFILE.read_text().strip()
+        if old.isdigit():
+            rc, _ = sh(["kill", "-0", old])
+            if rc == 0:
+                log("already running as pid %s; refusing to double-start" % old)
+                return 1
+    for d in (EVENTS, LOCKS, LOGS, PACKETS, SESSIONS):
+        d.mkdir(parents=True, exist_ok=True)
+    if STOPFILE.exists():
+        STOPFILE.unlink()
+    PIDFILE.write_text(str(os.getpid()))
+
+    stopping = {"v": False}
+
+    def handle(signum, frame):
+        stopping["v"] = True
+        log("signal %s received; stopping after this pass" % signum)
+
+    signal.signal(signal.SIGTERM, handle)
+    signal.signal(signal.SIGINT, handle)
+
+    log("orchestrator started pid=%d repo=%s" % (os.getpid(), REPO))
+    try:
+        while True:
+            state = load_json(QUEUE, {"tasks": []})
+            try:
+                reconcile(state)
+            except Exception as exc:  # keep the loop alive on transient errors
+                log("reconcile error: %r" % exc)
+            if once or stopping["v"] or STOPFILE.exists():
+                break
+            time.sleep(POLL_SECONDS)
+    finally:
+        if PIDFILE.exists():
+            PIDFILE.unlink()
+        log("orchestrator stopped")
+    return 0
+
+
+def cmd_stop() -> int:
+    STOPFILE.write_text("stop")
+    if PIDFILE.exists():
+        pid = PIDFILE.read_text().strip()
+        if pid.isdigit():
+            sh(["kill", "-TERM", pid])
+            print("graceful stop requested for pid %s" % pid)
+            return 0
+    print("no running orchestrator; stop flag written")
+    return 0
+
+
+def main() -> int:
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "status"
+    if cmd == "start":
+        return cmd_start()
+    if cmd == "once":
+        return cmd_start(once=True)
+    if cmd == "status":
+        return cmd_status()
+    if cmd == "stop":
+        return cmd_stop()
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fleet/orchestratord.sh
+++ b/scripts/fleet/orchestratord.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Start, stop, or inspect the orchestrator as a detached background process.
+#
+# Detached means it survives the shell and the Claude Code session that started
+# it: no controlling terminal, its own process group, output to .fleet/logs.
+# No sudo, no system-wide daemon, no secrets outside the repo.
+set -uo pipefail
+REPO="/Users/yoshinagatatsuya/Documents/apps/noren"
+PY="$REPO/scripts/fleet/orchestrator.py"
+OUT="$REPO/.fleet/logs/orchestrator.out"
+PIDF="$REPO/.fleet/orchestrator.pid"
+
+case "${1:-status}" in
+  start)
+    if [ -f "$PIDF" ] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then
+      echo "already running as pid $(cat "$PIDF")"; exit 1
+    fi
+    mkdir -p "$REPO/.fleet/logs"
+    # Double-fork via python so the child is reparented away from this shell.
+    python3 - "$PY" "$OUT" <<'PYEOF'
+import os, sys
+py, out = sys.argv[1], sys.argv[2]
+if os.fork() > 0: os._exit(0)          # parent returns to the shell
+os.setsid()                            # new session, no controlling tty
+if os.fork() > 0: os._exit(0)          # ensure we cannot reacquire one
+fd = os.open(out, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+os.dup2(fd, 1); os.dup2(fd, 2)
+os.dup2(os.open(os.devnull, os.O_RDONLY), 0)
+os.execv(sys.executable, [sys.executable, py, "start"])
+PYEOF
+    sleep 4
+    if [ -f "$PIDF" ]; then echo "started pid $(cat "$PIDF")"; else
+      echo "failed to start; see $OUT"; tail -5 "$OUT" 2>/dev/null; exit 1; fi
+    ;;
+  stop)    python3 "$PY" stop ;;
+  status)  python3 "$PY" status ;;
+  logs)    tail -n "${2:-40}" "$OUT" ;;
+  *) echo "usage: orchestratord.sh {start|stop|status|logs [n]}"; exit 2 ;;
+esac


### PR DESCRIPTION
Moves coordination off the conversation session and onto tracked files plus a plain
Python process, so the fleet keeps working when no model is watching.

## Why

Until now the coordinator was the state: it polled CI, polled quota, and held the
task list in conversation. That burns coordinator tokens on waiting and loses
everything when a session ends.

## Tracked state — survives any session

- `docs/coordination/tasks/<id>.md` — goal, base SHA, dependencies, **exact file
  lease**, forbidden files, API contract, acceptance criteria, required tests,
  assigned lane, independent verifier, stop conditions.
- `docs/coordination/handoffs/<lane>.md` — branch, exact commit SHA, changed files,
  **commands actually executed**, real test results, unresolved findings,
  assumptions, self-review limitations, and whether the lane also authored the code
  under review.

Acceptance criterion for both: another model must be able to resume from these files
plus Git history alone, with no conversation context.

Runtime state stays in the gitignored `.fleet/` — queue, events, locks, logs,
sessions, decision packets.

## The orchestrator is a process, not a model

`scripts/fleet/orchestrator.py` resolves dependencies, checks quota, assigns
worktrees, takes file leases, dispatches lanes, **distinguishes an init stall from a
permission stall**, watches for real state changes, and runs `merge_gate.py`.

It escalates to a coordinator only for **decisions** — API contracts, lease
conflicts, non-obvious conflicts, BLOCKERs, code-caused CI failures, gate refusals,
ready-to-merge — and never for waiting. Events are hashed so the same one is never
raised twice.

It deliberately **cannot**: make architecture decisions, ignore a BLOCKER, merge
without review or with unresolved threads, push to `main`, touch credentials, assign
two writers to one file, or accept a lane's self-report as proof of completion.

## Concurrency safety

Files that reliably conflict — crate `lib.rs` exports, `main.rs`, `Cargo.toml`,
`Cargo.lock` — are integration paths: only a lane holding the integration lease may
edit them, one at a time. Implementation lanes get new modules and their own test
files instead, with export wiring deferred to a serial integration commit. Verified
in practice: five lanes dispatched with nine leases held, all disjoint, one writer
per file.

## Detached execution

`scripts/fleet/orchestratord.sh {start|stop|status|logs}` runs it via a double fork:
no controlling terminal, reparented to init (**verified PPID 1**), output to
`.fleet/logs`, PID recorded, **double-start refused**, graceful stop. No sudo, no
system-wide daemon, no secrets outside the repo.

## Also included

- The **Fugu lane** for Zellij/OpenSSH/remote process-boundary work. This is a lane
  assignment, not the start of SSH implementation.
- **D-M3-001**, the minimum session API contract the parallel M3 lanes code against,
  written to respect ADR 0003: no pane, tab, or layout type anywhere, and sessions
  are opaque to Noren.
- Six M3 task specs with **fully disjoint file leases**.

`python3 scripts/check_docs.py` passes. No crate source changed.