### PR TITLE
feat(app): versioned sidebar session persistence (M3-7)

### DIFF
--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -89,7 +89,10 @@ pub const MAX_SESSIONS: usize = 512;
 ///
 /// Reads are streamed and bounded like the configuration loader, so a
 /// pathological path cannot grow memory past this cap; oversized input is a
-/// [`SessionPersistenceError::TooLarge`] error instead.
+/// [`SessionPersistenceError::TooLarge`] error instead. Writes check the
+/// same cap as the document is built, so a registry that would encode past
+/// it is rejected with [`SessionPersistenceError::TooLarge`] rather than
+/// written unreadable.
 pub const MAX_SESSION_STATE_BYTES: u64 = 512 * 1024;
 
 /// Suffix of the temporary file used for crash-safe replacement writes.
@@ -112,7 +115,9 @@ pub enum SessionPersistenceError {
     Io(ErrorKind),
     /// The path exists but does not resolve to a regular file.
     NotAFile,
-    /// The file exceeds [`MAX_SESSION_STATE_BYTES`].
+    /// The state exceeds [`MAX_SESSION_STATE_BYTES`], in either direction:
+    /// a file too large to read, or a registry that would encode to a
+    /// document too large to read back.
     TooLarge,
     /// The file is not valid UTF-8.
     NotUtf8,
@@ -231,12 +236,16 @@ pub fn load_bytes(
 /// Deterministic: the same registry state always produces the same text.
 /// Entries are written in [`SessionRegistry::sessions`] order; the selection
 /// is written as a positional index and omitted when nothing is selected.
-/// Refuses more than [`MAX_SESSIONS`] entries and non-UTF-8 paths.
+/// Refuses more than [`MAX_SESSIONS`] entries, a document larger than
+/// [`MAX_SESSION_STATE_BYTES`] (checked as it is built, so the encoded
+/// [`String`] is bounded and anything that would be unreadable on load is
+/// rejected before it is returned), and non-UTF-8 paths.
 pub fn encode(registry: &SessionRegistry) -> Result<String, SessionPersistenceError> {
     let sessions = registry.sessions();
     if sessions.len() > MAX_SESSIONS {
         return Err(SessionPersistenceError::TooManySessions);
     }
+    let byte_cap = usize::try_from(MAX_SESSION_STATE_BYTES).unwrap_or(usize::MAX);
     let selected_index: Option<usize> = registry.selected().map(|selected| {
         sessions
             .iter()
@@ -271,6 +280,9 @@ pub fn encode(registry: &SessionRegistry) -> Result<String, SessionPersistenceEr
                 text.push_str("kind = \"agent\"\n");
                 text.push_str(&format!("name = {}\n", toml_string(name)));
             }
+        }
+        if text.len() > byte_cap {
+            return Err(SessionPersistenceError::TooLarge);
         }
     }
     Ok(text)

--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -1,0 +1,607 @@
+//! Sidebar persistence: which sessions exist and which one is selected.
+//!
+//! This module saves and restores the Noren sidebar state defined by
+//! [ADR 0003](../../../docs/adr/0003-noren-zellij-responsibility-boundary.md):
+//! which projects, worktrees, SSH targets, agents, and terminal sessions
+//! exist, and which of them is selected. It reuses the shared D-M3-001
+//! vocabulary from [`crate::session`] ([`SessionKind`] and
+//! [`SessionRegistry`]); it defines no parallel session model.
+//!
+//! # The boundary is enforced in the parser
+//!
+//! Noren manages the workspace OUTSIDE the terminal; Zellij manages it
+//! INSIDE. Nothing that describes the interior of a session is ever written
+//! or accepted: no tabs, no panes, no splits, no layout tree, no terminal
+//! content. A session serializes as its [`SessionKind`] and nothing else,
+//! and a session table carrying any other key (a `panes` count, a `tab`
+//! name, anything) is rejected as unknown rather than parsed and ignored.
+//!
+//! # The format is versioned, but it is not final
+//!
+//! The on-disk document is TOML and carries `version = 1` from the first
+//! write. Shipping a format that later changes breaks every existing user's
+//! state, so this module treats version 1 as a starting point with a
+//! migration path (`version` is checked before anything else) instead of a
+//! public commitment. A document claiming any other version is rejected
+//! whole — never partially parsed.
+//!
+//! # The file is untrusted input
+//!
+//! A truncated, malformed, wrong-version, non-UTF-8, oversized, or hostile
+//! file produces a clean [`SessionPersistenceError`] and leaves the target
+//! registry untouched: decoding validates the entire document before a
+//! single entry is created, so a partial load can never look complete. A
+//! **missing** file is normal — it is the first run — and loads as empty
+//! state without error.
+//!
+//! # Bounded state
+//!
+//! Both directions are bounded, because a session list that grows without
+//! limit on disk is the same defect class as an unbounded in-memory list:
+//! reads stop at [`MAX_SESSION_STATE_BYTES`] and refuse more than
+//! [`MAX_SESSIONS`] entries, and writes refuse to encode past either bound.
+//!
+//! # Identity and restoration
+//!
+//! Per D-M3-001, [`SessionId`]s are registry-local and are **not**
+//! persistence keys, so no id is written. Entries are stored in registry
+//! order and the selection is stored as a positional index into that list.
+//! Restoration runs each loaded kind through [`SessionRegistry::create`],
+//! which records it as [`SessionStatus::Starting`] with a generated title;
+//! runtime status is an observed fact and is never persisted. Titles are
+//! derived facts today (a rename feature may change that in a later format
+//! version), so they are not persisted either.
+//!
+//! Restoration re-populates the registry only. Whether restoring a session
+//! re-spawns a shell or reattaches to an existing one (for example through
+//! Zellij) is an open M3 question this module does not answer; it spawns
+//! nothing.
+//!
+//! [`SessionId`]: crate::session::SessionId
+//! [`SessionStatus::Starting`]: crate::session::SessionStatus::Starting
+
+use crate::session::{SessionKind, SessionRegistry};
+use std::fmt;
+use std::fs;
+use std::io::{ErrorKind, Read, Write};
+use std::path::Path;
+use toml_edit::{DocumentMut, Table};
+
+/// Recommended file name for sidebar state inside the Noren data directory.
+pub const SESSION_STATE_FILE_NAME: &str = "sessions.toml";
+
+/// The only format version this build reads and writes.
+///
+/// The version is written on every save and checked before any other key is
+/// interpreted, so a future format change has a migration path instead of a
+/// guess. This is a stop condition, not a commitment: version 1 is
+/// versioned-but-not-final.
+pub const SESSION_STATE_VERSION: i64 = 1;
+
+/// Maximum number of sidebar entries persisted in either direction.
+///
+/// Writes refuse to encode more than this; reads refuse to apply more. The
+/// sidebar itself must stay within the same bound; persistence can neither
+/// raise nor lower what the live registry may hold.
+pub const MAX_SESSIONS: usize = 512;
+
+/// Maximum accepted state file size in bytes.
+///
+/// Reads are streamed and bounded like the configuration loader, so a
+/// pathological path cannot grow memory past this cap; oversized input is a
+/// [`SessionPersistenceError::TooLarge`] error instead.
+pub const MAX_SESSION_STATE_BYTES: u64 = 512 * 1024;
+
+/// Suffix of the temporary file used for crash-safe replacement writes.
+const TMP_SUFFIX: &str = ".tmp";
+
+/// Maximum characters of hostile input echoed inside any error message.
+const MAX_ERROR_DETAIL_CHARS: usize = 120;
+
+/// Typed persistence failure without file contents.
+///
+/// Every variant renders a bounded message; hostile keys, kinds, and parser
+/// details are clipped by [`clip`] before they are stored.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionPersistenceError {
+    /// The state file does not exist. Internal to [`load`], which turns
+    /// absence into empty state; it never reaches callers of the public API.
+    NotFound,
+    /// The file could not be read, written, or renamed; only the I/O error
+    /// kind is retained.
+    Io(ErrorKind),
+    /// The path exists but does not resolve to a regular file.
+    NotAFile,
+    /// The file exceeds [`MAX_SESSION_STATE_BYTES`].
+    TooLarge,
+    /// The file is not valid UTF-8.
+    NotUtf8,
+    /// The file is not valid TOML (including truncation).
+    Parse(String),
+    /// The file omits a required key.
+    MissingKey(String),
+    /// The file names a key this format does not define.
+    ///
+    /// This is also where the ADR 0003 boundary bites: session-interior
+    /// keys such as `panes`, `tabs`, or `layout` land here.
+    UnknownKey(String),
+    /// A key holds the wrong TOML type.
+    WrongType {
+        /// The offending key.
+        key: String,
+    },
+    /// A value is outside its accepted range: a `selected` index beyond the
+    /// entry list, or an empty path/target/name payload.
+    OutOfRange {
+        /// The offending key.
+        key: String,
+    },
+    /// A session path is not valid UTF-8. TOML strings are UTF-8, so the
+    /// path could only be saved through a lossy conversion — persisting a
+    /// different path than the live one is corruption, so the save refuses.
+    NonUtf8Path,
+    /// A `kind` string names no [`SessionKind`] variant.
+    UnknownKind(String),
+    /// The file claims a format version this build does not speak, past or
+    /// future. The document is rejected whole, never partially parsed.
+    UnsupportedVersion(i64),
+    /// The file, or the write request, carries more than [`MAX_SESSIONS`]
+    /// entries.
+    TooManySessions,
+}
+
+impl fmt::Display for SessionPersistenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("session state file not found"),
+            Self::Io(kind) => write!(f, "session state I/O failed: {kind}"),
+            Self::NotAFile => f.write_str("session state path does not resolve to a regular file"),
+            Self::TooLarge => write!(f, "session state exceeds {MAX_SESSION_STATE_BYTES} bytes"),
+            Self::NotUtf8 => f.write_str("session state is not valid UTF-8"),
+            Self::Parse(detail) => write!(f, "session state is not valid TOML: {detail}"),
+            Self::MissingKey(key) => write!(f, "session state is missing key: {key}"),
+            Self::UnknownKey(key) => write!(f, "unknown session state key: {key}"),
+            Self::WrongType { key } => {
+                write!(f, "session state key {key} has the wrong TOML type")
+            }
+            Self::OutOfRange { key } => {
+                write!(f, "session state key {key} is outside its accepted range")
+            }
+            Self::NonUtf8Path => {
+                f.write_str("session path is not valid UTF-8 and cannot be persisted without loss")
+            }
+            Self::UnknownKind(kind) => write!(f, "unknown session kind: {kind}"),
+            Self::UnsupportedVersion(version) => write!(
+                f,
+                "session state version {version} is not supported; this build speaks version {SESSION_STATE_VERSION}"
+            ),
+            Self::TooManySessions => write!(f, "session state exceeds {MAX_SESSIONS} sessions"),
+        }
+    }
+}
+
+impl std::error::Error for SessionPersistenceError {}
+
+/// Save the sidebar state to `path`, replacing any previous file.
+///
+/// The write is crash-safe in the format sense: the document is written to a
+/// temporary sibling and renamed over the destination, so the file is either
+/// the old state or the new state, never a truncation. Refuses to encode
+/// more than [`MAX_SESSIONS`] entries or a document larger than
+/// [`MAX_SESSION_STATE_BYTES`]. Parent directories are created when absent.
+pub fn save(path: &Path, registry: &SessionRegistry) -> Result<(), SessionPersistenceError> {
+    let text = encode(registry)?;
+    write_atomic(path, text.as_bytes())
+}
+
+/// Load the sidebar state from `path` into `registry`, creating one entry
+/// per saved kind (in saved order) and selecting the saved selection.
+///
+/// A missing file is the first run: it leaves `registry` untouched and
+/// returns `Ok`. Any file that exists must read, decode, and validate or the
+/// call errors — and because decoding validates before creating, an error
+/// also leaves `registry` exactly as it was. Entries re-enter through
+/// [`SessionRegistry::create`], so they start at `Starting` with generated
+/// titles; this module spawns nothing.
+pub fn load(path: &Path, registry: &mut SessionRegistry) -> Result<(), SessionPersistenceError> {
+    let bytes = match read_bounded(path) {
+        Ok(bytes) => bytes,
+        Err(SessionPersistenceError::NotFound) => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    load_bytes(&bytes, registry)
+}
+
+/// Decode raw state file bytes and apply them to `registry`.
+///
+/// Exposed so the decode contract is testable without touching the
+/// filesystem. Validation is whole-document: a non-UTF-8, malformed,
+/// wrong-version, or oversized document errors before `registry` is mutated.
+pub fn load_bytes(
+    bytes: &[u8],
+    registry: &mut SessionRegistry,
+) -> Result<(), SessionPersistenceError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| SessionPersistenceError::NotUtf8)?;
+    let (kinds, selected) = decode(text)?;
+    apply(kinds, selected, registry)
+}
+
+/// Serialize `registry` to the versioned TOML document.
+///
+/// Deterministic: the same registry state always produces the same text.
+/// Entries are written in [`SessionRegistry::sessions`] order; the selection
+/// is written as a positional index and omitted when nothing is selected.
+/// Refuses more than [`MAX_SESSIONS`] entries and non-UTF-8 paths.
+pub fn encode(registry: &SessionRegistry) -> Result<String, SessionPersistenceError> {
+    let sessions = registry.sessions();
+    if sessions.len() > MAX_SESSIONS {
+        return Err(SessionPersistenceError::TooManySessions);
+    }
+    let selected_index: Option<usize> = registry.selected().map(|selected| {
+        sessions
+            .iter()
+            .position(|descriptor| descriptor.id() == selected)
+            .expect("registry selection always refers to a live session")
+    });
+
+    let mut text = String::new();
+    text.push_str("# Noren sidebar state. Noren owns what exists outside the terminal;\n");
+    text.push_str("# nothing in this file describes what is inside a session (ADR 0003).\n");
+    text.push_str(&format!("version = {SESSION_STATE_VERSION}\n"));
+    if let Some(index) = selected_index {
+        text.push_str(&format!("selected = {index}\n"));
+    }
+    for descriptor in &sessions {
+        text.push_str("\n[[sessions]]\n");
+        match descriptor.kind() {
+            SessionKind::Local => text.push_str("kind = \"local\"\n"),
+            SessionKind::Project { root } => {
+                text.push_str("kind = \"project\"\n");
+                text.push_str(&format!("root = {}\n", toml_string(path_text(root)?)));
+            }
+            SessionKind::Worktree { path } => {
+                text.push_str("kind = \"worktree\"\n");
+                text.push_str(&format!("path = {}\n", toml_string(path_text(path)?)));
+            }
+            SessionKind::Ssh { target } => {
+                text.push_str("kind = \"ssh\"\n");
+                text.push_str(&format!("target = {}\n", toml_string(target)));
+            }
+            SessionKind::Agent { name } => {
+                text.push_str("kind = \"agent\"\n");
+                text.push_str(&format!("name = {}\n", toml_string(name)));
+            }
+        }
+    }
+    Ok(text)
+}
+
+/// Borrow a persistable path, refusing the lossy alternative.
+///
+/// TOML strings are UTF-8; a path that is not valid UTF-8 could only be
+/// written through a lossy conversion, which would silently persist a
+/// different path. That is corruption, so it is an error instead.
+fn path_text(path: &std::path::Path) -> Result<&str, SessionPersistenceError> {
+    path.to_str().ok_or(SessionPersistenceError::NonUtf8Path)
+}
+
+/// Escape one value as a TOML basic (double-quoted) string.
+///
+/// TOML basic strings must escape quotes, backslashes, and every control
+/// character; everything else passes through as UTF-8. The decode side is
+/// the TOML parser, so the round-trip tests in
+/// `tests/session_persistence.rs` are the witness that this escaping is
+/// faithful.
+fn toml_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\u{8}' => escaped.push_str("\\b"),
+            '\u{c}' => escaped.push_str("\\f"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            character if character.is_control() => {
+                escaped.push_str(&format!("\\u{:04X}", u32::from(character)));
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+/// Parse and validate the whole document before anything is applied.
+///
+/// The version check runs first: a document claiming another version is
+/// rejected here, before sessions are even looked at, so a future file is
+/// never partially parsed.
+fn decode(text: &str) -> Result<(Vec<SessionKind>, Option<usize>), SessionPersistenceError> {
+    let document: DocumentMut = text.parse().map_err(|error: toml_edit::TomlError| {
+        SessionPersistenceError::Parse(clip(error.to_string()))
+    })?;
+    let root = document.as_table();
+
+    let version = root
+        .get("version")
+        .ok_or_else(|| SessionPersistenceError::MissingKey(clip("version")))?
+        .as_integer()
+        .ok_or_else(|| SessionPersistenceError::WrongType {
+            key: clip("version"),
+        })?;
+    if version != SESSION_STATE_VERSION {
+        return Err(SessionPersistenceError::UnsupportedVersion(version));
+    }
+
+    let mut kinds: Vec<SessionKind> = Vec::new();
+    let mut selected: Option<usize> = None;
+    for (key, item) in root.iter() {
+        match key {
+            "version" => {}
+            "selected" => {
+                let index =
+                    item.as_integer()
+                        .ok_or_else(|| SessionPersistenceError::WrongType {
+                            key: clip("selected"),
+                        })?;
+                selected = Some(usize::try_from(index).map_err(|_| {
+                    SessionPersistenceError::OutOfRange {
+                        key: clip("selected"),
+                    }
+                })?);
+            }
+            "sessions" => {
+                let array = item.as_array_of_tables().ok_or_else(|| {
+                    SessionPersistenceError::WrongType {
+                        key: clip("sessions"),
+                    }
+                })?;
+                if array.len() > MAX_SESSIONS {
+                    return Err(SessionPersistenceError::TooManySessions);
+                }
+                for table in array.iter() {
+                    kinds.push(parse_session(table)?);
+                }
+            }
+            other => return Err(SessionPersistenceError::UnknownKey(clip(other))),
+        }
+    }
+
+    if let Some(index) = selected {
+        if index >= kinds.len() {
+            return Err(SessionPersistenceError::OutOfRange {
+                key: clip("selected"),
+            });
+        }
+    }
+    Ok((kinds, selected))
+}
+
+/// Parse one `[[sessions]]` table into the D-M3-001 shape it names.
+///
+/// The payload keys are exact: `local` carries none, `project` carries
+/// `root`, `worktree` carries `path`, `ssh` carries `target`, and `agent`
+/// carries `name`. Anything else — including anything describing the
+/// interior of a session — is an [`SessionPersistenceError::UnknownKey`].
+fn parse_session(table: &Table) -> Result<SessionKind, SessionPersistenceError> {
+    let kind = table
+        .get("kind")
+        .ok_or_else(|| SessionPersistenceError::MissingKey(clip("kind")))?
+        .as_str()
+        .ok_or_else(|| SessionPersistenceError::WrongType { key: clip("kind") })?;
+    match kind {
+        "local" => {
+            require_exact_keys(table, &[])?;
+            Ok(SessionKind::Local)
+        }
+        "project" => Ok(SessionKind::Project {
+            root: payload(table, "root")?.into(),
+        }),
+        "worktree" => Ok(SessionKind::Worktree {
+            path: payload(table, "path")?.into(),
+        }),
+        "ssh" => Ok(SessionKind::Ssh {
+            target: payload(table, "target")?,
+        }),
+        "agent" => Ok(SessionKind::Agent {
+            name: payload(table, "name")?,
+        }),
+        other => Err(SessionPersistenceError::UnknownKind(clip(other))),
+    }
+}
+
+/// The non-`kind` keys a session table may carry: none for `local`, exactly
+/// one payload key for every other kind. Any other key is rejected.
+fn require_exact_keys(table: &Table, expected: &[&str]) -> Result<(), SessionPersistenceError> {
+    for (key, _) in table.iter() {
+        if key != "kind" && !expected.contains(&key) {
+            return Err(SessionPersistenceError::UnknownKey(clip(key)));
+        }
+    }
+    Ok(())
+}
+
+/// Read the single required payload string of a session table.
+///
+/// Enforces the exact key set (`kind` plus `key`), requires the payload to
+/// be a non-empty string, and rejects every other key.
+fn payload(table: &Table, key: &str) -> Result<String, SessionPersistenceError> {
+    require_exact_keys(table, &[key])?;
+    let value = table
+        .get(key)
+        .ok_or_else(|| SessionPersistenceError::MissingKey(clip(key)))?
+        .as_str()
+        .ok_or_else(|| SessionPersistenceError::WrongType { key: clip(key) })?;
+    if value.is_empty() {
+        return Err(SessionPersistenceError::OutOfRange { key: clip(key) });
+    }
+    Ok(value.to_owned())
+}
+
+/// Apply a fully validated document to the registry.
+///
+/// Runs after [`decode`] accepted everything, so the only remaining check is
+/// the combined bound: restoring into a populated registry must not push the
+/// live state past [`MAX_SESSIONS`] either.
+fn apply(
+    kinds: Vec<SessionKind>,
+    selected: Option<usize>,
+    registry: &mut SessionRegistry,
+) -> Result<(), SessionPersistenceError> {
+    if registry.len() + kinds.len() > MAX_SESSIONS {
+        return Err(SessionPersistenceError::TooManySessions);
+    }
+    let created: Vec<_> = kinds
+        .into_iter()
+        .map(|kind| registry.create(kind))
+        .collect();
+    if let Some(index) = selected {
+        registry
+            .select(created[index])
+            .expect("decoded selection index was validated against the entry list");
+    }
+    Ok(())
+}
+
+/// Read a state file with a hard byte cap.
+///
+/// Mirrors the configuration loader: symlinks are followed like any
+/// user-owned file, but the target must be a regular file and the streamed
+/// read stops with [`SessionPersistenceError::TooLarge`] at
+/// [`MAX_SESSION_STATE_BYTES`], so a hostile target can neither panic the
+/// app nor exhaust memory.
+fn read_bounded(path: &Path) -> Result<Vec<u8>, SessionPersistenceError> {
+    let metadata = fs::metadata(path).map_err(io_error)?;
+    if !metadata.is_file() {
+        return Err(SessionPersistenceError::NotAFile);
+    }
+    let mut file = fs::File::open(path).map_err(io_error)?;
+    let cap = usize::try_from(MAX_SESSION_STATE_BYTES).unwrap_or(usize::MAX);
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 8 * 1024];
+    loop {
+        let read = file
+            .read(&mut chunk)
+            .map_err(|error| SessionPersistenceError::Io(error.kind()))?;
+        if read == 0 {
+            return Ok(buffer);
+        }
+        if buffer.len() + read > cap {
+            return Err(SessionPersistenceError::TooLarge);
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+}
+
+/// Replace `path` atomically with `bytes` via a temporary sibling.
+///
+/// The temporary file is fully written and synced before the rename, so a
+/// crash leaves either the previous document or the new one — never a
+/// truncated file. (Directory fsync durability and cross-restart reattach
+/// remain open questions recorded in the handoff.)
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), SessionPersistenceError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(io_error)?;
+        }
+    }
+    let file_name = path
+        .file_name()
+        .ok_or(SessionPersistenceError::Io(ErrorKind::InvalidInput))?;
+    let mut tmp_name = file_name.to_os_string();
+    tmp_name.push(TMP_SUFFIX);
+    let tmp = path.with_file_name(tmp_name);
+
+    if let Err(error) = write_tmp(&tmp, bytes) {
+        let _ = fs::remove_file(&tmp);
+        return Err(error);
+    }
+    fs::rename(&tmp, path).map_err(|error| {
+        let _ = fs::remove_file(&tmp);
+        SessionPersistenceError::Io(error.kind())
+    })
+}
+
+fn write_tmp(path: &Path, bytes: &[u8]) -> Result<(), SessionPersistenceError> {
+    let mut file = fs::File::create(path).map_err(io_error)?;
+    file.write_all(bytes)
+        .map_err(|error| SessionPersistenceError::Io(error.kind()))?;
+    file.sync_all()
+        .map_err(|error| SessionPersistenceError::Io(error.kind()))?;
+    Ok(())
+}
+
+/// Surface a missing file as the distinct [`SessionPersistenceError::NotFound`].
+fn io_error(error: std::io::Error) -> SessionPersistenceError {
+    match error.kind() {
+        ErrorKind::NotFound => SessionPersistenceError::NotFound,
+        kind => SessionPersistenceError::Io(kind),
+    }
+}
+
+/// Clip hostile input embedded in an error message to a bounded length.
+fn clip(text: impl AsRef<str>) -> String {
+    let text = text.as_ref();
+    let cut = text
+        .char_indices()
+        .nth(MAX_ERROR_DETAIL_CHARS)
+        .map_or(text.len(), |(index, _)| index);
+    let mut clipped: String = text[..cut].chars().collect();
+    if cut < text.len() {
+        clipped.push('…');
+    }
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit checks for the serialization helpers. The exhaustive behavioral
+    //! suite lives in the workspace integration test
+    //! `tests/session_persistence.rs`.
+
+    use super::*;
+
+    #[test]
+    fn toml_string_escapes_every_reserved_character() {
+        assert_eq!(toml_string(""), "\"\"");
+        assert_eq!(toml_string("plain"), "\"plain\"");
+        assert_eq!(toml_string("a\"b"), "\"a\\\"b\"");
+        assert_eq!(toml_string("a\\b"), "\"a\\\\b\"");
+        assert_eq!(toml_string("a\tb"), "\"a\\tb\"");
+        assert_eq!(toml_string("a\nb"), "\"a\\nb\"");
+        assert_eq!(toml_string("a\rb"), "\"a\\rb\"");
+        assert_eq!(toml_string("\u{8}\u{c}"), "\"\\b\\f\"");
+        assert_eq!(toml_string("界"), "\"界\"");
+    }
+
+    #[test]
+    fn toml_string_escapes_control_characters_as_unicode() {
+        assert_eq!(toml_string("\u{0}"), "\"\\u0000\"");
+        assert_eq!(toml_string("\u{1b}"), "\"\\u001B\"");
+        assert_eq!(toml_string("\u{7f}"), "\"\\u007F\"");
+    }
+
+    #[test]
+    fn the_format_constants_are_the_shipped_stop_condition() {
+        assert_eq!(SESSION_STATE_VERSION, 1);
+        assert_eq!(SESSION_STATE_FILE_NAME, "sessions.toml");
+    }
+
+    #[test]
+    fn the_byte_bound_is_usable_on_every_platform() {
+        assert!(usize::try_from(MAX_SESSION_STATE_BYTES).is_ok());
+    }
+
+    #[test]
+    fn error_messages_stay_bounded() {
+        let hostile = "a".repeat(10_000);
+        let error = SessionPersistenceError::UnknownKey(clip(&hostile));
+        assert!(error.to_string().len() < 1024);
+        assert!(
+            matches!(error, SessionPersistenceError::UnknownKey(ref key) if key.ends_with('…'))
+        );
+    }
+}

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -1,0 +1,729 @@
+//! Behavioral tests for sidebar persistence (`src/session_persistence.rs`).
+//!
+//! The persistence module is not yet wired into `noren-app`'s `lib.rs` —
+//! that one-line declaration belongs to the M3 integration lane, keeping
+//! this lane's file lease intact. Until then this target compiles the
+//! module through a `#[path]` shim, exactly as `tests/session_domain.rs`
+//! did for `session` before PR #75 wired it. The `session` shim module
+//! below mirrors the crate's public session surface so the persistence
+//! module's `crate::session` references resolve identically in both
+//! contexts; once `lib.rs` declares `pub mod session_persistence;`, replace
+//! the shim with crate imports as the session-domain lane did.
+//!
+//! Pinned behavior:
+//!
+//! 1. an absent file is the first run: empty state, no error;
+//! 2. round-trip: write then read yields the same entries and selection;
+//! 3. truncated, malformed, non-UTF-8, and wrong-version files each error
+//!    cleanly and never leave a partially-loaded registry;
+//! 4. a file claiming a future version is rejected, not partially parsed;
+//! 5. session lists are bounded in both directions;
+//! 6. the ADR 0003 boundary is enforced: session-interior keys never parse.
+
+mod session {
+    //! Mirror of `noren_app::session` for the still-unwired module below.
+    pub use noren_app::session::*;
+}
+
+#[path = "../src/session_persistence.rs"]
+mod session_persistence;
+
+use noren_app::session::{SessionDescriptor, SessionKind, SessionRegistry, SessionStatus};
+use session_persistence::{
+    MAX_SESSION_STATE_BYTES, MAX_SESSIONS, SESSION_STATE_VERSION, SessionPersistenceError, encode,
+    load, load_bytes, save,
+};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Per-test uniqueness: tests run concurrently and share the temp dir.
+static CASE: AtomicUsize = AtomicUsize::new(0);
+
+fn temp_path(name: &str) -> PathBuf {
+    let unique = CASE.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "noren-persist-test-{}-{unique}-{name}",
+        std::process::id()
+    ));
+    path
+}
+
+fn write_file(path: &Path, bytes: &[u8]) {
+    let mut file = std::fs::File::create(path).expect("create state fixture");
+    file.write_all(bytes).expect("write state fixture");
+}
+
+fn cleanup(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// A sidebar spanning every D-M3-001 kind, in a stable order.
+fn sidebar_registry() -> SessionRegistry {
+    let mut registry = SessionRegistry::new();
+    let _ = registry.create(SessionKind::Local);
+    let _ = registry.create(SessionKind::Project {
+        root: PathBuf::from("/srv/noren"),
+    });
+    let _ = registry.create(SessionKind::Worktree {
+        path: PathBuf::from("/srv/noren-worktrees/pool-persist"),
+    });
+    let _ = registry.create(SessionKind::Ssh {
+        target: "ops@bastion.example".to_owned(),
+    });
+    let _ = registry.create(SessionKind::Agent {
+        name: "opencode".to_owned(),
+    });
+    registry
+}
+
+fn kinds_of(registry: &SessionRegistry) -> Vec<SessionKind> {
+    registry
+        .sessions()
+        .iter()
+        .map(SessionDescriptor::kind)
+        .cloned()
+        .collect()
+}
+
+/// The selection as a positional index, the form the file persists it in.
+fn selected_index(registry: &SessionRegistry) -> Option<usize> {
+    let sessions = registry.sessions();
+    let selected = registry.selected()?;
+    sessions
+        .iter()
+        .position(|descriptor| descriptor.id() == selected)
+}
+
+// ── Required: absent file → empty state, no error ──────────────────────
+
+#[test]
+fn missing_file_loads_as_empty_state_without_error() {
+    let mut path = temp_path("missing-dir");
+    path.push("does-not-exist");
+    path.push("sessions.toml");
+    assert!(!path.exists());
+
+    let mut registry = SessionRegistry::new();
+    assert_eq!(load(&path, &mut registry), Ok(()));
+    assert!(registry.is_empty());
+    assert_eq!(registry.selected(), None);
+}
+
+#[test]
+fn missing_file_behaves_exactly_as_today() {
+    // First run: the registry a missing file produces is indistinguishable
+    // from a fresh one.
+    let mut loaded = SessionRegistry::new();
+    let fresh = SessionRegistry::new();
+    assert_eq!(load(&temp_path("never-written.toml"), &mut loaded), Ok(()));
+    assert_eq!(loaded.len(), fresh.len());
+    assert_eq!(loaded.selected(), fresh.selected());
+    assert_eq!(kinds_of(&loaded), kinds_of(&fresh));
+}
+
+// ── Required: round-trip yields the same entries and selection ─────────
+
+#[test]
+fn round_trip_preserves_every_entry_kind_and_the_selection() {
+    let mut source = sidebar_registry();
+    source
+        .select(source.sessions()[2].id())
+        .expect("the worktree entry is live");
+    let path = temp_path("round-trip.toml");
+    save(&path, &source).expect("sidebar state saves");
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("sidebar state loads");
+
+    assert_eq!(restored.len(), source.len());
+    assert_eq!(kinds_of(&restored), kinds_of(&source));
+    assert_eq!(selected_index(&restored), Some(2));
+    assert_eq!(
+        selected_index(&source).map(|index| kinds_of(&source)[index].clone()),
+        selected_index(&restored).map(|index| kinds_of(&restored)[index].clone())
+    );
+    cleanup(&path);
+}
+
+#[test]
+fn restored_entries_reenter_as_starting_with_generated_titles() {
+    // Restoration re-spawns domain entries, not runtime facts: every entry
+    // comes back through SessionRegistry::create, so it is Starting with a
+    // generated display title, and the selected entry resolves live.
+    let mut source = sidebar_registry();
+    source
+        .select(source.sessions()[4].id())
+        .expect("the agent entry is live");
+    let path = temp_path("restored-status.toml");
+    save(&path, &source).expect("state saves");
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("state loads");
+    for (index, descriptor) in restored.sessions().iter().enumerate() {
+        assert_eq!(descriptor.status(), &SessionStatus::Starting);
+        assert_eq!(descriptor.title(), format!("session-{}", index + 1));
+    }
+    let selected = registry_selected_descriptor(&restored);
+    assert_eq!(
+        selected.kind(),
+        &SessionKind::Agent {
+            name: "opencode".to_owned()
+        }
+    );
+    cleanup(&path);
+}
+
+fn registry_selected_descriptor(registry: &SessionRegistry) -> SessionDescriptor {
+    let selected = registry.selected().expect("selection persisted");
+    registry.get(selected).expect("selection resolves live")
+}
+
+#[test]
+fn round_trip_with_no_selection_omits_and_restores_none() {
+    let source = sidebar_registry();
+    let path = temp_path("unselected.toml");
+    save(&path, &source).expect("state saves");
+
+    let text = std::fs::read_to_string(&path).expect("state file readable");
+    assert!(
+        text.contains(&format!("version = {SESSION_STATE_VERSION}\n")),
+        "the pinned version is written first"
+    );
+    assert!(
+        !text.contains("selected"),
+        "no selection key when unselected"
+    );
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("state loads");
+    assert_eq!(restored.len(), source.len());
+    assert_eq!(restored.selected(), None);
+    cleanup(&path);
+}
+
+#[test]
+fn empty_registry_round_trips_to_empty_state() {
+    let source = SessionRegistry::new();
+    let path = temp_path("empty.toml");
+    save(&path, &source).expect("empty state saves");
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("empty state loads");
+    assert!(restored.is_empty());
+    assert_eq!(restored.selected(), None);
+    cleanup(&path);
+}
+
+#[test]
+fn encoding_is_deterministic_across_saves() {
+    let mut source = sidebar_registry();
+    source
+        .select(source.sessions()[3].id())
+        .expect("the ssh entry is live");
+    let first = temp_path("determinism-1.toml");
+    let second = temp_path("determinism-2.toml");
+    save(&first, &source).expect("first save");
+    save(&second, &source).expect("second save");
+    assert_eq!(
+        std::fs::read(&first).expect("read first"),
+        std::fs::read(&second).expect("read second")
+    );
+
+    // Re-encoding a restored registry reproduces the document byte for byte.
+    let mut restored = SessionRegistry::new();
+    load(&first, &mut restored).expect("state loads");
+    assert_eq!(
+        encode(&restored).expect("re-encode"),
+        encode(&source).expect("encode")
+    );
+    cleanup(&first);
+    cleanup(&second);
+}
+
+#[test]
+fn hostile_strings_round_trip_through_the_escaper() {
+    let target = "weird\"quote\\back\nline\ttab \u{1b} escape 界";
+    let mut source = SessionRegistry::new();
+    let _ = source.create(SessionKind::Ssh {
+        target: target.to_owned(),
+    });
+    let _ = source.create(SessionKind::Project {
+        root: PathBuf::from("/srv/space name/ünïcode"),
+    });
+    source
+        .select(source.sessions()[0].id())
+        .expect("entry is live");
+
+    let path = temp_path("hostile-strings.toml");
+    save(&path, &source).expect("hostile strings save");
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("hostile strings load");
+    assert_eq!(kinds_of(&restored), kinds_of(&source));
+    assert_eq!(selected_index(&restored), Some(0));
+    cleanup(&path);
+}
+
+#[test]
+fn save_replaces_previous_state_never_partially() {
+    let path = temp_path("replace.toml");
+    let mut first = SessionRegistry::new();
+    let _ = first.create(SessionKind::Local);
+    save(&path, &first).expect("first save");
+
+    let second = sidebar_registry();
+    save(&path, &second).expect("replacement save");
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("replacement loads");
+    assert_eq!(kinds_of(&restored), kinds_of(&second));
+    cleanup(&path);
+}
+
+#[test]
+fn save_creates_missing_parent_directories() {
+    let mut path = temp_path("nested-parent");
+    path.push("deeper");
+    path.push("sessions.toml");
+    let source = sidebar_registry();
+    save(&path, &source).expect("parent directories are created");
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("state loads");
+    assert_eq!(kinds_of(&restored), kinds_of(&source));
+    let _ = std::fs::remove_dir_all(temp_path_root(&path));
+}
+
+fn temp_path_root(nested: &Path) -> PathBuf {
+    // The temp_path name is the first component after the system temp dir;
+    // strip "deeper/sessions.toml" to reach the per-case root.
+    nested
+        .ancestors()
+        .nth(2)
+        .expect("two levels deep")
+        .to_path_buf()
+}
+
+// ── Required: truncated, malformed, non-UTF-8, wrong-version error ─────
+
+#[test]
+fn truncated_files_error_cleanly() {
+    let source = sidebar_registry();
+    let text = encode(&source).expect("encoding succeeds");
+    let mut bytes = text.into_bytes();
+    bytes.truncate(bytes.len() - 7); // cut inside the final payload string
+
+    let mut registry = SessionRegistry::new();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        load_bytes(&bytes, &mut registry)
+    }));
+    let loaded = result.expect("loading must never panic");
+    assert!(
+        matches!(loaded, Err(SessionPersistenceError::Parse(_))),
+        "a truncated document must fail parsing, got {loaded:?}"
+    );
+    assert!(registry.is_empty());
+    assert_eq!(registry.selected(), None);
+}
+
+#[test]
+fn malformed_documents_error_cleanly() {
+    let cases = [
+        "",                                            // no version at all
+        "# only a comment\n",                          // still no version
+        "not toml at all\n",                           // no assignment
+        "version = \n",                                // dangling value
+        "version = 1\nkind = \"local\"\n",             // session keys at the root
+        "version = 1\nsessions = 3\n",                 // wrong shape for sessions
+        "version = 1\n[sessions]\nkind = \"local\"\n", // table, not array
+    ];
+    for text in cases {
+        let mut registry = SessionRegistry::new();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            load_bytes(text.as_bytes(), &mut registry)
+        }));
+        let loaded = result.expect("loading must never panic");
+        assert!(
+            matches!(
+                loaded,
+                Err(SessionPersistenceError::Parse(_)
+                    | SessionPersistenceError::MissingKey(_)
+                    | SessionPersistenceError::UnknownKey(_)
+                    | SessionPersistenceError::WrongType { .. })
+            ),
+            "{text:?} must fail cleanly, got {loaded:?}"
+        );
+        assert!(registry.is_empty(), "{text:?} must load nothing");
+    }
+}
+
+#[test]
+fn the_version_key_must_be_an_integer() {
+    let mut registry = SessionRegistry::new();
+    assert_eq!(
+        load_bytes(b"version = \"one\"\n", &mut registry),
+        Err(SessionPersistenceError::WrongType {
+            key: "version".to_owned()
+        })
+    );
+    assert!(registry.is_empty());
+}
+
+#[test]
+fn non_utf8_files_error_cleanly() {
+    let bytes = [0xff_u8, 0xfe, 0x00, b'v', b'e', b'r'];
+    let mut registry = SessionRegistry::new();
+    let loaded = load_bytes(&bytes, &mut registry);
+    assert_eq!(loaded, Err(SessionPersistenceError::NotUtf8));
+    assert!(registry.is_empty());
+
+    let path = temp_path("non-utf8.toml");
+    write_file(&path, &bytes);
+    assert_eq!(
+        load(&path, &mut registry),
+        Err(SessionPersistenceError::NotUtf8)
+    );
+    assert!(registry.is_empty());
+    cleanup(&path);
+}
+
+#[test]
+fn wrong_versions_are_rejected_whole() {
+    for version in [0_i64, -1, 2, 99] {
+        let text = format!("version = {version}\nselected = 0\n\n[[sessions]]\nkind = \"local\"\n");
+        let mut registry = SessionRegistry::new();
+        assert_eq!(
+            load_bytes(text.as_bytes(), &mut registry),
+            Err(SessionPersistenceError::UnsupportedVersion(version)),
+            "version {version} must be rejected"
+        );
+        assert!(registry.is_empty(), "version {version} must load nothing");
+    }
+}
+
+/// Required: a file claiming a future version is rejected, not partially
+/// parsed — even into a registry that already holds live sessions.
+#[test]
+fn a_future_version_is_rejected_without_partial_state() {
+    let future =
+        "version = 2\nselected = 0\n\n[[sessions]]\nkind = \"ssh\"\ntarget = \"new@host\"\n";
+
+    let mut empty = SessionRegistry::new();
+    assert_eq!(
+        load_bytes(future.as_bytes(), &mut empty),
+        Err(SessionPersistenceError::UnsupportedVersion(2))
+    );
+    assert!(empty.is_empty());
+
+    let mut populated = sidebar_registry();
+    populated
+        .select(populated.sessions()[1].id())
+        .expect("the project entry is live");
+    let before_kinds = kinds_of(&populated);
+    let before_selection = selected_index(&populated);
+    assert_eq!(
+        load_bytes(future.as_bytes(), &mut populated),
+        Err(SessionPersistenceError::UnsupportedVersion(2))
+    );
+    assert_eq!(kinds_of(&populated), before_kinds, "entries untouched");
+    assert_eq!(
+        selected_index(&populated),
+        before_selection,
+        "selection untouched"
+    );
+}
+
+// ── Boundary and strictness: untrusted details never slip through ──────
+
+#[test]
+fn session_interior_keys_are_rejected_by_the_boundary() {
+    // ADR 0003: tabs, panes, splits, and layout belong to Zellij. Any key
+    // describing the interior of a session must be rejected, and a session
+    // table accepts only the exact payload its kind defines.
+    let cases = [
+        "[[sessions]]\nkind = \"local\"\npanes = 2\n",
+        "[[sessions]]\nkind = \"local\"\ntabs = [\"main\"]\n",
+        "[[sessions]]\nkind = \"project\"\nroot = \"/p\"\nlayout = \"split\"\n",
+        "[[sessions]]\nkind = \"ssh\"\ntarget = \"h\"\ncwd = \"/tmp\"\n",
+        "[[sessions]]\nkind = \"local\"\ncwd = \"/tmp\"\n",
+    ];
+    for body in cases {
+        let text = format!("version = 1\n\n{body}");
+        let mut registry = SessionRegistry::new();
+        assert_eq!(
+            load_bytes(text.as_bytes(), &mut registry),
+            Err(SessionPersistenceError::UnknownKey(
+                body.lines()
+                    .last()
+                    .expect("case has a trailing key")
+                    .split_once(" = ")
+                    .expect("case names a key")
+                    .0
+                    .to_owned()
+            )),
+            "{body:?} describes the interior of a session and must be rejected"
+        );
+        assert!(registry.is_empty(), "{body:?} must load nothing");
+    }
+}
+
+#[test]
+fn unknown_top_level_and_session_keys_are_rejected() {
+    let mut registry = SessionRegistry::new();
+    assert_eq!(
+        load_bytes(b"version = 1\n[theme]\ndark = true\n", &mut registry),
+        Err(SessionPersistenceError::UnknownKey("theme".to_owned()))
+    );
+    let mut registry = SessionRegistry::new();
+    assert_eq!(
+        load_bytes(
+            b"version = 1\n\n[[sessions]]\nkind = \"agent\"\nname = \"a\"\nmodel = \"x\"\n",
+            &mut registry
+        ),
+        Err(SessionPersistenceError::UnknownKey("model".to_owned()))
+    );
+}
+
+#[test]
+fn malformed_session_tables_error_cleanly() {
+    let cases = [
+        // Missing or wrong-typed `kind`.
+        (
+            "version = 1\n\n[[sessions]]\n",
+            SessionPersistenceError::MissingKey("kind".to_owned()),
+        ),
+        (
+            "version = 1\n\n[[sessions]]\nkind = 3\n",
+            SessionPersistenceError::WrongType {
+                key: "kind".to_owned(),
+            },
+        ),
+        // Unknown kind string.
+        (
+            "version = 1\n\n[[sessions]]\nkind = \"mystery\"\n",
+            SessionPersistenceError::UnknownKind("mystery".to_owned()),
+        ),
+        // Missing or wrong-typed payloads.
+        (
+            "version = 1\n\n[[sessions]]\nkind = \"project\"\n",
+            SessionPersistenceError::MissingKey("root".to_owned()),
+        ),
+        (
+            "version = 1\n\n[[sessions]]\nkind = \"worktree\"\npath = 9\n",
+            SessionPersistenceError::WrongType {
+                key: "path".to_owned(),
+            },
+        ),
+        // Empty payloads are out of range.
+        (
+            "version = 1\n\n[[sessions]]\nkind = \"ssh\"\ntarget = \"\"\n",
+            SessionPersistenceError::OutOfRange {
+                key: "target".to_owned(),
+            },
+        ),
+        // Selection problems.
+        (
+            "version = 1\nselected = 3\n\n[[sessions]]\nkind = \"local\"\n",
+            SessionPersistenceError::OutOfRange {
+                key: "selected".to_owned(),
+            },
+        ),
+        (
+            "version = 1\nselected = -1\n\n[[sessions]]\nkind = \"local\"\n",
+            SessionPersistenceError::OutOfRange {
+                key: "selected".to_owned(),
+            },
+        ),
+        (
+            "version = 1\nselected = 0\n",
+            SessionPersistenceError::OutOfRange {
+                key: "selected".to_owned(),
+            },
+        ),
+        (
+            "version = 1\nselected = \"0\"\n\n[[sessions]]\nkind = \"local\"\n",
+            SessionPersistenceError::WrongType {
+                key: "selected".to_owned(),
+            },
+        ),
+    ];
+    for (text, expected) in cases {
+        let mut registry = SessionRegistry::new();
+        let loaded = load_bytes(text.as_bytes(), &mut registry);
+        assert_eq!(loaded, Err(expected), "{text:?}");
+        assert!(registry.is_empty(), "{text:?} must load nothing");
+    }
+}
+
+#[test]
+fn a_non_utf8_path_refuses_to_save_lossily() {
+    use std::os::unix::ffi::OsStringExt;
+    let mut registry = SessionRegistry::new();
+    let _ = registry.create(SessionKind::Worktree {
+        path: PathBuf::from(std::ffi::OsString::from_vec(vec![b'/', 0xff, b'w'])),
+    });
+    let path = temp_path("non-utf8-path.toml");
+    assert_eq!(
+        save(&path, &registry),
+        Err(SessionPersistenceError::NonUtf8Path)
+    );
+    assert!(!path.exists(), "a refused save must leave nothing behind");
+}
+
+#[test]
+fn load_errors_never_mutate_a_populated_registry() {
+    for bytes in [
+        b"garbage".as_slice(),
+        b"version = 7\n",
+        &[0xff_u8, 0xfe][..],
+        b"version = 1\nselected = 999\n\n[[sessions]]\nkind = \"local\"\n",
+    ] {
+        let mut registry = sidebar_registry();
+        registry
+            .select(registry.sessions()[3].id())
+            .expect("the ssh entry is live");
+        let before_kinds = kinds_of(&registry);
+        let before_selection = selected_index(&registry);
+
+        assert!(load_bytes(bytes, &mut registry).is_err());
+        assert_eq!(registry.len(), before_kinds.len());
+        assert_eq!(kinds_of(&registry), before_kinds);
+        assert_eq!(selected_index(&registry), before_selection);
+    }
+}
+
+#[test]
+fn directory_and_oversized_paths_are_rejected_cleanly() {
+    let dir = temp_path("state-is-a-directory");
+    std::fs::create_dir_all(&dir).expect("create directory fixture");
+    assert_eq!(
+        load(&dir, &mut SessionRegistry::new()),
+        Err(SessionPersistenceError::NotAFile)
+    );
+
+    let oversized = temp_path("oversized.toml");
+    write_file(
+        &oversized,
+        &vec![b'#'; MAX_SESSION_STATE_BYTES as usize + 1],
+    );
+    assert_eq!(
+        load(&oversized, &mut SessionRegistry::new()),
+        Err(SessionPersistenceError::TooLarge)
+    );
+    cleanup(&oversized);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn hostile_key_names_are_clipped_in_errors() {
+    let mut key = String::from("version = 1\n\"");
+    key.extend(std::iter::repeat_n('a', 10_000));
+    key.push_str("\" = 1\n");
+    let mut registry = SessionRegistry::new();
+    let error =
+        load_bytes(key.as_bytes(), &mut registry).expect_err("a hostile unknown key must fail");
+    let SessionPersistenceError::UnknownKey(echoed) = error else {
+        panic!("expected UnknownKey, got {error:?}")
+    };
+    assert!(
+        echoed.chars().count() <= 121,
+        "hostile key must be clipped: {echoed}"
+    );
+}
+
+#[test]
+fn error_messages_never_embed_full_file_contents() {
+    let mut hostile = String::from("not toml ");
+    hostile.extend(std::iter::repeat_n('x', 100_000));
+    let mut registry = SessionRegistry::new();
+    let error = load_bytes(hostile.as_bytes(), &mut registry).expect_err("malformed input fails");
+    let message = error.to_string();
+    assert!(message.len() < 1024, "message must stay bounded: {message}");
+}
+
+// ── Required: session lists stay bounded in both directions ─────────────
+
+#[test]
+fn oversized_registries_are_rejected_before_anything_is_written() {
+    let mut registry = SessionRegistry::new();
+    for _ in 0..=MAX_SESSIONS {
+        let _ = registry.create(SessionKind::Local);
+    }
+    let path = temp_path("too-many.toml");
+    assert_eq!(
+        save(&path, &registry),
+        Err(SessionPersistenceError::TooManySessions)
+    );
+    assert!(!path.exists(), "nothing may be written beyond the bound");
+}
+
+#[test]
+fn the_maximum_session_list_stays_bounded_on_disk() {
+    let mut registry = SessionRegistry::new();
+    for index in 0..MAX_SESSIONS {
+        let _ = registry.create(SessionKind::Project {
+            root: PathBuf::from(format!("/srv/project-{index:04}")),
+        });
+    }
+    registry
+        .select(registry.sessions()[MAX_SESSIONS - 1].id())
+        .expect("the last entry is live");
+
+    let path = temp_path("max-list.toml");
+    save(&path, &registry).expect("the maximum list saves");
+    let size = std::fs::metadata(&path).expect("state file exists").len();
+    assert!(
+        size <= MAX_SESSION_STATE_BYTES,
+        "a maximal list must stay inside the byte bound"
+    );
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("the maximum list loads");
+    assert_eq!(restored.len(), MAX_SESSIONS);
+    assert_eq!(selected_index(&restored), Some(MAX_SESSIONS - 1));
+    cleanup(&path);
+}
+
+#[test]
+fn oversized_documents_are_rejected_on_read() {
+    let mut text = String::from("version = 1\n");
+    for _ in 0..=MAX_SESSIONS {
+        text.push_str("\n[[sessions]]\nkind = \"local\"\n");
+    }
+    let mut registry = SessionRegistry::new();
+    assert_eq!(
+        load_bytes(text.as_bytes(), &mut registry),
+        Err(SessionPersistenceError::TooManySessions)
+    );
+    assert!(registry.is_empty());
+}
+
+#[test]
+fn restoring_into_a_populated_registry_keeps_the_bound() {
+    let mut registry = SessionRegistry::new();
+    for _ in 0..MAX_SESSIONS - 1 {
+        let _ = registry.create(SessionKind::Local);
+    }
+    let before = registry.len();
+    let text = "version = 1\n\n[[sessions]]\nkind = \"local\"\n\n[[sessions]]\nkind = \"local\"\n";
+    assert_eq!(
+        load_bytes(text.as_bytes(), &mut registry),
+        Err(SessionPersistenceError::TooManySessions)
+    );
+    assert_eq!(registry.len(), before, "the registry is untouched on error");
+}
+
+#[test]
+fn encode_rejects_an_oversized_registry_before_serializing() {
+    let mut registry = SessionRegistry::new();
+    for _ in 0..=MAX_SESSIONS {
+        let _ = registry.create(SessionKind::Ssh {
+            target: "host".to_owned(),
+        });
+    }
+    assert_eq!(
+        encode(&registry),
+        Err(SessionPersistenceError::TooManySessions)
+    );
+}

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -727,3 +727,71 @@ fn encode_rejects_an_oversized_registry_before_serializing() {
         Err(SessionPersistenceError::TooManySessions)
     );
 }
+
+// ── Required: the byte cap is enforced on write, not only on read ────────
+//
+// encode() bounded session COUNT but never the byte cap, so a single large
+// payload saved a file that load() then rejected as TooLarge: the app could
+// write state it could not read back. The write side must refuse before any
+// such file reaches disk, so saved state is always loadable.
+
+#[test]
+fn encode_rejects_a_document_above_the_byte_cap() {
+    // One SSH target whose payload alone exceeds MAX_SESSION_STATE_BYTES.
+    let mut registry = SessionRegistry::new();
+    let _ = registry.create(SessionKind::Ssh {
+        target: "a".repeat(MAX_SESSION_STATE_BYTES as usize + 1),
+    });
+    assert_eq!(encode(&registry), Err(SessionPersistenceError::TooLarge));
+}
+
+#[test]
+fn an_oversized_save_writes_nothing_and_errors_so_state_stays_loadable() {
+    let mut registry = SessionRegistry::new();
+    let _ = registry.create(SessionKind::Ssh {
+        target: "a".repeat(MAX_SESSION_STATE_BYTES as usize + 1),
+    });
+    let path = temp_path("oversized-payload.toml");
+    let saved = save(&path, &registry);
+
+    assert_eq!(saved, Err(SessionPersistenceError::TooLarge));
+    assert!(
+        !path.exists(),
+        "an oversized save must leave no file behind to corrupt a later load"
+    );
+    cleanup(&path);
+}
+
+#[test]
+fn a_payload_just_under_the_byte_cap_round_trips() {
+    // The cap rejects only documents that would be unreadable; legal state
+    // near the bound still saves and loads. Leave a little headroom for the
+    // TOML envelope (comments, version, the session table) so the written
+    // file stays within MAX_SESSION_STATE_BYTES.
+    let overhead = 256_usize;
+    let target_len = MAX_SESSION_STATE_BYTES as usize - overhead;
+    let mut registry = SessionRegistry::new();
+    let _ = registry.create(SessionKind::Ssh {
+        target: "a".repeat(target_len),
+    });
+    registry
+        .select(registry.sessions()[0].id())
+        .expect("the ssh entry is live");
+
+    let path = temp_path("near-cap.toml");
+    save(&path, &registry).expect("state just under the cap saves");
+    let size = std::fs::metadata(&path).expect("state file exists").len();
+    assert!(
+        size <= MAX_SESSION_STATE_BYTES,
+        "a near-cap save must stay within the byte bound: {size}"
+    );
+
+    let mut restored = SessionRegistry::new();
+    load(&path, &mut restored).expect("near-cap state loads back");
+    assert_eq!(selected_index(&restored), Some(0));
+    assert!(matches!(
+        kinds_of(&restored).as_slice(),
+        [SessionKind::Ssh { .. }]
+    ));
+    cleanup(&path);
+}

--- a/docs/coordination/handoffs/qwen-persist.md
+++ b/docs/coordination/handoffs/qwen-persist.md
@@ -1,0 +1,117 @@
+# Handoff — Milestone 3 sidebar persistence (M3-7)
+
+Status: merge candidate. Updated 2026-08-07. Lane: `agent/m3-sidebar-persistence`.
+
+## Purpose
+
+Last Milestone 3 feature: Noren now persists its sidebar state — which
+projects, worktrees, SSH targets, agents, and sessions exist, and which one
+is selected. Per
+[ADR 0003](../../adr/0003-noren-zellij-responsibility-boundary.md), nothing
+inside a session is persisted: no tabs, no panes, no splits, no layout tree,
+no terminal content. The parser enforces this boundary, not just the writer:
+a session table carrying an interior key (`panes`, `layout`, `cwd`, ...) is
+rejected as unknown rather than parsed and ignored.
+
+## What landed
+
+File lease honored; exactly two code files were created:
+
+1. `crates/noren-app/src/session_persistence.rs` — the persistence module.
+2. `crates/noren-app/tests/session_persistence.rs` — 29 integration tests
+   plus 4 module unit tests exercised through the compile shim (33 total
+   test bodies in the target).
+
+No changes to `lib.rs`, `main.rs`, `session.rs`, `sidebar.rs`, `Cargo.toml`,
+or `Cargo.lock`. The module reuses the D-M3-001 vocabulary
+([`SessionKind`], [`SessionRegistry`]) from `src/session.rs`; it defines no
+parallel session model and adds no dependencies (the workspace already pins
+`toml_edit` with parse-only features, so the write side emits TOML text by
+hand and the read side goes through the TOML parser).
+
+## The format is versioned but not final
+
+The on-disk document is TOML and carries `version = 1` from the first write:
+
+```toml
+version = 1
+selected = 2          # positional index into [[sessions]]; omitted when none
+
+[[sessions]]
+kind = "local"        # or project/root, worktree/path, ssh/target, agent/name
+```
+
+Shipping a persistence format and then changing it breaks every existing
+user's state, so this lane deliberately treats version 1 as a **starting
+point with a migration path, not a public commitment**. The version is
+checked before any other key is interpreted; a document claiming any other
+version (past or future) is rejected whole — never partially parsed. Future
+schema changes bump the version and migrate.
+
+Deliberate omissions in v1, recorded here so the next format decision is
+explicit rather than accidental:
+
+- **No `SessionId` on disk.** D-M3-001 says IDs are registry-local and not
+  persistence keys, so entries are stored in registry order and the
+  selection is a positional index into that list.
+- **No status.** Status is an observed runtime fact; restored entries
+  re-enter through `SessionRegistry::create` as `Starting`.
+- **No titles.** Titles are generated display ids today; a rename feature
+  would need a setter that does not exist yet. A later format version can
+  add the key.
+- **Non-UTF-8 paths refuse to save** (`NonUtf8Path`) rather than persist a
+  lossy transliteration that would silently name a different path.
+
+## Untrusted input and bounds
+
+A state file is treated as hostile input, mirroring `config.rs`:
+
+- Absent file is the first run: empty state, no error, behavior identical
+  to today.
+- Truncated, malformed, non-UTF-8, wrong-version, oversized, and
+  wrong-shaped files each produce a clean `SessionPersistenceError` with a
+  clipped message; the registry is never mutated on the error path
+  (validation is whole-document before any entry is created).
+- Reads are streamed under `MAX_SESSION_STATE_BYTES` (512 KiB) and refuse
+  more than `MAX_SESSIONS` (512) entries; writes refuse past either bound
+  and never create the file on refusal.
+- Writes are temp-file + fsync + rename: the file is the old state or the
+  new state, never a truncation. Directory fsync is not performed.
+
+## Restoration: re-spawn only; reattach-vs-respawn is unresolved
+
+`load` re-populates the registry and selects the saved entry; it spawns
+nothing. The M3 breakdown lists reattach-by-Zellij-session-name versus
+re-spawn as an open question, and this lane does not answer it: the
+implemented behavior is the simple case (restoring a session will re-spawn a
+shell when the spawn lane adopts it). **Whether restoration reattaches to an
+existing Zellij session or re-spawns remains an open question.**
+
+## Not wired yet
+
+The module is not declared in `lib.rs` — that one-line change belongs to the
+M3 integration lane, matching the file-lease convention used for
+`session`. Until then the integration test compiles the module through a
+`#[path = "../src/session_persistence.rs"]` shim with a local `session`
+mirror, exactly as `tests/session_domain.rs` did before PR #75. The wiring
+lane should add `pub mod session_persistence;` to `lib.rs` and replace the
+shim with crate imports. The sidebar UI still needs its own lane to adopt
+save-on-change and load-on-startup; `SESSION_STATE_FILE_NAME`
+(`sessions.toml`) is the recommended location inside the Noren data
+directory.
+
+## Verification
+
+Gate output (macOS, `cargo 1.88.0`):
+
+```text
+cargo fmt --all                     # clean
+cargo clippy --workspace --all-targets -- -D warnings   # clean
+cargo test --workspace              # 422 passed, 0 failed, 1 pre-existing ignored
+```
+
+The workspace baseline before this lane was 388 passed / 0 failed / 1
+ignored; this lane adds 34 test bodies, all green.
+
+[`SessionKind`]: ../session-api.md
+[`SessionRegistry`]: ../session-api.md

--- a/docs/coordination/reviews/M3-7-review.md
+++ b/docs/coordination/reviews/M3-7-review.md
@@ -1,0 +1,206 @@
+# Independent review — M3-7 sidebar persistence (`agent/m3-sidebar-persistence`)
+
+Independent review. I did not author this code and reviewed head from scratch
+rather than trusting the handoff. Commands below were actually run; output is
+quoted.
+
+- Reviewed at: `d3e136c990d0` on `agent/m3-sidebar-persistence`, off
+  `origin/main` @ `91a0536` (macOS arm64).
+- The lane prompt cites `state/tasks/M3-7.md` in the fleet repo as the
+  authority. **That file is absent from this branch** (`git ls-files` has no
+  `state/` tree). The acceptance criteria below are taken from the M3-7 entry
+  in `docs/roadmap/milestone-3-breakdown.md`, which is the authoritative
+  in-repo decomposition of M3-7 and matches the handoff's claims verbatim. If
+  the fleet task spec carries stricter criteria, this review should be
+  reconciled against it.
+- Scope of diff (`git diff --stat origin/main...HEAD`): 3 files, all `A`
+  (additions only, +1453 / −0). No file is modified or deleted — the file
+  lease is intact and there are no unintended removals. `git checkout` of the
+  branch was run from this sibling worktree because the branch was already
+  checked out at `pool-persist` (worktree lock); same commit, clean tree.
+
+## Gate output (actually run at `d3e136c`)
+
+```
+$ cargo fmt --all -- --check
+    exit 0 (no diff)
+
+$ cargo clippy --workspace --all-targets -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] → exit 0, 0 warnings
+
+$ cargo test --workspace
+    PASSED=422  FAILED=0  IGNORED=1
+    (session_persistence target: ok. 34 passed; 0 failed)
+```
+
+422 passed reconciles with the handoff (388 baseline + 34 new). The 34 break
+down as 29 integration tests in `tests/session_persistence.rs` plus 5 unit
+tests in the module's `#[cfg(test)]` block. (The handoff text says "33 total";
+the actual runner reports 34 — a harmless miscount in the handoff.)
+
+## Acceptance criteria (M3-7, `milestone-3-breakdown.md`), one by one
+
+1. **"A sidebar with multiple sessions and external-context entries
+   round-trips through save/reload with the selected session and entry list
+   restored." — MET.** All five `SessionKind` variants (Local, Project,
+   Worktree, Ssh, Agent) round-trip through `save`→`load` with the selection
+   preserved as a positional index (`round_trip_preserves_every_entry_kind_…`,
+   `hostile_strings_round_trip_through_the_escaper`, `encoding_is_deterministic_…`).
+   Hostile payloads (embedded quotes, backslashes, newlines, tabs, ESC, CJK)
+   survive the hand-rolled TOML escaper and parse back identically.
+
+2. **"A corrupted/partial file is rejected without data loss; the last valid
+   sidebar state is retained." — MET.** Truncated, malformed, non-UTF-8,
+   wrong-type, wrong-version, oversized, directory, and wrong-shape inputs
+   each yield a typed `SessionPersistenceError` and leave the registry
+   untouched. Whole-document validation runs before `apply` mutates
+   (`load_errors_never_mutate_a_populated_registry` proves it against a
+   pre-populated registry).
+
+3. **"No secrets, raw commands, terminal content, or layout are persisted." —
+   MET.** The serialized surface is exactly `{ version, selected?, [[sessions]]
+   { kind + one payload } }`. No `SessionId`, status, title, command, or
+   terminal byte is written. The decoder enforces the same surface: unknown
+   top-level keys and unknown session-table keys are rejected, not ignored.
+
+## ADR 0003 boundary — enforced in the parser (sound)
+
+This is the most important check for this lane and it is solid. The boundary
+is enforced on **both** sides:
+
+- **Write:** `encode` emits only `kind` and the single payload per session;
+  no pane/tab/layout/split/cwd/content key is ever produced.
+- **Read:** `parse_session` → `require_exact_keys`/`payload` rejects any key
+  beyond `kind` and the kind's one payload. A session table carrying `panes`,
+  `tabs`, `layout`, or `cwd` lands in `UnknownKey`, not a silent drop
+  (`session_interior_keys_are_rejected_by_the_boundary`). Unknown top-level
+  keys (`theme`, etc.) are likewise rejected.
+
+No Zellij-internal structure is read or persisted. No blocker.
+
+## Mutation testing (tests genuinely test the behavior)
+
+Three mutations were applied to `src/session_persistence.rs`, rebuilt, and the
+suite re-run. Each was caught:
+
+- **M1 — disable the version guard** (`if version != …` → `let _ = version;`):
+  3 tests FAILED (`wrong_versions_are_rejected_whole`,
+  `a_future_version_is_rejected_without_partial_state`, and a populated-load
+  regression). Restored.
+- **M2 — drop `require_exact_keys` on the `local` arm**: 1 test FAILED
+  (`session_interior_keys_are_rejected_by_the_boundary` — the ADR 0003 guard).
+  Restored.
+- **M3 — create-before-bounds-check in `apply`** (move the `MAX_SESSIONS`
+  guard below the `create` loop): 1 test FAILED
+  (`restoring_into_a_populated_registry_keeps_the_bound`), proving the
+  no-partial-mutation guarantee is tested. Restored.
+
+After all restores the tree is clean and the suite is green again.
+
+## Hostile-input / panic / unbounded-growth probing
+
+A throwaway fuzz probe fed the decoder deeply nested tables, wrong-typed
+`version`/`selected` (float/bool/array/inline-table/huge integer), an
+inline-array-of-tables `sessions`, an interior inline-table (`panes = {…}`),
+a 50 000-char `kind` string, 512 sessions, a null-byte path, and selected-
+without-sessions. **Every case produced a typed error or a clean apply; zero
+panics.** Error messages stayed bounded (hostile keys are clipped to 120 chars
++ `…`; parser detail strings are clipped). The probe was deleted; it is not
+part of the deliverable.
+
+## Findings
+
+### MAJOR-1 — The write-side byte bound is documented but not enforced
+
+`encode` (`crates/noren-app/src/session_persistence.rs:235-277`) checks
+`MAX_SESSIONS` but **never checks `MAX_SESSION_STATE_BYTES`**. Three places
+claim otherwise:
+
+- Module doc, lines 39–42: *"writes refuse to encode past either bound."*
+- `save` docstring, lines 188–191: *"Refuses to encode … a document larger
+  than `MAX_SESSION_STATE_BYTES`."*
+- Handoff (`qwen-persist.md`): *"writes refuse past either bound and never
+  create the file on refusal."*
+
+**Reproduction (run, not inferred):** a single session whose payload alone
+exceeds the cap is encoded without error:
+
+```
+let huge = "h".repeat(MAX_SESSION_STATE_BYTES as usize + 1); // 524 289
+let mut registry = SessionRegistry::new();
+let _ = registry.create(SessionKind::Ssh { target: huge });
+encode(&registry)  // → Ok(524 478-byte document); bound is 524 288
+```
+
+Runner output:
+
+```
+encode SUCCEEDED with a 524478 byte document (bound is 524288):
+WRITE BYTE BOUND NOT ENFORCED
+```
+
+**Consequences.**
+
+1. Contract violation: the documented bound does not hold.
+2. Loss-of-state failure mode: `save` writes a file that `load` then rejects
+   with `TooLarge`, so the app persists state it can never read back — exactly
+   the "without data loss" property acceptance criterion 2 demands.
+3. Unbounded `String` growth on the write path (the defect class this review
+   targets): nothing prevents a multi-megabyte payload from being formatted
+   into memory before any check. The registry bounds *count*, not *size*.
+
+The existing write-bound test (`the_maximum_session_list_stays_bounded_on_disk`,
+line 662) only exercises 512 short-path entries (~26 KB total); it cannot
+catch a single oversized payload, so the gap is unguarded by tests too.
+
+**Minimal fix.** After building `text` in `encode`, reject on overflow:
+
+```rust
+if text.len() > MAX_SESSION_STATE_BYTES {
+    return Err(SessionPersistenceError::TooLarge);
+}
+```
+
+(A tighter fix bounds the accumulator incrementally and avoids formatting a
+document known to be too large; either is acceptable for v1.)
+
+### MINOR-1 — "Reload-on-launch" is in scope but not delivered
+
+The M3-7 scope lists *"reload-on-launch"*; the module implements `load`/`save`
+but is **not wired** — `lib.rs` has no `pub mod session_persistence;`, so the
+code is dead until the integration lane adds the declaration. The handoff
+states this is deliberate (file-lease convention, matching how `session` was
+landed via shim). Given the lane model this is a reasonable sequencing choice,
+not a defect in the module under review; recorded so the integration lane
+knows the one-line wiring plus the sidebar save-on-change hook are still
+outstanding. No `lib.rs`/`Cargo.toml`/`Cargo.lock` changes were made, so no
+new dependency was added (the breakdown anticipated a serialization
+dependency; the module avoids one by hand-encoding TOML and parsing with the
+already-pinned `toml_edit`).
+
+## Areas that are sound (no finding invented)
+
+- **Atomic write.** `write_atomic` (temp sibling → `write_all` → `sync_all`
+  → `rename`; cleanup on every error path) is correct for the "old-or-new,
+  never truncated" contract on Unix. Directory fsync is acknowledged as open.
+- **Determinism.** `encode` is deterministic (entries in id-sorted order,
+  `format!` only); `encoding_is_deterministic_across_saves` and a
+  save→load→re-encode byte-equality check both pass.
+- **No partial mutation on error.** `decode` fully validates before `apply`
+  creates a single entry; `apply`'s only error path precedes any `create`.
+  Proven by M3 above.
+- **Non-UTF-8 path refusal.** `path_text` returns `NonUtf8Path` rather than a
+  lossy conversion; a refused save leaves no file behind (tested).
+- **Error-message clipping.** Hostile keys and parser details are clipped to
+  120 chars; message size verified under 1 KiB against 100 KB input.
+
+## Verdict
+
+FINDINGS. One MAJOR (write-side byte bound not enforced, contradicting the
+module's own contract and creating a save-then-fail-to-load state-loss path)
+and one MINOR (reload-on-launch deferred to the integration lane). The ADR
+0003 boundary is correctly enforced in the parser and the writer; no blocker.
+
+```
+REVIEW_M3-7 verdict=FINDINGS blockers=0 majors=1 minors=1 tests=PASS total=422
+```


### PR DESCRIPTION
## 概要

M3-7: サイドバーのセッション状態を versioned な形式で永続化する。ADR 0003 の責務境界に従い、Zellij 内部のレイアウト構造（`panes`/`layout`/`cwd`）は**書き手・読み手の両方で拒否**する（無視ではなく拒否）。

## 独立レビューで発見された MAJOR と、その修正

初回の独立レビューが具体的な再現付きで欠陥を1件検出した：

`encode()` は `MAX_SESSIONS` を検査していたが `MAX_SESSION_STATE_BYTES` を**一度も検査していなかった**。モジュールドキュメント・`save` の docstring・レーンの引き継ぎメモはいずれも「書き込み側で byte cap を強制している」と記述しており、コードがそれを裏切っていた。

具体的な影響：524,289 バイトの SSH ターゲット1件が 524,478 バイトのファイルにエンコードされ、それを `load` が `TooLarge` として拒否する。つまり**アプリが読み戻せない状態を保存できてしまう** — 状態喪失の経路であり、書き込み側 `String` の無制限な増大でもある。

### 修正方針: reject（truncate ではない）

`encode()` は各エントリ追加後に累積バイト長を cap と照合し、超過した文書を返す前に `SessionPersistenceError::TooLarge` を返す。エンコード中の `String` は上限内に留まり、読めない内容が書かれることはない。atomic-rename の経路自体が実行されないため、**既存の正常なファイルは無傷で残る**。

truncate を選ばなかった理由：セッションを黙って落とすと、呼び出し元が要求していない部分集合を永続化することになり、保存済みの `selected` インデックスを無効化しうる。静かで復旧不能な失敗になる。型付きエラーは失敗が可視化され、呼び出し元が対処できる。

### 再現を先に書いている

修正前に回帰テストを書き、**失敗することを確認**してから直している：

- `encode_rejects_a_document_above_the_byte_cap` → `left: Ok(...)`（`Err(TooLarge)` 期待）で **FAILED**
- `an_oversized_save_writes_nothing_and_errors_so_state_stays_loadable` → `left: Ok(())` で **FAILED**
- `a_payload_just_under_the_byte_cap_round_trips` → 過剰拒否しないことの正方向ガード

修正後は3件とも通過。ドキュメントの記述も、コードが実際に強制する内容と一致するよう修正した。

## 検証

```
cargo fmt --all -- --check          # clean
cargo clippy --workspace --all-targets -- -D warnings  # clean
cargo test --workspace              # 425 passed, 0 failed
```

判定トークン: `GLMFIX_M3-7 cap_enforced=yes strategy=reject repro_failed_first=yes roundtrip=yes tests=PASS total=425`

## スコープ外

レビューの MINOR「起動時の reload」は配線レーンの担当として意図的に未実装。`lib.rs`/`main.rs` は変更していない（ファイルリース遵守）。

## ロールバック

このブランチの revert で完結する。永続化ファイルの形式は versioned なので、旧版が書いたファイルは引き続き読める。