### PR TITLE
chore: clear four review follow-ups (#87 #93 #94 #95)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,12 +64,20 @@ direct `zsh` child, and that child's tty reported `30 90` — the 900x600 window
 by the 10x20 cell, so the window to grid to PTY chain agrees. On termination the app
 exited, the child was reaped, and the pty device was gone.
 
-**What this does not establish.** There is still no rendered-frame oracle and no key
-injection into the real window, so glyph correctness and live input remain unverified
-by automation; the byte-level input contract is covered by tests instead. Mouse
-reporting is unimplemented and, per Issue #46, belongs in an input encoder rather than
-output-side parsing. Truecolor is modelled in terminal state but not yet wired to
-drawing. IME and accessibility remain deferred.
+**What this does not establish.** A rendered-frame oracle now exists
+(`crates/noren-app/tests/frame_oracle.rs`, `crates/noren-app/src/renderer_capture.rs`,
+PR #89): it drives the real `wgpu` pipeline offscreen and checks *structural*
+properties — blank cells are dark, distinct glyphs have distinct lit patterns,
+glyphs do not bleed into neighbouring cells, and the drawn grid agrees with the
+terminal-state snapshot. It does **not** verify that an `A` is shaped like an A,
+and two of its tests are `#[ignore]`d because they document real font defects
+(case-folding in the bitmap font, and every non-ASCII code point falling through
+to the `?` glyph). Key injection into the real window still does not exist, so
+live keyboard input remains unverified by automation; the byte-level input
+contract is covered by tests instead. Mouse reporting is implemented as an input
+encoder (PR #79, `crates/noren-app/src/mouse.rs`). Truecolor is modelled in
+terminal state but not yet wired to drawing. IME and accessibility remain
+deferred.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.

--- a/crates/noren-app/src/palette.rs
+++ b/crates/noren-app/src/palette.rs
@@ -24,7 +24,7 @@
 //! enum of its own, so it cannot drift into a parallel vocabulary. At wire-up
 //! (a separate, serial commit owned by another lane) `A` is bound to the shared
 //! action type that reuses `SessionAction` from
-//! `docs/coordination/decisions/D-M3-001-session-api.md`; this module supplies
+//! `docs/coordination/session-api.md`; this module supplies
 //! only the stable IDs, labels, and matching policy.
 //!
 //! # Matching

--- a/crates/noren-app/src/session_supervisor.rs
+++ b/crates/noren-app/src/session_supervisor.rs
@@ -43,13 +43,35 @@
 //! trait, the [`Spawner`] seam, [`SessionSupervisor`] itself, the reaping state
 //! machine, the mock) is this lane's real, non-stub deliverable.
 //!
-//! # Not wired yet
+//! # Wiring status
 //!
-//! This module is intentionally **not** declared in `crates/noren-app/src/lib.rs`
-//! (wiring is a later serial integration commit). The integration test includes
-//! it via `#[path = "../src/session_supervisor.rs"]` so it compiles and runs as
-//! a standalone test target against a fake/mock process model plus a failure
-//! matrix. See `tests/session_supervisor.rs`.
+//! This module is on `main` in three senses, only the last of which is
+//! load-bearing for shipping:
+//!
+//! 1. It is a file in the source tree.
+//! 2. It is declared in `crates/noren-app/src/lib.rs` and compiled into the
+//!    **library** (PR #92), so CI clippy and dead-code checks cover it.
+//! 3. It is **not in the linked binary**: `main.rs` imports none of the M3
+//!    modules (`session_supervisor`, `session`, `sidebar`, `palette`,
+//!    `passthrough`, `session_persistence`, `mouse`), so the linker strips
+//!    them. A reviewer confirmed with `nm` — zero `session_supervisor`
+//!    symbols, against controls (`config`, `diagnostics`, `renderer`) that
+//!    do appear in the binary.
+//!
+//! # Why the integration tests still use `#[path]`
+//!
+//! `mock` is `#[cfg(test)]`, and `cfg(test)` is set only for the crate
+//! under test — not for its dependencies. An integration test is a separate
+//! crate that links the `noren_app` library as a dependency; the library was
+//! compiled *without* `cfg(test)`, so the `mock` module does not exist in it
+//! and the test cannot reach it through the `noren_app::session_supervisor`
+//! path. The integration tests `tests/session_supervisor.rs` and
+//! `tests/session_adversarial.rs` therefore include this file via
+//! `#[path = "../src/session_supervisor.rs"]`, which compiles a private copy
+//! *inside the test crate* where `cfg(test)` **is** set. This is also why
+//! the unit tests below run in three targets (the library's own test build
+//! plus each integration test). The `#[path]` includes are not redundant
+//! with the `lib.rs` declaration — removing them breaks the tests.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -749,10 +771,13 @@ fn shutdown_to_failure(reason: ShutdownError) -> SessionFailure {
 // The mock is a tiny shared-state machine a test drives through a
 // [`mock::MockController`]: flip the child to exited, or toggle poll/shutdown
 // failures. This is what makes the failure matrix deterministic without
-// spawning real processes. It is `pub` under `cfg(test)` so both this module's
-// unit tests and the `tests/session_supervisor.rs` integration target (which
-// includes this file via `#[path]`, and for which `cfg(test)` is also enabled)
-// share one definition. Production never references it.
+// spawning real processes. It is `pub` under `cfg(test)` so this module's
+// unit tests and the `tests/session_supervisor.rs` and
+// `tests/session_adversarial.rs` integration targets (which include this file
+// via `#[path]`, and for which `cfg(test)` is also enabled) share one
+// definition. See the module-level "Why the integration tests still use
+// `#[path]`" section for why the `#[path]` includes cannot be replaced by a
+// library path. Production never references it.
 
 #[cfg(test)]
 pub mod mock {

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -41,9 +41,7 @@
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
 
-use noren_app::{
-    MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH,
-};
+use noren_app::{POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
@@ -378,32 +376,4 @@ fn utf8_cell_is_at_least_lit_so_the_pipeline_handles_wide_input() {
     let frame = render(&renderer, &snap);
     // c, a, f are ASCII and lit; the final cell holds the non-ASCII 'é' lead.
     assert!(cell_is_lit(&frame, 0, 3), "non-ASCII cell drew nothing");
-}
-
-// Keep the render-grid clamps reachable from the oracle's view of the world.
-#[test]
-fn oracle_constants_match_the_renderer_clamps() {
-    // The renderer clamps to MAX_RENDER_ROWS x MAX_RENDER_COLS; the oracle must
-    // reason in the same bounds or its "grid matches state" claim is hollow.
-    //
-    // Asserting the constants are positive would be a tautology the compiler
-    // optimises away. Instead drive a state larger than the clamp through the
-    // real vertex path and confirm the drawn grid actually stops at the clamp —
-    // that is the property the oracle depends on.
-    let oversized = snapshot(MAX_RENDER_ROWS + 4, MAX_RENDER_COLS + 4, b"");
-    let vertices = renderer_capture::renderer_source::glyph_vertices(
-        Some(&oversized),
-        None,
-        u32::from(MAX_RENDER_COLS + 4) * CELL_WIDTH,
-        u32::from(MAX_RENDER_ROWS + 4) * CELL_HEIGHT,
-    );
-    let max_vertices = (MAX_RENDER_ROWS as usize) * (MAX_RENDER_COLS as usize) * 35 * 6;
-    assert!(
-        vertices.len() <= max_vertices,
-        "renderer emitted {} vertices, past the {}x{} clamp ceiling of {}",
-        vertices.len(),
-        MAX_RENDER_ROWS,
-        MAX_RENDER_COLS,
-        max_vertices
-    );
 }

--- a/docs/coordination/handoffs/glm-palette.md
+++ b/docs/coordination/handoffs/glm-palette.md
@@ -49,7 +49,7 @@ A test asserts that no canonical command id or label contains `pane`, `tab`,
 `Command<A>` is **generic over the action type**. The palette defines no session or
 sidebar action enum of its own, so it cannot drift into a parallel vocabulary. At
 wire-up, `A` is bound to the shared action type that reuses `SessionAction` from
-`docs/coordination/decisions/D-M3-001-session-api.md` (which did not yet exist on
+`docs/coordination/session-api.md` (which did not yet exist on
 `main` when this lane ran). `Palette::noren(create, select, close, sidebar_focus)`
 takes the four dispatchable actions from the caller — the wiring layer supplies the
 real `SessionAction`/sidebar values, and the palette only assigns the stable IDs and


### PR DESCRIPTION
レビューで発見され、より大きな作業を優先して意図的に繰り延べられていた4件を一括処理。**Issue ごとに1コミット**なので個別に revert できる。

`GLMFOLLOWUPS i87=fixed i93=deleted i94=fixed stale_claims_in_roadmap=3 i95=fixed tests=PASS total=601`

## Issue #87 — 存在しないファイルへの参照

`palette.rs` と `glm-palette.md` が `docs/coordination/decisions/D-M3-001-session-api.md` を引用していたが、**このファイルは存在したことがない**。実体は `docs/coordination/session-api.md`。

配線レーンはこの引用を辿って session API 契約を学ぶよう指示されるため、死んだ参照は実装者を憶測に追い込む。

## Issue #93 — 恒真テストを**削除**した（置き換えではなく）

`oracle_constants_match_the_renderer_clamps` は空のターミナルを渡していたため `0 <= 604800` で自明に真だった。

指示では「中身の詰まったグリッドを流すか、削除するか」を判断させたが、レーンは**実験して**判断している：

> 5万個の `A` でグリッドを埋め、`glyph_vertices` の行・列両方の `.clamp()` を削除したが、**テストは依然として通った** — `MAX_VERTICES` の早期リターンが同じ上限で独立に頂点数を抑えるため。`<=` 系のアサーションでは行・列クランプとこのバックストップを区別できず、置き換えても同じ誤りを繰り返すことになる。

既存のユニットテスト `glyph_input_is_bounded_to_visible_poc_grid` が実入力での頂点上限を既にカバーしているため削除で十分。実験後にクランプは復元済み。

**「置き換えを書く」より「なぜ置き換えが不可能か」を示した方が価値が高い**判断。

## Issue #94 — ROADMAP の M2 エビデンス節、陳腐化3件

| 主張 | 訂正 |
|---|---|
| 「レンダーフレームオラクルがない」 | 存在する（PR #89）。ただし構造的検査のみで、2件は `#[ignore]` されたフォント欠陥テスト |
| 「グリフの正しさは未検証」 | 構造的には検証済み。**字形**は未検証 |
| 「マウスレポートは未実装」 | 入力エンコーダとして実装済み（PR #79） |

真である主張（実ウィンドウへのキー注入なし、truecolor が描画に届かない、IME・アクセシビリティ繰り延べ）は保持。

## Issue #95 — `session_supervisor.rs` のドキュメント

`# Not wired yet` を、正確な3層の状態に置き換えた：`main` のファイル → `lib.rs` で宣言されライブラリにコンパイル（PR #92）→ **リンク済みバイナリには不在**（`nm` で確認）。

加えて `#[cfg(test)]` の `mock` 制約を専用節で文書化した。`cfg(test)` はテスト対象クレートにのみ設定されるため統合テストから到達できず、`tests/session_supervisor.rs` と `tests/session_adversarial.rs` が `#[path]` を維持している理由と、**それを「整理」するとテストが壊れる**ことを明記している。

## 検証

fmt / clippy(-D warnings) / test / `--ignored`（2件失敗を維持）/ check_docs すべて通過。**601 passed**（#93 のテスト削除により 602 から1減）。