### PR TITLE
fix(app): compile merged M3 modules into the library (#88)

### DIFF
--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -12,7 +12,12 @@ mod clipboard;
 pub mod config;
 pub mod diagnostics;
 mod input;
+pub mod mouse;
+pub mod palette;
+pub mod passthrough;
 pub mod session;
+pub mod session_persistence;
+pub mod session_supervisor;
 pub mod sidebar;
 
 pub use clipboard::{

--- a/crates/noren-app/tests/mouse_encoding.rs
+++ b/crates/noren-app/tests/mouse_encoding.rs
@@ -1,18 +1,14 @@
 //! Byte-exact verification of the mouse input encoder (`src/mouse.rs`).
 //!
-//! The mouse module is not yet wired into `lib.rs` (export wiring is a
-//! separate serial commit owned by another lane). It is self-contained — no
-//! `crate::` items — so this target compiles it directly from its source path
-//! and exercises the public API the way the future terminal-mode wiring will.
+//! The mouse module is wired into `lib.rs` as `pub mod mouse`. It is
+//! self-contained — no `crate::` items — and these tests exercise the public
+//! API the way the future terminal-mode wiring will.
 //!
 //! Coordinate convention used throughout: `col`/`row` are 0-based cell indices;
 //! the encoder clamps to the grid and emits 1-based `Cx`/`Cy`. A click at
 //! `col=9, row=4` on any grid that contains it resolves to `Cx=10, Cy=5`.
 
-#[path = "../src/mouse.rs"]
-mod mouse;
-
-use mouse::{
+use noren_app::mouse::{
     MODE_ANY_EVENT, MODE_BUTTON_EVENT, MODE_NORMAL, MODE_SGR, MODE_URXVT, MODE_UTF8, MouseButton,
     MouseEncoder, MouseGrid, MouseModes, PointerEvent, PointerModifiers, WheelDirection,
     X10_MAX_COORD,

--- a/crates/noren-app/tests/palette.rs
+++ b/crates/noren-app/tests/palette.rs
@@ -3,15 +3,10 @@
 //! renderer and the future wiring layer will: building the canonical catalog,
 //! searching it, and resolving stable IDs to actions.
 //!
-//! The palette module is not yet wired into `lib.rs` (that export is a separate
-//! serial commit owned by another lane), so the module is included here by
-//! path. Once wired, the `#[path]` line is removed and these tests reach the
-//! type through `noren_app::palette` instead.
+//! The palette module is wired into `lib.rs` as `pub mod palette`, so these
+//! tests reach the type through the crate path `noren_app::palette`.
 
-#[path = "../src/palette.rs"]
-mod palette;
-
-use palette::{Command, CommandId, Palette};
+use noren_app::palette::{Command, CommandId, Palette};
 
 /// A tiny stand-in for the shared action vocabulary the wiring layer will bind
 /// to `A`. The palette is action-agnostic, so any owned type proves the action

--- a/crates/noren-app/tests/passthrough.rs
+++ b/crates/noren-app/tests/passthrough.rs
@@ -1,18 +1,14 @@
 //! Integration tests for the Zellij pass-through lane (M3-5, ADR 0003
 //! boundary).
 //!
-//! The file lease for this lane excludes `lib.rs`, so the pass-through module
-//! is included from source; an integration lane later declares it in the
-//! crate. The tests bind the pass-through decision to the app's byte contract
+//! The pass-through module is wired into `lib.rs` as `pub mod passthrough`.
+//! The tests bind the pass-through decision to the app's byte contract
 //! through [`noren_app::KeyEncoder`]: unclaimed input must produce exactly
 //! the bytes a direct encode produces, and claimed input must produce none.
 
-#[path = "../src/passthrough.rs"]
-mod passthrough;
-
 use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, InputMode, Key, KeyEncoder, KeyInput, KeyPhase,
-    Modifiers as AppModifiers,
+    Modifiers as AppModifiers, passthrough,
 };
 use passthrough::{
     CLAIM_ID_EXIT, CLAIM_ID_PALETTE, Chord, ChordSeq, CollisionKind, GateKind, KeyCode, Modifiers,

--- a/crates/noren-app/tests/session_adversarial.rs
+++ b/crates/noren-app/tests/session_adversarial.rs
@@ -49,9 +49,11 @@
 //! modules (`src/session.rs`, `src/session_supervisor.rs`). The original
 //! `#[ignore]` reproducers mirrored the buggy algorithm through the fakes; the
 //! fix lane replaces them with normal `#[test]` regression guards that compile
-//! and run against the **real merged modules** (included below via `#[path]`),
-//! not the fakes. The fakes and their 20 defensive tests remain as the original
-//! attack record; the three regression guards live in the final section.
+//! and run against the **real merged modules** (still pulled in via `#[path]`
+//! because the supervisor's `mock` harness is `#[cfg(test)]` and unreachable
+//! from an integration test through the crate path), not the fakes. The fakes
+//! and their 20 defensive tests remain as the original attack record; the three
+//! regression guards live in the final section.
 
 // The two `fake_*` modules intentionally mirror the *full* published API
 // surface of the branch modules line-for-line, including methods and enum
@@ -64,8 +66,19 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // The real merged modules. The three regression guards at the end of this file
 // compile against these (not the fakes), so they guard the actual fixed code.
-// `cfg(test)` is enabled for an integration binary, which also brings the
-// supervisor's `mock` harness and each module's own unit tests into scope.
+// `session` and `session_supervisor` are both declared in `lib.rs`
+// (`pub mod session`, `pub mod session_supervisor`), so their non-test public
+// surface is reachable from outside the crate. The supervisor's `mock` harness,
+// however, is `#[cfg(test)]` inside `src/session_supervisor.rs`, and an
+// integration test is a separate crate — `cfg(test)` is not set for the
+// `noren-app` dependency, so `noren_app::session_supervisor::mock` does not
+// resolve here. Two of the three regression guards use that `mock` harness, so
+// both real modules are still compiled into this test binary directly via
+// `#[path]`, where `cfg(test)` *is* enabled for the test binary. (`session`
+// itself could be reached via `noren_app::session`; it is kept via `#[path]`
+// for file coherence, and its reachability is independently proven by
+// `tests/session_domain.rs`, `tests/sidebar_view.rs`, and the migrated
+// `tests/session_persistence.rs`.)
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[path = "../src/session.rs"]
@@ -73,7 +86,6 @@ mod session;
 
 #[path = "../src/session_supervisor.rs"]
 mod session_supervisor;
-
 // ─────────────────────────────────────────────────────────────────────────────
 // fake_domain — mirror of `session.rs` (lane glm-a / D-M3-001 shape).
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1396,11 +1408,12 @@ fn controlled_children(n: usize) -> (Vec<MockChild>, Vec<MockController>) {
 // algorithm through the `fake_*` modules above). The defects are fixed in
 // `src/session.rs` and `src/session_supervisor.rs`, so each guard below
 // compiles and runs against the real merged code via the `#[path]` includes at
-// the top of this file. They assert the fixed property holds; if any fix
-// regresses they fail. The property each guards is the same the original
-// reproducer attacked; the assertions are adapted to the fixed contracts
-// (regressions now error / unknown ids now surface honestly) rather than
-// weakened.
+// the top of this file (`session_supervisor::mock` is `#[cfg(test)]`, so the
+// crate path is unavailable to this integration test). They assert the fixed
+// property holds; if any fix regresses they fail. The property each guards is
+// the same the original reproducer attacked; the assertions are adapted to the
+// fixed contracts (regressions now error / unknown ids now surface honestly)
+// rather than weakened.
 // ═════════════════════════════════════════════════════════════════════════════
 
 #[test]

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -1,14 +1,9 @@
 //! Behavioral tests for sidebar persistence (`src/session_persistence.rs`).
 //!
-//! The persistence module is not yet wired into `noren-app`'s `lib.rs` —
-//! that one-line declaration belongs to the M3 integration lane, keeping
-//! this lane's file lease intact. Until then this target compiles the
-//! module through a `#[path]` shim, exactly as `tests/session_domain.rs`
-//! did for `session` before PR #75 wired it. The `session` shim module
-//! below mirrors the crate's public session surface so the persistence
-//! module's `crate::session` references resolve identically in both
-//! contexts; once `lib.rs` declares `pub mod session_persistence;`, replace
-//! the shim with crate imports as the session-domain lane did.
+//! The persistence module is wired into `lib.rs` as
+//! `pub mod session_persistence`; its `crate::session` references resolve to
+//! the crate's real public session module, so this target reaches both through
+//! their crate paths.
 //!
 //! Pinned behavior:
 //!
@@ -20,16 +15,8 @@
 //! 5. session lists are bounded in both directions;
 //! 6. the ADR 0003 boundary is enforced: session-interior keys never parse.
 
-mod session {
-    //! Mirror of `noren_app::session` for the still-unwired module below.
-    pub use noren_app::session::*;
-}
-
-#[path = "../src/session_persistence.rs"]
-mod session_persistence;
-
 use noren_app::session::{SessionDescriptor, SessionKind, SessionRegistry, SessionStatus};
-use session_persistence::{
+use noren_app::session_persistence::{
     MAX_SESSION_STATE_BYTES, MAX_SESSIONS, SESSION_STATE_VERSION, SessionPersistenceError, encode,
     load, load_bytes, save,
 };

--- a/crates/noren-app/tests/session_supervisor.rs
+++ b/crates/noren-app/tests/session_supervisor.rs
@@ -1,11 +1,17 @@
 //! Independent verification of the session-supervisor lane (M3-1b).
 //!
 //! This target is written as an outside-in check of the public contract the
-//! task describes, against a fake/mock process model. The module under review
-//! is **not** wired into `noren-app/src/lib.rs` yet (wiring is a later serial
-//! integration commit), so it is compiled into this test binary via `#[path]`.
-//! `cfg(test)` is enabled for the test binary, which also brings the lane's
-//! `mock` harness into scope.
+//! task describes, against a fake/mock process model. The module is wired into
+//! `noren-app/src/lib.rs` as `pub mod session_supervisor`, but this test also
+//! exercises the lane's `mock` harness, which is `#[cfg(test)]` inside
+//! `src/session_supervisor.rs`. A `#[cfg(test)]` item is only visible when the
+//! crate **itself** is the test target; an integration test is a separate
+//! crate, so `cfg(test)` is not set for the `noren-app` dependency and
+//! `noren_app::session_supervisor::mock` does not resolve here. The module is
+//! therefore still compiled into this test binary directly via `#[path]`, where
+//! `cfg(test)` *is* enabled for the test binary and `mock` is in scope. The
+//! non-`mock` public surface (`SessionSupervisor`, `SessionStatus`, …) is
+//! reachable from outside the crate; only the test-only `mock` harness is not.
 //!
 //! The load-bearing claim under test — the reason this lane exists — is that a
 //! dead child surfaces as `Exited`/`Failed` and never stays `Running`, that


### PR DESCRIPTION
## 問題（Issue #88）

Milestone 3 の7モジュールがすべて `main` にマージ済みだったが、`lib.rs` が宣言していたのは `session` と `sidebar` の2つだけだった。

残る `mouse`・`palette`・`passthrough`・`session_persistence`・`session_supervisor` は、統合テストが `#[path]` 属性で個別に取り込んでいたため、**非テストビルドでは一度もコンパイルされていなかった**。CI の clippy も dead_code 検査も、これらに対しては効いていなかった。

`GLMWIRE declared=5 tests_migrated=4 dead_code_items=0 reachable_verified=4/5 tests=PASS total=602`

## このPRが達成すること — そして達成しないこと

**達成する**: 5モジュールが**ライブラリにコンパイルされる**ようになる。CI のコンパイル・clippy・dead_code 検査が実際に効き、配線可能な状態になる。

**達成しない**: **製品バイナリにはまだ載らない。** 独立レビューがビルド済みバイナリに `nm` をかけて実証した — 5モジュールおよびその特徴的な項目（`MouseEncoder`・`Palette`・`Chord`・`SessionSupervisor`・`SessionPersistenceError`）のシンボルは**0件**。対照群（`config`=4・`diagnostics`=1・`renderer`=9）は存在する。

`main.rs` がどのモジュールも import していないため、リンク時にデッドストリップされる。既存の `session`・`sidebar` も同じ状態（シンボル0件）。

**バイナリに載せるには `main.rs` の配線コミットが必要**で、それは本PRのリース外。本PRはその必要な前提条件にあたる。

（当初このPRは「so they ship」と題していたが、レビューの指摘を受けて訂正した。）

## 可視性の選択（一律ではなく既存の慣習に沿って判断）

既存の `lib.rs` は2通りに分かれている：

- **名前空間としてパスで辿るドメインモジュール**（`session`・`sidebar`・`config`・`diagnostics`）→ `pub mod`
- **フラットな再エクスポートで露出するインフラ**（`clipboard`・`input`）→ `mod` + `pub use`

新規5モジュールはいずれも複数項目の表面をパスで辿るサブシステムであり（`mouse` → `MouseEncoder`/`MouseGrid`/`MouseModes`、`palette` → `Command`/`CommandId`/`Palette` 等）、前者に該当。**すべて `pub mod`**。

## `#[path]` からクレートインポートへの移行（4件）

`tests/palette.rs`・`tests/mouse_encoding.rs`・`tests/passthrough.rs`・`tests/session_persistence.rs` は `use noren_app::<module>` で到達する。`session_persistence` の `mod session` シムも削除。

## 移行できなかった2件（正直に報告）

`tests/session_supervisor.rs` と `tests/session_adversarial.rs` は `#[path]` のまま。回帰ガードが `session_supervisor::mock` に依存しており、これは `#[cfg(test)]`。**`cfg(test)` はテスト対象クレートにのみ設定され依存先には設定されない**ため、別クレートである統合テストからは解決できない。

この結果、`session_supervisor` の内部ユニットテスト14件が3ターゲット（lib + 統合2本）で実行される。カバレッジが増える良性の冗長であり、モジュール本体を変更せずには避けられない（リース外）。

## dead_code = 0

`src/` の `#[allow(dead_code)]` は `session_supervisor.rs` の `MockChild::exited` 1件のみで、**`origin/main` に既に存在**していた（本PRの追加ではない）。一律の `#[allow]` による握りつぶしは行っていない。

## テスト

3ゲートすべて緑。**602 passed, 0 failed**。テストの消失なし（レビュアーが名前単位で検証済み）。

## 既知のフォローアップ

`src/session_supervisor.rs` のモジュールドキュメントに「意図的に `lib.rs` で宣言されていない」という記述があり、本PRによって偽になる。同ファイルはリース外のため本PRでは修正できない。

## ロールバック

このブランチの revert で完結する。モジュール本体には一切変更を加えていない（宣言と可視性のみ）。