### PR TITLE
docs: record the decided scope of the first public preview (D-M8-001)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,10 +81,11 @@ concluded that the current tree cannot honestly be released as "0.1.0-preview of
 the Noren terminal." The reasoning and the decision are recorded in
 [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
 
-- **The workspace is landed, not shipped.** All seven Milestone 3 modules are
-  files on `main`, but only `session` and `sidebar` are declared in `lib.rs`;
-  the rest are compiled only by tests via `#[path]` and are unreachable from the
-  binary (Issue #88). Launching the build still presents no workspace sidebar.
+- **The workspace is landed, not shipped.** The Milestone 3 modules (and the
+  M2 `mouse` module) are files on `main` and declared in `lib.rs` (PR #92), so
+  the library compiles them and CI covers them, but `main.rs` consumes none of
+  them and they are absent from the linked binary (Issue #88). Launching the
+  build still presents no workspace sidebar.
 - **The renderer is monochrome.** `renderer.rs:40` returns a constant colour and
   the vertex layout carries no colour channel, so `ls --color`, `vim`, and
   Zellij's status bar all draw in one shade. Truecolor is modelled in terminal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Only evidence-backed work is marked complete.
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | Not started |
 | 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | Not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | Not started |
-| 8 — Public Preview | Honest docs/site, binaries, checksums, release review, known limitations and `0.1.0-preview` | Not started |
+| 8 — Public Preview | Honest docs/site, binaries, checksums, release review, known limitations and `0.1.0-preview` | Not started; scope decided by [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md) |
 
 A renderer-independent terminal state core is merged as PR
 [#19](https://github.com/ta-061/noren/pull/19) (`c695920`), described in
@@ -73,3 +73,30 @@ drawing. IME and accessibility remain deferred.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.
+
+## What blocks a public preview
+
+Two independent specification reviews, run without sight of each other, both
+concluded that the current tree cannot honestly be released as "0.1.0-preview of
+the Noren terminal." The reasoning and the decision are recorded in
+[D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
+
+- **The workspace is not on `main`.** Noren's defining feature is the external
+  sidebar (ADR 0003). Of the Milestone 3 modules, only `session.rs` has landed;
+  the sidebar, palette, pass-through, supervisor, and persistence exist only in
+  unmerged PRs. What `main` contains today is a terminal foundation.
+- **The renderer is monochrome.** `renderer.rs:35` returns a constant colour and
+  the vertex layout carries no colour channel, so `ls --color`, `vim`, and
+  Zellij's status bar all draw in one shade. Truecolor is modelled in terminal
+  state and never reaches drawing.
+- **The font is ASCII-only and case-blind.** Non-ASCII renders as `?`, and
+  `renderer.rs:457` asserts `glyph_rows('a') == glyph_rows('A')`.
+- **FR-005's rendered-frame oracle does not exist**, so glyph correctness has
+  never been mechanically verified. Waiving the project's own PoC gate in silence
+  is the one path that would make a release claim dishonest.
+- **NFR-009 requires release-integrity gates** — signing, notarization,
+  packaging — to pass before any Preview claim.
+
+Milestone 8 therefore stops at a release candidate. Signing keys, Apple
+certificates, tagging, and publication are owner decisions and are not taken
+autonomously.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,19 +81,19 @@ concluded that the current tree cannot honestly be released as "0.1.0-preview of
 the Noren terminal." The reasoning and the decision are recorded in
 [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
 
-- **The workspace is not on `main`.** Noren's defining feature is the external
-  sidebar (ADR 0003). Of the Milestone 3 modules, only `session.rs` has landed;
-  the sidebar, palette, pass-through, supervisor, and persistence exist only in
-  unmerged PRs. What `main` contains today is a terminal foundation.
-- **The renderer is monochrome.** `renderer.rs:35` returns a constant colour and
+- **The workspace is landed, not shipped.** All seven Milestone 3 modules are
+  files on `main`, but only `session` and `sidebar` are declared in `lib.rs`;
+  the rest are compiled only by tests via `#[path]` and are unreachable from the
+  binary (Issue #88). Launching the build still presents no workspace sidebar.
+- **The renderer is monochrome.** `renderer.rs:40` returns a constant colour and
   the vertex layout carries no colour channel, so `ls --color`, `vim`, and
   Zellij's status bar all draw in one shade. Truecolor is modelled in terminal
   state and never reaches drawing.
 - **The font is ASCII-only and case-blind.** Non-ASCII renders as `?`, and
-  `renderer.rs:457` asserts `glyph_rows('a') == glyph_rows('A')`.
-- **FR-005's rendered-frame oracle does not exist**, so glyph correctness has
-  never been mechanically verified. Waiving the project's own PoC gate in silence
-  is the one path that would make a release claim dishonest.
+  `renderer.rs:474` asserts `glyph_rows('a') == glyph_rows('A')`.
+- **The FR-005 rendered-frame oracle now exists** (PR #89). It drives the real
+  pipeline offscreen, and its `#[ignore]`d defect tests record the font's
+  case-fold and non-ASCII-`?` failures — the same defects above.
 - **NFR-009 requires release-integrity gates** — signing, notarization,
   packaging — to pass before any Preview claim.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Only evidence-backed work is marked complete.
 | 0 — Discovery | Landscape, feature/library matrices, risks, agent inventory and calibration | Complete |
 | 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Complete |
 | 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | Complete |
-| 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | Not started |
+| 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | Not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | Not started |
 | 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | Not started |
@@ -86,12 +86,13 @@ the Noren terminal." The reasoning and the decision are recorded in
   the library compiles them and CI covers them, but `main.rs` consumes none of
   them and they are absent from the linked binary (Issue #88). Launching the
   build still presents no workspace sidebar.
-- **The renderer is monochrome.** `renderer.rs:40` returns a constant colour and
-  the vertex layout carries no colour channel, so `ls --color`, `vim`, and
-  Zellij's status bar all draw in one shade. Truecolor is modelled in terminal
-  state and never reaches drawing.
-- **The font is ASCII-only and case-blind.** Non-ASCII renders as `?`, and
-  `renderer.rs:474` asserts `glyph_rows('a') == glyph_rows('A')`.
+- **The renderer is monochrome.** The fragment shader `fs_main` in
+  `renderer.rs` returns a constant colour and the vertex layout carries no
+  colour channel, so `ls --color`, `vim`, and Zellij's status bar all draw in
+  one shade. Truecolor is modelled in terminal state and never reaches drawing.
+- **The font is ASCII-only and case-blind.** Non-ASCII renders as `?`, and the
+  `renderer.rs` test `ascii_glyphs_are_distinct_and_unknown_is_question_mark`
+  asserts `glyph_rows('a') == glyph_rows('A')`.
 - **The FR-005 rendered-frame oracle now exists** (PR #89). It drives the real
   pipeline offscreen, and its `#[ignore]`d defect tests record the font's
   case-fold and non-ASCII-`?` failures — the same defects above.

--- a/docs/coordination/decisions/D-M8-001-preview-scope.md
+++ b/docs/coordination/decisions/D-M8-001-preview-scope.md
@@ -29,18 +29,24 @@ The convergence is worth more than either answer alone because the reasoning
 differed: one grounded the objection in the missing workspace feature, the other
 in monochrome rendering being disqualifying for a terminal.
 
-The brief's errors, corrected by both and confirmed against the tree:
+The brief's errors, corrected by both and re-confirmed against the current tree:
 
 - The brief claimed 388 tests. `ROADMAP.md:44` says **353**.
 - The brief claimed Milestone 3 was "largely verified." `ROADMAP.md:11` says
-  **Not started**, and the tree agrees: of the M3 modules, only `session.rs` is
-  on `main`. `sidebar.rs`, `palette.rs`, `passthrough.rs`,
-  `session_supervisor.rs`, and `session_persistence.rs` exist **only in unmerged
-  PRs**. "Verified" described lane state, not `main`.
+  **Not started**, and the tree bears this out more sharply than the brief
+  allowed. All seven M3 modules — `session`, `sidebar`, `palette`,
+  `passthrough`, `session_supervisor`, `session_persistence`, and `mouse` — are
+  now files on `main` (PRs #77, #78, #79, #81, #82, and #84 merged after the
+  brief was written). But only `session` and `sidebar` are declared in `lib.rs`;
+  the other five are compiled solely by integration tests through `#[path]`
+  shims and are neither part of the library nor reachable from the product
+  binary (Issue #88). "Verified" described lane state, not the application a
+  user runs: launching the build still presents no workspace sidebar.
 
-That second correction is the one that decides the question. It was also the
-falsifier one session named for its own recommendation: *if M3 were merged,
-option A would become defensible.* It is not merged, so A is not.
+The distinction that carries the decision is not *merged versus unmerged* — that
+line has already moved and may move again — but *landed in the repository versus
+shipped in the running application*. And the reason A fails does not turn on
+either: it turns on the renderer, which no M3 merge touches.
 
 ## Decision
 
@@ -49,33 +55,46 @@ not "0.1.0-preview of the Noren terminal."
 
 The reasoning that survives both sessions:
 
-**Why not B.** The accepted requirements deliberately defer CJK, IME, and
-accessibility to "Later" (`docs/requirements/v0.1.md:46`, FR-012). Blocking the
-preview on a full font stack re-litigates a decision already made and holds the
-artifact hostage to Milestone 6, which has not started.
+**Why not B.** The accepted requirements deliberately defer themes,
+IME/CJK/HiDPI, and keyboard/accessibility work to "Later"
+(`docs/requirements/v0.1.md:28`, FR-012). Blocking the preview on a full font
+stack re-litigates a decision already made and holds the artifact hostage to
+Milestone 6, which has not started.
 
-**Why not A.** What `main` contains today is a terminal *foundation*, not Noren.
+**Why not A.** The renderer is the reason, and no M3 merge touches it. It is
+monochrome: `renderer.rs:40` returns a constant colour and the vertex format at
+`renderer.rs:135-143` carries no colour channel, so `ls --color`, `vim`, and
+Zellij's own status bar all draw in one shade of green. The bitmap is worse than
+"ASCII-only": `renderer.rs:474` asserts `glyph_rows('a') == glyph_rows('A')`, so
+the font cannot distinguish case, and `renderer.rs:475` asserts every non-ASCII
+glyph collapses to `?`. This is now mechanically documented, not merely
+asserted: the FR-005 rendered-frame oracle landed on `main` with PR #89
+(`a2271a9`), drives the real `wgpu` pipeline offscreen, and its defect tests —
+written to pass only under a correct renderer and `#[ignore]`d today — record
+exactly these two failures (`frame_oracle.rs`,
+`lowercase_distinct_from_uppercase` and `non_ascii_glyph_is_not_the_question_mark`).
+An oracle that exists, runs, and on its face documents the renderer's defects is
+evidence against shipping as "the Noren terminal," not for it.
+
 Noren's defining feature is the external workspace sidebar (ADR 0003;
-`v0.1.md:25` FR-009) — and it is not on `main`. Beyond that, the renderer is
-monochrome: `renderer.rs:35` returns a constant colour and the vertex format at
-`renderer.rs:117-125` carries no colour channel. A terminal where `ls --color`,
-`vim`, and Zellij's own status bar are all one shade of green, and where CJK and
-any non-ASCII path render as `?` (`renderer.rs:353`, asserted at `:458`), is a
-technology demo. Filing that under "known limitations" is dishonest by omission.
-
-The font is worse than "ASCII-only" implies: `renderer.rs:457` asserts
-`glyph_rows('a') == glyph_rows('A')`. The bitmap does not distinguish case.
+`v0.1.md:25` FR-009). Its modules have landed on `main`, but they are not wired
+into the application (Issue #88): only `session` and `sidebar` are declared in
+`lib.rs`, and nothing presents a sidebar to a user. The merges are real
+progress; what a user sees is unchanged. Filing monochrome rendering and an
+invisible workspace under "known limitations" is dishonest by omission.
 
 ## Blocking preconditions
 
 These are **not** M8 polish items; they gate the artifact reaching strangers.
 
-1. **A rendered-frame oracle, or an explicit written admission that none
-   exists.** FR-005 (`v0.1.md:21`) requires that "a macOS rendered-frame capture
-   match their oracles." It does not exist — `ROADMAP.md:68-70` concedes glyph
-   correctness is unverified by automation. Silently waiving the project's own
-   PoC gate is the one path that would make the release claim dishonest, which
-   is precisely what this project's evidence rule forbids.
+1. **The FR-005 rendered-frame oracle exists — its findings must not be hidden.**
+   FR-005 (`v0.1.md:21`) requires that "state snapshots and a macOS rendered-frame
+   capture match their oracles." PR #89 (`a2271a9`) supplied the rendered-frame
+   half, driving the real pipeline offscreen. Its passing tests verify glyph
+   geometry and grid mapping; its two ignored tests record the font's case-fold
+   and non-ASCII-`?` defects. The gate is no longer missing — it is satisfied on
+   structure and honest about its gaps. Hiding those gaps would be the dishonest
+   path, and the project's evidence rule forbids it.
 2. **Release-integrity gates.** NFR-009 (`v0.1.md:46`) states signing,
    notarization, packaging, and release-integrity gates "must pass before Preview
    claims." Reproducible binaries, checksums, and toolchain provenance are
@@ -98,11 +117,17 @@ unprompted:
 - **Wire colour to drawing.** Truecolor is already modelled in terminal state and
   simply never reaches the renderer. This is far cheaper than a font stack and
   removes the single most disqualifying visual defect.
-- **Merge the verified M3 work**, which would materially change what a preview
-  can honestly claim, and would reopen option A on its own stated falsifier.
+- **Wire the merged M3 modules into the application.** They have landed on
+  `main` but are not declared in `lib.rs` or reachable from the binary
+  (Issue #88); the workspace is still invisible to a user. Wiring it — together
+  with wiring colour to the renderer — is what would materially change what a
+  preview can honestly claim.
 
 ## What would change this decision
 
-If a rendered-frame oracle is built and the M3 workspace lands on `main`, the
-premises behind C no longer hold and option A should be re-argued on the evidence
-at that time.
+Option C stands until a user launching the build sees a wired, visible workspace
+sidebar **and** the renderer draws colour and real glyphs — distinct upper and
+lower case, and real shapes for non-ASCII. Modules appearing in the repository
+does not change this: they must reach the running application, and the
+renderer's defects must be fixed. Short of both, re-arguing A would be
+re-arguing against the evidence.

--- a/docs/coordination/decisions/D-M8-001-preview-scope.md
+++ b/docs/coordination/decisions/D-M8-001-preview-scope.md
@@ -31,22 +31,26 @@ in monochrome rendering being disqualifying for a terminal.
 
 The brief's errors, corrected by both and re-confirmed against the current tree:
 
-- The brief claimed 388 tests. `ROADMAP.md:44` says **353**.
-- The brief claimed Milestone 3 was "largely verified." `ROADMAP.md:11` says
-  **Not started**, and the tree bears this out more sharply than the brief
-  allowed. All seven M3 modules — `session`, `sidebar`, `palette`,
-  `passthrough`, `session_supervisor`, `session_persistence`, and `mouse` — are
+- The brief claimed 388 tests. The Milestone 2 completion evidence in
+  `ROADMAP.md` records **353**.
+- The brief claimed Milestone 3 was "largely verified." The milestone table in
+  `ROADMAP.md` marks Milestone 3 **Not started**, and the tree bears this out
+  more sharply than the brief allowed. The six M3 modules — `session`,
+  `sidebar`, `palette`, `passthrough`, `session_supervisor`, and
+  `session_persistence` — plus `mouse` (an M2 input deliverable, PR #79) are
   now files on `main` (PRs #77, #78, #79, #81, #82, and #84 merged after the
-  brief was written). But only `session` and `sidebar` are declared in `lib.rs`;
-  the other five are compiled solely by integration tests through `#[path]`
-  shims and are neither part of the library nor reachable from the product
-  binary (Issue #88). "Verified" described lane state, not the application a
-  user runs: launching the build still presents no workspace sidebar.
+  brief was written), and PR #92 declared all seven in `lib.rs`, so they are
+  compiled into the library and covered by CI's clippy and dead-code checks.
+  But `main.rs` imports none of them, the linked binary contains no symbols
+  from them, and nothing presents a sidebar to a user (Issue #88). "Verified"
+  described lane state, not the application a user runs: launching the build
+  still presents no workspace sidebar.
 
-The distinction that carries the decision is not *merged versus unmerged* — that
-line has already moved and may move again — but *landed in the repository versus
-shipped in the running application*. And the reason A fails does not turn on
-either: it turns on the renderer, which no M3 merge touches.
+The distinction that carries the decision is neither *merged versus unmerged*
+nor *declared versus undeclared in the library* — the first line moved with
+PRs #77–#84, the second with PR #92, and either may move again — but *present
+in the running application versus absent from it*. And the reason A fails does
+not turn on any of these: it turns on the renderer, which no M3 merge touches.
 
 ## Decision
 
@@ -56,19 +60,21 @@ not "0.1.0-preview of the Noren terminal."
 The reasoning that survives both sessions:
 
 **Why not B.** The accepted requirements deliberately defer themes,
-IME/CJK/HiDPI, and keyboard/accessibility work to "Later"
-(`docs/requirements/v0.1.md:28`, FR-012). Blocking the preview on a full font
+IME/CJK/HiDPI, and keyboard/accessibility work to "Later" (FR-012 in
+`docs/requirements/v0.1.md`). Blocking the preview on a full font
 stack re-litigates a decision already made and holds the artifact hostage to
 Milestone 6, which has not started.
 
 **Why not A.** The renderer is the reason, and no M3 merge touches it. It is
-monochrome: `renderer.rs:40` returns a constant colour and the vertex format at
-`renderer.rs:135-143` carries no colour channel, so `ls --color`, `vim`, and
-Zellij's own status bar all draw in one shade of green. The bitmap is worse than
-"ASCII-only": `renderer.rs:474` asserts `glyph_rows('a') == glyph_rows('A')`, so
-the font cannot distinguish case, and `renderer.rs:475` asserts every non-ASCII
-glyph collapses to `?`. This is now mechanically documented, not merely
-asserted: the FR-005 rendered-frame oracle landed on `main` with PR #89
+monochrome: the fragment shader `fs_main` in `renderer.rs` returns a constant
+colour and the vertex format produced by `glyph_vertices` carries no colour
+channel, so `ls --color`, `vim`, and Zellij's own status bar all draw in one
+shade of green. The bitmap is worse than "ASCII-only": the `renderer.rs` test
+`ascii_glyphs_are_distinct_and_unknown_is_question_mark` asserts
+`glyph_rows('a') == glyph_rows('A')`, so the font cannot distinguish case, and
+asserts a non-ASCII glyph collapses to `?`. This is now mechanically
+documented, not merely asserted: the FR-005 rendered-frame oracle landed on
+`main` with PR #89
 (`a2271a9`), drives the real `wgpu` pipeline offscreen, and its defect tests —
 written to pass only under a correct renderer and `#[ignore]`d today — record
 exactly these two failures (`frame_oracle.rs`,
@@ -76,26 +82,29 @@ exactly these two failures (`frame_oracle.rs`,
 An oracle that exists, runs, and on its face documents the renderer's defects is
 evidence against shipping as "the Noren terminal," not for it.
 
-Noren's defining feature is the external workspace sidebar (ADR 0003;
-`v0.1.md:25` FR-009). Its modules have landed on `main`, but they are not wired
-into the application (Issue #88): only `session` and `sidebar` are declared in
-`lib.rs`, and nothing presents a sidebar to a user. The merges are real
-progress; what a user sees is unchanged. Filing monochrome rendering and an
-invisible workspace under "known limitations" is dishonest by omission.
+Noren's defining feature is the external workspace sidebar (ADR 0003; FR-009 in
+`docs/requirements/v0.1.md`). Its modules are on `main` and declared in
+`lib.rs`, but they are not wired into the application (Issue #88): `main.rs`
+imports none of them, the linked binary contains none of their code, and
+nothing presents a sidebar to a user. The merges and the library declarations
+are real progress; what a user sees is unchanged. Filing monochrome rendering
+and an invisible workspace under "known limitations" is dishonest by omission.
 
 ## Blocking preconditions
 
 These are **not** M8 polish items; they gate the artifact reaching strangers.
 
 1. **The FR-005 rendered-frame oracle exists — its findings must not be hidden.**
-   FR-005 (`v0.1.md:21`) requires that "state snapshots and a macOS rendered-frame
+   FR-005 (`docs/requirements/v0.1.md`) requires that "state snapshots and a
+   macOS rendered-frame
    capture match their oracles." PR #89 (`a2271a9`) supplied the rendered-frame
    half, driving the real pipeline offscreen. Its passing tests verify glyph
    geometry and grid mapping; its two ignored tests record the font's case-fold
    and non-ASCII-`?` defects. The gate is no longer missing — it is satisfied on
    structure and honest about its gaps. Hiding those gaps would be the dishonest
    path, and the project's evidence rule forbids it.
-2. **Release-integrity gates.** NFR-009 (`v0.1.md:46`) states signing,
+2. **Release-integrity gates.** NFR-009 (`docs/requirements/v0.1.md`) states
+   signing,
    notarization, packaging, and release-integrity gates "must pass before Preview
    claims." Reproducible binaries, checksums, and toolchain provenance are
    required by NFR-008.
@@ -117,17 +126,17 @@ unprompted:
 - **Wire colour to drawing.** Truecolor is already modelled in terminal state and
   simply never reaches the renderer. This is far cheaper than a font stack and
   removes the single most disqualifying visual defect.
-- **Wire the merged M3 modules into the application.** They have landed on
-  `main` but are not declared in `lib.rs` or reachable from the binary
-  (Issue #88); the workspace is still invisible to a user. Wiring it — together
-  with wiring colour to the renderer — is what would materially change what a
-  preview can honestly claim.
+- **Wire the merged M3 modules into the application.** They are on `main` and
+  declared in `lib.rs` (PR #92), but `main.rs` consumes none of them and they
+  do not reach the linked binary (Issue #88); the workspace is still invisible
+  to a user. Wiring it — together with wiring colour to the renderer — is what
+  would materially change what a preview can honestly claim.
 
 ## What would change this decision
 
 Option C stands until a user launching the build sees a wired, visible workspace
 sidebar **and** the renderer draws colour and real glyphs — distinct upper and
-lower case, and real shapes for non-ASCII. Modules appearing in the repository
-does not change this: they must reach the running application, and the
-renderer's defects must be fixed. Short of both, re-arguing A would be
-re-arguing against the evidence.
+lower case, and real shapes for non-ASCII. Modules appearing in the repository,
+or in the library's module list, does not change this: they must reach the
+running application, and the renderer's defects must be fixed. Short of both,
+re-arguing A would be re-arguing against the evidence.

--- a/docs/coordination/decisions/D-M8-001-preview-scope.md
+++ b/docs/coordination/decisions/D-M8-001-preview-scope.md
@@ -1,0 +1,108 @@
+# D-M8-001 — The honest scope of the first public preview
+
+Status: **Decided** (coordinator, 2026-08-07). Supersedes nothing; constrains
+Milestone 8 planning.
+
+## Question
+
+What is the minimum honest scope of a `0.1.0-preview`, given the real state of
+the code rather than the state the roadmap aspires to?
+
+Three options were weighed:
+
+- **A** — ship `0.1.0-preview` with the current bitmap font, documenting
+  "ASCII-only rendering" as a known limitation.
+- **B** — block the preview on a real font stack (rasterization, atlas, shaping,
+  fallback).
+- **C** — ship a narrower, explicitly-labelled preview that does not claim to be
+  the product.
+
+## How this was decided
+
+Two independent sessions were consulted, each without sight of the other's
+answer, and each instructed to reject false premises rather than agree with the
+brief. Both were given the same facts to verify rather than to trust.
+
+Both returned **C**. Both independently corrected two errors in the brief they
+were given, and both raised the same blocker that the brief had not asked about.
+The convergence is worth more than either answer alone because the reasoning
+differed: one grounded the objection in the missing workspace feature, the other
+in monochrome rendering being disqualifying for a terminal.
+
+The brief's errors, corrected by both and confirmed against the tree:
+
+- The brief claimed 388 tests. `ROADMAP.md:44` says **353**.
+- The brief claimed Milestone 3 was "largely verified." `ROADMAP.md:11` says
+  **Not started**, and the tree agrees: of the M3 modules, only `session.rs` is
+  on `main`. `sidebar.rs`, `palette.rs`, `passthrough.rs`,
+  `session_supervisor.rs`, and `session_persistence.rs` exist **only in unmerged
+  PRs**. "Verified" described lane state, not `main`.
+
+That second correction is the one that decides the question. It was also the
+falsifier one session named for its own recommendation: *if M3 were merged,
+option A would become defensible.* It is not merged, so A is not.
+
+## Decision
+
+**Option C.** The first public artifact is an explicitly dated developer preview,
+not "0.1.0-preview of the Noren terminal."
+
+The reasoning that survives both sessions:
+
+**Why not B.** The accepted requirements deliberately defer CJK, IME, and
+accessibility to "Later" (`docs/requirements/v0.1.md:46`, FR-012). Blocking the
+preview on a full font stack re-litigates a decision already made and holds the
+artifact hostage to Milestone 6, which has not started.
+
+**Why not A.** What `main` contains today is a terminal *foundation*, not Noren.
+Noren's defining feature is the external workspace sidebar (ADR 0003;
+`v0.1.md:25` FR-009) — and it is not on `main`. Beyond that, the renderer is
+monochrome: `renderer.rs:35` returns a constant colour and the vertex format at
+`renderer.rs:117-125` carries no colour channel. A terminal where `ls --color`,
+`vim`, and Zellij's own status bar are all one shade of green, and where CJK and
+any non-ASCII path render as `?` (`renderer.rs:353`, asserted at `:458`), is a
+technology demo. Filing that under "known limitations" is dishonest by omission.
+
+The font is worse than "ASCII-only" implies: `renderer.rs:457` asserts
+`glyph_rows('a') == glyph_rows('A')`. The bitmap does not distinguish case.
+
+## Blocking preconditions
+
+These are **not** M8 polish items; they gate the artifact reaching strangers.
+
+1. **A rendered-frame oracle, or an explicit written admission that none
+   exists.** FR-005 (`v0.1.md:21`) requires that "a macOS rendered-frame capture
+   match their oracles." It does not exist — `ROADMAP.md:68-70` concedes glyph
+   correctness is unverified by automation. Silently waiving the project's own
+   PoC gate is the one path that would make the release claim dishonest, which
+   is precisely what this project's evidence rule forbids.
+2. **Release-integrity gates.** NFR-009 (`v0.1.md:46`) states signing,
+   notarization, packaging, and release-integrity gates "must pass before Preview
+   claims." Reproducible binaries, checksums, and toolchain provenance are
+   required by NFR-008.
+3. **Front-loaded honest documentation** — monochrome, ASCII-only and
+   case-insensitive glyphs, no IME, no accessibility surface, macOS-only, and no
+   workspace sidebar — stated where a reader meets them first, not in a footnote.
+4. **Framing that does not imply** the workspace, colour, or CJK support exist.
+
+## Consequences and owner decisions required
+
+Precondition 2 collides with a reserved owner decision: signing and notarization
+were deferred until immediately before distribution, and that moment *is* this
+one. Signing keys, Apple certificates, and any public release are owner-only
+actions. **Milestone 8 therefore stops at a release candidate.**
+
+Two cheap items are worth doing regardless of scope, and both were raised
+unprompted:
+
+- **Wire colour to drawing.** Truecolor is already modelled in terminal state and
+  simply never reaches the renderer. This is far cheaper than a font stack and
+  removes the single most disqualifying visual defect.
+- **Merge the verified M3 work**, which would materially change what a preview
+  can honestly claim, and would reopen option A on its own stated falsifier.
+
+## What would change this decision
+
+If a rendered-frame oracle is built and the M3 workspace lands on `main`, the
+premises behind C no longer hold and option A should be re-argued on the evidence
+at that time.

--- a/docs/coordination/decisions/D-M8-001-preview-scope.md
+++ b/docs/coordination/decisions/D-M8-001-preview-scope.md
@@ -33,18 +33,20 @@ The brief's errors, corrected by both and re-confirmed against the current tree:
 
 - The brief claimed 388 tests. The Milestone 2 completion evidence in
   `ROADMAP.md` records **353**.
-- The brief claimed Milestone 3 was "largely verified." The milestone table in
-  `ROADMAP.md` marks Milestone 3 **Not started**, and the tree bears this out
-  more sharply than the brief allowed. The six M3 modules — `session`,
-  `sidebar`, `palette`, `passthrough`, `session_supervisor`, and
-  `session_persistence` — plus `mouse` (an M2 input deliverable, PR #79) are
-  now files on `main` (PRs #77, #78, #79, #81, #82, and #84 merged after the
-  brief was written), and PR #92 declared all seven in `lib.rs`, so they are
-  compiled into the library and covered by CI's clippy and dead-code checks.
-  But `main.rs` imports none of them, the linked binary contains no symbols
-  from them, and nothing presents a sidebar to a user (Issue #88). "Verified"
-  described lane state, not the application a user runs: launching the build
-  still presents no workspace sidebar.
+- The brief claimed Milestone 3 was "largely verified." It is not. The
+  milestone table in `ROADMAP.md` marks Milestone 3 **In progress**, which is
+  accurate in both directions: the six M3 modules — `session`, `sidebar`,
+  `palette`, `passthrough`, `session_supervisor`, and `session_persistence` —
+  plus `mouse` (an M2 input deliverable, PR #79) are now files on `main` (PRs
+  #77, #78, #79, #81, #82, and #84 merged after the brief was written), and
+  PR #92 declared all seven in `lib.rs`, so they are compiled into the library
+  and covered by CI's clippy and dead-code checks. Those merges are genuine
+  progress, and why the table moved off "Not started." But the progress is
+  landed, not shipped: `main.rs` imports none of them, the linked binary
+  contains no symbols from them, and nothing presents a sidebar to a user
+  (Issue #88). What a user sees is unchanged. "Verified" described lane state,
+  not the application a user runs: launching the build still presents no
+  workspace sidebar.
 
 The distinction that carries the decision is neither *merged versus unmerged*
 nor *declared versus undeclared in the library* — the first line moved with
@@ -103,11 +105,14 @@ These are **not** M8 polish items; they gate the artifact reaching strangers.
    and non-ASCII-`?` defects. The gate is no longer missing — it is satisfied on
    structure and honest about its gaps. Hiding those gaps would be the dishonest
    path, and the project's evidence rule forbids it.
-2. **Release-integrity gates.** NFR-009 (`docs/requirements/v0.1.md`) states
-   signing,
-   notarization, packaging, and release-integrity gates "must pass before Preview
-   claims." Reproducible binaries, checksums, and toolchain provenance are
-   required by NFR-008.
+2. **Release-integrity and reproducibility gates.** NFR-009
+   (`docs/requirements/v0.1.md`) states signing, notarization, packaging, and
+   release-integrity gates "must pass before Preview claims"; checksums are a
+   release-integrity concern, so they fall to NFR-009. NFR-008 separately
+   requires reproducibility: CI and local handoff record `rustc`/`cargo`
+   versions, installed targets, macOS version, architecture, the lockfile, and
+   exact direct dependencies — the toolchain provenance a reproducible build
+   rests on.
 3. **Front-loaded honest documentation** — monochrome, ASCII-only and
    case-insensitive glyphs, no IME, no accessibility surface, macOS-only, and no
    workspace sidebar — stated where a reader meets them first, not in a footnote.


### PR DESCRIPTION
## 概要

Milestone 8（Public Preview）の**正直なスコープ**を決定し、記録する。

## 決定方法

2つの独立したセッションに、互いの回答を見せずに同じ質問をした。両方に「前提が誤っていれば指摘せよ、期待されていそうな答えに同意するな」と明示的に指示している。

**両方が独立に C（明示的に限定した開発者向けプレビュー）を推奨**した。収束そのものより、根拠が異なっていたことに価値がある — 一方はワークスペース機能の欠落を、他方はモノクロレンダリングの致命性を軸にしている。

## 両方が独立に訂正した、私の前提の誤り

- ブリーフは「388テスト」と述べたが、`ROADMAP.md:44` は **353**
- ブリーフは M3 を「largely verified」と述べたが、`ROADMAP.md:11` は **Not started**

2点目はツリーが決着させた。M3 モジュールのうち `main` にあるのは `session.rs` のみで、`sidebar.rs` `palette.rs` `passthrough.rs` `session_supervisor.rs` `session_persistence.rs` は**未マージPRの中にしか存在しない**。「verified」はレーンの状態を指しており、`main` の状態ではなかった。

この訂正が結論を決めた。しかもこれは、一方のセッションが**自分の推奨に対する反証条件として自ら명示していた**もの：「M3がマージ済みなら A が妥当になる」。マージされていないので A は成立しない。

## 決定内容

最初の公開成果物は、**日付を明示した開発者向けプレビュー**であり、「0.1.0-preview of the Noren terminal」ではない。

### A を採らない理由

今日の `main` にあるのはターミナルの土台であって Noren ではない。加えてレンダラは**モノクロ**（`renderer.rs:35` が定数を返し、頂点レイアウトに色チャンネルがない）。`ls --color`・`vim`・Zellij のステータスバーが単色で描かれ、CJK が `?` になる端末は技術デモであり、これを「既知の制限」に並べるのは**不作為による不誠実**にあたる。

フォントは「ASCIIのみ」より悪い。`renderer.rs:457` が `glyph_rows('a') == glyph_rows('A')` を主張しており、**大文字小文字すら区別しない**。

### B を採らない理由

CJK・IME・アクセシビリティは要件で意図的に「Later」に置かれている（`v0.1.md:46` FR-012）。フォントスタック完成を条件にすると、未着手の M6 に成果物が人質に取られ、既に下した決定を蒸し返すことになる。

## ブロッキング条件（M8のポリッシュではなく、公開の可否を決める）

1. **FR-005 のレンダーフレームオラクル**（`v0.1.md:21`）が存在しない。プロジェクト自身のPoCゲートを黙って免除することが、リリース表明を不誠実にする唯一の経路。
2. **NFR-009 のリリース完全性ゲート**（`v0.1.md:46`）— 署名・notarization・パッケージングは「Preview を名乗る前に通過必須」と明記されている。
3. 前置きされた正直なドキュメント
4. ワークスペース・色・CJK があると誤認させない表現

## 帰結

条件2は保留中のオーナー判断と衝突する（署名・notarization は配布直前まで保留とされ、その時点が今）。したがって **Milestone 8 はリリース候補で停止**する。署名鍵・Apple証明書・タグ・公開はオーナー専権であり、自律的には実行しない。

## 検証

`python3 scripts/check_docs.py` — OK（構造・リンク・空白・UTF-8・秘密情報パターン）