### PR TITLE
feat(app): session lifecycle supervisor (M3-1b)

### DIFF
--- a/crates/noren-app/src/session_supervisor.rs
+++ b/crates/noren-app/src/session_supervisor.rs
@@ -1,0 +1,1063 @@
+//! Session lifecycle supervisor: spawn, terminate, select, process ownership,
+//! child reaping, and stale/dead session handling.
+//!
+//! # What this lane owns
+//!
+//! The supervisor is the sole owner of live child handles. It:
+//!
+//! - **spawns** sessions through an injected [`Spawner`] (the seam where the
+//!   real PTY wiring drops in),
+//! - **reaps** them on a non-blocking [`SessionSupervisor::poll`] so a child
+//!   that died is surfaced as [`SessionStatus::Exited`] or
+//!   [`SessionStatus::Failed`] — never a stuck [`SessionStatus::Running`],
+//! - **terminates** them with [`SessionSupervisor::terminate`], which delegates
+//!   to the child's own kill+reap under one shared deadline and is idempotent,
+//! - **selects** the focused session, refusing to focus a dead one, and
+//! - **forgets** terminal sessions so their records can be retired.
+//!
+//! The registry (the parallel session-domain lane) never owns a child handle;
+//! it observes status through this module by id. That ownership split is the
+//! point of the lane: a dead child must become `Exited`/`Failed`, not a frozen
+//! `Running`, and only the supervisor can move that needle because only it holds
+//! the handle.
+//!
+//! # Termination contract
+//!
+//! Termination matches the existing PTY behaviour (`crates/noren-pty/src/lib.rs`
+//! `PtySession::shutdown`): it is bounded by a single deadline, reaps the child,
+//! and is idempotent. [`SessionSupervisor::shutdown_all`] computes one absolute
+//! deadline and feeds it to every session so the whole batch finishes within
+//! that budget rather than `n * deadline`. A second call on an already-terminal
+//! session returns the recorded status without redoing work and without
+//! re-invoking the backend.
+//!
+//! # Integration with D-M3-001 (stub boundary)
+//!
+//! The session-domain lane (`agent/m3-session-domain`) is defining the shared
+//! session API contract in parallel; it is **not** on `main` yet. The types
+//! marked `STUB` below — [`SessionId`], [`SessionStatus`], and
+//! [`SessionFailure`] — are the minimal local stand-ins needed to compile and
+//! test. They reference decision **D-M3-001**. Integration is a **deletion, not
+//! a merge**: delete the `STUB` block and re-export the domain's types, then
+//! point [`SessionSupervisor`] at them. Everything else here (the [`Child`]
+//! trait, the [`Spawner`] seam, [`SessionSupervisor`] itself, the reaping state
+//! machine, the mock) is this lane's real, non-stub deliverable.
+//!
+//! # Not wired yet
+//!
+//! This module is intentionally **not** declared in `crates/noren-app/src/lib.rs`
+//! (wiring is a later serial integration commit). The integration test includes
+//! it via `#[path = "../src/session_supervisor.rs"]` so it compiles and runs as
+//! a standalone test target against a fake/mock process model plus a failure
+//! matrix. See `tests/session_supervisor.rs`.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::time::{Duration, Instant};
+
+/// Deadline for orderly shutdown of one session or the whole batch.
+///
+/// Mirrors `noren-pty::SHUTDOWN_DEADLINE` so termination budgets agree across
+/// the two layers. Termination never blocks longer than this.
+pub const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(2);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// STUB block — delete on integration with D-M3-001 (session-domain lane).
+// These stand in for the domain's `SessionId` / status / failure types only so
+// this lane compiles and tests in isolation. Do not extend them.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// STUB (D-M3-001): opaque session identifier.
+///
+/// Locally an incrementing `u64`. The domain's id type replaces this verbatim;
+/// the supervisor only stores and compares ids and never inspects their bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SessionId(u64);
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "session#{}", self.0)
+    }
+}
+
+/// STUB (D-M3-001): observed lifecycle status of a supervised session.
+///
+/// The two terminal variants are the load-bearing distinction: once the child
+/// is dead it is [`SessionStatus::Exited`] (it ran and stopped, with an exit
+/// code when the backend reported one) or [`SessionStatus::Failed`] (the
+/// supervisor could not cleanly reap it). It is never left as
+/// [`SessionStatus::Running`] after death.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionStatus {
+    /// Spawned and not yet observed to have exited.
+    Running,
+    /// Reaped after exiting. `code` is `Some(n)` when the backend reported an
+    /// exit code and `None` for a signal-style death with no code.
+    Exited {
+        /// Backend-reported exit code, if any.
+        code: Option<u32>,
+    },
+    /// Reaped or abandoned after an operational fault: spawn/kill/reap error or
+    /// a reap that overshot the deadline.
+    Failed {
+        /// Typed reason, control-plane only (no child output).
+        reason: SessionFailure,
+    },
+}
+
+/// STUB (D-M3-001): why a session became [`SessionStatus::Failed`].
+///
+/// Control-plane only: it never carries PTY bytes, screen text, or commands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionFailure {
+    /// The spawner could not produce a child handle.
+    SpawnFailed,
+    /// A non-blocking liveness poll reported a backend error.
+    PollFailed,
+    /// The backend kill/reap returned a hard error (not a timeout).
+    ShutdownFailed,
+    /// The kill/reap did not complete before the deadline; the child was
+    /// abandoned as failed rather than left `Running`.
+    ReapTimeout,
+}
+
+impl fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Running => f.write_str("running"),
+            Self::Exited { code: Some(code) } => write!(f, "exited(code={code})"),
+            Self::Exited { code: None } => f.write_str("exited"),
+            Self::Failed { reason } => write!(f, "failed({reason})"),
+        }
+    }
+}
+
+impl fmt::Display for SessionFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SpawnFailed => f.write_str("spawn-failed"),
+            Self::PollFailed => f.write_str("poll-failed"),
+            Self::ShutdownFailed => f.write_str("shutdown-failed"),
+            Self::ReapTimeout => f.write_str("reap-timeout"),
+        }
+    }
+}
+
+/// True when the status is one of the terminal (`Exited`/`Failed`) variants.
+fn is_terminal(status: SessionStatus) -> bool {
+    !matches!(status, SessionStatus::Running)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process handle trait — the supervisor owns this; the registry never does.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Failure reported by a [`Child`] operation. Control-plane only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChildError {
+    /// A non-blocking liveness poll failed.
+    Poll,
+    /// The bounded kill/reap failed. `TimedOut` means the deadline elapsed
+    /// before the child was reaped; `Failed` is any other backend error.
+    Shutdown(ShutdownError),
+}
+
+/// Outcome of a non-blocking [`Child::poll_exit`] probe.
+///
+/// This exists specifically to keep "still alive" distinct from "exited with no
+/// code" — the ambiguity that would otherwise let a dead child read as `Running`.
+/// A reaped child is always [`PollOutcome::Exited`], with `code: None` for a
+/// signal-style death; only a genuinely live child is [`PollOutcome::StillRunning`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PollOutcome {
+    /// The child is still alive; no exit has been reaped.
+    StillRunning,
+    /// The child has exited and been reaped. `code` is `Some(n)` when the
+    /// backend reported a code and `None` for a signal-style death.
+    Exited {
+        /// Backend-reported exit code, if any.
+        code: Option<u32>,
+    },
+}
+
+/// Sub-reason for a [`ChildError::Shutdown`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShutdownError {
+    /// The backend returned a hard error from kill or reap.
+    Failed,
+    /// The deadline elapsed before reap completed.
+    TimedOut,
+}
+
+impl fmt::Display for ChildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Poll => f.write_str("child poll failed"),
+            Self::Shutdown(ShutdownError::Failed) => f.write_str("child shutdown failed"),
+            Self::Shutdown(ShutdownError::TimedOut) => f.write_str("child shutdown timed out"),
+        }
+    }
+}
+
+impl fmt::Display for ShutdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Failed => f.write_str("failed"),
+            Self::TimedOut => f.write_str("timed-out"),
+        }
+    }
+}
+
+impl std::error::Error for ChildError {}
+
+/// A supervised child process handle.
+///
+/// The supervisor holds the only strong reference to a live child; the registry
+/// never does. The trait deliberately exposes only the two operations the
+/// supervisor needs:
+///
+/// - [`Child::poll_exit`] is the non-blocking reaping probe. It returns
+///   [`PollOutcome::StillRunning`] while the child is alive and
+///   [`PollOutcome::Exited`] once the backend has observed and reaped the exit.
+///   The explicit outcome is what turns a dead child into `Exited` instead of a
+///   stuck `Running` — "exited with no code" must not be confusable with
+///   "still alive".
+/// - [`Child::shutdown`] performs kill + reap + join under the supplied
+///   deadline and is idempotent at the backend level (a repeat call after exit
+///   is a no-op), mirroring `noren-pty::PtySession::shutdown`.
+///
+/// Production wiring is a thin adapter over `noren-pty::PtySession`:
+/// `poll_exit` drains `try_recv` for `PtyEvent::Exited` (mapping it to
+/// [`PollOutcome::Exited`], and absence to [`PollOutcome::StillRunning`]), and
+/// `shutdown` forwards to `PtySession::shutdown`. That adapter lives in the
+/// serial integration commit, not here, so this module stays free of PTY types.
+pub trait Child: Send {
+    /// Non-blocking liveness probe.
+    fn poll_exit(&mut self) -> Result<PollOutcome, ChildError>;
+
+    /// Kill, reap, and join before `deadline`. Idempotent.
+    fn shutdown(&mut self, deadline: Instant) -> Result<(), ChildError>;
+}
+
+/// Factory that creates a [`Child`] for a new session.
+///
+/// This is the seam where real PTY spawn wiring drops in. The supervisor owns
+/// child *handles*; it does not own spawn policy (program, argv, cwd, size),
+/// which is the domain lane's concern and arrives through this trait.
+pub trait Spawner: Send {
+    /// Create one child handle. The returned box is owned solely by the
+    /// supervisor from this point on.
+    fn spawn(&mut self) -> Result<Box<dyn Child + Send>, SessionFailure>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Selection and record-management errors.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Why a [`SessionSupervisor::select`] or [`SessionSupervisor::forget`] failed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionOpError {
+    /// The id is unknown to the supervisor.
+    Unknown,
+    /// A select targeted a session that is no longer running.
+    NotRunning,
+    /// A forget targeted a session that must be terminated first.
+    StillRunning,
+}
+
+impl fmt::Display for SessionOpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unknown => f.write_str("unknown session"),
+            Self::NotRunning => f.write_str("session is not running"),
+            Self::StillRunning => f.write_str("session is still running"),
+        }
+    }
+}
+
+impl std::error::Error for SessionOpError {}
+
+/// Transitions observed during one [`SessionSupervisor::poll`] pass.
+///
+/// Lists exactly the sessions that left `Running` this pass, in insertion order.
+/// `Exited` and `Failed` are reported separately so a caller can distinguish a
+/// natural exit from an operational fault without re-reading status.
+#[derive(Debug, Default)]
+pub struct ReapReport {
+    exited: Vec<(SessionId, Option<u32>)>,
+    failed: Vec<(SessionId, SessionFailure)>,
+}
+
+impl ReapReport {
+    /// Sessions that exited this pass with their backend exit code.
+    #[must_use]
+    pub fn exited(&self) -> &[(SessionId, Option<u32>)] {
+        &self.exited
+    }
+
+    /// Sessions that failed this pass with their typed reason.
+    #[must_use]
+    pub fn failed(&self) -> &[(SessionId, SessionFailure)] {
+        &self.failed
+    }
+
+    /// Total sessions that left `Running` this pass.
+    #[must_use]
+    pub fn transitioned(&self) -> usize {
+        self.exited.len() + self.failed.len()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The supervisor.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One supervised session: an optional live child handle plus its status.
+///
+/// `child` is `None` once the session is terminal — the supervisor has reaped
+/// and released the handle. The status remains so callers can observe the
+/// outcome by id.
+struct SupervisedSession {
+    child: Option<Box<dyn Child + Send>>,
+    status: SessionStatus,
+}
+
+/// Lifecycle supervisor owning every live child handle.
+///
+/// Construct with [`SessionSupervisor::new`] and an injected [`Spawner`]. The
+/// supervisor is single-threaded by design (it runs on the app's main thread or
+/// a dedicated worker); it does not need to be `Send` because child handles need
+/// not be `Sync`.
+pub struct SessionSupervisor {
+    sessions: HashMap<SessionId, SupervisedSession>,
+    order: Vec<SessionId>,
+    selected: Option<SessionId>,
+    spawner: Box<dyn Spawner>,
+    next_id: u64,
+}
+
+impl fmt::Debug for SessionSupervisor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SessionSupervisor")
+            .field("sessions", &self.sessions.len())
+            .field("selected", &self.selected)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionSupervisor {
+    /// Create an empty supervisor that spawns children through `spawner`.
+    pub fn new(spawner: Box<dyn Spawner>) -> Self {
+        Self {
+            sessions: HashMap::new(),
+            order: Vec::new(),
+            selected: None,
+            spawner,
+            next_id: 0,
+        }
+    }
+
+    /// Spawn a new session.
+    ///
+    /// On success the session is `Running` and becomes the selected one. On
+    /// failure no session is recorded and the typed reason is returned; the
+    /// spawner retains ownership of any partial child it created.
+    pub fn spawn(&mut self) -> Result<SessionId, SessionFailure> {
+        let child = self.spawner.spawn()?;
+        let id = self.fresh_id();
+        self.sessions.insert(
+            id,
+            SupervisedSession {
+                child: Some(child),
+                status: SessionStatus::Running,
+            },
+        );
+        self.order.push(id);
+        self.selected = Some(id);
+        Ok(id)
+    }
+
+    /// Current status of `id`, or `None` if unknown.
+    #[must_use]
+    pub fn status(&self, id: SessionId) -> Option<SessionStatus> {
+        self.sessions.get(&id).map(|session| session.status)
+    }
+
+    /// Number of tracked sessions (running or terminal).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// Whether any session is tracked.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    /// Number of sessions still `Running`.
+    #[must_use]
+    pub fn running_count(&self) -> usize {
+        self.sessions
+            .values()
+            .filter(|session| session.status == SessionStatus::Running)
+            .count()
+    }
+
+    /// The currently selected session id, if any.
+    #[must_use]
+    pub fn selected(&self) -> Option<SessionId> {
+        self.selected
+    }
+
+    /// Focus `id`. Fails if `id` is unknown or not `Running`: a dead session
+    /// surfaces as [`SessionOpError::NotRunning`], never as a silently-stuck
+    /// selection.
+    pub fn select(&mut self, id: SessionId) -> Result<(), SessionOpError> {
+        let session = self.sessions.get(&id).ok_or(SessionOpError::Unknown)?;
+        if session.status != SessionStatus::Running {
+            return Err(SessionOpError::NotRunning);
+        }
+        self.selected = Some(id);
+        Ok(())
+    }
+
+    /// Clear the current selection without terminating anything.
+    pub fn clear_selection(&mut self) {
+        self.selected = None;
+    }
+
+    /// Non-blocking reap pass over every `Running` session.
+    ///
+    /// For each still-running session this probes [`Child::poll_exit`]; a child
+    /// that has exited is moved to `Exited` and one whose poll errored is moved
+    /// to `Failed`. If the selected session transitioned, the selection is
+    /// cleared so a caller does not address a dead session as if it were live.
+    /// The transitioned sessions are returned in a [`ReapReport`].
+    pub fn poll(&mut self) -> ReapReport {
+        let mut report = ReapReport::default();
+        // Collect ids first to avoid borrowing `sessions` across child calls.
+        let running: Vec<SessionId> = self
+            .sessions
+            .iter()
+            .filter(|(_, session)| session.status == SessionStatus::Running)
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in running {
+            let outcome = match self.sessions.get_mut(&id) {
+                Some(session) => match session.child.as_mut() {
+                    Some(child) => child.poll_exit(),
+                    // No handle and still Running is an internal inconsistency;
+                    // surface it as a failure rather than freezing.
+                    None => Err(ChildError::Poll),
+                },
+                None => continue,
+            };
+            match outcome {
+                Ok(PollOutcome::StillRunning) => {}
+                Ok(PollOutcome::Exited { code }) => self.mark_exited(&mut report, id, code),
+                Err(ChildError::Poll) => {
+                    self.mark_failed(&mut report, id, SessionFailure::PollFailed)
+                }
+                Err(ChildError::Shutdown(reason)) => {
+                    self.mark_failed(&mut report, id, shutdown_to_failure(reason));
+                }
+            }
+        }
+        report
+    }
+
+    /// Terminate `id`: kill + reap under `deadline`, idempotently.
+    ///
+    /// - If `id` is already terminal, returns its status without redoing work.
+    /// - If `deadline` has already passed, marks `Failed(ReapTimeout)`.
+    /// - Otherwise delegates to [`Child::shutdown`], then reads the exit code:
+    ///   a code → `Exited`, no observable code → `Exited { code: None }`, a
+    ///   backend error → `Failed`.
+    ///
+    /// The child handle is released once terminal.
+    pub fn terminate(&mut self, id: SessionId, deadline: Instant) -> SessionStatus {
+        // Fast path: already terminal — idempotent, no backend call.
+        let already = self.sessions.get(&id).map(|session| session.status);
+        match already {
+            Some(status) if is_terminal(status) => return status,
+            None => {
+                return SessionStatus::Failed {
+                    reason: SessionFailure::PollFailed,
+                };
+            }
+            _ => {}
+        }
+
+        if Instant::now() >= deadline {
+            return self.finalize_failed(id, SessionFailure::ReapTimeout);
+        }
+
+        let backend = self
+            .sessions
+            .get_mut(&id)
+            .and_then(|session| session.child.as_mut());
+        let result = match backend {
+            Some(child) => child.shutdown(deadline),
+            None => Err(ChildError::Poll),
+        };
+
+        match result {
+            Ok(()) => {
+                // After a successful shutdown the backend has reaped the child;
+                // read the recorded code. `shutdown` returning `Ok` is itself the
+                // terminal signal, so even `StillRunning` (a backend
+                // inconsistency) is recorded as `Exited { code: None }` rather
+                // than leaving the session `Running`.
+                let code = match self.poll_after_shutdown(id) {
+                    Ok(PollOutcome::Exited { code }) => code,
+                    Ok(PollOutcome::StillRunning) => None,
+                    Err(_) => None,
+                };
+                self.finalize_exited(id, code)
+            }
+            Err(ChildError::Shutdown(reason)) => {
+                self.finalize_failed(id, shutdown_to_failure(reason))
+            }
+            Err(ChildError::Poll) => self.finalize_failed(id, SessionFailure::ShutdownFailed),
+        }
+    }
+
+    /// Read the post-shutdown outcome without borrowing `sessions` across calls.
+    fn poll_after_shutdown(&mut self, id: SessionId) -> Result<PollOutcome, ChildError> {
+        match self.sessions.get_mut(&id) {
+            Some(session) => match session.child.as_mut() {
+                Some(child) => child.poll_exit(),
+                None => Ok(PollOutcome::Exited { code: None }),
+            },
+            None => Ok(PollOutcome::Exited { code: None }),
+        }
+    }
+
+    /// Terminate `id` under the standard [`SHUTDOWN_DEADLINE`] from now.
+    pub fn terminate_now(&mut self, id: SessionId) -> SessionStatus {
+        let deadline = Instant::now() + SHUTDOWN_DEADLINE;
+        self.terminate(id, deadline)
+    }
+
+    /// Terminate every session under one shared deadline.
+    ///
+    /// Computes a single `now + SHUTDOWN_DEADLINE` and feeds it to each
+    /// [`Self::terminate`], so the whole batch is bounded by one deadline
+    /// rather than `n * deadline`. Already-terminal sessions are skipped.
+    /// Idempotent: a second call performs no backend work. Returns the final
+    /// status of every session in insertion order, and clears the selection.
+    pub fn shutdown_all(&mut self) -> Vec<(SessionId, SessionStatus)> {
+        let deadline = Instant::now() + SHUTDOWN_DEADLINE;
+        let ids = self.order.clone();
+        let mut results = Vec::with_capacity(ids.len());
+        for id in ids {
+            let status = self.terminate(id, deadline);
+            results.push((id, status));
+        }
+        self.selected = None;
+        results
+    }
+
+    /// Retire a terminal session's record.
+    ///
+    /// Returns [`SessionOpError::StillRunning`] for a live session (terminate it
+    /// first) and [`SessionOpError::Unknown`] for an unknown id.
+    pub fn forget(&mut self, id: SessionId) -> Result<(), SessionOpError> {
+        let status = self
+            .sessions
+            .get(&id)
+            .ok_or(SessionOpError::Unknown)?
+            .status;
+        if status == SessionStatus::Running {
+            return Err(SessionOpError::StillRunning);
+        }
+        self.sessions.remove(&id);
+        self.order.retain(|existing| *existing != id);
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+        Ok(())
+    }
+
+    fn fresh_id(&mut self) -> SessionId {
+        let id = SessionId(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        id
+    }
+
+    fn mark_exited(&mut self, report: &mut ReapReport, id: SessionId, code: Option<u32>) {
+        if let Some(session) = self.sessions.get_mut(&id) {
+            session.status = SessionStatus::Exited { code };
+            session.child = None;
+        }
+        report.exited.push((id, code));
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+    }
+
+    fn mark_failed(&mut self, report: &mut ReapReport, id: SessionId, reason: SessionFailure) {
+        if let Some(session) = self.sessions.get_mut(&id) {
+            session.status = SessionStatus::Failed { reason };
+            session.child = None;
+        }
+        report.failed.push((id, reason));
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+    }
+
+    fn finalize_exited(&mut self, id: SessionId, code: Option<u32>) -> SessionStatus {
+        if let Some(session) = self.sessions.get_mut(&id) {
+            session.status = SessionStatus::Exited { code };
+            session.child = None;
+        }
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+        SessionStatus::Exited { code }
+    }
+
+    fn finalize_failed(&mut self, id: SessionId, reason: SessionFailure) -> SessionStatus {
+        if let Some(session) = self.sessions.get_mut(&id) {
+            session.status = SessionStatus::Failed { reason };
+            session.child = None;
+        }
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+        SessionStatus::Failed { reason }
+    }
+}
+
+fn shutdown_to_failure(reason: ShutdownError) -> SessionFailure {
+    match reason {
+        ShutdownError::TimedOut => SessionFailure::ReapTimeout,
+        ShutdownError::Failed => SessionFailure::ShutdownFailed,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock process model + scripted failure harness (test-only).
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The mock is a tiny shared-state machine a test drives through a
+// [`mock::MockController`]: flip the child to exited, or toggle poll/shutdown
+// failures. This is what makes the failure matrix deterministic without
+// spawning real processes. It is `pub` under `cfg(test)` so both this module's
+// unit tests and the `tests/session_supervisor.rs` integration target (which
+// includes this file via `#[path]`, and for which `cfg(test)` is also enabled)
+// share one definition. Production never references it.
+
+#[cfg(test)]
+pub mod mock {
+    use super::{Child, ChildError, PollOutcome, SessionFailure, ShutdownError};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    #[derive(Debug)]
+    struct MockState {
+        alive: bool,
+        exit_code: Option<u32>,
+        poll_error: bool,
+        shutdown_error: Option<ShutdownError>,
+        shutdown_calls: u32,
+        poll_calls: u32,
+    }
+
+    impl Default for MockState {
+        fn default() -> Self {
+            Self {
+                alive: true,
+                exit_code: None,
+                poll_error: false,
+                shutdown_error: None,
+                shutdown_calls: 0,
+                poll_calls: 0,
+            }
+        }
+    }
+
+    /// Scripted child for the failure matrix. Shares its state with a
+    /// [`MockController`] the test holds.
+    pub struct MockChild {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    /// Test-side handle that scripts a [`MockChild`] the supervisor owns.
+    pub struct MockController {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    impl MockChild {
+        /// A live child with no scripted failure.
+        #[must_use]
+        pub fn running() -> Self {
+            Self::running_with_control().0
+        }
+
+        /// A live child plus the controller that scripts it.
+        #[must_use]
+        pub fn running_with_control() -> (Self, MockController) {
+            let state = Arc::new(Mutex::new(MockState::default()));
+            (
+                Self {
+                    state: Arc::clone(&state),
+                },
+                MockController { state },
+            )
+        }
+    }
+
+    impl Child for MockChild {
+        fn poll_exit(&mut self) -> Result<PollOutcome, ChildError> {
+            let mut state = self.state.lock().expect("mock lock");
+            state.poll_calls += 1;
+            if state.poll_error {
+                return Err(ChildError::Poll);
+            }
+            if state.alive {
+                Ok(PollOutcome::StillRunning)
+            } else {
+                // The recorded code verbatim: `Some(n)` for a self-exit with a
+                // code, `None` for a signal-style death or a supervisor kill
+                // (kill produces no clean exit code in this model). The
+                // outcome stays `Exited`, never `StillRunning`, once dead.
+                Ok(PollOutcome::Exited {
+                    code: state.exit_code,
+                })
+            }
+        }
+
+        fn shutdown(&mut self, _deadline: Instant) -> Result<(), ChildError> {
+            let mut state = self.state.lock().expect("mock lock");
+            state.shutdown_calls += 1;
+            if let Some(error) = state.shutdown_error {
+                return Err(ChildError::Shutdown(error));
+            }
+            // Kill takes effect: the child is no longer alive. The exit code is
+            // whatever the controller scripted (None for a signal-style kill,
+            // which is the default).
+            state.alive = false;
+            Ok(())
+        }
+    }
+
+    impl MockController {
+        /// Make the child exit on its own with `code` (`None` = signal-style).
+        pub fn exit(&self, code: Option<u32>) {
+            let mut state = self.state.lock().expect("mock lock");
+            state.alive = false;
+            state.exit_code = code;
+        }
+
+        /// Cause the next and subsequent `poll_exit` calls to error.
+        pub fn fail_poll(&self) {
+            self.state.lock().expect("mock lock").poll_error = true;
+        }
+
+        /// Cause the next and subsequent `shutdown` calls to error with `reason`.
+        pub fn fail_shutdown(&self, reason: ShutdownError) {
+            self.state.lock().expect("mock lock").shutdown_error = Some(reason);
+        }
+
+        /// Number of times the supervisor called `shutdown`.
+        #[must_use]
+        pub fn shutdown_count(&self) -> u32 {
+            self.state.lock().expect("mock lock").shutdown_calls
+        }
+
+        /// Number of times the supervisor called `poll_exit`.
+        #[must_use]
+        pub fn poll_count(&self) -> u32 {
+            self.state.lock().expect("mock lock").poll_calls
+        }
+    }
+
+    /// Spawner that dispenses pre-built children in order.
+    pub struct MockSpawner {
+        children: std::collections::VecDeque<MockChild>,
+        fail_next: bool,
+    }
+
+    impl MockSpawner {
+        /// Dispense `children` in order.
+        #[must_use]
+        pub fn from_children(children: Vec<MockChild>) -> Self {
+            Self {
+                children: children.into(),
+                fail_next: false,
+            }
+        }
+
+        /// A spawner whose next `spawn` fails with [`SessionFailure::SpawnFailed`].
+        #[must_use]
+        pub fn failing() -> Self {
+            Self {
+                children: std::collections::VecDeque::new(),
+                fail_next: true,
+            }
+        }
+    }
+
+    impl super::Spawner for MockSpawner {
+        fn spawn(&mut self) -> Result<Box<dyn Child + Send>, SessionFailure> {
+            if self.fail_next {
+                return Err(SessionFailure::SpawnFailed);
+            }
+            self.children
+                .pop_front()
+                .map(|child| Box::new(child) as Box<dyn Child + Send>)
+                .ok_or(SessionFailure::SpawnFailed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The supervisor's own failure-matrix unit tests. The independent
+    //! integration verification lives in `tests/session_supervisor.rs`.
+
+    use super::mock::{MockChild, MockSpawner};
+    use super::{
+        ChildError, SessionFailure, SessionOpError, SessionStatus, SessionSupervisor, ShutdownError,
+    };
+
+    fn supervisor_with(children: Vec<MockChild>) -> SessionSupervisor {
+        SessionSupervisor::new(Box::new(MockSpawner::from_children(children)))
+    }
+
+    #[test]
+    fn spawn_assigns_unique_ids_and_selects_newest() {
+        let mut sup = supervisor_with(vec![MockChild::running(), MockChild::running()]);
+        let a = sup.spawn().expect("first spawn");
+        let b = sup.spawn().expect("second spawn");
+        assert_ne!(a, b);
+        assert_eq!(sup.status(a), Some(SessionStatus::Running));
+        assert_eq!(sup.status(b), Some(SessionStatus::Running));
+        assert_eq!(sup.selected(), Some(b));
+        assert_eq!(sup.running_count(), 2);
+        assert_eq!(sup.len(), 2);
+        assert!(!sup.is_empty());
+    }
+
+    #[test]
+    fn poll_surfaces_unprompted_exit_as_exited_not_running() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        assert_eq!(sup.status(id), Some(SessionStatus::Running));
+
+        // The child exits on its own with code 0; poll must discover it.
+        ctrl.exit(Some(0));
+        let report = sup.poll();
+        assert_eq!(report.transitioned(), 1);
+        assert_eq!(report.exited(), &[(id, Some(0))]);
+        assert_eq!(
+            sup.status(id),
+            Some(SessionStatus::Exited { code: Some(0) })
+        );
+        // The load-bearing invariant: not Running, and selection cleared.
+        assert_ne!(sup.status(id), Some(SessionStatus::Running));
+        assert_eq!(sup.selected(), None);
+    }
+
+    #[test]
+    fn non_zero_and_signal_like_exits_round_trip_through_poll() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        ctrl.exit(Some(7));
+        let _ = sup.poll();
+        assert_eq!(
+            sup.status(id),
+            Some(SessionStatus::Exited { code: Some(7) })
+        );
+
+        // A signal-style death reports no code and is still Exited.
+        let (child2, ctrl2) = MockChild::running_with_control();
+        let mut sup2 = supervisor_with(vec![child2]);
+        let id2 = sup2.spawn().expect("spawn");
+        ctrl2.exit(None);
+        let _ = sup2.poll();
+        assert_eq!(sup2.status(id2), Some(SessionStatus::Exited { code: None }));
+    }
+
+    #[test]
+    fn poll_error_surfaces_as_failed_not_running() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        ctrl.fail_poll();
+        let report = sup.poll();
+        assert_eq!(report.failed(), &[(id, SessionFailure::PollFailed)]);
+        assert_eq!(
+            sup.status(id),
+            Some(SessionStatus::Failed {
+                reason: SessionFailure::PollFailed
+            })
+        );
+        assert_ne!(sup.status(id), Some(SessionStatus::Running));
+    }
+
+    #[test]
+    fn terminate_reaps_a_running_child_and_is_idempotent() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+
+        let status = sup.terminate_now(id);
+        // The mock's shutdown kills the child; a kill yields no clean exit code,
+        // so the recorded status is `Exited { code: None }`.
+        assert_eq!(status, SessionStatus::Exited { code: None });
+        assert_eq!(ctrl.shutdown_count(), 1);
+
+        // Idempotent: no second backend shutdown, same status.
+        let again = sup.terminate_now(id);
+        assert_eq!(again, status);
+        assert_eq!(ctrl.shutdown_count(), 1);
+    }
+
+    #[test]
+    fn terminate_already_terminal_does_no_backend_work() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        ctrl.exit(Some(3));
+        let _ = sup.poll();
+        let before = ctrl.shutdown_count();
+        let status = sup.terminate_now(id);
+        assert_eq!(status, SessionStatus::Exited { code: Some(3) });
+        assert_eq!(ctrl.shutdown_count(), before);
+    }
+
+    #[test]
+    fn terminate_shutdown_failure_surfaces_as_failed() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        ctrl.fail_shutdown(ShutdownError::Failed);
+        let status = sup.terminate_now(id);
+        assert_eq!(
+            status,
+            SessionStatus::Failed {
+                reason: SessionFailure::ShutdownFailed
+            }
+        );
+    }
+
+    #[test]
+    fn terminate_deadline_timeout_surfaces_as_reap_timeout() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        ctrl.fail_shutdown(ShutdownError::TimedOut);
+        let status = sup.terminate_now(id);
+        assert_eq!(
+            status,
+            SessionStatus::Failed {
+                reason: SessionFailure::ReapTimeout
+            }
+        );
+    }
+
+    #[test]
+    fn terminate_with_elapsed_deadline_is_reap_timeout_without_backend_call() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        let past = std::time::Instant::now();
+        let status = sup.terminate(id, past);
+        assert_eq!(
+            status,
+            SessionStatus::Failed {
+                reason: SessionFailure::ReapTimeout
+            }
+        );
+        assert_eq!(ctrl.shutdown_count(), 0);
+    }
+
+    #[test]
+    fn shutdown_all_terminates_every_session_under_one_deadline_and_is_idempotent() {
+        let mut sup = supervisor_with(vec![
+            MockChild::running(),
+            MockChild::running(),
+            MockChild::running(),
+        ]);
+        let ids: Vec<_> = (0..3).map(|_| sup.spawn().expect("spawn")).collect();
+        assert_eq!(sup.running_count(), 3);
+
+        let results = sup.shutdown_all();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results.iter().map(|(id, _)| *id).collect::<Vec<_>>(), ids);
+        for (_, status) in &results {
+            assert_ne!(*status, SessionStatus::Running);
+        }
+        assert_eq!(sup.running_count(), 0);
+        assert_eq!(sup.selected(), None);
+
+        // Idempotent: a second pass keeps everything terminal.
+        let again = sup.shutdown_all();
+        assert_eq!(again.len(), 3);
+        assert_eq!(sup.running_count(), 0);
+    }
+
+    #[test]
+    fn select_refuses_dead_and_unknown() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        // Unknown id.
+        assert_eq!(
+            sup.select(super::SessionId(999)),
+            Err(SessionOpError::Unknown)
+        );
+        // Live session is selectable.
+        sup.select(id).expect("select live");
+        // Once dead, selecting it again surfaces NotRunning, not a stuck focus.
+        ctrl.exit(Some(0));
+        let _ = sup.poll();
+        assert_eq!(sup.select(id), Err(SessionOpError::NotRunning));
+    }
+
+    #[test]
+    fn forget_requires_terminal_and_removes_record() {
+        let (child, ctrl) = MockChild::running_with_control();
+        let mut sup = supervisor_with(vec![child]);
+        let id = sup.spawn().expect("spawn");
+        assert_eq!(sup.forget(id), Err(SessionOpError::StillRunning));
+        ctrl.exit(Some(0));
+        let _ = sup.poll();
+        sup.forget(id).expect("forget terminal");
+        assert_eq!(sup.status(id), None);
+        assert!(sup.is_empty());
+        assert_eq!(sup.forget(id), Err(SessionOpError::Unknown));
+    }
+
+    #[test]
+    fn spawn_failure_records_no_session() {
+        let mut sup = supervisor_with(vec![]); // empty dispenser -> SpawnFailed
+        let result = sup.spawn();
+        assert_eq!(result, Err(SessionFailure::SpawnFailed));
+        assert!(sup.is_empty());
+        assert_eq!(sup.selected(), None);
+    }
+
+    #[test]
+    fn displays_carry_no_child_content() {
+        assert_eq!(
+            format!(
+                "{}",
+                SessionStatus::Failed {
+                    reason: SessionFailure::SpawnFailed
+                }
+            ),
+            "failed(spawn-failed)"
+        );
+        assert_eq!(format!("{}", super::SessionId(4)), "session#4");
+        let err = ChildError::Shutdown(ShutdownError::TimedOut);
+        assert_eq!(format!("{err}"), "child shutdown timed out");
+    }
+}

--- a/crates/noren-app/src/session_supervisor.rs
+++ b/crates/noren-app/src/session_supervisor.rs
@@ -231,6 +231,19 @@ impl std::error::Error for ChildError {}
 /// [`PollOutcome::Exited`], and absence to [`PollOutcome::StillRunning`]), and
 /// `shutdown` forwards to `PtySession::shutdown`. That adapter lives in the
 /// serial integration commit, not here, so this module stays free of PTY types.
+///
+/// # Drop semantics (integration note)
+///
+/// The production adapter (`noren-pty::PtySession`) runs a full `shutdown` in
+/// its `Drop` impl under its own internal deadline. Two consequences the serial
+/// integration commit must resolve: (a) `PtySession::shutdown` takes no
+/// deadline argument, so the `deadline` parameter here is advisory and the
+/// adapter's internal `SHUTDOWN_DEADLINE` governs; (b) when `terminate` marks
+/// `Failed(ReapTimeout)` on an already-elapsed deadline it drops the handle
+/// *without* calling `shutdown`, but the adapter's `Drop` will still run a
+/// shutdown attempt — so "no backend call" (asserted by the mock tests) will
+/// not hold in production. The integrator should either deadline-parameterise
+/// the adapter or make the kill path concurrent.
 pub trait Child: Send {
     /// Non-blocking liveness probe.
     fn poll_exit(&mut self) -> Result<PollOutcome, ChildError>;
@@ -328,6 +341,15 @@ struct SupervisedSession {
 /// supervisor is single-threaded by design (it runs on the app's main thread or
 /// a dedicated worker); it does not need to be `Send` because child handles need
 /// not be `Sync`.
+///
+/// # Record retention
+///
+/// Every spawned session's record is retained — even after it exits — until
+/// [`SessionSupervisor::forget`] is called. There is no automatic reaping of
+/// terminal records and no cap. A long-running supervisor whose owner never
+/// forgets grows without bound; the registry/domain (D-M3-001) must own an
+/// explicit retirement policy (e.g. forget after the UI observes the terminal
+/// status, or a record cap).
 pub struct SessionSupervisor {
     sessions: HashMap<SessionId, SupervisedSession>,
     order: Vec<SessionId>,
@@ -436,12 +458,18 @@ impl SessionSupervisor {
     /// The transitioned sessions are returned in a [`ReapReport`].
     pub fn poll(&mut self) -> ReapReport {
         let mut report = ReapReport::default();
-        // Collect ids first to avoid borrowing `sessions` across child calls.
+        // Collect ids in insertion order from `order`, not from `sessions` (a
+        // HashMap whose iteration order is randomized). The report's contract
+        // promises insertion order; iterating `order` is what delivers it.
         let running: Vec<SessionId> = self
-            .sessions
+            .order
             .iter()
-            .filter(|(_, session)| session.status == SessionStatus::Running)
-            .map(|(id, _)| *id)
+            .copied()
+            .filter(|id| {
+                self.sessions
+                    .get(id)
+                    .is_some_and(|session| session.status == SessionStatus::Running)
+            })
             .collect();
 
         for id in running {
@@ -475,6 +503,12 @@ impl SessionSupervisor {
     /// - Otherwise delegates to [`Child::shutdown`], then reads the exit code:
     ///   a code → `Exited`, no observable code → `Exited { code: None }`, a
     ///   backend error → `Failed`.
+    /// - An unknown `id` (never spawned or already forgotten) is reported as
+    ///   `Failed(PollFailed)` because `terminate` has no dedicated error
+    ///   channel. This is a defensive classification, not a genuine poll fault;
+    ///   callers that must distinguish unknown ids should check
+    ///   [`Self::status`] first. At D-M3-001 integration a typed `Unknown`
+    ///   variant (or a `Result` return) should replace this.
     ///
     /// The child handle is released once terminal.
     pub fn terminate(&mut self, id: SessionId, deadline: Instant) -> SessionStatus {
@@ -665,6 +699,7 @@ pub mod mock {
         shutdown_error: Option<ShutdownError>,
         shutdown_calls: u32,
         poll_calls: u32,
+        deadlines: Vec<Instant>,
     }
 
     impl Default for MockState {
@@ -676,6 +711,7 @@ pub mod mock {
                 shutdown_error: None,
                 shutdown_calls: 0,
                 poll_calls: 0,
+                deadlines: Vec::new(),
             }
         }
     }
@@ -731,9 +767,10 @@ pub mod mock {
             }
         }
 
-        fn shutdown(&mut self, _deadline: Instant) -> Result<(), ChildError> {
+        fn shutdown(&mut self, deadline: Instant) -> Result<(), ChildError> {
             let mut state = self.state.lock().expect("mock lock");
             state.shutdown_calls += 1;
+            state.deadlines.push(deadline);
             if let Some(error) = state.shutdown_error {
                 return Err(ChildError::Shutdown(error));
             }
@@ -773,6 +810,12 @@ pub mod mock {
         #[must_use]
         pub fn poll_count(&self) -> u32 {
             self.state.lock().expect("mock lock").poll_calls
+        }
+
+        /// Deadlines passed to each `shutdown` call, in call order.
+        #[must_use]
+        pub fn deadlines(&self) -> Vec<Instant> {
+            self.state.lock().expect("mock lock").deadlines.clone()
         }
     }
 

--- a/crates/noren-app/tests/session_supervisor.rs
+++ b/crates/noren-app/tests/session_supervisor.rs
@@ -273,3 +273,102 @@ fn error_and_status_displays_redact_all_child_content() {
         assert_eq!(rendered, expected);
     }
 }
+
+// ── Claim 7: ReapReport delivers transitions in insertion order ───────────
+//
+// The contract on `ReapReport` promises insertion order. `poll` collects ids
+// from `self.order` (a Vec), not from `sessions` (a HashMap with randomized
+// iteration order). A single-element case trivially passes regardless of the
+// source, so this test transitions enough sessions in one pass that a HashMap
+// order would almost certainly differ (10! permutations; only one is sorted).
+
+#[test]
+fn poll_reports_multi_session_transitions_in_insertion_order() {
+    const N: usize = 10;
+    let mut ctrls = Vec::new();
+    let mut children = Vec::new();
+    for _ in 0..N {
+        let (child, ctrl) = MockChild::running_with_control();
+        children.push(child);
+        ctrls.push(ctrl);
+    }
+    let mut sup = supervisor_with(children);
+    let ids: Vec<_> = (0..N).map(|_| sup.spawn().expect("spawn")).collect();
+
+    // Exit every child with a distinct code before polling so one pass observes
+    // all N transitions. Distinct codes also verify the right code is tied to
+    // the right id, not just that the id set matches.
+    for (i, ctrl) in ctrls.iter().enumerate() {
+        ctrl.exit(Some(i as u32));
+    }
+    let report = sup.poll();
+    assert_eq!(report.transitioned(), N);
+
+    let reported_ids: Vec<_> = report.exited().iter().map(|(id, _)| *id).collect();
+    assert_eq!(
+        reported_ids, ids,
+        "ReapReport must deliver transitions in insertion order"
+    );
+}
+
+// ── Claim 8: shutdown_all feeds one shared deadline to every child ─────────
+//
+// The shared-deadline contract (`shutdown_all` computes one Instant and feeds
+// it to every session, not n * deadline) cannot be caught by a wall-clock
+// assertion with an instant mock. This test records the deadline argument each
+// child received and asserts they are all identical — directly proving one
+// shared Instant reached the whole batch.
+
+#[test]
+fn shutdown_all_feeds_one_shared_deadline_to_every_child() {
+    const N: usize = 4;
+    let mut ctrls = Vec::new();
+    let mut children = Vec::new();
+    for _ in 0..N {
+        let (child, ctrl) = MockChild::running_with_control();
+        children.push(child);
+        ctrls.push(ctrl);
+    }
+    let mut sup = supervisor_with(children);
+    for _ in 0..N {
+        sup.spawn().expect("spawn");
+    }
+
+    let _results = sup.shutdown_all();
+
+    let all_deadlines: Vec<Instant> = ctrls.iter().flat_map(|c| c.deadlines()).collect();
+    assert_eq!(all_deadlines.len(), N, "each child shut down exactly once");
+    let shared = all_deadlines[0];
+    assert!(
+        all_deadlines.iter().all(|d| *d == shared),
+        "all children received the same shared deadline"
+    );
+}
+
+// ── Claim 9: forget + shutdown_all — forgotten ids stay forgotten ──────────
+//
+// `forget` removes the id from both `sessions` and `order`. If the `order`
+// removal regressed, `shutdown_all` (which iterates `order`) would resurrect
+// the forgotten id and report a fabricated failure for it.
+
+#[test]
+fn forget_then_shutdown_all_omits_the_forgotten_id() {
+    let mut sup = supervisor_with(vec![
+        MockChild::running(),
+        MockChild::running(),
+        MockChild::running(),
+    ]);
+    let a = sup.spawn().expect("spawn");
+    let b = sup.spawn().expect("spawn");
+    let c = sup.spawn().expect("spawn");
+
+    // Terminate + forget the middle session.
+    sup.terminate_now(b);
+    sup.forget(b).expect("retire middle");
+
+    // shutdown_all reports only the remaining ids, in insertion order — the
+    // forgotten id must not be resurrected.
+    let results = sup.shutdown_all();
+    let reported: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(reported, vec![a, c]);
+}

--- a/crates/noren-app/tests/session_supervisor.rs
+++ b/crates/noren-app/tests/session_supervisor.rs
@@ -1,0 +1,275 @@
+//! Independent verification of the session-supervisor lane (M3-1b).
+//!
+//! This target is written as an outside-in check of the public contract the
+//! task describes, against a fake/mock process model. The module under review
+//! is **not** wired into `noren-app/src/lib.rs` yet (wiring is a later serial
+//! integration commit), so it is compiled into this test binary via `#[path]`.
+//! `cfg(test)` is enabled for the test binary, which also brings the lane's
+//! `mock` harness into scope.
+//!
+//! The load-bearing claim under test — the reason this lane exists — is that a
+//! dead child surfaces as `Exited`/`Failed` and never stays `Running`, that
+//! termination reaps and is idempotent under one deadline, and that the
+//! supervisor (not a registry) owns the child handle.
+
+#![forbid(unsafe_code)]
+
+#[path = "../src/session_supervisor.rs"]
+mod session_supervisor;
+
+use session_supervisor::SessionSupervisor;
+use session_supervisor::mock::{MockChild, MockSpawner};
+use session_supervisor::{
+    ChildError, SessionFailure, SessionOpError, SessionStatus, ShutdownError,
+};
+use std::time::{Duration, Instant};
+
+/// Build a supervisor whose injected spawner dispenses `children` in order.
+fn supervisor_with(children: Vec<MockChild>) -> SessionSupervisor {
+    SessionSupervisor::new(Box::new(MockSpawner::from_children(children)))
+}
+
+// ── Claim 1: a dead child never remains Running ──────────────────────────
+
+#[test]
+fn unprompted_death_surfaces_as_exited_within_one_poll() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+
+    // Before death: Running and selected.
+    assert_eq!(sup.status(id), Some(SessionStatus::Running));
+    assert_eq!(sup.selected(), Some(id));
+
+    // The child exits on its own (stale/dead case). One poll must surface it.
+    ctrl.exit(Some(42));
+    let report = sup.poll();
+    assert_eq!(report.exited(), &[(id, Some(42))]);
+    assert_eq!(
+        sup.status(id),
+        Some(SessionStatus::Exited { code: Some(42) })
+    );
+    assert_ne!(sup.status(id), Some(SessionStatus::Running));
+    // Selection over a dead session is dropped, not frozen on it.
+    assert_eq!(sup.selected(), None);
+}
+
+#[test]
+fn a_poll_error_kills_the_session_as_failed_not_running() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    ctrl.fail_poll();
+    let _ = sup.poll();
+    assert_eq!(
+        sup.status(id),
+        Some(SessionStatus::Failed {
+            reason: SessionFailure::PollFailed
+        })
+    );
+    assert_ne!(sup.status(id), Some(SessionStatus::Running));
+}
+
+// ── Claim 2: termination reaps and is idempotent under one deadline ───────
+
+#[test]
+fn terminate_reaps_and_second_call_is_a_no_op() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+
+    let started = Instant::now();
+    let status = sup.terminate(id, started + Duration::from_secs(1));
+    assert!(matches!(status, SessionStatus::Exited { .. }));
+    assert!(started.elapsed() <= Duration::from_secs(1));
+    let shutdowns_after_first = ctrl.shutdown_count();
+    assert_eq!(shutdowns_after_first, 1);
+    let polls_after_first = ctrl.poll_count();
+
+    // Idempotent: status stable, no further backend work or reaping polls.
+    let again = sup.terminate_now(id);
+    assert_eq!(again, status);
+    assert_eq!(ctrl.shutdown_count(), shutdowns_after_first);
+    assert_eq!(ctrl.poll_count(), polls_after_first);
+}
+
+#[test]
+fn terminate_a_batch_under_one_shared_deadline() {
+    let mut sup = supervisor_with(vec![
+        MockChild::running(),
+        MockChild::running(),
+        MockChild::running(),
+        MockChild::running(),
+    ]);
+    let ids: Vec<_> = (0..4).map(|_| sup.spawn().expect("spawn")).collect();
+    assert_eq!(sup.running_count(), 4);
+
+    let started = Instant::now();
+    let results = sup.shutdown_all();
+    let elapsed = started.elapsed();
+
+    assert_eq!(results.len(), ids.len());
+    assert_eq!(results.iter().map(|(id, _)| *id).collect::<Vec<_>>(), ids);
+    for (_, status) in &results {
+        assert!(matches!(
+            status,
+            SessionStatus::Exited { .. } | SessionStatus::Failed { .. }
+        ));
+        assert_ne!(*status, SessionStatus::Running);
+    }
+    // One shared deadline means the whole batch is bounded by it, not by
+    // sessions * deadline. The mock backend is instant, so this is comfortably
+    // under the 2s budget; the assertion guards against an n*deadline bug.
+    assert!(elapsed <= session_supervisor::SHUTDOWN_DEADLINE);
+    assert_eq!(sup.running_count(), 0);
+
+    // Fully idempotent on a second pass.
+    let again = sup.shutdown_all();
+    assert_eq!(again.len(), ids.len());
+    assert_eq!(sup.running_count(), 0);
+}
+
+// ── Claim 3: failure matrix — every fault path lands in a terminal state ──
+
+#[test]
+fn spawn_failure_records_nothing_and_reports_spawn_failed() {
+    let mut sup = SessionSupervisor::new(Box::new(MockSpawner::failing()));
+    assert_eq!(sup.spawn(), Err(SessionFailure::SpawnFailed));
+    assert_eq!(sup.len(), 0);
+    assert_eq!(sup.selected(), None);
+}
+
+#[test]
+fn shutdown_hard_error_becomes_failed_shutdown_failed() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    ctrl.fail_shutdown(ShutdownError::Failed);
+    let status = sup.terminate_now(id);
+    assert_eq!(
+        status,
+        SessionStatus::Failed {
+            reason: SessionFailure::ShutdownFailed
+        }
+    );
+}
+
+#[test]
+fn shutdown_timeout_becomes_failed_reap_timeout_and_does_not_hang() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    ctrl.fail_shutdown(ShutdownError::TimedOut);
+    let started = Instant::now();
+    let status = sup.terminate_now(id);
+    assert!(started.elapsed() <= session_supervisor::SHUTDOWN_DEADLINE);
+    assert_eq!(
+        status,
+        SessionStatus::Failed {
+            reason: SessionFailure::ReapTimeout
+        }
+    );
+    // A reap-timeout child never becomes stuck Running.
+    assert_ne!(sup.status(id), Some(SessionStatus::Running));
+}
+
+#[test]
+fn an_already_passed_deadline_skips_the_backend_and_times_out() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    let status = sup.terminate(id, Instant::now());
+    assert_eq!(
+        status,
+        SessionStatus::Failed {
+            reason: SessionFailure::ReapTimeout
+        }
+    );
+    assert_eq!(ctrl.shutdown_count(), 0);
+}
+
+// ── Claim 4: selection refuses a dead session (ownership observable by id) ─
+
+#[test]
+fn selection_cannot_focus_a_dead_session() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let extra = MockChild::running();
+    let mut sup = supervisor_with(vec![child, extra]);
+    let live = sup.spawn().expect("spawn");
+    let other = sup.spawn().expect("spawn other");
+
+    // Live is focusable.
+    sup.select(live).expect("select live");
+
+    // Terminate + forget `other` so its id is genuinely unknown to the
+    // supervisor (this avoids depending on the STUB id's private constructor).
+    sup.terminate_now(other);
+    sup.forget(other).expect("retire other");
+    assert_eq!(sup.select(other), Err(SessionOpError::Unknown));
+
+    // Once `live` dies, the same id is rejected as NotRunning — the death is
+    // visible through the selection path, not hidden behind a stale focus.
+    ctrl.exit(Some(0));
+    let _ = sup.poll();
+    assert_eq!(sup.select(live), Err(SessionOpError::NotRunning));
+}
+
+#[test]
+fn clear_selection_is_independent_of_termination() {
+    let (child, _ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    assert_eq!(sup.selected(), Some(id));
+    sup.clear_selection();
+    assert_eq!(sup.selected(), None);
+    // The session is unaffected and still Running.
+    assert_eq!(sup.status(id), Some(SessionStatus::Running));
+}
+
+// ── Claim 5: forget retires only terminal records ─────────────────────────
+
+#[test]
+fn forget_refuses_running_and_removes_terminal() {
+    let (child, ctrl) = MockChild::running_with_control();
+    let mut sup = supervisor_with(vec![child]);
+    let id = sup.spawn().expect("spawn");
+    assert_eq!(sup.forget(id), Err(SessionOpError::StillRunning));
+
+    ctrl.exit(Some(9));
+    let _ = sup.poll();
+    sup.forget(id).expect("retire terminal");
+    assert_eq!(sup.status(id), None);
+    assert_eq!(sup.len(), 0);
+    // Retiring an already-forgotten id is Unknown.
+    assert_eq!(sup.forget(id), Err(SessionOpError::Unknown));
+}
+
+// ── Claim 6: error types are control-plane only and carry no child content ─
+
+#[test]
+fn error_and_status_displays_redact_all_child_content() {
+    let cases: Vec<(String, &str)> = vec![
+        (
+            format!(
+                "{}",
+                SessionStatus::Failed {
+                    reason: SessionFailure::ReapTimeout
+                }
+            ),
+            "failed(reap-timeout)",
+        ),
+        (
+            format!("{}", SessionStatus::Exited { code: None }),
+            "exited",
+        ),
+        (
+            format!("{}", ChildError::Shutdown(ShutdownError::Failed)),
+            "child shutdown failed",
+        ),
+    ];
+    for (rendered, expected) in cases {
+        // No secret/child bytes leak into control-plane strings.
+        assert!(rendered.len() < 64);
+        assert_eq!(rendered, expected);
+    }
+}

--- a/docs/coordination/handoffs/glm-b.md
+++ b/docs/coordination/handoffs/glm-b.md
@@ -138,20 +138,21 @@ result:` lines):
 |---|---|---|---|
 | noren-app lib unittests (`src/lib.rs`) | 79 | 0 | 1 (pre-existing) |
 | noren-app bin unittests (`src/main.rs`) | 24 | 0 | 0 |
-| **`tests/session_supervisor.rs` (NEW)** | **26** | **0** | **0** |
+| **`tests/session_supervisor.rs` (NEW)** | **29** | **0** | **0** |
 | `tests/verify59_independent.rs` | 19 | 0 | 0 |
 | noren-pty lib unittests | 10 | 0 | 0 |
 | noren-terminal lib unittests | 45 | 0 | 0 |
 | noren-terminal integration tests (`adversarial`, `adversarial_kimi`, `alternate_screen`, `application_modes`, `bracketed_paste`, `control_sequences`, `embedded_c0`, `erase_operations`, `scroll_regions`, `scrollback`, `selection`, `sgr_attributes`, `string_states`, `terminal_state`, `unicode_width`, `vt_compat`) | 23+20+7+6+3+9+6+6+9+6+17+25+6+7+22+4 = 176 | 0 | 0 |
 | doc-tests (3 crates) | 0 each | 0 | 0 |
 
-**Total: 379 passed, 0 failed, 1 ignored.** The 1 ignored test is pre-existing
-(in `noren-app` lib), not introduced by this lane. The new
-`tests/session_supervisor.rs` target contributes **26 tests** = 14 inline unit
+**Total: 382 passed, 0 failed, 1 ignored.** The 1 ignored test is pre-existing
+(in `noren-app` lib), not introduced by this lane. The
+`tests/session_supervisor.rs` target contributes **29 tests** = 14 inline unit
 tests (`session_supervisor::tests::*`, compiled into the test binary via the
-`#[path]` include) + 12 independent integration tests, all green. The mainline
-baseline on `origin/main` was 353 passing; 353 + 26 = 379, confirming this lane
-added exactly its 26 tests and broke nothing.
+`#[path]` include) + 15 independent integration tests (12 original + 3 added by
+the review fix), all green. The mainline baseline on `origin/main` was 353
+passing; 353 + 29 = 382, confirming this lane added exactly its 29 tests and
+broke nothing.
 
 **Commands run during development that surfaced bugs** (kept for the record):
 two earlier iterations of `cargo test --workspace` caught (a) the private-stub
@@ -233,3 +234,70 @@ documented in §5. Both were fixed before the final green run above.
    `crates/noren-app/src/lib.rs`, and write the `PtySession`-backed `Child` +
    `Spawner` adapters (per the contract notes in §5.1 and §5.2). The test file's
    `#[path]` include can then be replaced with `use noren_app::session_supervisor`.
+
+## 8. Independent review fix-up (post-review commit)
+
+An independent Qwen review (`docs/coordination/reviews/M3-1b-review.md`) found 1
+MAJOR + 5 MINORs. The coordinator judged the MAJOR real. All were addressed on
+this branch in a follow-up commit.
+
+### MAJOR 1 — `ReapReport` order (fixed)
+
+`poll` collected running ids from `self.sessions.iter()` — a `HashMap` with
+randomized iteration order — but `ReapReport`'s contract promises insertion
+order. **Fix:** `poll` now iterates `self.order` (the `Vec<SessionId>` that holds
+insertion order), filtering to `Running` sessions. **Test added:**
+`poll_reports_multi_session_transitions_in_insertion_order` spawns 10 sessions,
+exits all before one `poll`, and asserts the reported id sequence equals the
+spawn order. 10 elements gives 10! permutations (only one is sorted), so a
+HashMap source would fail this test on virtually every run.
+
+### MINOR 2 — shared-deadline test gap (fixed)
+
+The shared-deadline contract of `shutdown_all` had no test that a wall-clock
+assertion with an instant mock could catch. **Fix:** the mock's `MockController`
+now records the `deadline` argument of every `shutdown` call (`deadlines()`).
+**Test added:** `shutdown_all_feeds_one_shared_deadline_to_every_child` asserts
+all recorded deadlines across all children are identical — directly proving one
+shared `Instant` reached the batch. Moving the deadline inside the loop (the
+n*deadline regression) makes each value distinct and fails this test.
+
+### MINOR 3 — forget + shutdown_all interaction (fixed)
+
+`forget`'s `order.retain` had no committed coverage; deleting it left the suite
+green while `shutdown_all` resurrected forgotten ids. **Test added:**
+`forget_then_shutdown_all_omits_the_forgotten_id` spawns 3, terminates+forgets
+the middle one, and asserts `shutdown_all` reports exactly the remaining two in
+insertion order. Deleting `order.retain` makes the forgotten id reappear and
+fails this test.
+
+### MINOR 4 — `terminate` on unknown id fabricates `Failed(PollFailed)` (documented)
+
+`terminate` has no error channel, so an unknown id is defensively classified as
+`Failed(PollFailed)`. **Disposition: documented** on the method's rustdoc. A
+typed `Unknown` variant (or a `Result` return) is deferred to D-M3-001
+integration because `SessionFailure` is a STUB type that the domain lane
+replaces; adding a variant now risks a conflicting shape at the deletion/merge.
+
+### MINOR 5 — `Child::shutdown` deadline vs production `Drop` (documented)
+
+The production adapter's `shutdown` takes no deadline (uses its internal 2 s) and
+its `Drop` runs a full shutdown attempt, so the "no backend call" path asserted
+by mock tests will not hold in production. **Disposition: documented** on the
+`Child` trait as a "Drop semantics (integration note)" section. No code change
+is possible in this lane (the adapter does not exist yet); the serial
+integration commit must decide between a deadline-parameterised adapter or a
+concurrent kill path.
+
+### MINOR 6 — unbounded terminal-record retention (documented)
+
+Terminal records are retained until cooperative `forget` with no cap. This is a
+deliberate design (callers observe outcomes by id), but nothing enforces a
+retirement policy. **Disposition: documented** on `SessionSupervisor` as a
+"Record retention" section. The registry/domain (D-M3-001) must own the policy.
+
+### Summary
+
+`minors_fixed=3` (2, 3), `minors_deferred=3` (4, 5, 6 — all documented with
+clear integration guidance). The MAJOR is fixed with a regression-catching test.
+All three gates pass on the fix-up commit.

--- a/docs/coordination/handoffs/glm-b.md
+++ b/docs/coordination/handoffs/glm-b.md
@@ -1,0 +1,235 @@
+# Handoff — M3-1b session lifecycle supervisor (GLM-b lane)
+
+- **Lane:** `agent/m3-session-supervisor` (lifecycle supervisor — spawn,
+  terminate, select, process ownership, child reaping, stale/dead handling).
+- **Branch:** `agent/m3-session-supervisor` (created from `origin/main` at
+  `1d329a51582a937c37e5357e21d9a37eb49079bc`).
+- **Code commit:** `e4d647962358c477ee834a7b088f444af3783857`
+  ("feat(app): add session lifecycle supervisor (M3-1b)").
+- **This handoff commit:** see `git log -1` on this file's commit (the handoff
+  is committed separately so it can record the code commit's exact SHA).
+- **Author of the code under review:** Yes — this lane both authored and
+  self-verified the module. There is no second reviewer in this session.
+- **TEMPLATE note:** `docs/coordination/handoffs/TEMPLATE.md` was **not present
+  on `main` at `1d329a5`** (the `handoffs/` directory did not exist). This file
+  follows the structure and tone of `docs/coordination/reviews/*.md` plus the
+  handoff requirements stated in the task prompt. If a template lands later,
+  reshape this file to match; no content here depends on the absent template.
+
+A second model should be able to resume from this file plus `git log`/`git show`
+alone, with no conversation context.
+
+## 1. Task authority and what was actually available
+
+The task prompt names two authority documents:
+
+- `docs/coordination/tasks/M3-1b.md` — **not present** on `main` at `1d329a5`
+  (verified: `ls docs/coordination/tasks/` → no such directory).
+- `docs/coordination/decisions/D-M3-001-session-api.md` — **not present**
+  (verified: `ls docs/coordination/decisions/` → no such directory; the sibling
+  lane `agent/m3-session-domain` that authors D-M3-001 is checked out in a
+  separate worktree `pool-m3a` but is also at `1d329a5` — i.e. its work had not
+  landed when this lane started).
+
+Per the prompt's explicit guidance ("the session-domain lane … may not exist on
+`main` yet. Therefore: build against a fake/mock process model first, plus a
+failure matrix"), I treated **the prompt itself as the authority** and built
+against a mock process model. The prompt's bullet list of responsibilities
+(spawn, terminate, select, process ownership, child reaping, stale/dead
+handling) and its two hard invariants drove the design:
+
+1. The supervisor owns child handles; the registry never does.
+2. A dead child surfaces as `Exited`/`Failed`, not a stuck `Running`.
+
+For broader M3 context I read `origin/docs/m3-breakdown:docs/roadmap/milestone-3-breakdown.md`
+(branch `docs/m3-breakdown`, not merged) which decomposes M3-1 as the
+pane/tab/workspace foundation. This lane is a slice of that: the lifecycle
+supervisor that the workspace will own.
+
+## 2. What this lane built
+
+Two files (the entire file lease):
+
+- `crates/noren-app/src/session_supervisor.rs` — the module.
+- `crates/noren-app/tests/session_supervisor.rs` — independent verification.
+
+**The module's public surface** (this lane's real, non-stub deliverable):
+
+- `Child` trait — the process handle the supervisor owns. Two methods:
+  `poll_exit() -> Result<PollOutcome, ChildError>` (non-blocking reap probe) and
+  `shutdown(deadline: Instant) -> Result<(), ChildError>` (bounded, idempotent
+  kill+reap, mirroring `noren-pty::PtySession::shutdown`).
+- `PollOutcome { StillRunning, Exited { code } }` — the explicit reap outcome.
+  This exists to kill the ambiguity where "exited with no code" could otherwise
+  be read as "still alive" (see §5 — this was a real bug caught during
+  verification).
+- `ChildError { Poll, Shutdown(ShutdownError) }`, `ShutdownError { Failed, TimedOut }`.
+- `Spawner` trait — the seam where real PTY spawn wiring drops in. The
+  supervisor owns child *handles*; it does not own spawn policy.
+- `SessionSupervisor` — owns every live child handle. Methods: `spawn`,
+  `status`, `selected`, `select`, `clear_selection`, `poll` (non-blocking reap
+  pass → `ReapReport`), `terminate(id, deadline)`, `terminate_now`,
+  `shutdown_all` (one shared deadline), `forget` (retire a terminal record),
+  plus `len`/`is_empty`/`running_count`.
+- `ReapReport` — the set of sessions that left `Running` on one `poll` pass.
+- `SessionOpError { Unknown, NotRunning, StillRunning }`.
+- `SHUTDOWN_DEADLINE = 2s` — mirrors `noren-pty::SHUTDOWN_DEADLINE`.
+
+**The STUB block** (clearly marked in the source; delete on integration):
+`SessionId`, `SessionStatus`, `SessionFailure`. These reference D-M3-001 and
+stand in for the domain's types so this lane compiles/tests in isolation.
+Integration is a **deletion, not a merge**: drop the STUB block, re-export the
+domain's types, point `SessionSupervisor` at them.
+
+**The mock** (`#[cfg(test)] pub mod mock`): `MockChild` + `MockController`
+(shared-state machine driven by the test) and `MockSpawner`. It is `pub` under
+`cfg(test)` so both the inline unit tests and the integration test (which
+includes the module via `#[path]`, and for which `cfg(test)` is also enabled)
+share one definition.
+
+## 3. How the invariants are enforced
+
+- **Supervisor owns handles; registry does not.** `SupervisedSession.child` is
+  the only strong reference to a `Box<dyn Child + Send>`. The registry (when it
+  lands) observes `SessionStatus` by `SessionId`; it has no path to the handle.
+  On any terminal transition `child` is set to `None`.
+- **Dead ⇒ Exited/Failed, never Running.** Every transition path
+  (`poll`/`terminate`/`shutdown_all`) writes a terminal `SessionStatus` and
+  drops the handle. `select` refuses a non-`Running` id with `NotRunning`. The
+  selected id is cleared when it transitions, so a caller never addresses a dead
+  session as live.
+- **Termination reaps, is idempotent, under one deadline.** `terminate` has a
+  fast path for already-terminal ids (no backend call). `shutdown_all` computes
+  one `now + SHUTDOWN_DEADLINE` and feeds that same absolute `Instant` to each
+  `terminate`, so the batch is bounded by one deadline, not `n * deadline`. An
+  already-elapsed deadline marks `Failed(ReapTimeout)` without calling the
+  backend.
+
+## 4. Commands actually run and real results
+
+Run from the worktree root `/Users/yoshinagatatsuya/Documents/apps/noren-worktrees/pool-m3b`
+on branch `agent/m3-session-supervisor`, toolchain `1.88.0` (`rust-toolchain.toml`).
+
+```
+$ cargo fmt --all
+$ echo $?
+0
+```
+
+```
+$ cargo clippy --workspace --all-targets -- -D warnings
+$ echo $?
+0
+    Checking noren-app v0.1.0
+    Finished `dev` profile [unoptimized + debuginfo] target(s)
+```
+(No warnings, no errors.)
+
+```
+$ cargo test --workspace
+$ echo $?
+0
+```
+
+Per-binary results (`cargo test --workspace`, parsed from the `Running`/`test
+result:` lines):
+
+| binary | passed | failed | ignored |
+|---|---|---|---|
+| noren-app lib unittests (`src/lib.rs`) | 79 | 0 | 1 (pre-existing) |
+| noren-app bin unittests (`src/main.rs`) | 24 | 0 | 0 |
+| **`tests/session_supervisor.rs` (NEW)** | **26** | **0** | **0** |
+| `tests/verify59_independent.rs` | 19 | 0 | 0 |
+| noren-pty lib unittests | 10 | 0 | 0 |
+| noren-terminal lib unittests | 45 | 0 | 0 |
+| noren-terminal integration tests (`adversarial`, `adversarial_kimi`, `alternate_screen`, `application_modes`, `bracketed_paste`, `control_sequences`, `embedded_c0`, `erase_operations`, `scroll_regions`, `scrollback`, `selection`, `sgr_attributes`, `string_states`, `terminal_state`, `unicode_width`, `vt_compat`) | 23+20+7+6+3+9+6+6+9+6+17+25+6+7+22+4 = 176 | 0 | 0 |
+| doc-tests (3 crates) | 0 each | 0 | 0 |
+
+**Total: 379 passed, 0 failed, 1 ignored.** The 1 ignored test is pre-existing
+(in `noren-app` lib), not introduced by this lane. The new
+`tests/session_supervisor.rs` target contributes **26 tests** = 14 inline unit
+tests (`session_supervisor::tests::*`, compiled into the test binary via the
+`#[path]` include) + 12 independent integration tests, all green. The mainline
+baseline on `origin/main` was 353 passing; 353 + 26 = 379, confirming this lane
+added exactly its 26 tests and broke nothing.
+
+**Commands run during development that surfaced bugs** (kept for the record):
+two earlier iterations of `cargo test --workspace` caught (a) the private-stub
+constructor access from the integration test, and (b) the `Ok(None)` ambiguity
+documented in §5. Both were fixed before the final green run above.
+
+## 5. Unresolved findings / design notes for the integrator
+
+1. **`poll_exit` outcome semantics (resolved during this lane).** The first
+   design returned `Result<Option<u32>, _>`, which conflated "still running"
+   with "exited with no code" — a signal-style death read as `Running`. This is
+   exactly the stuck-`Running` failure the lane exists to prevent, so the trait
+   now returns an explicit `PollOutcome { StillRunning, Exited { code } }`. The
+   production PTY adapter **must** map `PtyEvent::Exited { code }` to
+   `PollOutcome::Exited { code }` and event-absence to `StillRunning` (never
+   collapse them). This is the single most important contract note.
+
+2. **`shutdown_all` shared-deadline caveat.** The supervisor passes one absolute
+   `Instant` to each child's `shutdown`. In production each `PtySession` enforces
+   its **own** internal `SHUTDOWN_DEADLINE` (2s) and does not accept a tighter
+   caller deadline. With `n` sessions, a strict reading of "one shared deadline"
+   is therefore only achievable if (a) the adapter exposes a
+   deadline-parameterised shutdown, or (b) sessions are killed concurrently then
+   reaped. This lane's contract is correct for any backend that honours the
+   passed deadline (the mock does); the production wiring commit must decide
+   between (a) and (b) and is the right place to revisit. No code change is
+   needed in this module for either choice.
+
+3. **Kill-vs-exit code modelling.** In the mock, a supervisor kill yields
+   `Exited { code: None }` (no clean code), matching the `poll_exit` contract.
+   In production, `noren-pty`'s `PtyEvent::Exited { code }` carries a code even
+   after kill (the reaped wait status). The adapter surfaces whatever the PTY
+   reports; the supervisor is code-agnostic. Both are `Exited`, never `Running`.
+
+4. **Not wired into the crate.** As required by the file lease, the module is
+   **not** declared in `crates/noren-app/src/lib.rs`, so it does **not**
+   compile into the `noren-app` library or binary yet. It is verified only via
+   the `tests/session_supervisor.rs` target, which includes it with
+   `#[path = "../src/session_supervisor.rs"]`. `cargo build` of the workspace
+   does **not** exercise this module; only `cargo test` does. This is the
+   intended state pending the serial integration commit.
+
+5. **Boundary (ADR 0003, owner-decided).** This lane touches only process
+   *lifecycle*. It introduces no pane, tab, layout, split, or any Noren-side
+   workspace geometry. There is no Zellij pane/layout type here, and none is
+   wanted. If a future change to this module feels like it needs a layout type,
+   that is the boundary: stop and flag it rather than adding one.
+
+## 6. What I could NOT judge about my own work
+
+- **No independent reviewer ran.** I authored the module and wrote the
+  verification suite. The 12 integration tests were written to exercise the
+  public contract "the way the task describes" (mirroring the approach in
+  `tests/verify59_independent.rs`), but they are my own tests, not a second
+  model's. A true independent review is still owed.
+- **The stubs may not match the domain's final shapes.** `SessionId`
+  (locally `u64`), `SessionStatus`, and `SessionFailure` are my stand-ins. If
+  D-M3-001 settles different variant names or a different id type, the STUB
+  block and the supervisor's signatures change at integration time. I could not
+  verify against a contract that does not exist yet.
+- **Production performance under load.** All tests use an instant mock backend.
+  Real `PtySession::shutdown` does blocking I/O on a supervisor thread; with
+  many sessions the `shutdown_all` ordering (sequential reap under one deadline)
+  is only as good as the caveat in §5.2. I did not measure real-process
+  teardown because wiring is pending.
+- **`PollOutcome` as a public type.** I introduced it because the lane's central
+  invariant demanded it, but whether the domain lane also models reap outcomes
+  this way is unknown. If D-M3-001 defines its own, the `Child` trait's return
+  type should adopt that instead — a one-line change at integration.
+
+## 7. Resume instructions
+
+1. `git checkout agent/m3-session-supervisor`.
+2. `git show e4d6479` for the full diff (the two code files).
+3. `cargo test --workspace` → expect 0 failures (26 in the new target).
+4. To integrate once D-M3-001 lands: delete the STUB block in
+   `session_supervisor.rs`, re-export the domain's `SessionId`/`SessionStatus`/
+   `SessionFailure`, add `mod session_supervisor;` (or `pub mod`) to
+   `crates/noren-app/src/lib.rs`, and write the `PtySession`-backed `Child` +
+   `Spawner` adapters (per the contract notes in §5.1 and §5.2). The test file's
+   `#[path]` include can then be replaced with `use noren_app::session_supervisor`.

--- a/docs/coordination/reviews/M3-1b-review.md
+++ b/docs/coordination/reviews/M3-1b-review.md
@@ -1,24 +1,31 @@
-# Review — M3-1b session lifecycle supervisor (independent)
+# Re-review — M3-1b session lifecycle supervisor (independent)
 
 - Reviewed branch: `agent/m3-session-supervisor`
-- Reviewed head SHA: `79dff71e3f26` (code commit `e4d6479`, handoff `79dff71`)
-- Base: `origin/main` at `1d329a5`
+- Reviewed head SHA: `2686956b93d9024fadcd0f3dc3367ae7a26c17ce` (fix-up commit
+  `2686956`; code commits `e4d6479`, review/handoff commits `79dff71`, `21d4b49`)
+- Base: `origin/main` at `1d329a51582a937c37e5357e21d9a37eb49079bc`
+  (`git merge-base origin/main HEAD` confirms)
 - Task authority: `state/tasks/M3-1b.md` (fleet repo `noren-fleet-private`)
-- Reviewer: independent (did not author the code under review), run from the
-  `pool-rev-b` worktree checked out detached at `79dff71`.
+- Author handoff: `docs/coordination/handoffs/glm-b.md` (§8 documents the fixes)
+- Reviewer: independent; did not author the code under review. This RE-review
+  supersedes the earlier review of `79dff71` (which found 1 MAJOR + 5 MINORs);
+  that review is void and every claim below was re-derived from the current head.
 
 ## Verdict
 
-**FINDINGS** — 0 blockers, 1 major, 5 minors. All three gates pass; all four
-acceptance criteria and all four required tests are met. The major finding is a
-public contract the docs promise and the code demonstrably does not deliver
-(`ReapReport` ordering). The minors are test-coverage gaps proven by mutation
-testing, a misleading error classification, and two integration notes. No
-ADR 0003 boundary violation, no unintended deletions, no panic/leak surface.
+**FINDINGS** — 0 blockers, 0 majors, 1 minor. All three gates pass. All four
+acceptance criteria and all four required tests are met. Every prior finding is
+genuinely resolved: MAJOR 1 and MINORs 2/3 are fixed with regression-catching
+tests (proven by mutation, below); MINORs 4/5/6 are documented exactly as the
+agreed disposition stated. The single new finding is a non-blocking
+documentation-clarity nit (mixed-pass ordering semantics of `ReapReport`).
+No ADR 0003 violation, no unintended deletions, no panic/leak/unbounded-growth
+surface beyond the retention policy that is now documented on the type.
 
 ## Gates (real output)
 
-Toolchain: `rustc 1.88.0` via `rust-toolchain.toml`.
+Toolchain: `rustc 1.88.0 (6b00bc388 2025-06-23)` via `rust-toolchain.toml`
+(channel `1.88.0`, target `aarch64-apple-darwin`).
 
 ```
 $ cargo fmt --all -- --check
@@ -28,256 +35,206 @@ $ echo $?
 (No output — format clean.)
 
 ```
+$ cargo clean -p noren-app          # force a fresh check, not cache
 $ cargo clippy --workspace --all-targets -- -D warnings
-...
-    Checking noren-app v0.1.0 (...)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.79s
+    Checking noren-app v0.1.0 (.../pool-m3b/crates/noren-app)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.76s
 $ echo $?
 0
 ```
+(Deliberately re-ran after `cargo clean -p noren-app` because the first run was
+fully cached; no warnings, no errors on the fresh check.)
 
 ```
 $ cargo test --workspace
 ```
-Per-binary `test result:` lines (all `ok`):
+All 25 `test result:` lines are `ok`. Per-binary breakdown:
 
 | binary | passed | failed | ignored |
 |---|---|---|---|
 | noren-app lib (`src/lib.rs`) | 79 | 0 | 1 (pre-existing) |
 | noren-app bin (`src/main.rs`) | 24 | 0 | 0 |
-| `tests/session_supervisor.rs` (new) | 26 | 0 | 0 |
+| `tests/session_supervisor.rs` (the lane's target) | 29 | 0 | 0 |
 | `tests/verify59_independent.rs` | 19 | 0 | 0 |
 | noren-pty lib | 10 | 0 | 0 |
 | noren-terminal lib | 45 | 0 | 0 |
 | noren-terminal integration (16 targets) | 176 | 0 | 0 |
 | doc-tests (3 crates) | 0 | 0 | 0 |
 
-Total **379 passed, 0 failed, 1 ignored**. The 1 ignored test is
-`crates/noren-app/src/clipboard.rs:228` (`#[ignore = "touches the real macOS
-system clipboard"]`), present identically on `origin/main` — not introduced by
-this lane. The handoff's count claims (353 baseline + 26 new = 379; 14 inline +
-12 integration = 26) reproduce exactly.
+**Total: 382 passed, 0 failed, 1 ignored.** The 1 ignored test is the
+pre-existing `#[ignore = "touches the real macOS system clipboard"]` in
+`crates/noren-app/src/clipboard.rs:228`, present identically on `origin/main`
+(verified with `git show origin/main:crates/noren-app/src/clipboard.rs`).
+The lane target's 29 = 14 inline unit tests + 15 integration tests (12
+original + 3 added by the fix-up), matching the handoff §4/§8 claims exactly.
+Baseline check: `origin/main` at `1d329a5` has 353 passing; 353 + 29 = 382,
+so the lane adds exactly its tests and breaks nothing.
+
+## Prior findings — genuinely resolved, verified by mutation
+
+The fix-up's own claims were not trusted; each was re-verified by mutating the
+current head and re-running the committed suite. All mutations were reverted
+afterwards (`git status --short` clean).
+
+| prior finding | fix claimed | mutation applied at head | committed suite result | verdict |
+|---|---|---|---|---|
+| MAJOR 1 — `poll` delivered HashMap order | iterate `self.order` + 10-session order test | revert `poll` to `self.sessions.iter()` | `poll_reports_multi_session_transitions_in_insertion_order` FAILS (28 passed; 1 failed) | genuinely fixed |
+| MINOR 2 — shared deadline untested | mock records deadlines + all-equal assertion | move `deadline` computation inside the loop (`n × deadline` regression) | `shutdown_all_feeds_one_shared_deadline_to_every_child` FAILS (28 passed; 1 failed) | genuinely fixed |
+| MINOR 3 — forget+shutdown_all untested | `forget_then_shutdown_all_omits_the_forgotten_id` | delete `order.retain` in `forget` | `forget_then_shutdown_all_omits_the_forgotten_id` FAILS (28 passed; 1 failed) | genuinely fixed |
+| MINOR 4 — unknown-id `Failed(PollFailed)` | documented | n/a (documentation disposition) | rustdoc at `src/session_supervisor.rs:506-511` matches probe-verified behavior | resolved as agreed |
+| MINOR 5 — deadline advisory vs `Drop` | documented | n/a (documentation disposition) | "Drop semantics (integration note)" at `src/session_supervisor.rs:235-246` | resolved as agreed |
+| MINOR 6 — unbounded retention | documented | n/a (documentation disposition) | "Record retention" section at `src/session_supervisor.rs:345-352` | resolved as agreed |
+
+One extra mutation for the core invariant (independent of prior findings):
+suppressing the `Exited` transition in `poll` (stuck `Running`) makes **9
+committed tests fail** (20 passed; 9 failed) — the central contract is
+behavior-bound, not documented into existence.
 
 ## Acceptance criteria (one by one)
 
 1. **Supervisor owns child handles; the registry never does. — MET.**
-   `SupervisedSession.child` (`src/session_supervisor.rs:320-323`) is the only
-   strong reference to `Box<dyn Child + Send>`; every terminal transition sets
-   it to `None` (`mark_exited` line 593, `mark_failed` line 604,
-   `finalize_exited` line 615, `finalize_failed` line 626). No registry exists
-   on this branch (M3-1a unmerged), and the module is not declared in
-   `lib.rs`, so nothing else can hold a handle. Structural, and enforced by
-   type ownership.
-
+   `SupervisedSession.child` (`src/session_supervisor.rs:333-336`) is the only
+   strong reference to `Box<dyn Child + Send>`. Every terminal transition drops
+   it: `mark_exited` (:627), `mark_failed` (:638), `finalize_exited` (:649),
+   `finalize_failed` (:660). No registry exists on this branch (M3-1a
+   unmerged), the module is not declared in `lib.rs` (grep: no reference in
+   `crates/noren-app/src/lib.rs` or `main.rs`), so nothing else can hold a
+   handle. Probe P5 (below) confirms a terminal session's handle is gone:
+   `terminate` after poll-recorded failure performs zero backend calls.
 2. **A dead child produces Exited/Failed rather than a stuck Running. — MET.**
-   Verified by probe: unprompted exit (`ctrl.exit(Some(42))`) is surfaced by a
-   single `poll()` as `Exited { code: Some(42) }`; poll backend error becomes
-   `Failed(PollFailed)`; shutdown timeout becomes `Failed(ReapTimeout)`;
-   elapsed deadline becomes `Failed(ReapTimeout)` without a backend call; even
-   the defensive "handle missing while Running" case (line 452-453) resolves to
-   `Failed`, never `Running`. Also verified a racing natural exit then
-   `terminate_now` keeps the natural code `Exited { code: Some(42) }`.
-
-3. **Termination reaps the child and is idempotent. — MET.** Verified by
-   reading and mutating: with the fast path deleted, 3 committed tests fail
-   (see mutation section). `shutdown_all` is idempotent at the backend level:
-   my probe recorded per-child `shutdown` call counts `[1, 1, 1]` after the
-   first pass and unchanged after a second pass.
-
+   Verified by mutation (9 failures when the transition is suppressed) and by
+   probes: unprompted exit, poll backend error, shutdown hard error, shutdown
+   timeout, elapsed deadline, deadline boundary (`Instant::now()`), and even
+   the defensive handle-missing branch (`src/session_supervisor.rs:479-481`).
+   Every path lands terminal.
+3. **Termination reaps the child and is idempotent. — MET.**
+   `terminate_reaps_and_second_call_is_a_no_op` asserts `shutdown_count == 1`
+   and stable poll counts after a second call; probe P4 extends this to
+   `shutdown_all`'s second pass (zero additional backend calls per child).
 4. **Until M3-1a lands, only a fake process model and a failure matrix exist.
-   — MET.** `docs/coordination/decisions/D-M3-001-session-api.md` is absent on
-   this branch (the `decisions/` directory does not exist); the STUB block
-   (lines 64-149) is clearly marked; the mock + tests are the only executable
-   surface; the module is not wired into `lib.rs` (forbidden by the lease).
+   — MET.** `docs/coordination/decisions/` does not exist on this branch
+   (D-M3-001 absent); the STUB block (`src/session_supervisor.rs:64-149`) is
+   clearly marked; the mock + tests are the only executable surface; the module
+   is not wired into `lib.rs` (forbidden by the lease).
 
 ## Required tests — present and behavior-bound
 
-- spawn then Running via fake supervisor: `spawn_assigns_unique_ids_and_selects_newest`
-  (inline) — mutates `fresh_id` → fails.
-- child crash surfaces as Failed/Exited: `poll_surfaces_unprompted_exit...`,
-  `unprompted_death_surfaces_as_exited_within_one_poll`, plus the poll-error
-  pair.
+- spawn then Running via fake supervisor: `spawn_assigns_unique_ids_and_selects_newest` (inline).
+- child crash surfaces as Failed/Exited: `poll_surfaces_unprompted_exit_as_exited_not_running`,
+  `unprompted_death_surfaces_as_exited_within_one_poll`, plus the poll-error pair.
 - double terminate idempotent, reaps once: `terminate_reaps_a_running_child_and_is_idempotent`,
-  `terminate_reaps_and_second_call_is_a_no_op` (asserts backend call counts).
-- stale session detected: `poll` over a child that died with no status update
-  is exactly the unprompted-death tests above.
+  `terminate_reaps_and_second_call_is_a_no_op` (both assert backend call counts).
+- stale session detected: the unprompted-death tests (child dies with no status
+  update; one `poll` surfaces it).
 
-## Interaction / adversarial tests beyond the author's suite
+## Interactions the author did not test (reviewer probes, temporary — removed)
 
-The author tested each feature alone; this project has repeatedly shipped
-combined-feature defects, so I probed combinations (temporary probes, since
-removed):
+A throwaway `tests/zz_review_probe.rs` (10 tests) was written, run, and deleted
+before the review commit. Three probes failed on their first draft and all
+three were flaws in the probes, not the code — recorded here for honesty:
+selecting the victim instead of the keeper; expecting `shutdown_count == 0`
+when `terminate` kills a child that died unobserved (the supervisor cannot know
+without polling; the natural exit code still survives, which is the real
+invariant); miscounting records after an extra `forget`. After fixing the
+probes, **all 10 pass**:
 
-- **forget + shutdown_all** (finding 3): spawn 3, terminate+forget the middle,
-  `shutdown_all` reports only the two tracked ids. Current behavior correct;
-  not covered by any committed test (proven by mutation).
-- **racing natural exit + terminate**: `exit(Some(42))` then `terminate_now` →
-  `Exited { code: Some(42) }`; the natural code survives the kill path.
-- **terminate after poll-failure**: poll marks `Failed(PollFailed)`; a later
-  `terminate_now` returns the recorded status and performs **zero** backend
-  calls — correct fast-path behavior for `Failed`, not just `Exited`.
-- **shared deadline proof**: a deadline-recording `Child` confirmed all three
-  children in a batch receive the *same* `Instant` from `shutdown_all`.
-- **terminate(unknown id)**: after forget, `terminate_now(id)` fabricates
-  `Failed(PollFailed)` (finding 4).
-- **Degenerate input**: no parse surface — the module is a state machine
-  driven by app code. Panic surface is limited to `.expect("mock lock")` in
-  test-only code. `fresh_id` uses `wrapping_add` (collision after 2^64 spawns;
-  theoretical, noted, not a finding). `shutdown_all` clones `order` (O(n),
-  bounded by session count). No unbounded buffers beyond the intentional
-  terminal-record retention (finding 5 territory — see below).
+- **P1 mixed pass**: 6 sessions, alternating exit/fail, one `poll` → `exited()`
+  and `failed()` each in insertion order, all 6 terminal, `running_count == 0`.
+- **P2 unrelated death preserves selection**: non-selected session dies →
+  selection stays on the live session.
+- **P3 spawn failure preserves state**: failed spawn leaves existing selection
+  and records untouched.
+- **P4 second `shutdown_all` pass does zero backend work** (per-child
+  `shutdown_count` stays 1, poll counts unchanged).
+- **P5 terminate after poll-recorded failure**: fast path, zero backend calls,
+  recorded status returned.
+- **P6 unobserved death then terminate**: natural code `Exited { code: Some(42) }`
+  survives the kill path.
+- **P7 terminate on a forgotten id** returns the documented defensive
+  `Failed(PollFailed)` (matches the new rustdoc, MINOR 4 disposition).
+- **P8 forget mid-lifecycle then new spawn**: `order`/`poll`/selection stay
+  coherent.
+- **P9 shutdown_all reports a pre-terminal status verbatim** (`Exited { code:
+  Some(7) }`) in insertion order, then reaps the rest.
+- **P10 deadline boundary** `Instant::now()`: `Failed(ReapTimeout)`, no panic;
+  generous deadline → `Exited`.
 
-## Mutation testing — do the tests test the behavior?
+## Panics, leaks, unbounded growth
 
-All mutations were applied, tested, and reverted; the tree is clean again.
-
-| mutation | committed suite | verdict |
-|---|---|---|
-| suppress `Exited` transition in `poll` (stuck `Running`) | **8 failures** | caught |
-| delete `terminate` terminal fast path | **3 failures** | caught |
-| per-iteration deadline in `shutdown_all` (n*deadline bug) | **26 pass** | **NOT caught** — only a deadline-recording probe catches it |
-| delete `order.retain` in `forget` (zombie ids re-terminated by `shutdown_all`) | **26 pass** | **NOT caught** — only the forget+shutdown_all probe catches it |
-
-The first two columns show the load-bearing invariants are genuinely tested.
-The last two are findings 2 and 3: real, documented contracts with zero
-committed coverage.
+- No panic surface in production code: the only `.expect()`/`unwrap()` calls
+  are inside `#[cfg(test)]` regions (mock lock, test bodies). No indexing, no
+  arithmetic that can trap (`fresh_id` uses `wrapping_add`; the 2^64 id
+  collision is theoretical and was already noted by the prior review).
+- No `unsafe` anywhere; the integration target carries `#![forbid(unsafe_code)]`.
+- No unbounded buffers beyond the intentional record retention, which is now
+  documented on the type ("Record retention", `src/session_supervisor.rs:345-352`).
+  `order`/`sessions` grow only with spawn count; `ReapReport` is per-pass and
+  bounded by tracked sessions; the mock's `deadlines` vec is test-only and
+  bounded by backend call count. Probe suite fed degenerate inputs (elapsed
+  deadline, unknown/forgotten ids, empty spawner, alternating fault patterns);
+  no panic, no stuck state.
 
 ## Unintended deletions / lease
 
-`git diff --stat origin/main...HEAD`: 3 files, **1573 insertions(+), 0
-deletions**. `git diff --diff-filter=D` lists nothing. Forbidden files
-(`lib.rs`, `main.rs`, `Cargo.toml`, `Cargo.lock`, `status.md`) untouched —
-verified by the diff stat above; `cargo build` therefore still excludes the
-module, as intended. The handoff doc is outside the leased code paths but is
-the workflow's required coordination artifact.
+```
+$ git diff --name-status origin/main...HEAD
+A   crates/noren-app/src/session_supervisor.rs
+A   crates/noren-app/tests/session_supervisor.rs
+A   docs/coordination/handoffs/glm-b.md
+A   docs/coordination/reviews/M3-1b-review.md
+$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
+0
+```
+
+Additions only; nothing deleted. Forbidden files (`lib.rs`, `main.rs`,
+`Cargo.toml`, `Cargo.lock`, `status.md`) untouched — the module still does not
+compile into the library/binary (`cargo build` excludes it; only `cargo test`
+exercises it via the `#[path]` include), exactly as the lease requires. The
+handoff and this review are coordination artifacts outside the two leased code
+paths, required by the workflow. The fix-up commit's own diff touches only the
+two leased code files plus the handoff.
 
 ## ADR 0003 boundary
 
-Clean. No pane, tab, layout tree, or split type anywhere in the diff; grep for
-`pane|layout|split|zellij|tab` over both files matches only the word
-"ownership split" in a comment (line 19). The module owns process lifecycle
-only; `select` is session focus, which the task spec itself assigns to this
-lane ("spawn/terminate/select"). No Zellij internal layout is read or
-persisted.
+Clean. `grep -niE "pane|layout|zellij|\btab\b|split"` across both code files
+matches nothing except the phrase "ownership split" in a comment (excluded).
+The module owns process lifecycle only; `select` is session focus, which the
+task spec assigns to this lane. No Zellij internal layout is introduced, read,
+or persisted.
 
-## Findings
+## Findings (new at this head)
 
-### MAJOR 1 — `ReapReport` promises insertion order; `poll` delivers HashMap order
+### MINOR R1 — `ReapReport`'s "in insertion order" is per-list on mixed passes; docs may promise more
 
-- Location: contract at `crates/noren-app/src/session_supervisor.rs:282-284`
+- Location: contract at `crates/noren-app/src/session_supervisor.rs:293-297`
   ("Lists exactly the sessions that left `Running` this pass, **in insertion
-  order**") vs implementation at `crates/noren-app/src/session_supervisor.rs:440-445`
-  (ids collected from `self.sessions.iter()` — a `HashMap` with randomized
-  iteration order). The insertion order is kept in `self.order` (line 333) but
-  `poll` never consults it.
-- Reproduction (reviewer probe, since removed): spawn 10 sessions, exit all
-  via their controllers, one `poll`:
-  ```
-  left:  [SessionId(6), SessionId(1), SessionId(7), SessionId(0), SessionId(4),
-          SessionId(8), SessionId(2), SessionId(3), SessionId(9), SessionId(5)]
-  right: [SessionId(0), SessionId(1), ..., SessionId(9)]
-  assertion `left == right` failed: ReapReport promises insertion order
-  ```
-- Expected: `report.exited()` in spawn order `[0..9]`. Actual: arbitrary
-  `RandomState` order, nondeterministic supervisor-to-supervisor.
-- Impact: no committed test transitions more than one session per `poll`, so
-  the suite cannot see this. A future UI/event loop that renders or applies a
-  pass's transitions in reported order gets shuffled, nondeterministic output.
-- Minimal fix: in `poll`, collect ids from `self.order.iter().filter(...)`
-  (filtering to `Running`) instead of `self.sessions.iter()`, and add one test
-  that transitions ≥2 sessions in a single pass and asserts report order.
-
-### MINOR 2 — shared-deadline contract of `shutdown_all` has no test that can catch a regression
-
-- Location: `crates/noren-app/src/session_supervisor.rs:551-561`; the only
-  timing assertion is `tests/session_supervisor.rs:123`
-  (`elapsed <= SHUTDOWN_DEADLINE`).
-- Evidence: with the deadline moved inside the loop (regressing to
-  `n * SHUTDOWN_DEADLINE` — the exact bug the module doc and commit message
-  claim to prevent), `cargo test -p noren-app --test session_supervisor` still
-  reports `test result: ok. 26 passed; 0 failed`. An instant mock can never
-  make a wall-clock assertion catch this.
-- Current behavior is correct (probe confirmed one shared `Instant` reaches
-  every child); the contract is simply unguarded.
-- Minimal fix: add a `Child` impl that records the `deadline` argument of each
-  `shutdown` call, and assert all recorded values are identical after
-  `shutdown_all`.
-
-### MINOR 3 — `forget`'s `order` maintenance and the forget+`shutdown_all` interaction are untested
-
-- Location: `crates/noren-app/src/session_supervisor.rs:577`
-  (`self.order.retain(...)`).
-- Evidence: deleting the `retain` line leaves committed tests green
-  (`test result: ok. 26 passed`), while `shutdown_all` then resurrects the
-  forgotten id and reports it as `Failed(PollFailed)`. No committed test
-  combines `forget` with `shutdown_all`.
-- Current behavior is correct; the interaction is unguarded.
-- Minimal fix: test spawn-3 → terminate+forget one → `shutdown_all` reports
-  exactly the remaining ids (this is precisely the reviewer probe that caught
-  the mutation).
-
-### MINOR 4 — `terminate` on an unknown id fabricates `Failed(PollFailed)`
-
-- Location: `crates/noren-app/src/session_supervisor.rs:485-489`.
-- Reproduction: spawn → terminate → `forget(id)` → `terminate_now(id)` returns
-  `SessionStatus::Failed { reason: SessionFailure::PollFailed }` (probe-verified).
-- Expected vs actual: `select`/`forget` correctly report
-  `SessionOpError::Unknown` for such ids, but `terminate` has no error channel
-  and invents a "poll failed" status for a session that never existed; a UI
-  rendering statuses cannot tell "unknown id" from a genuine backend poll
-  fault. The reason recorded has no relation to what happened.
-- Minimal fix: at minimum use a dedicated classification (or `Unknown` if one
-  is added to `SessionFailure` at D-M3-001 integration); preferably give
-  `terminate` a `Result<SessionStatus, SessionOpError>` so unknown ids surface
-  as `Unknown`. If kept as-is, document the chosen semantics on the method.
-
-### MINOR 5 — `Child::shutdown` deadline parameter cannot be honored by the known production backend; abandon path may still block in `Drop`
-
-- Location: contract `crates/noren-app/src/session_supervisor.rs:238-239`
-  ("Kill, reap, and join before `deadline`"); pre-check at lines 493-495;
-  production backend `crates/noren-pty/src/lib.rs:376-407` (`shutdown` takes
-  no deadline, uses its own internal `SHUTDOWN_DEADLINE`) and
-  `crates/noren-pty/src/lib.rs:420-424` (`impl Drop for PtySession` calls
-  `shutdown()`).
-- Consequences once the real adapter is wired: (a) the deadline argument is
-  dead weight for `PtySession` (tight caller budgets can be exceeded by the
-  internal 2 s); (b) `terminate`'s already-elapsed-deadline path marks
-  `Failed(ReapTimeout)` and drops the handle *without* calling `shutdown` —
-  but the adapter's `Drop` will then run a full shutdown attempt anyway, so
-  "no backend call" (asserted by the mock-based test at lines 967-980) will not
-  hold in production.
-- The handoff §5.2 flags half of this; the Drop interaction seems new. No code
-  change is required in this lane — but the serial integration commit must
-  decide (deadline-parameterised adapter vs concurrent kill) and the `Child`
-  doc should note Drop semantics. Recorded so the integrator cannot miss it.
-
-### MINOR 6 — terminal records are retained without bound until cooperative `forget`
-
-- Location: `crates/noren-app/src/session_supervisor.rs:315-323` (record
-  kept), 563-582 (`forget` is the only removal path).
-- Behavior: every spawned session's record stays in `sessions` (and `order`)
-  until someone calls `forget`; nothing reaps records automatically and there
-  is no cap. A long-running supervisor whose owner never forgets grows without
-  bound.
-- Assessment: this is a deliberate, documented design ("The status remains so
-  callers can observe the outcome by id", lines 317-319), and the retirement
-  API exists. Ranking MINOR because the retention policy is delegated to a
-  registry that does not exist yet and nothing enforces it. Suggested fix:
-  at integration, the registry/domain must own an explicit retirement policy
-  (e.g., forget after the UI observes the terminal status, or a record cap);
-  alternatively document on the type that the map grows until `forget`.
+  order**"); implementation `mark_exited`/`mark_failed` push into two separate
+  `Vec`s (`src/session_supervisor.rs:300-301`).
+- Reproduction: 6 sessions, alternating exit/fail, one `poll` (reviewer probe
+  P1): `exited() == [id0, id2, id4]`, `failed() == [id1, id3, id5]`.
+- Expected vs actual: under a strict reading of the contract sentence a caller
+  could expect to reconstruct the single global order `[id0..id5]`; the actual
+  API exposes two parallel lists, each internally in insertion order, with no
+  accessor for the combined order. Behavior is correct and matches the most
+  natural reading of the next sentence ("Exited and Failed are reported
+  separately"); this is a doc-clarity gap, not a behavioral defect — a consumer
+  that needs global order can still query `status(id)` per id.
+- Severity: MINOR, non-blocking. Raised only because the MAJOR fixed in this
+  re-review was itself an ordering promise, so the remaining ambiguity is worth
+  pinning down at integration time.
+- Minimal fix: clarify the rustdoc — "insertion order is preserved *within each
+  of the two lists*" — or add a merged-view accessor at D-M3-001 integration.
 
 ## Areas checked and found sound
 
-- Idempotency of `terminate` and `shutdown_all` (mutation-verified, §above).
-- Selection safety: selecting a dead session is refused; selection is cleared
-  on every terminal transition of the selected id (all four `mark_*`/`finalize_*`
-  paths, lines 596-598, 607-609, 617-619, 627-629); `forget` also clears it
-  defensively.
-- The `Ok(())`-shutdown path reads the code via a second `poll_exit` and never
-  leaves the session `Running`, even on backend inconsistency (lines 507-517).
-- `#[path]` inclusion mechanics: the module compiles once per test binary only;
-  `cfg(test)` gating keeps `mock` out of production; `#![forbid(unsafe_code)]`
-  in the integration target; no `unsafe` in the module.
-- File lease and forbidden files (§above); handoff factual claims
-  (§Gates — all reproduce).
+- Idempotency of `terminate` and `shutdown_all` (committed tests + probe P4).
+- Selection safety: selection cleared exactly when the selected session
+  transitions (all four finalizers) and on `forget`; unrelated deaths leave it
+  alone (probe P2); `select` refuses dead/unknown ids.
+- The `Ok(())`-shutdown path (`poll_after_shutdown`,
+  `src/session_supervisor.rs:561-570`) never leaves a session `Running`, even
+  on backend inconsistency.
+- Handoff §4 numbers reproduce exactly (382/0/1; 29 lane tests); §8 fix claims
+  all hold under mutation.
+- No regressions elsewhere in the workspace: all pre-existing targets pass
+  unchanged at the lane's head.

--- a/docs/coordination/reviews/M3-1b-review.md
+++ b/docs/coordination/reviews/M3-1b-review.md
@@ -1,0 +1,283 @@
+# Review — M3-1b session lifecycle supervisor (independent)
+
+- Reviewed branch: `agent/m3-session-supervisor`
+- Reviewed head SHA: `79dff71e3f26` (code commit `e4d6479`, handoff `79dff71`)
+- Base: `origin/main` at `1d329a5`
+- Task authority: `state/tasks/M3-1b.md` (fleet repo `noren-fleet-private`)
+- Reviewer: independent (did not author the code under review), run from the
+  `pool-rev-b` worktree checked out detached at `79dff71`.
+
+## Verdict
+
+**FINDINGS** — 0 blockers, 1 major, 5 minors. All three gates pass; all four
+acceptance criteria and all four required tests are met. The major finding is a
+public contract the docs promise and the code demonstrably does not deliver
+(`ReapReport` ordering). The minors are test-coverage gaps proven by mutation
+testing, a misleading error classification, and two integration notes. No
+ADR 0003 boundary violation, no unintended deletions, no panic/leak surface.
+
+## Gates (real output)
+
+Toolchain: `rustc 1.88.0` via `rust-toolchain.toml`.
+
+```
+$ cargo fmt --all -- --check
+$ echo $?
+0
+```
+(No output — format clean.)
+
+```
+$ cargo clippy --workspace --all-targets -- -D warnings
+...
+    Checking noren-app v0.1.0 (...)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.79s
+$ echo $?
+0
+```
+
+```
+$ cargo test --workspace
+```
+Per-binary `test result:` lines (all `ok`):
+
+| binary | passed | failed | ignored |
+|---|---|---|---|
+| noren-app lib (`src/lib.rs`) | 79 | 0 | 1 (pre-existing) |
+| noren-app bin (`src/main.rs`) | 24 | 0 | 0 |
+| `tests/session_supervisor.rs` (new) | 26 | 0 | 0 |
+| `tests/verify59_independent.rs` | 19 | 0 | 0 |
+| noren-pty lib | 10 | 0 | 0 |
+| noren-terminal lib | 45 | 0 | 0 |
+| noren-terminal integration (16 targets) | 176 | 0 | 0 |
+| doc-tests (3 crates) | 0 | 0 | 0 |
+
+Total **379 passed, 0 failed, 1 ignored**. The 1 ignored test is
+`crates/noren-app/src/clipboard.rs:228` (`#[ignore = "touches the real macOS
+system clipboard"]`), present identically on `origin/main` — not introduced by
+this lane. The handoff's count claims (353 baseline + 26 new = 379; 14 inline +
+12 integration = 26) reproduce exactly.
+
+## Acceptance criteria (one by one)
+
+1. **Supervisor owns child handles; the registry never does. — MET.**
+   `SupervisedSession.child` (`src/session_supervisor.rs:320-323`) is the only
+   strong reference to `Box<dyn Child + Send>`; every terminal transition sets
+   it to `None` (`mark_exited` line 593, `mark_failed` line 604,
+   `finalize_exited` line 615, `finalize_failed` line 626). No registry exists
+   on this branch (M3-1a unmerged), and the module is not declared in
+   `lib.rs`, so nothing else can hold a handle. Structural, and enforced by
+   type ownership.
+
+2. **A dead child produces Exited/Failed rather than a stuck Running. — MET.**
+   Verified by probe: unprompted exit (`ctrl.exit(Some(42))`) is surfaced by a
+   single `poll()` as `Exited { code: Some(42) }`; poll backend error becomes
+   `Failed(PollFailed)`; shutdown timeout becomes `Failed(ReapTimeout)`;
+   elapsed deadline becomes `Failed(ReapTimeout)` without a backend call; even
+   the defensive "handle missing while Running" case (line 452-453) resolves to
+   `Failed`, never `Running`. Also verified a racing natural exit then
+   `terminate_now` keeps the natural code `Exited { code: Some(42) }`.
+
+3. **Termination reaps the child and is idempotent. — MET.** Verified by
+   reading and mutating: with the fast path deleted, 3 committed tests fail
+   (see mutation section). `shutdown_all` is idempotent at the backend level:
+   my probe recorded per-child `shutdown` call counts `[1, 1, 1]` after the
+   first pass and unchanged after a second pass.
+
+4. **Until M3-1a lands, only a fake process model and a failure matrix exist.
+   — MET.** `docs/coordination/decisions/D-M3-001-session-api.md` is absent on
+   this branch (the `decisions/` directory does not exist); the STUB block
+   (lines 64-149) is clearly marked; the mock + tests are the only executable
+   surface; the module is not wired into `lib.rs` (forbidden by the lease).
+
+## Required tests — present and behavior-bound
+
+- spawn then Running via fake supervisor: `spawn_assigns_unique_ids_and_selects_newest`
+  (inline) — mutates `fresh_id` → fails.
+- child crash surfaces as Failed/Exited: `poll_surfaces_unprompted_exit...`,
+  `unprompted_death_surfaces_as_exited_within_one_poll`, plus the poll-error
+  pair.
+- double terminate idempotent, reaps once: `terminate_reaps_a_running_child_and_is_idempotent`,
+  `terminate_reaps_and_second_call_is_a_no_op` (asserts backend call counts).
+- stale session detected: `poll` over a child that died with no status update
+  is exactly the unprompted-death tests above.
+
+## Interaction / adversarial tests beyond the author's suite
+
+The author tested each feature alone; this project has repeatedly shipped
+combined-feature defects, so I probed combinations (temporary probes, since
+removed):
+
+- **forget + shutdown_all** (finding 3): spawn 3, terminate+forget the middle,
+  `shutdown_all` reports only the two tracked ids. Current behavior correct;
+  not covered by any committed test (proven by mutation).
+- **racing natural exit + terminate**: `exit(Some(42))` then `terminate_now` →
+  `Exited { code: Some(42) }`; the natural code survives the kill path.
+- **terminate after poll-failure**: poll marks `Failed(PollFailed)`; a later
+  `terminate_now` returns the recorded status and performs **zero** backend
+  calls — correct fast-path behavior for `Failed`, not just `Exited`.
+- **shared deadline proof**: a deadline-recording `Child` confirmed all three
+  children in a batch receive the *same* `Instant` from `shutdown_all`.
+- **terminate(unknown id)**: after forget, `terminate_now(id)` fabricates
+  `Failed(PollFailed)` (finding 4).
+- **Degenerate input**: no parse surface — the module is a state machine
+  driven by app code. Panic surface is limited to `.expect("mock lock")` in
+  test-only code. `fresh_id` uses `wrapping_add` (collision after 2^64 spawns;
+  theoretical, noted, not a finding). `shutdown_all` clones `order` (O(n),
+  bounded by session count). No unbounded buffers beyond the intentional
+  terminal-record retention (finding 5 territory — see below).
+
+## Mutation testing — do the tests test the behavior?
+
+All mutations were applied, tested, and reverted; the tree is clean again.
+
+| mutation | committed suite | verdict |
+|---|---|---|
+| suppress `Exited` transition in `poll` (stuck `Running`) | **8 failures** | caught |
+| delete `terminate` terminal fast path | **3 failures** | caught |
+| per-iteration deadline in `shutdown_all` (n*deadline bug) | **26 pass** | **NOT caught** — only a deadline-recording probe catches it |
+| delete `order.retain` in `forget` (zombie ids re-terminated by `shutdown_all`) | **26 pass** | **NOT caught** — only the forget+shutdown_all probe catches it |
+
+The first two columns show the load-bearing invariants are genuinely tested.
+The last two are findings 2 and 3: real, documented contracts with zero
+committed coverage.
+
+## Unintended deletions / lease
+
+`git diff --stat origin/main...HEAD`: 3 files, **1573 insertions(+), 0
+deletions**. `git diff --diff-filter=D` lists nothing. Forbidden files
+(`lib.rs`, `main.rs`, `Cargo.toml`, `Cargo.lock`, `status.md`) untouched —
+verified by the diff stat above; `cargo build` therefore still excludes the
+module, as intended. The handoff doc is outside the leased code paths but is
+the workflow's required coordination artifact.
+
+## ADR 0003 boundary
+
+Clean. No pane, tab, layout tree, or split type anywhere in the diff; grep for
+`pane|layout|split|zellij|tab` over both files matches only the word
+"ownership split" in a comment (line 19). The module owns process lifecycle
+only; `select` is session focus, which the task spec itself assigns to this
+lane ("spawn/terminate/select"). No Zellij internal layout is read or
+persisted.
+
+## Findings
+
+### MAJOR 1 — `ReapReport` promises insertion order; `poll` delivers HashMap order
+
+- Location: contract at `crates/noren-app/src/session_supervisor.rs:282-284`
+  ("Lists exactly the sessions that left `Running` this pass, **in insertion
+  order**") vs implementation at `crates/noren-app/src/session_supervisor.rs:440-445`
+  (ids collected from `self.sessions.iter()` — a `HashMap` with randomized
+  iteration order). The insertion order is kept in `self.order` (line 333) but
+  `poll` never consults it.
+- Reproduction (reviewer probe, since removed): spawn 10 sessions, exit all
+  via their controllers, one `poll`:
+  ```
+  left:  [SessionId(6), SessionId(1), SessionId(7), SessionId(0), SessionId(4),
+          SessionId(8), SessionId(2), SessionId(3), SessionId(9), SessionId(5)]
+  right: [SessionId(0), SessionId(1), ..., SessionId(9)]
+  assertion `left == right` failed: ReapReport promises insertion order
+  ```
+- Expected: `report.exited()` in spawn order `[0..9]`. Actual: arbitrary
+  `RandomState` order, nondeterministic supervisor-to-supervisor.
+- Impact: no committed test transitions more than one session per `poll`, so
+  the suite cannot see this. A future UI/event loop that renders or applies a
+  pass's transitions in reported order gets shuffled, nondeterministic output.
+- Minimal fix: in `poll`, collect ids from `self.order.iter().filter(...)`
+  (filtering to `Running`) instead of `self.sessions.iter()`, and add one test
+  that transitions ≥2 sessions in a single pass and asserts report order.
+
+### MINOR 2 — shared-deadline contract of `shutdown_all` has no test that can catch a regression
+
+- Location: `crates/noren-app/src/session_supervisor.rs:551-561`; the only
+  timing assertion is `tests/session_supervisor.rs:123`
+  (`elapsed <= SHUTDOWN_DEADLINE`).
+- Evidence: with the deadline moved inside the loop (regressing to
+  `n * SHUTDOWN_DEADLINE` — the exact bug the module doc and commit message
+  claim to prevent), `cargo test -p noren-app --test session_supervisor` still
+  reports `test result: ok. 26 passed; 0 failed`. An instant mock can never
+  make a wall-clock assertion catch this.
+- Current behavior is correct (probe confirmed one shared `Instant` reaches
+  every child); the contract is simply unguarded.
+- Minimal fix: add a `Child` impl that records the `deadline` argument of each
+  `shutdown` call, and assert all recorded values are identical after
+  `shutdown_all`.
+
+### MINOR 3 — `forget`'s `order` maintenance and the forget+`shutdown_all` interaction are untested
+
+- Location: `crates/noren-app/src/session_supervisor.rs:577`
+  (`self.order.retain(...)`).
+- Evidence: deleting the `retain` line leaves committed tests green
+  (`test result: ok. 26 passed`), while `shutdown_all` then resurrects the
+  forgotten id and reports it as `Failed(PollFailed)`. No committed test
+  combines `forget` with `shutdown_all`.
+- Current behavior is correct; the interaction is unguarded.
+- Minimal fix: test spawn-3 → terminate+forget one → `shutdown_all` reports
+  exactly the remaining ids (this is precisely the reviewer probe that caught
+  the mutation).
+
+### MINOR 4 — `terminate` on an unknown id fabricates `Failed(PollFailed)`
+
+- Location: `crates/noren-app/src/session_supervisor.rs:485-489`.
+- Reproduction: spawn → terminate → `forget(id)` → `terminate_now(id)` returns
+  `SessionStatus::Failed { reason: SessionFailure::PollFailed }` (probe-verified).
+- Expected vs actual: `select`/`forget` correctly report
+  `SessionOpError::Unknown` for such ids, but `terminate` has no error channel
+  and invents a "poll failed" status for a session that never existed; a UI
+  rendering statuses cannot tell "unknown id" from a genuine backend poll
+  fault. The reason recorded has no relation to what happened.
+- Minimal fix: at minimum use a dedicated classification (or `Unknown` if one
+  is added to `SessionFailure` at D-M3-001 integration); preferably give
+  `terminate` a `Result<SessionStatus, SessionOpError>` so unknown ids surface
+  as `Unknown`. If kept as-is, document the chosen semantics on the method.
+
+### MINOR 5 — `Child::shutdown` deadline parameter cannot be honored by the known production backend; abandon path may still block in `Drop`
+
+- Location: contract `crates/noren-app/src/session_supervisor.rs:238-239`
+  ("Kill, reap, and join before `deadline`"); pre-check at lines 493-495;
+  production backend `crates/noren-pty/src/lib.rs:376-407` (`shutdown` takes
+  no deadline, uses its own internal `SHUTDOWN_DEADLINE`) and
+  `crates/noren-pty/src/lib.rs:420-424` (`impl Drop for PtySession` calls
+  `shutdown()`).
+- Consequences once the real adapter is wired: (a) the deadline argument is
+  dead weight for `PtySession` (tight caller budgets can be exceeded by the
+  internal 2 s); (b) `terminate`'s already-elapsed-deadline path marks
+  `Failed(ReapTimeout)` and drops the handle *without* calling `shutdown` —
+  but the adapter's `Drop` will then run a full shutdown attempt anyway, so
+  "no backend call" (asserted by the mock-based test at lines 967-980) will not
+  hold in production.
+- The handoff §5.2 flags half of this; the Drop interaction seems new. No code
+  change is required in this lane — but the serial integration commit must
+  decide (deadline-parameterised adapter vs concurrent kill) and the `Child`
+  doc should note Drop semantics. Recorded so the integrator cannot miss it.
+
+### MINOR 6 — terminal records are retained without bound until cooperative `forget`
+
+- Location: `crates/noren-app/src/session_supervisor.rs:315-323` (record
+  kept), 563-582 (`forget` is the only removal path).
+- Behavior: every spawned session's record stays in `sessions` (and `order`)
+  until someone calls `forget`; nothing reaps records automatically and there
+  is no cap. A long-running supervisor whose owner never forgets grows without
+  bound.
+- Assessment: this is a deliberate, documented design ("The status remains so
+  callers can observe the outcome by id", lines 317-319), and the retirement
+  API exists. Ranking MINOR because the retention policy is delegated to a
+  registry that does not exist yet and nothing enforces it. Suggested fix:
+  at integration, the registry/domain must own an explicit retirement policy
+  (e.g., forget after the UI observes the terminal status, or a record cap);
+  alternatively document on the type that the map grows until `forget`.
+
+## Areas checked and found sound
+
+- Idempotency of `terminate` and `shutdown_all` (mutation-verified, §above).
+- Selection safety: selecting a dead session is refused; selection is cleared
+  on every terminal transition of the selected id (all four `mark_*`/`finalize_*`
+  paths, lines 596-598, 607-609, 617-619, 627-629); `forget` also clears it
+  defensively.
+- The `Ok(())`-shutdown path reads the code via a second `poll_exit` and never
+  leaves the session `Running`, even on backend inconsistency (lines 507-517).
+- `#[path]` inclusion mechanics: the module compiles once per test binary only;
+  `cfg(test)` gating keeps `mock` out of production; `#![forbid(unsafe_code)]`
+  in the integration target; no `unsafe` in the module.
+- File lease and forbidden files (§above); handoff factual claims
+  (§Gates — all reproduce).


### PR DESCRIPTION
Milestone 3 task M3-1b.

Session spawn, terminate, and select lifecycle with process ownership, child reaping, and stale/dead-session handling. The supervisor owns child handles; the registry stays pure state so domain tests run without spawning anything.

**Independently verified.** A Qwen session that did not write the code reviewed it and reported `blockers=0 majors=0`. An earlier review found a MAJOR — `ReapReport` promised insertion order while `poll` delivered `HashMap` order, which would have broken consumers intermittently and looked unrelated — and that was fixed before this verdict.

Task spec and handoff are in the branch under `docs/coordination/`.