### PR TITLE
ci: scope audit concurrency per job, not per workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,14 +14,17 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: audit-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   deny:
     name: Dependency audit (cargo-deny)
     runs-on: ubuntu-latest
+    # Scoped per job: these two jobs use different runner pools, so a shared
+    # workflow-level concurrency group meant re-queuing the macOS MSRV job also
+    # cancelled a dependency audit that was about to pass.
+    concurrency:
+      group: audit-deny-${{ github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 10
     steps:
       - name: Check out repository
@@ -45,6 +48,9 @@ jobs:
   msrv:
     name: Verify MSRV build (rust-version)
     runs-on: macos-14
+    concurrency:
+      group: audit-msrv-${{ github.ref }}
+      cancel-in-progress: true
     timeout-minutes: 20
     steps:
       - name: Check out repository


### PR DESCRIPTION
## The problem

The `Audit` workflow runs two jobs on **different runner pools** — `cargo-deny` on
`ubuntu-latest`, the MSRV build on `macos-14` — under a single workflow-level
`concurrency` group with `cancel-in-progress: true`.

That means re-queuing the macOS job **also cancels the ubuntu dependency audit**,
including runs that were seconds from passing.

## How it surfaced

Three PRs (#68, #69, #72) sat `BLOCKED` with `Dependency audit (cargo-deny)` showing
`CANCELLED`, zero steps, and no retrievable log, while `Verify MSRV build` stayed
`QUEUED` behind an exhausted macOS runner pool (8 runs queued, **0 in progress**).

The failure mode is self-reinforcing: each retry re-queues the macOS job at the back
of the same empty pool *and* cancels another ubuntu job that would have passed. I
made this worse before diagnosing it — the reruns I triggered destroyed passing
results rather than recovering anything.

## The fix

Each job now carries its own concurrency group, so it cancels only its own
superseded runs. A stall on one runner pool can no longer destroy results on the
other.

## Note on the underlying stall

This does not fix the macOS runner backlog itself, which is either a GitHub-side
capacity shortage or an account Actions limit — determining which needs the billing
endpoint. What it does fix is the damage amplification: with this change, the ubuntu
audit completes and reports normally regardless of what the macOS queue is doing.