### PR TITLE
docs: sync known limitations, roadmap, and README to the M3 slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 > A Zellij-friendly terminal for local, remote, and agent workflows.
 
-> **Project status: Discovery.** Noren does not yet contain a terminal
-> application, installable binaries, or a Preview release. Everything described
-> below is a product goal until the implementation and release evidence says
-> otherwise.
+> **Current state: terminal foundation, not the product.** What exists on
+> `main` is a macOS window over a local `zsh` PTY with a tested terminal state
+> core. It renders in a single colour, in a case-insensitive 5x7 ASCII bitmap
+> font, with all non-ASCII shown as `?`, no IME, no accessibility surface, and
+> no workspace sidebar. There are no published binaries. Read
+> **[docs/known-limitations.md](docs/known-limitations.md)** first — it is the
+> accurate predictor of what happens when you run the build. Everything below
+> the status block describes **intent**, not current capability.
 
 Noren (ノレン) is being designed as a Rust workspace terminal for macOS and
 Linux. Its name comes from the Japanese *noren*: a curtain that divides a space
@@ -33,8 +37,10 @@ pass-through takes priority over Noren shortcuts.
 
 ## Current phase
 
-The project is completing Discovery and requirements work before production
-implementation. The required sequence is:
+Milestones 0–2 (discovery, requirements/design, terminal foundation) are
+complete on the evidence recorded in [ROADMAP.md](ROADMAP.md); the workspace,
+SSH, agent-experience, theming/accessibility, quality, and preview milestones
+are open. The required sequence remains:
 
 1. verify tools, upstream behavior, licenses, and project constraints;
 2. calibrate the available AI contributors on the same bounded task;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 > `main` is a macOS window over a local `zsh` PTY with a tested terminal state
 > core. It renders in a single colour, in a case-insensitive 5x7 ASCII bitmap
 > font, with all non-ASCII shown as `?`, no IME, no accessibility surface, and
-> no workspace sidebar. There are no published binaries. Read
+> no visible workspace sidebar (the view model exists, but nothing draws it).
+> There are no published binaries. Read
 > **[docs/known-limitations.md](docs/known-limitations.md)** first — it is the
 > accurate predictor of what happens when you run the build. Everything below
 > the status block describes **intent**, not current capability.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 > A Zellij-friendly terminal for local, remote, and agent workflows.
 
-> **Current state: terminal foundation, not the product.** What exists on
-> `main` is a macOS window over a local `zsh` PTY with a tested terminal state
-> core. It renders in a single colour, in a case-insensitive 5x7 ASCII bitmap
-> font, with all non-ASCII shown as `?`, no IME, no accessibility surface, and
-> no visible workspace sidebar (the view model exists, but nothing draws it).
-> There are no published binaries. Read
+> **Current state: a first workspace slice on a terminal foundation.** What
+> exists on `main` is a macOS window over a local `zsh` PTY with a tested
+> terminal state core, plus a drawn workspace sidebar, a `Super+p` command
+> palette that creates/selects/closes local sessions, mouse reporting that
+> reaches the program inside, and sidebar state that survives a restart.
+>
+> It still renders in a single colour, in a case-insensitive 5x7 ASCII bitmap
+> font, with all non-ASCII shown as `?`, no visible cursor, no IME, and no
+> accessibility surface. Only local sessions can be launched — SSH hosts, git
+> worktrees, and agents are modelled but unreachable — and keybindings are not
+> configurable. There are no published binaries. Read
 > **[docs/known-limitations.md](docs/known-limitations.md)** first — it is the
 > accurate predictor of what happens when you run the build. Everything below
 > the status block describes **intent**, not current capability.
@@ -39,9 +44,13 @@ pass-through takes priority over Noren shortcuts.
 ## Current phase
 
 Milestones 0–2 (discovery, requirements/design, terminal foundation) are
-complete on the evidence recorded in [ROADMAP.md](ROADMAP.md); the workspace,
-SSH, agent-experience, theming/accessibility, quality, and preview milestones
-are open. The required sequence remains:
+complete on the evidence recorded in [ROADMAP.md](ROADMAP.md). Milestone 3
+(workspace) is **in progress**: the vertical slice — sidebar, palette, session
+lifecycle, persistence, Zellij pass-through — has landed, while configurable
+keybindings and the SSH/agent session kinds have not; the reasoning is in
+[Milestone 3 status](ROADMAP.md#milestone-3-status). The SSH,
+agent-experience, theming/accessibility, quality, and preview milestones are
+open. The required sequence remains:
 
 1. verify tools, upstream behavior, licenses, and project constraints;
 2. calibrate the available AI contributors on the same bounded task;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Only evidence-backed work is marked complete.
 | 0 — Discovery | Landscape, feature/library matrices, risks, agent inventory and calibration | Complete |
 | 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Complete |
 | 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | Complete |
-| 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress |
+| 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress — vertical slice landed; see [Milestone 3 status](#milestone-3-status) |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | Not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | Not started |
 | 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | Not started |
@@ -74,13 +74,51 @@ and two of its tests are `#[ignore]`d because they document real font defects
 (case-folding in the bitmap font, and every non-ASCII code point falling through
 to the `?` glyph). Key injection into the real window still does not exist, so
 live keyboard input remains unverified by automation; the byte-level input
-contract is covered by tests instead. Mouse reporting is implemented as an input
-encoder (PR #79, `crates/noren-app/src/mouse.rs`). Truecolor is modelled in
-terminal state but not yet wired to drawing. IME and accessibility remain
-deferred.
+contract is covered by tests instead. Mouse reporting is no longer encoder-only:
+`MouseEncoder::encode` (`crates/noren-app/src/mouse.rs`) is now called from the
+pointer and wheel handlers in `main.rs`, which write the report bytes to the
+PTY. Truecolor is modelled in terminal state but not yet wired to drawing. IME
+and accessibility remain deferred.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.
+
+## Milestone 3 status
+
+**In progress, not Complete.** The vertical slice reached the binary: launching
+the build now draws a workspace sidebar, and sessions can be created, selected,
+and closed from a command palette.
+
+The milestone's own scope line is the test, so it is quoted here in full:
+
+> External workspace management (sidebar: projects, git worktrees, SSH
+> connections, agents, terminal sessions), single-session view, session
+> lifecycle, sidebar-state persistence, palette, configurable keybindings,
+> Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per
+> ADR 0003)
+
+Measured against it, item by item:
+
+| Scope item | State | Evidence |
+| --- | --- | --- |
+| Sidebar drawn | Done | `SIDEBAR_COLS` reserved in `renderer.rs`; `glyph_vertices` applies the column offset; `sidebar_text_lines` formats rows |
+| — projects, git worktrees | Modelled, not launchable | `EntryKind::Project`/`Worktree`, `SessionKind::Project`/`Worktree` exist; no creation path constructs them |
+| — SSH connections, agents | Fixture only | `EntryKind::SshConnection`/`Agent` are documented "reserved… no connection is opened", "no agent is launched" |
+| — terminal sessions | Done | `SessionKind::Local` is created, selected, and closed from the running binary |
+| Single-session view | Done | Terminal drawn beside the sidebar, narrowed to the remaining columns |
+| Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` |
+| Sidebar-state persistence | Done | `sessions.toml` (`SESSION_STATE_FILE_NAME`) under the `config::default_path` directory, resolved by `session_state_path` |
+| Palette | Done | `Super+p` via `palette_policy`; `Palette::noren`'s four commands dispatched by `handle_palette_key` |
+| Configurable keybindings | **Not started** | `palette_policy` and `handle_palette_key` hard-code the chords; `config.rs` exposes no keymap surface |
+| Zellij pass-through | Done | `passthrough.rs` policy claims only Super-space chords the pinned Zellij default corpus never binds |
+
+Two named scope items are unsatisfied: **configurable keybindings do not exist
+at all**, and the sidebar's **SSH-connection and agent kinds are fixtures** that
+open no connection and launch no agent. Since "Only evidence-backed work is
+marked complete" and the scope line names both, Milestone 3 stays **In
+progress**. The SSH and agent session kinds also depend on Milestones 4 and 5;
+whether they are retired from Milestone 3's scope or carried is an open
+scoping decision, not something to settle by relabelling the status.
 
 ## What blocks a public preview
 
@@ -89,11 +127,13 @@ concluded that the current tree cannot honestly be released as "0.1.0-preview of
 the Noren terminal." The reasoning and the decision are recorded in
 [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
 
-- **The workspace is landed, not shipped.** The Milestone 3 modules (and the
-  M2 `mouse` module) are files on `main` and declared in `lib.rs` (PR #92), so
-  the library compiles them and CI covers them, but `main.rs` consumes none of
-  them and they are absent from the linked binary (Issue #88). Launching the
-  build still presents no workspace sidebar.
+- **The workspace is a slice, not a product.** The Milestone 3 modules now
+  reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
+  sessions are created/selected/closed, mouse reports reach the PTY, and
+  sidebar state persists across a restart. What is still missing is breadth —
+  only `SessionKind::Local` is ever constructed, so SSH hosts, git worktrees,
+  and agents are modelled but unreachable, and keybindings are not
+  configurable. See [Milestone 3 status](#milestone-3-status).
 - **The renderer is monochrome.** The fragment shader `fs_main` in
   `renderer.rs` returns a constant colour and the vertex layout carries no
   colour channel, so `ls --color`, `vim`, and Zellij's status bar all draw in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,9 +75,10 @@ and two of its tests are `#[ignore]`d because they document real font defects
 to the `?` glyph). Key injection into the real window still does not exist, so
 live keyboard input remains unverified by automation; the byte-level input
 contract is covered by tests instead. Mouse reporting is no longer encoder-only:
-`MouseEncoder::encode` (`crates/noren-app/src/mouse.rs`) is now called from the
-pointer and wheel handlers in `main.rs`, which write the report bytes to the
-PTY. Truecolor is modelled in terminal state but not yet wired to drawing. IME
+`MouseEncoder::encode` (`crates/noren-app/src/mouse.rs`) is now reached from the
+pointer and wheel handlers in `main.rs` through their shared
+`encode_and_send_mouse` helper, which writes the report bytes to the PTY.
+Truecolor is modelled in terminal state but not yet wired to drawing. IME
 and accessibility remain deferred.
 
 No milestone date is promised. Implementation advances through scoped Issues,
@@ -110,7 +111,7 @@ Measured against it, item by item:
 | Sidebar-state persistence | Done | `sessions.toml` (`SESSION_STATE_FILE_NAME`) under the `config::default_path` directory, resolved by `session_state_path` |
 | Palette | Done | `Super+p` via `palette_policy`; `Palette::noren`'s four commands dispatched by `handle_palette_key` |
 | Configurable keybindings | **Not started** | `palette_policy` and `handle_palette_key` hard-code the chords; `config.rs` exposes no keymap surface |
-| Zellij pass-through | Done | `passthrough.rs` policy claims only Super-space chords the pinned Zellij default corpus never binds |
+| Zellij pass-through | Done against a pinned corpus | `passthrough.rs` policy claims only Super-space chords that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds; no test drives a live Zellij |
 
 Two named scope items are unsatisfied: **configurable keybindings do not exist
 at all**, and the sidebar's **SSH-connection and agent kinds are fixtures** that
@@ -131,8 +132,8 @@ the Noren terminal." The reasoning and the decision are recorded in
   reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
   sessions are created/selected/closed, mouse reports reach the PTY, and
   sidebar state persists across a restart. What is still missing is breadth —
-  only `SessionKind::Local` is ever constructed, so SSH hosts, git worktrees,
-  and agents are modelled but unreachable, and keybindings are not
+  no runtime path constructs anything but `SessionKind::Local`, so SSH hosts,
+  git worktrees and agents are modelled but unreachable, and keybindings are not
   configurable. See [Milestone 3 status](#milestone-3-status).
 - **The renderer is monochrome.** The fragment shader `fs_main` in
   `renderer.rs` returns a constant colour and the vertex layout carries no

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -4,25 +4,61 @@ This document exists so that the first thing a reader meets is what Noren
 **cannot** do today, not what it hopes to do. Decision D-M8-001 settled that the
 first artifact is an explicitly dated developer preview, not a
 `0.1.0-preview` of the product; this page is the substance behind that framing.
-Every claim below was verified against the tree on 2026-08-07; citations point
-at the file, function, or test that establishes them, and a line number appears
-only where a name would not pin the evidence. If anything here has drifted,
+Every claim below was verified against the tree on 2026-08-08; citations point
+at the file, function, type, constant, or test that establishes them. Names are
+used rather than line numbers, which rot; where a count is genuinely needed the
+command that reproduces it is given instead. If anything here has drifted,
 treat the code as correct and this page as a bug.
 
 ## What Noren is today
 
-Noren today is a terminal **foundation**: a macOS window backed by a working
-PTY that spawns a local `/bin/zsh`, a renderer-independent terminal state core
-(scroll regions, alternate screen, SGR attributes, Unicode display width,
-bounded scrollback, selection, clipboard, search), and an input encoder that
-covers xterm modifier parameters and application cursor/keypad modes. Several of
-those state features are not yet visible on screen — see "What does not work"
-below, which is the more useful list. It is
-**not yet** the workspace product that [ADR
-0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: no workspace
-sidebar is drawn, and what runs is a single window onto one local shell
-(a single `PtySession::spawn` call in `main.rs`'s `initialize`). Milestones 3–8 are open on the
-[roadmap](../ROADMAP.md).
+Noren today is a **working single-session workspace on a terminal foundation**:
+a macOS window backed by a PTY that spawns a local `/bin/zsh`, a
+renderer-independent terminal state core (scroll regions, alternate screen, SGR
+attributes, Unicode display width, bounded scrollback, selection, clipboard,
+search), and an input encoder covering xterm modifier parameters and
+application cursor/keypad modes.
+
+Since the first draft of this page, the Milestone 3 vertical slice reached the
+binary. What now actually happens on screen:
+
+- **A sidebar is drawn.** The leftmost `SIDEBAR_COLS` columns (a constant equal
+  to 16 in `renderer.rs`) are reserved for workspace rows, and the terminal is
+  drawn starting at that column offset with its grid narrowed to match — see
+  `glyph_vertices` in `renderer.rs`, which takes a `sidebar` argument and
+  applies `col_offset`, and `sidebar_text_lines` in `main.rs`, which formats the
+  rows.
+- **Sessions can be created, selected, and closed.** `Super+p` opens a command
+  palette (claimed by `palette_policy` in `main.rs` as
+  `PassthroughAction::OpenCommandPalette`), and `c`/`s`/`x`/`f` dispatch new
+  session, switch session, close session, and focus sidebar — the four commands
+  built by `Palette::noren`, routed through `handle_palette_key`. Arrow keys and
+  Enter navigate the same list; Escape dismisses it.
+- **Mouse reporting reaches the program.** `handle_mouse_button`,
+  `handle_mouse_move`, and `handle_mouse_wheel` in `main.rs` call
+  `MouseEncoder::encode` and write the resulting report bytes to the PTY, so
+  clicks, drags, and the wheel now work in Zellij, `vim` with `set mouse=a`, and
+  `tmux`.
+- **Configured cell size reaches the renderer.** `[font] cell_width` /
+  `cell_height` flow through `GridGeometry::with_cells` to the drawing path;
+  the regression test `configured_cell_sizes_drive_the_app_geometry` in
+  `main.rs` pins it, and a mutation note in `renderer.rs`'s tests records that
+  reverting `push_glyph` to the fixed `POC_CELL_WIDTH` constants must fail.
+- **Sidebar state survives a restart.** State is written to `sessions.toml`
+  (`SESSION_STATE_FILE_NAME`) in the directory `config::default_path` resolves —
+  `~/Library/Application Support/Noren/` on macOS — resolved by
+  `session_state_path` in `main.rs`. With `HOME` unset the app runs in-memory
+  only, by design.
+- **Session status reflects the real lifecycle.** `SessionStatus` advances
+  `Starting -> Running -> Exited/Failed` through `SessionRegistry::observe`
+  rather than sitting at a permanent "starting"; `main.rs` observes `Running` on
+  spawn and `Exited { code }` on child exit.
+
+It is still **not** the full workspace product that [ADR
+0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — one local
+shell at a time, and the non-local session kinds are modelled but unreachable.
+See "What does not work" below, which remains the more useful list. Milestones
+3–8 are open on the [roadmap](../ROADMAP.md).
 
 ## What does not work
 
@@ -58,23 +94,12 @@ Each item states what you would actually see if you ran the build.
   `ascii_glyphs_are_distinct_and_unknown_is_question_mark` test. CJK text,
   accented characters, box-drawing output, and
   emoji all appear as `?` — even though the terminal state core measures their
-  display width correctly (`ROADMAP.md:38`).
+  display width correctly (Unicode/CJK display width, recorded in the
+  [roadmap](../ROADMAP.md)).
 - **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
   the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
   drops the event without forwarding it. Japanese, Chinese, and
   Korean input methods produce nothing.
-- **Mouse reporting never reaches the program.** `mouse.rs` ships a complete,
-  tested `MouseEncoder::encode` for xterm tracking modes 1000/1002/1003 and
-  encodings 1006/1015/X10, but `main.rs` never calls it: neither `MouseEncoder`
-  nor `noren_app::mouse` appears in `main.rs` (the `MouseButton` it matches on
-  comes from `winit::event`, not the mouse module). The pointer handlers there
-  (`handle_mouse_button`, `handle_mouse_move`) drive **local text selection
-  only** — `handle_mouse_button` returns early for anything but a left click,
-  and neither handler ever writes report bytes to the PTY. In practice: the
-  mouse selects and copies text in Noren's own window, but the program running
-  inside sees nothing — in `vim` with `set mouse=a`, in `tmux`, and above all
-  in **Zellij**, clicks, drags, and the scroll wheel do nothing. Issue #96
-  tracks wiring the encoder to the PTY.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
@@ -97,40 +122,53 @@ Each item states what you would actually see if you ran the build.
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.
-- **No workspace sidebar is drawn.** Noren's defining feature per ADR 0003 and
-  FR-009 (`docs/requirements/v0.1.md`) is not yet visible on screen. A
-  renderer-independent sidebar view model exists — `sidebar.rs` (M3-3) defines
-  `EntryKind`, `SidebarRow`, and `SessionViewport`, describing *what* the
-  workspace shows without *how* to paint it — but nothing renders it: the
-  `sidebar` module is declared only in `lib.rs`, and neither `main.rs` nor
-  `renderer.rs` imports it, so the render path still emits only terminal cells
-  plus an optional status line (`glyph_vertices`). Sibling workspace
-  models are present in the tree (`session.rs`, `session_supervisor.rs`,
-  `session_persistence.rs`, `palette.rs`, `passthrough.rs`) but are models and
-  persistence, not a painted workspace, so what runs is still one window on
-  one local shell.
+- **Only local sessions can actually be launched.** `SessionKind` models
+  `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
+  `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
+  but every creation path in the running binary passes `SessionKind::Local`
+  (the only variant `main.rs` constructs). The doc comments on the `Ssh` and
+  `Agent` variants say so directly: *reserved*, *fixture only — no connection is
+  opened*, *no agent is launched*. In practice: the palette's "New Session"
+  gives you another local `zsh`, and there is no way to open an SSH host, a git
+  worktree, or an agent from the workspace. Milestones 4 and 5 own those.
+- **One session is visible at a time.** The sidebar lists sessions and selection
+  moves between them, but a single terminal viewport is drawn beside it; there
+  is no split, tiled, or multi-session view. Panes and layout *inside* a session
+  are delegated to Zellij by design — see "What is deliberately delegated".
+- **Keybindings are not configurable.** The palette opener (`Super+p`), the exit
+  leader (`Super+Escape`), and the `c`/`s`/`x`/`f` command keys are compiled in:
+  `palette_policy` and `handle_palette_key` in `main.rs` hard-code them, and the
+  config parser (`config.rs`) exposes no keybinding or keymap surface. Rebinding
+  requires editing source.
+- **A restored session's shell is not running.** Sidebar state persists across a
+  restart, but a restored entry comes back as `SessionStatus::Starting` — a
+  visible row whose PTY does not exist yet. The comment on `teardown` in
+  `main.rs` records this as the deliberate meaning of a restored session.
 
 ## What is verified, and how
 
 - **Automated tests.** The workspace commits **hundreds of `#[test]` functions
   across three crates**, and the total grows with every merge — reproduce the
   current count with `grep -rh '#\[test\]' crates/ | wc -l` rather than
-  trusting any number printed here. `ROADMAP.md:44` records **353 workspace
-  tests passing** at the Milestone 2 close (`1d329a5`), a closed-milestone
-  snapshot that does not move; the M2-MOUSE, M3-ADVFIX, M3-5/6/7, M3-3, and
-  FR-005 frame-oracle (PR #89) merges since then each passed CI, which is where
-  the later growth is witnessed. The suites include a bounded VT compatibility
-  harness, two independent adversarial hostile-input suites (`ROADMAP.md:58-60`),
-  and the FR-005 rendered-frame oracle added by PR #89.
-- **Four CI gates** required by branch protection (`ROADMAP.md:46-47`,
-  `.github/workflows/`): the Rust workflow (`cargo fmt --check`, `cargo clippy
-  --workspace --all-targets -- -D warnings`, `cargo test --workspace` on macOS
-  arm64), the documentation validator (`scripts/check_docs.py`), `cargo deny
-  check`, and an MSRV build.
-- **A manual macOS check**, re-run at the M2 close head (`ROADMAP.md:62-65`):
-  a release build opened a window, owned a direct `zsh` child whose tty
-  reported the expected grid size, and on exit the child was reaped and the pty
-  device was gone.
+  trusting any number printed here. The [roadmap](../ROADMAP.md)'s Milestone 2
+  completion evidence records the test count at that close as a
+  closed-milestone snapshot that does not move; the workspace, mouse-wiring,
+  cell-size, persistence, and frame-oracle merges since then each passed CI,
+  which is where the later growth is witnessed. The suites include a bounded VT
+  compatibility harness, two independent adversarial hostile-input suites, and
+  the FR-005 rendered-frame oracle. Workspace behaviour has its own integration
+  suites under `crates/noren-app/tests/` — `sidebar_view.rs`, `palette.rs`,
+  `session_domain.rs`, `session_supervisor.rs`, `session_persistence.rs`,
+  `session_adversarial.rs`, `mouse_encoding.rs`, and `passthrough.rs`.
+- **Four CI gates** required by branch protection (see the
+  [roadmap](../ROADMAP.md) and `.github/workflows/`): the Rust workflow
+  (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace` on macOS arm64), the documentation validator
+  (`scripts/check_docs.py`), `cargo deny check`, and an MSRV build.
+- **A manual macOS check**, re-run at the Milestone 2 close head and recorded
+  under the roadmap's manual gate: a release build opened a window, owned a
+  direct `zsh` child whose tty reported the expected grid size, and on exit the
+  child was reaped and the pty device was gone.
 
 What this evidence now covers that the M2 snapshot did not: PR #89 added the
 **FR-005 rendered-frame oracle** (`crates/noren-app/tests/frame_oracle.rs`,
@@ -144,7 +182,9 @@ lit/blank agrees with `TerminalSnapshot` across the FR-005 fixture classes. It
 does **not** assert an `A` looks like an A — only that the structure is right.
 Its two `#[ignore]`d tests (`lowercase_distinct_from_uppercase`,
 `non_ascii_glyph_is_not_the_question_mark`) are the executable specifications of
-the two font defects below, left failing rather than weakened. The oracle needs
+the two font defects listed above — case-blindness and non-ASCII falling
+through to `?` — left failing rather than weakened, and their `#[ignore]`
+attributes say so in the source. The oracle needs
 a headless Metal adapter and reports `offscreen=blocked` honestly when the host
 has none.
 
@@ -167,12 +207,18 @@ two layers owning the same abstraction was judged worse than delegating it.
 When Zellij is running, correct input pass-through takes priority over Noren
 shortcuts. Please do not file the absence of native tabs or panes as a bug —
 but do hold Noren to its side of the boundary: a workspace *outside* the
-terminal, which is precisely the part not built yet.
+terminal. That side now has a first vertical slice — a drawn sidebar, a command
+palette, session create/select/close, and state that survives a restart — and
+the gaps that remain there (non-local session kinds, configurable keybindings)
+are legitimate things to report.
 
 ## What this preview is not
 
 No binary, installer, checksum, or release tag is published with this document;
 building and running from source is the only way to see the current state, and
 publishing any artifact is a reserved owner decision. Nothing here should be
-read as "nearly done": the honest summary is that the foundation is tested and
-the product is not yet present.
+read as "nearly done": the honest summary is that the foundation is tested, a
+first workspace slice is now real and visible, and what stands between this and
+a usable daily terminal is not workspace plumbing but the display itself —
+colour, a real font, a cursor. Those are the things a user sees first, and they
+are the things still missing.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -35,10 +35,10 @@ binary. What now actually happens on screen:
   built by `Palette::noren`, routed through `handle_palette_key`. Arrow keys and
   Enter navigate the same list; Escape dismisses it.
 - **Mouse reporting reaches the program.** `handle_mouse_button`,
-  `handle_mouse_move`, and `handle_mouse_wheel` in `main.rs` call
-  `MouseEncoder::encode` and write the resulting report bytes to the PTY, so
-  clicks, drags, and the wheel now work in Zellij, `vim` with `set mouse=a`, and
-  `tmux`.
+  `handle_mouse_move`, and `handle_mouse_wheel` in `main.rs` each call
+  `encode_and_send_mouse`, the helper that invokes `MouseEncoder::encode` and
+  writes the resulting report bytes to the PTY, so clicks, drags, and the wheel
+  now work in Zellij, `vim` with `set mouse=a`, and `tmux`.
 - **Configured cell size reaches the renderer.** `[font] cell_width` /
   `cell_height` flow through `GridGeometry::with_cells` to the drawing path;
   the regression test `configured_cell_sizes_drive_the_app_geometry` in
@@ -126,7 +126,8 @@ Each item states what you would actually see if you ran the build.
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
   but every creation path in the running binary passes `SessionKind::Local`
-  (the only variant `main.rs` constructs). The doc comments on the `Ssh` and
+  (the other variants are constructed only in `main.rs`'s tests, never on a
+  runtime path). The doc comments on the `Ssh` and
   `Agent` variants say so directly: *reserved*, *fixture only — no connection is
   opened*, *no agent is launched*. In practice: the palette's "New Session"
   gives you another local `zsh`, and there is no way to open an SSH host, a git

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -14,7 +14,9 @@ Noren today is a terminal **foundation**: a macOS window backed by a working
 PTY that spawns a local `/bin/zsh`, a renderer-independent terminal state core
 (scroll regions, alternate screen, SGR attributes, Unicode display width,
 bounded scrollback, selection, clipboard, search), and an input encoder that
-covers xterm modifier parameters and application cursor/keypad modes. It is
+covers xterm modifier parameters and application cursor/keypad modes. Several of
+those state features are not yet visible on screen — see "What does not work"
+below, which is the more useful list. It is
 **not yet** the workspace product that [ADR
 0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: there is no
 workspace sidebar, and what runs is a single window onto one local shell
@@ -25,6 +27,13 @@ workspace sidebar, and what runs is a single window onto one local shell
 
 Each item states what you would actually see if you ran the build.
 
+- **There is no visible cursor.** The terminal state tracks a cursor position
+  and moves it correctly, but the render path never draws it: `glyph_vertices`
+  (`crates/noren-app/src/renderer.rs:275-326`) emits only character bitmaps from
+  `display_lines` plus an optional status line, and the word "cursor" does not
+  appear anywhere in `renderer.rs`. In practice: you type, characters appear,
+  and nothing shows you where the insertion point is. This is the first thing
+  most people notice.
 - **Everything renders in one colour.** The fragment shader returns a constant
   pale green (`crates/noren-app/src/renderer.rs:35`) and the vertex layout
   carries only a position, no colour channel (`renderer.rs:117-125`). SGR
@@ -48,8 +57,16 @@ Each item states what you would actually see if you ran the build.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
-- **macOS only, one fixed shell.** The renderer requests Metal only
-  (`renderer.rs:70`) and the app crate does not compile for other platforms.
+- **Selection and scrollback work, but you cannot see them.** Selection is
+  tracked and copy extracts it, yet the renderer does not highlight the selected
+  region — `main.rs:44-46` says so in the source itself. Scrollback is bounded
+  and searchable, but the renderer has no scroll offset and always draws the
+  bottom `visible_rows` (`renderer.rs:296`), so you cannot scroll the viewport
+  back through it. The data is there; the view onto it is not.
+- **macOS only, one fixed shell.** The renderer requests Metal exclusively
+  (`renderer.rs:70`), so it does not *run* on other platforms — it acquires no
+  adapter and fails at startup. (The app crate has no `cfg(target_os)` gating,
+  so it may well compile elsewhere; compiling is not the barrier, running is.)
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`crates/noren-pty/src/lib.rs:33`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -18,8 +18,8 @@ covers xterm modifier parameters and application cursor/keypad modes. Several of
 those state features are not yet visible on screen — see "What does not work"
 below, which is the more useful list. It is
 **not yet** the workspace product that [ADR
-0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: there is no
-workspace sidebar, and what runs is a single window onto one local shell
+0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: no workspace
+sidebar is drawn, and what runs is a single window onto one local shell
 (`crates/noren-app/src/main.rs:118`). Milestones 3–8 are open on the
 [roadmap](../ROADMAP.md).
 
@@ -64,29 +64,38 @@ Each item states what you would actually see if you ran the build.
   bottom `visible_rows` (`renderer.rs:296`), so you cannot scroll the viewport
   back through it. The data is there; the view onto it is not.
 - **macOS only, one fixed shell.** The renderer requests Metal exclusively
-  (`renderer.rs:70`), so it does not *run* on other platforms — it acquires no
-  adapter and fails at startup. (The app crate has no `cfg(target_os)` gating,
-  so it may well compile elsewhere; compiling is not the barrier, running is.)
+  (`renderer.rs:70`), so it does not *run* on other platforms — on a non-macOS
+  host it acquires no adapter, the renderer fails to start, and the window
+  opens to show "Noren renderer start failed" (`main.rs:132-140`) rather than a
+  usable terminal. (The app crate has no `cfg(target_os)` gating, so it may
+  well compile elsewhere; compiling is not the barrier, running is.)
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`crates/noren-pty/src/lib.rs:33`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.
-- **No workspace sidebar.** Noren's defining feature per ADR 0003 and FR-009
-  (`docs/requirements/v0.1.md:25`) is absent from the build: there is no
-  `sidebar.rs` in `crates/noren-app/src/`. Sidebar-adjacent modules *are* on
-  `main` — `session.rs`, `session_supervisor.rs`, `session_persistence.rs`,
-  `palette.rs`, `passthrough.rs` — but they are models and persistence, not a
-  visible workspace, and `ROADMAP.md:11` still lists Milestone 3 as **Not
-  started**.
+- **No workspace sidebar is drawn.** Noren's defining feature per ADR 0003 and
+  FR-009 (`docs/requirements/v0.1.md:25`) is not yet visible on screen. A
+  renderer-independent sidebar view model exists — `sidebar.rs` (M3-3) defines
+  `EntryKind`, `SidebarRow`, and `SessionViewport`, describing *what* the
+  workspace shows without *how* to paint it — but nothing renders it: the
+  `sidebar` module is declared only in `lib.rs`, and neither `main.rs` nor
+  `renderer.rs` imports it, so the render path still emits only terminal cells
+  plus an optional status line (`renderer.rs:275-326`). Sibling workspace
+  models are present in the tree (`session.rs`, `session_supervisor.rs`,
+  `session_persistence.rs`, `palette.rs`, `passthrough.rs`) but are models and
+  persistence, not a painted workspace, so what runs is still one window on
+  one local shell.
 
 ## What is verified, and how
 
-- **Automated tests.** The workspace commits 546 `#[test]` functions across the
-  three crates (count them: `grep -rc '#\[test\]' crates/`). `ROADMAP.md:44`
-  records **353 workspace tests passing** at the Milestone 2 close (`1d329a5`);
-  the M2-MOUSE and M3-5/6/7 merges since then each passed CI, which is where
-  the remaining tests are witnessed. The suites include a bounded VT
-  compatibility harness and two independent adversarial hostile-input suites
-  (`ROADMAP.md:58-60`).
+- **Automated tests.** The workspace commits **hundreds of `#[test]` functions
+  across three crates**, and the total grows with every merge — reproduce the
+  current count with `grep -rh '#\[test\]' crates/ | wc -l` rather than
+  trusting any number printed here. `ROADMAP.md:44` records **353 workspace
+  tests passing** at the Milestone 2 close (`1d329a5`), a closed-milestone
+  snapshot that does not move; the M2-MOUSE, M3-ADVFIX, M3-5/6/7, and M3-3
+  merges since then each passed CI, which is where the later growth is
+  witnessed. The suites include a bounded VT compatibility harness and two
+  independent adversarial hostile-input suites (`ROADMAP.md:58-60`).
 - **Four CI gates** required by branch protection (`ROADMAP.md:46-47`,
   `.github/workflows/`): the Rust workflow (`cargo fmt --check`, `cargo clippy
   --workspace --all-targets -- -D warnings`, `cargo test --workspace` on macOS

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,109 @@
+# Known limitations
+
+This document exists so that the first thing a reader meets is what Noren
+**cannot** do today, not what it hopes to do. Decision D-M8-001 settled that the
+first artifact is an explicitly dated developer preview, not a
+`0.1.0-preview` of the product; this page is the substance behind that framing.
+Every claim below was verified against the tree on 2026-08-07 and cites
+`file:line`. If anything here has drifted, treat the code as correct and this
+page as a bug.
+
+## What Noren is today
+
+Noren today is a terminal **foundation**: a macOS window backed by a working
+PTY that spawns a local `/bin/zsh`, a renderer-independent terminal state core
+(scroll regions, alternate screen, SGR attributes, Unicode display width,
+bounded scrollback, selection, clipboard, search), and an input encoder that
+covers xterm modifier parameters and application cursor/keypad modes. It is
+**not yet** the workspace product that [ADR
+0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: there is no
+workspace sidebar, and what runs is a single window onto one local shell
+(`crates/noren-app/src/main.rs:118`). Milestones 3–8 are open on the
+[roadmap](../ROADMAP.md).
+
+## What does not work
+
+Each item states what you would actually see if you ran the build.
+
+- **Everything renders in one colour.** The fragment shader returns a constant
+  pale green (`crates/noren-app/src/renderer.rs:35`) and the vertex layout
+  carries only a position, no colour channel (`renderer.rs:117-125`). SGR
+  colours — including 256-colour and truecolor — are parsed and modelled in
+  terminal state but never reach drawing (`ROADMAP.md:71-72`). In practice:
+  `ls --color`, `vim` syntax highlighting, and Zellij's status bar all appear
+  in one shade of green.
+- **The font cannot distinguish case.** Glyphs are a hand-built 5x7 ASCII
+  bitmap indexed through `to_ascii_uppercase()` (`renderer.rs:354`); a test
+  asserts `glyph_rows('a') == glyph_rows('A')` (`renderer.rs:457`). `a` and `A`
+  are pixel-identical, so code, filenames, and password prompts lose case
+  visually.
+- **All non-ASCII renders as `?`.** Every character outside the bitmap table
+  falls through to the question-mark glyph (`renderer.rs:424`, asserted at
+  `renderer.rs:458`). CJK text, accented characters, box-drawing output, and
+  emoji all appear as `?` — even though the terminal state core measures their
+  display width correctly (`ROADMAP.md:38`).
+- **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
+  the terminal (`crates/noren-app/src/main.rs:612-614`). Japanese, Chinese, and
+  Korean input methods produce nothing.
+- **There is no accessibility surface.** Nothing in the tree integrates with
+  assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
+  a screen reader has nothing to work with.
+- **macOS only, one fixed shell.** The renderer requests Metal only
+  (`renderer.rs:70`) and the app crate does not compile for other platforms.
+  The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
+  arguments (`crates/noren-pty/src/lib.rs:33`). Linux support and SSH/remote
+  sessions are roadmap intent (Milestones 4 and 6), not current capability.
+- **No workspace sidebar.** Noren's defining feature per ADR 0003 and FR-009
+  (`docs/requirements/v0.1.md:25`) is absent from the build: there is no
+  `sidebar.rs` in `crates/noren-app/src/`. Sidebar-adjacent modules *are* on
+  `main` — `session.rs`, `session_supervisor.rs`, `session_persistence.rs`,
+  `palette.rs`, `passthrough.rs` — but they are models and persistence, not a
+  visible workspace, and `ROADMAP.md:11` still lists Milestone 3 as **Not
+  started**.
+
+## What is verified, and how
+
+- **Automated tests.** The workspace commits 546 `#[test]` functions across the
+  three crates (count them: `grep -rc '#\[test\]' crates/`). `ROADMAP.md:44`
+  records **353 workspace tests passing** at the Milestone 2 close (`1d329a5`);
+  the M2-MOUSE and M3-5/6/7 merges since then each passed CI, which is where
+  the remaining tests are witnessed. The suites include a bounded VT
+  compatibility harness and two independent adversarial hostile-input suites
+  (`ROADMAP.md:58-60`).
+- **Four CI gates** required by branch protection (`ROADMAP.md:46-47`,
+  `.github/workflows/`): the Rust workflow (`cargo fmt --check`, `cargo clippy
+  --workspace --all-targets -- -D warnings`, `cargo test --workspace` on macOS
+  arm64), the documentation validator (`scripts/check_docs.py`), `cargo deny
+  check`, and an MSRV build.
+- **A manual macOS check**, re-run at the M2 close head (`ROADMAP.md:62-65`):
+  a release build opened a window, owned a direct `zsh` child whose tty
+  reported the expected grid size, and on exit the child was reaped and the pty
+  device was gone.
+
+What this evidence does **not** cover (`ROADMAP.md:67-72`): there is no
+rendered-frame oracle and no key injection into the real window, so **glyph
+correctness and live input are unverified by automation** — the byte-level
+input contract is tested, but no test has ever looked at a rendered frame. The
+manual check above is a smoke test of the window→grid→PTY chain, not a
+correctness proof of what appears on screen. Colour, IME, and accessibility are
+absent from testing because they are absent from the build.
+
+## What is deliberately delegated
+
+Panes, tabs, splits, and layout **inside** a terminal session belong to Zellij
+(or to whatever runs inside the session), not to Noren. This is a design
+boundary recorded in [ADR
+0003](adr/0003-noren-zellij-responsibility-boundary.md), not a missing feature:
+two layers owning the same abstraction was judged worse than delegating it.
+When Zellij is running, correct input pass-through takes priority over Noren
+shortcuts. Please do not file the absence of native tabs or panes as a bug —
+but do hold Noren to its side of the boundary: a workspace *outside* the
+terminal, which is precisely the part not built yet.
+
+## What this preview is not
+
+No binary, installer, checksum, or release tag is published with this document;
+building and running from source is the only way to see the current state, and
+publishing any artifact is a reserved owner decision. Nothing here should be
+read as "nearly done": the honest summary is that the foundation is tested and
+the product is not yet present.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -62,6 +62,18 @@ Each item states what you would actually see if you ran the build.
   the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
   drops the event without forwarding it. Japanese, Chinese, and
   Korean input methods produce nothing.
+- **Mouse reporting never reaches the program.** `mouse.rs` ships a complete,
+  tested `MouseEncoder::encode` for xterm tracking modes 1000/1002/1003 and
+  encodings 1006/1015/X10, but `main.rs` never calls it: neither `MouseEncoder`
+  nor `noren_app::mouse` appears in `main.rs` (the `MouseButton` it matches on
+  comes from `winit::event`, not the mouse module). The pointer handlers there
+  (`handle_mouse_button`, `handle_mouse_move`) drive **local text selection
+  only** — `handle_mouse_button` returns early for anything but a left click,
+  and neither handler ever writes report bytes to the PTY. In practice: the
+  mouse selects and copies text in Noren's own window, but the program running
+  inside sees nothing — in `vim` with `set mouse=a`, in `tmux`, and above all
+  in **Zellij**, clicks, drags, and the scroll wheel do nothing. Issue #96
+  tracks wiring the encoder to the PTY.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -41,7 +41,8 @@ Each item states what you would actually see if you ran the build.
   the pipeline's vertex `buffers` slice carries a single `Float32x2` position
   attribute on an 8-byte stride, no colour channel. SGR
   colours — including 256-colour and truecolor — are parsed and modelled in
-  terminal state but never reach drawing (`ROADMAP.md:71-72`). In practice:
+  terminal state but never reach drawing ([ROADMAP, "What blocks a public
+  preview"](../ROADMAP.md#what-blocks-a-public-preview)). In practice:
   `ls --color`, `vim` syntax highlighting, and Zellij's status bar all appear
   in one shade of green.
 - **The font cannot distinguish case.** Glyphs are a hand-built 5x7 ASCII

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -4,9 +4,10 @@ This document exists so that the first thing a reader meets is what Noren
 **cannot** do today, not what it hopes to do. Decision D-M8-001 settled that the
 first artifact is an explicitly dated developer preview, not a
 `0.1.0-preview` of the product; this page is the substance behind that framing.
-Every claim below was verified against the tree on 2026-08-07 and cites
-`file:line`. If anything here has drifted, treat the code as correct and this
-page as a bug.
+Every claim below was verified against the tree on 2026-08-07; citations point
+at the file, function, or test that establishes them, and a line number appears
+only where a name would not pin the evidence. If anything here has drifted,
+treat the code as correct and this page as a bug.
 
 ## What Noren is today
 
@@ -20,7 +21,7 @@ below, which is the more useful list. It is
 **not yet** the workspace product that [ADR
 0003](adr/0003-noren-zellij-responsibility-boundary.md) describes: no workspace
 sidebar is drawn, and what runs is a single window onto one local shell
-(`crates/noren-app/src/main.rs:118`). Milestones 3–8 are open on the
+(a single `PtySession::spawn` call in `main.rs`'s `initialize`). Milestones 3–8 are open on the
 [roadmap](../ROADMAP.md).
 
 ## What does not work
@@ -28,58 +29,69 @@ sidebar is drawn, and what runs is a single window onto one local shell
 Each item states what you would actually see if you ran the build.
 
 - **There is no visible cursor.** The terminal state tracks a cursor position
-  and moves it correctly, but the render path never draws it: `glyph_vertices`
-  (`crates/noren-app/src/renderer.rs:275-326`) emits only character bitmaps from
-  `display_lines` plus an optional status line, and the word "cursor" does not
-  appear anywhere in `renderer.rs`. In practice: you type, characters appear,
+  and moves it correctly, but the render path never draws it: the
+  `glyph_vertices` function (`crates/noren-app/src/renderer.rs`) emits only
+  character bitmaps from `display_lines` plus an optional status line, and the
+  word "cursor" does not appear anywhere in `renderer.rs`. In practice: you type, characters appear,
   and nothing shows you where the insertion point is. This is the first thing
   most people notice.
 - **Everything renders in one colour.** The fragment shader returns a constant
-  pale green (`crates/noren-app/src/renderer.rs:35`) and the vertex layout
-  carries only a position, no colour channel (`renderer.rs:117-125`). SGR
+  pale green — the `fs_main` entry point returns a constant
+  `vec4<f32>(0.80, 0.92, 0.82, 1.0)` (`crates/noren-app/src/renderer.rs`) — and
+  the pipeline's vertex `buffers` slice carries a single `Float32x2` position
+  attribute on an 8-byte stride, no colour channel. SGR
   colours — including 256-colour and truecolor — are parsed and modelled in
   terminal state but never reach drawing (`ROADMAP.md:71-72`). In practice:
   `ls --color`, `vim` syntax highlighting, and Zellij's status bar all appear
   in one shade of green.
 - **The font cannot distinguish case.** Glyphs are a hand-built 5x7 ASCII
-  bitmap indexed through `to_ascii_uppercase()` (`renderer.rs:354`); a test
-  asserts `glyph_rows('a') == glyph_rows('A')` (`renderer.rs:457`). `a` and `A`
+  bitmap indexed through `character.to_ascii_uppercase()` inside the
+  `glyph_rows` function (`crates/noren-app/src/renderer.rs`); the test
+  `ascii_glyphs_are_distinct_and_unknown_is_question_mark` asserts
+  `glyph_rows('a') == glyph_rows('A')`. `a` and `A`
   are pixel-identical, so code, filenames, and password prompts lose case
   visually.
 - **All non-ASCII renders as `?`.** Every character outside the bitmap table
-  falls through to the question-mark glyph (`renderer.rs:424`, asserted at
-  `renderer.rs:458`). CJK text, accented characters, box-drawing output, and
+  falls through to the question-mark glyph — the final `_ =>` default arm of
+  `glyph_rows` (`crates/noren-app/src/renderer.rs`) — asserted by the same
+  `ascii_glyphs_are_distinct_and_unknown_is_question_mark` test. CJK text,
+  accented characters, box-drawing output, and
   emoji all appear as `?` — even though the terminal state core measures their
   display width correctly (`ROADMAP.md:38`).
 - **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
-  the terminal (`crates/noren-app/src/main.rs:612-614`). Japanese, Chinese, and
+  the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
+  drops the event without forwarding it. Japanese, Chinese, and
   Korean input methods produce nothing.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
 - **Selection and scrollback work, but you cannot see them.** Selection is
   tracked and copy extracts it, yet the renderer does not highlight the selected
-  region — `main.rs:44-46` says so in the source itself. Scrollback is bounded
-  and searchable, but the renderer has no scroll offset and always draws the
-  bottom `visible_rows` (`renderer.rs:296`), so you cannot scroll the viewport
+  region — the comment on the `selection` field in `main.rs` says so in the
+  source itself ("The renderer does not highlight it yet"). Scrollback is
+  bounded and searchable, but `glyph_vertices` always roots the layout at
+  `total_lines.saturating_sub(visible_rows)` with no scroll offset, so the
+  viewport always draws the bottom `visible_rows` and you cannot scroll it
   back through it. The data is there; the view onto it is not.
-- **macOS only, one fixed shell.** The renderer requests Metal exclusively
-  (`renderer.rs:70`), so it does not *run* on other platforms — on a non-macOS
-  host it acquires no adapter, the renderer fails to start, and the window
-  opens to show "Noren renderer start failed" (`main.rs:132-140`) rather than a
-  usable terminal. (The app crate has no `cfg(target_os)` gating, so it may
-  well compile elsewhere; compiling is not the barrier, running is.)
+- **macOS only, one fixed shell.**   `Renderer::new` requests Metal exclusively
+  (`instance_descriptor.backends = wgpu::Backends::METAL` in
+  `crates/noren-app/src/renderer.rs`), so it does not *run* on other platforms —
+  on a non-macOS host it acquires no adapter, the renderer fails to start, and
+  the window opens to show the "Noren renderer start failed" status (set in the
+  `Renderer::new` error arm of `main.rs`'s `initialize`) rather than a usable
+  terminal. (The app crate has no `cfg(target_os)` gating, so it may well
+  compile elsewhere; compiling is not the barrier, running is.)
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
-  arguments (`crates/noren-pty/src/lib.rs:33`). Linux support and SSH/remote
+  arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.
 - **No workspace sidebar is drawn.** Noren's defining feature per ADR 0003 and
-  FR-009 (`docs/requirements/v0.1.md:25`) is not yet visible on screen. A
+  FR-009 (`docs/requirements/v0.1.md`) is not yet visible on screen. A
   renderer-independent sidebar view model exists — `sidebar.rs` (M3-3) defines
   `EntryKind`, `SidebarRow`, and `SessionViewport`, describing *what* the
   workspace shows without *how* to paint it — but nothing renders it: the
   `sidebar` module is declared only in `lib.rs`, and neither `main.rs` nor
   `renderer.rs` imports it, so the render path still emits only terminal cells
-  plus an optional status line (`renderer.rs:275-326`). Sibling workspace
+  plus an optional status line (`glyph_vertices`). Sibling workspace
   models are present in the tree (`session.rs`, `session_supervisor.rs`,
   `session_persistence.rs`, `palette.rs`, `passthrough.rs`) but are models and
   persistence, not a painted workspace, so what runs is still one window on
@@ -92,10 +104,11 @@ Each item states what you would actually see if you ran the build.
   current count with `grep -rh '#\[test\]' crates/ | wc -l` rather than
   trusting any number printed here. `ROADMAP.md:44` records **353 workspace
   tests passing** at the Milestone 2 close (`1d329a5`), a closed-milestone
-  snapshot that does not move; the M2-MOUSE, M3-ADVFIX, M3-5/6/7, and M3-3
-  merges since then each passed CI, which is where the later growth is
-  witnessed. The suites include a bounded VT compatibility harness and two
-  independent adversarial hostile-input suites (`ROADMAP.md:58-60`).
+  snapshot that does not move; the M2-MOUSE, M3-ADVFIX, M3-5/6/7, M3-3, and
+  FR-005 frame-oracle (PR #89) merges since then each passed CI, which is where
+  the later growth is witnessed. The suites include a bounded VT compatibility
+  harness, two independent adversarial hostile-input suites (`ROADMAP.md:58-60`),
+  and the FR-005 rendered-frame oracle added by PR #89.
 - **Four CI gates** required by branch protection (`ROADMAP.md:46-47`,
   `.github/workflows/`): the Rust workflow (`cargo fmt --check`, `cargo clippy
   --workspace --all-targets -- -D warnings`, `cargo test --workspace` on macOS
@@ -106,13 +119,30 @@ Each item states what you would actually see if you ran the build.
   reported the expected grid size, and on exit the child was reaped and the pty
   device was gone.
 
-What this evidence does **not** cover (`ROADMAP.md:67-72`): there is no
-rendered-frame oracle and no key injection into the real window, so **glyph
-correctness and live input are unverified by automation** — the byte-level
-input contract is tested, but no test has ever looked at a rendered frame. The
-manual check above is a smoke test of the window→grid→PTY chain, not a
-correctness proof of what appears on screen. Colour, IME, and accessibility are
-absent from testing because they are absent from the build.
+What this evidence now covers that the M2 snapshot did not: PR #89 added the
+**FR-005 rendered-frame oracle** (`crates/noren-app/tests/frame_oracle.rs`,
+drawing through the shipped pipeline via
+`crates/noren-app/src/renderer_capture.rs`). It re-compiles the real `wgpu`
+glyph pipeline and drives it offscreen to assert **structural** properties,
+never a golden image: a cell the state says is blank contains no lit pixels;
+distinct glyphs produce distinct lit patterns; a glyph lights its own cell and
+not its neighbours; the drawn grid matches the state grid; and per-cell
+lit/blank agrees with `TerminalSnapshot` across the FR-005 fixture classes. It
+does **not** assert an `A` looks like an A — only that the structure is right.
+Its two `#[ignore]`d tests (`lowercase_distinct_from_uppercase`,
+`non_ascii_glyph_is_not_the_question_mark`) are the executable specifications of
+the two font defects below, left failing rather than weakened. The oracle needs
+a headless Metal adapter and reports `offscreen=blocked` honestly when the host
+has none.
+
+What this evidence does **not** cover: there is still **no key injection into
+the real window**, so live input is unverified end-to-end — the byte-level
+input contract is tested at the `KeyEncoder`, but no test synthesizes a real
+key event into a live window and observes the result. The oracle guards shape
+and grid mapping, not glyph identity or colour, so the manual check above
+remains a smoke test of the window→grid→PTY chain rather than a perceptual
+proof of what appears on screen. Colour, IME, and accessibility are absent
+from testing because they are absent from the build.
 
 ## What is deliberately delegated
 


### PR DESCRIPTION
## 概要

D-M8-001（PR #85）が決めた「明示的に日付を付した開発者向けプレビュー」という枠組みの**実質**にあたるドキュメント。読者が最初に出会うのが「今できないこと」になるよう、`README.md` の構成も変更している。

**実装は Kimi（別エンジン）が担当。** GLM が書いた D-M8-001 とは独立したエンジンによる検証になっている。

## 全主張をツリーに対して検証済み

`GLMDOCS limitations_verified=8 claims_corrected=1 sidebar_on_main=no docs_gate=PASS`

各項目に `file:line` を付し、「実際に走らせたら何が見えるか」を書いている。例：

- **すべてが単色で描画される** — シェーダが定数を返し（`renderer.rs:35`）、頂点レイアウトに色チャンネルがない（`:117-125`）。SGR の色は状態としては解析・保持されるが描画に到達しない。実際には `ls --color`・`vim` のシンタックスハイライト・Zellij のステータスバーが**すべて同じ緑**になる。
- **フォントが大文字小文字を区別できない** — `to_ascii_uppercase()` 経由でインデックスされる（`renderer.rs:354`）。`a` と `A` がピクセル単位で同一のため、コード・ファイル名・パスワードプロンプトで**視覚的に大小の情報が失われる**。
- **非ASCIIはすべて `?`** — CJK・アクセント付き文字・罫線・絵文字がすべて `?`。ターミナル状態コアは表示幅を正しく測っているにもかかわらず。
- **IME入力は破棄される**（`main.rs:612-614`）
- **アクセシビリティ面が存在しない** — AccessKit / AT-SPI / AppKit のいずれとも接続がなく、スクリーンリーダーが扱えるものがない
- **macOS専用・シェル固定** — Metal のみ要求（`renderer.rs:70`）、`/bin/zsh` 固定（`noren-pty/src/lib.rs:33`）。Linux 非対応は「未実装」ではなく**コンパイルが通らない**（実行環境が Linux だったため実地で確認された）

## 1件の訂正（claims_corrected=1）

指示書は D-M8-001 を既存文書として参照させたが、`docs/coordination/decisions/D-M8-001-preview-scope.md` は **`main` に存在しない**（未マージの `origin/docs/m8-preview-scope` にのみ存在）。内容は取得可能で、レンダラ関連の引用はすべて裏取りできたため、事実関係は維持したまま記述を調整している。

## サイドバーの状況をより正確に記述

D-M8-001 執筆後に M3-5/6/7 がマージされたため、状況が変化していた。ドキュメントはこのニュアンスを正確に書いている：

`sidebar.rs` は `main` に存在しない。一方で `session.rs`・`session_supervisor.rs`・`session_persistence.rs`・`palette.rs`・`passthrough.rs` は `main` にある。ただしこれらは**モデルと永続化であって、目に見えるワークスペースではない**。`ROADMAP.md:11` は依然として M3 を Not started としており、マイルストーン完了は主張していない。

## 検証

```
python3 scripts/check_docs.py   # 構造・ローカルリンク・空白・UTF-8・秘密情報パターン: OK
```

変更は `README.md` と `docs/known-limitations.md` の2ファイルのみ（`.rs` ファイルの混入なしを確認済み）。

## 意図的にやっていないこと

ダウンロードリンク・リリースタグ・インストール手順は**追加していない**。成果物はまだ公開されておらず、公開はオーナー判断のため。