### PR TITLE
feat(app): draw the sidebar as a left column with offset terminal (M3 step 2/3)

### DIFF
--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -4,9 +4,9 @@ mod renderer;
 
 use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
-    KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_ROWS, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH, PasteReject, Resize,
-    SystemClipboard,
+    KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_COLS,
+    MAX_RENDER_ROWS, Modifiers, PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH,
+    PasteReject, Resize, SystemClipboard,
     config::AppConfig,
     diagnostics::{self, PtyChildStatus},
     encode_paste,
@@ -490,8 +490,7 @@ impl NorenApp {
         let physical = window.inner_size();
         // The sidebar occupies the leftmost SIDEBAR_COLS cell columns; clicks
         // inside it do not address the terminal grid.
-        let sidebar_px = f64::from((renderer::SIDEBAR_COLS as u32) * POC_CELL_WIDTH);
-        if position.x < sidebar_px {
+        if position.x < sidebar_pixel_width() {
             return None;
         }
         let visible_rows = usize::try_from(physical.height / POC_CELL_HEIGHT)
@@ -514,8 +513,7 @@ impl NorenApp {
         if line_index >= usize::from(rows) {
             return None;
         }
-        let column =
-            pixel_row_index(position.x - sidebar_px, POC_CELL_WIDTH)?.min(usize::from(cols) - 1);
+        let column = terminal_column_at(position.x, cols)?;
         Some(GridPoint::new(
             terminal.scrollback_len() + line_index,
             column,
@@ -800,13 +798,22 @@ fn pty_size(rows: u16, cols: u16) -> Result<PtySize, noren_pty::PtyError> {
 }
 
 /// Terminal column count for a given window column count, reserving
-/// [`renderer::SIDEBAR_COLS`] columns on the left for the sidebar. The PTY
-/// winsize, terminal state's column count, and the renderer's drawn region all
-/// use this value so they never disagree.
+/// [`renderer::SIDEBAR_COLS`] columns on the left for the sidebar and clamping
+/// the remainder to the renderer's drawable budget. The PTY winsize, terminal
+/// state's column count, and the renderer's drawn region all use this value so
+/// they never disagree.
+///
+/// Reserve the sidebar first, then clamp the terminal to
+/// `MAX_RENDER_COLS - SIDEBAR_COLS` (floored at one). The sidebar sits *inside*
+/// the renderer's `MAX_RENDER_COLS` ceiling, so the terminal must never be told
+/// it owns more columns than the renderer can draw beside the sidebar —
+/// otherwise columns are clipped invisibly. `renderer::glyph_vertices` applies
+/// the identical formula independently; the sidebar geometry test pins that the
+/// two sites agree.
 fn terminal_cols(window_cols: u16) -> u16 {
-    window_cols
-        .saturating_sub(u16::try_from(renderer::SIDEBAR_COLS).unwrap_or(u16::MAX))
-        .max(1)
+    let sidebar = u16::try_from(renderer::SIDEBAR_COLS).unwrap_or(u16::MAX);
+    let budget = MAX_RENDER_COLS.saturating_sub(sidebar).max(1);
+    window_cols.saturating_sub(sidebar).clamp(1, budget)
 }
 
 /// Convert the sidebar view into text lines the renderer can draw.
@@ -843,6 +850,26 @@ fn pixel_row_index(pixel: f64, cell_size: u32) -> Option<usize> {
         return None;
     }
     Some((pixel / f64::from(cell_size)) as usize)
+}
+
+/// Pixel width of the sidebar's left strip: `SIDEBAR_COLS` cell columns. The
+/// terminal is drawn to the right of this edge, so a click at exactly this x is
+/// the first terminal column.
+fn sidebar_pixel_width() -> f64 {
+    f64::from((renderer::SIDEBAR_COLS as u32) * POC_CELL_WIDTH)
+}
+
+/// Terminal cell column under pixel x, or `None` when the click lands in the
+/// sidebar strip, on a non-finite coordinate, or past the grid. The sidebar
+/// boundary is exclusive: x exactly at [`sidebar_pixel_width`] is the first
+/// terminal column and maps to cell 0; anything strictly left of it is the
+/// sidebar and is rejected.
+fn terminal_column_at(pixel_x: f64, terminal_cols: u16) -> Option<usize> {
+    if !pixel_x.is_finite() || pixel_x < sidebar_pixel_width() {
+        return None;
+    }
+    pixel_row_index(pixel_x - sidebar_pixel_width(), POC_CELL_WIDTH)
+        .map(|raw| raw.min(usize::from(terminal_cols).saturating_sub(1)))
 }
 
 /// Number of visible grid rows the renderer will draw: rows up to and
@@ -1445,5 +1472,266 @@ mod tests {
                 .any(|hit| hit.command().id() == CommandId::SESSION_CREATE),
             "searching 'session' must find the create command"
         );
+    }
+
+    // =========================================================================
+    // Sidebar geometry: the terminal width, the PTY winsize, and the renderer's
+    // drawn region must all agree once the sidebar reserves 16 columns.
+    // =========================================================================
+
+    /// Number of terminal cell columns the renderer drew, measured from its
+    /// vertex output rather than restating the column formula. Each terminal
+    /// column is fed a glyph the renderer lights starting at the cell's left
+    /// pixel edge (`B` lights glyph column 0), so a drawn column is detectable
+    /// as a glyph rect whose LEFT edge sits on that boundary. Scanning runs
+    /// rightward from the first terminal column (`SIDEBAR_COLS`) until a column
+    /// has no glyph — terminal content is contiguous, so the first gap marks
+    /// the end of the drawn region.
+    ///
+    /// Matching a rect's left edge (its top-left corner) — not *any* vertex on
+    /// the boundary — is essential: a glyph's rightmost lit pixel column (e.g.
+    /// `B`, whose rows `17 = 0b10001` light glyph column 4) produces a rect
+    /// whose RIGHT edge lands exactly on the next column's left edge. Matching
+    /// arbitrary vertices would count that bleed as a drawn column and over-
+    /// count by one. Each rect is emitted as a 6-vertex fan whose first vertex
+    /// is its top-left corner, so the left edges are read from every 6th group.
+    fn rendered_terminal_columns(vertices: &[[f32; 2]], width: u32) -> usize {
+        let rect_lefts: Vec<f32> = vertices.chunks_exact(6).map(|rect| rect[0][0]).collect();
+        let mut drawn = 0;
+        for col in renderer::SIDEBAR_COLS..usize::from(MAX_RENDER_COLS) {
+            let edge = ((col as u32) * POC_CELL_WIDTH) as f32 / width as f32 * 2.0 - 1.0;
+            if rect_lefts.iter().any(|left| (left - edge).abs() < 1e-5) {
+                drawn += 1;
+            } else {
+                break;
+            }
+        }
+        drawn
+    }
+
+    /// Drive the three terminal-width consumers — `TerminalState`'s stored
+    /// column count, the PTY winsize, and the columns the renderer actually
+    /// draws — at one window width, asserting they all agree on
+    /// `terminal_cols(window_cols)`. Asserting `terminal_cols() == window_cols -
+    /// 16` would merely restate the formula and pass any consistent-but-wrong
+    /// value; instead this exercises the three real consumers and is shared by
+    /// the swept agreement test below across every regime where they can drift
+    /// apart.
+    fn assert_three_consumers_agree_at(width: u32) {
+        let height = 600_u32;
+        // Grid columns and the renderer's visible columns both derive
+        // `width / CELL_WIDTH`, so they share this `window_cols`.
+        let window_cols = u16::try_from(width / POC_CELL_WIDTH).expect("fits in u16");
+        let cols = terminal_cols(window_cols);
+
+        // Consumer 1: the terminal state stores the sidebar-adjusted width.
+        let rows = u16::try_from(height / POC_CELL_HEIGHT).expect("fits in u16");
+        let mut terminal = TerminalState::new(rows, cols).expect("valid terminal");
+        // Fill every terminal column of row 0 so each drawn column is visible
+        // to `rendered_terminal_columns` via its left pixel edge.
+        terminal.feed_bytes(&vec![b'B'; usize::from(cols)]);
+        let (_, term_cols) = terminal.size();
+        assert_eq!(
+            term_cols, cols,
+            "at {width}px: terminal must store terminal_cols({window_cols}) = {cols}"
+        );
+
+        // Consumer 2: the PTY winsize carries the same column count.
+        let pty = pty_size(rows, cols).expect("valid pty size");
+        assert_eq!(
+            pty.cols(),
+            cols,
+            "at {width}px: PTY winsize must agree with the terminal"
+        );
+
+        // Consumer 3: the renderer draws exactly that many terminal columns —
+        // measured from vertex output, independent of `terminal_cols`.
+        let snapshot = terminal.snapshot();
+        let sidebar: Vec<String> = Vec::new();
+        let vertices = renderer::glyph_vertices(
+            Some(&snapshot),
+            Some(sidebar.as_slice()),
+            None,
+            width,
+            height,
+        );
+        let drawn = rendered_terminal_columns(&vertices, width);
+        assert_eq!(
+            drawn,
+            usize::from(cols),
+            "at {width}px (window_cols={window_cols}): renderer drew {drawn} terminal columns but \
+             terminal/PTY agree on {cols} — the sidebar width is not consistently subtracted or \
+             the upper clamp is missing"
+        );
+    }
+
+    /// The PR's headline property: the three consumers agree once the sidebar
+    /// reserves 16 columns — swept across the input range rather than pinned at
+    /// one width. A single point cannot support "agreement across the range",
+    /// and the original 900px point sits squarely inside the band (17..=160
+    /// columns) where the pre-fix geometry already agreed. Each swept width
+    /// targets a distinct regime so a regression of either pre-fix defect is
+    /// caught:
+    ///   - 80px   (8 cols, below the sidebar width): the floor regime. A
+    ///     renderer that floored at zero terminal columns while the terminal
+    ///     and PTY held one is exposed.
+    ///   - 900px  (90 cols, a typical window): the common case — the very width
+    ///     a prior commit message wrongly cited as the divergence (both the
+    ///     pre- and post-fix geometry agree at 74 here).
+    ///   - 1600px (160 cols, exactly `MAX_RENDER_COLS`): the budget boundary,
+    ///     where the terminal fills the whole drawable budget (144).
+    ///   - 2000px (200 cols, above `MAX_RENDER_COLS`): the upper-clamp regime.
+    ///     A `terminal_cols` with no upper clamp would claim 184 columns while
+    ///     the renderer draws 144, silently clipping 40 columns of output.
+    ///
+    /// This is a regression guard, not a reproduced bug: at the moment this
+    /// test was added all three consumers already agreed at every swept width,
+    /// and it exists to hold that line. Mutating `terminal_cols` to drop the
+    /// sidebar subtraction breaks the typical/above-max widths, and dropping
+    /// the upper clamp breaks the 2000px width.
+    #[test]
+    fn terminal_cols_pty_winsize_and_renderer_agree_across_the_width_range() {
+        for width in [80_u32, 900, 1600, 2000] {
+            assert_three_consumers_agree_at(width);
+        }
+    }
+
+    /// MINOR-1: below ~160px the window fits inside the sidebar. `terminal_cols`
+    /// floors at one (the terminal/PTY reject zero columns); the renderer must
+    /// floor at the same one rather than drawing zero terminal columns while the
+    /// terminal still holds one. Drives the real renderer so the agreement is
+    /// measured, not assumed.
+    #[test]
+    fn terminal_cols_and_renderer_floor_at_one_below_the_sidebar() {
+        // A window exactly SIDEBAR_COLS wide: visible_cols == SIDEBAR_COLS, so
+        // the terminal region has no room — both floors must keep it at one.
+        let width = (renderer::SIDEBAR_COLS as u32) * POC_CELL_WIDTH;
+        let height = 600_u32;
+        let window_cols = u16::try_from(width / POC_CELL_WIDTH).expect("fits in u16");
+        assert_eq!(window_cols, u16::try_from(renderer::SIDEBAR_COLS).unwrap());
+        let cols = terminal_cols(window_cols);
+        assert_eq!(cols, 1, "terminal_cols floors at one, never zero");
+
+        let mut terminal = TerminalState::new(2, cols).expect("valid terminal");
+        terminal.feed_bytes(&vec![b'B'; usize::from(cols)]);
+        let snapshot = terminal.snapshot();
+        let sidebar: Vec<String> = Vec::new();
+        let vertices = renderer::glyph_vertices(
+            Some(&snapshot),
+            Some(sidebar.as_slice()),
+            None,
+            width,
+            height,
+        );
+        let drawn = rendered_terminal_columns(&vertices, width);
+        assert_eq!(
+            drawn,
+            usize::from(cols),
+            "renderer must draw the terminal's one column, not zero — the floor \
+             disagrees with terminal_cols below the sidebar width"
+        );
+    }
+
+    /// MINOR-2: `sidebar_text_lines` is the seam between the view model and the
+    /// renderer. Drive a real `SidebarView` built by the workspace from a live
+    /// registry — not hardcoded strings — so a change in how rows are formatted
+    /// is caught here.
+    #[test]
+    fn sidebar_text_lines_format_a_real_workspace_sidebar() {
+        // Empty workspace: the empty-state notice is the sole line.
+        let empty = WorkspaceState::new();
+        assert_eq!(
+            sidebar_text_lines(empty.sidebar()),
+            vec!["No sessions".to_string()],
+            "empty workspace renders its empty-state notice"
+        );
+
+        let mut state = WorkspaceState::new();
+        let first = state.create_session(SessionKind::Local);
+        let second = state.create_session(SessionKind::Local);
+        state.select_session(first).expect("first session is live");
+
+        let lines = sidebar_text_lines(state.sidebar());
+        assert_eq!(lines.len(), 2, "one formatted line per sidebar row");
+
+        // The selected row is prefixed with '>' and the unselected with a
+        // space; both carry the real descriptor's label and detail.
+        assert!(
+            lines[0].starts_with("> "),
+            "selected row must be marked with '>': {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[1].starts_with("  "),
+            "unselected row must be marked with a space: {:?}",
+            lines[1]
+        );
+        assert!(
+            lines[0].contains(first.to_string().as_str()),
+            "selected row carries the session label: {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[1].contains(second.to_string().as_str()),
+            "unselected row carries the session label: {:?}",
+            lines[1]
+        );
+        // A freshly created session sits at the Starting status, so the detail
+        // is derived from the real descriptor, not a constant.
+        assert!(
+            lines[0].contains("local · starting"),
+            "detail comes from the real descriptor: {:?}",
+            lines[0]
+        );
+    }
+
+    /// MINOR-3: `grid_point_at`'s sidebar boundary. A click in the last sidebar
+    /// column must be rejected, and a click at the first terminal column must
+    /// map to terminal cell 0. `grid_point_at` itself needs a live window this
+    /// harness cannot create, so this drives the extracted column mapper that
+    /// `grid_point_at` delegates to.
+    #[test]
+    fn terminal_column_at_rejects_the_sidebar_and_starts_the_terminal_at_zero() {
+        let cols = 40_u16;
+        let sidebar_edge = sidebar_pixel_width();
+
+        // The last sidebar column — just inside the sidebar's right edge — does
+        // not address the terminal grid.
+        assert_eq!(
+            terminal_column_at(sidebar_edge - 1.0, cols),
+            None,
+            "a click in the last sidebar column must be rejected"
+        );
+        // The first terminal column, exactly at the sidebar's right edge, maps
+        // to terminal cell 0.
+        assert_eq!(
+            terminal_column_at(sidebar_edge, cols),
+            Some(0),
+            "the first terminal column must map to cell 0"
+        );
+        // One cell width further in lands in terminal cell 1.
+        assert_eq!(
+            terminal_column_at(sidebar_edge + f64::from(POC_CELL_WIDTH), cols),
+            Some(1)
+        );
+        // The last terminal column maps to the highest valid cell.
+        assert_eq!(
+            terminal_column_at(
+                sidebar_edge + f64::from(POC_CELL_WIDTH) * f64::from(cols - 1),
+                cols
+            ),
+            Some(usize::from(cols - 1))
+        );
+        // A click past the last column clamps to the last cell, never overflows.
+        assert_eq!(
+            terminal_column_at(
+                sidebar_edge + f64::from(POC_CELL_WIDTH) * f64::from(cols),
+                cols
+            ),
+            Some(usize::from(cols - 1))
+        );
+        // Negative and non-finite clicks are rejected.
+        assert_eq!(terminal_column_at(-1.0, cols), None);
+        assert_eq!(terminal_column_at(f64::NAN, cols), None);
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -133,7 +133,6 @@ impl WorkspaceState {
     }
 
     /// The current sidebar view (immutable snapshot for the renderer).
-    #[allow(dead_code)]
     fn sidebar(&self) -> &SidebarView {
         &self.sidebar
     }
@@ -248,31 +247,32 @@ impl NorenApp {
             return;
         };
 
-        let Ok(terminal) = TerminalState::new(grid.rows(), grid.cols()) else {
+        let Ok(terminal) = TerminalState::new(grid.rows(), terminal_cols(grid.cols())) else {
             eprintln!("Noren terminal state creation failed");
             event_loop.exit();
             return;
         };
         self.terminal = Some(terminal);
-        self.pty = match pty_size(grid).and_then(PtySession::spawn) {
-            Ok(session) => {
-                self.status = "Noren PoC ready";
-                self.show_status = false;
-                self.pty_child = PtyChildStatus::Running;
-                let session_id = self.workspace.create_session(SessionKind::Local);
-                self.workspace
-                    .select_session(session_id)
-                    .expect("freshly created session is live");
-                self.active_session = Some(session_id);
-                Some(session)
-            }
-            Err(_) => {
-                self.status = "Noren PTY start failed";
-                self.show_status = true;
-                self.pty_child = PtyChildStatus::NotLaunched;
-                None
-            }
-        };
+        self.pty =
+            match pty_size(grid.rows(), terminal_cols(grid.cols())).and_then(PtySession::spawn) {
+                Ok(session) => {
+                    self.status = "Noren PoC ready";
+                    self.show_status = false;
+                    self.pty_child = PtyChildStatus::Running;
+                    let session_id = self.workspace.create_session(SessionKind::Local);
+                    self.workspace
+                        .select_session(session_id)
+                        .expect("freshly created session is live");
+                    self.active_session = Some(session_id);
+                    Some(session)
+                }
+                Err(_) => {
+                    self.status = "Noren PTY start failed";
+                    self.show_status = true;
+                    self.pty_child = PtyChildStatus::NotLaunched;
+                    None
+                }
+            };
         self.renderer = match Renderer::new(Arc::clone(&window)) {
             Ok(renderer) => Some(renderer),
             Err(_) => {
@@ -488,6 +488,12 @@ impl NorenApp {
         let terminal = self.terminal.as_ref()?;
         let window = self.window.as_ref()?;
         let physical = window.inner_size();
+        // The sidebar occupies the leftmost SIDEBAR_COLS cell columns; clicks
+        // inside it do not address the terminal grid.
+        let sidebar_px = f64::from((renderer::SIDEBAR_COLS as u32) * POC_CELL_WIDTH);
+        if position.x < sidebar_px {
+            return None;
+        }
         let visible_rows = usize::try_from(physical.height / POC_CELL_HEIGHT)
             .unwrap_or(0)
             .clamp(1, usize::from(MAX_RENDER_ROWS));
@@ -508,7 +514,8 @@ impl NorenApp {
         if line_index >= usize::from(rows) {
             return None;
         }
-        let column = pixel_row_index(position.x, POC_CELL_WIDTH)?.min(usize::from(cols) - 1);
+        let column =
+            pixel_row_index(position.x - sidebar_px, POC_CELL_WIDTH)?.min(usize::from(cols) - 1);
         Some(GridPoint::new(
             terminal.scrollback_len() + line_index,
             column,
@@ -588,13 +595,14 @@ impl NorenApp {
         // Resize re-addresses the grid, so captured coordinates expire.
         self.selection = None;
         self.drag_origin = None;
+        let cols = terminal_cols(grid.cols());
         if let Some(terminal) = &mut self.terminal {
-            if terminal.resize(grid.rows(), grid.cols()).is_err() {
+            if terminal.resize(grid.rows(), cols).is_err() {
                 self.status = "Noren terminal resize failed";
                 self.show_status = true;
             }
         }
-        if let (Some(session), Ok(size)) = (&self.pty, pty_size(grid)) {
+        if let (Some(session), Ok(size)) = (&self.pty, pty_size(grid.rows(), cols)) {
             if session.resize(size).is_err() {
                 self.status = "Noren PTY resize failed";
                 self.show_status = true;
@@ -690,10 +698,11 @@ impl NorenApp {
         } else {
             None
         };
+        let sidebar_lines = sidebar_text_lines(self.workspace.sidebar());
         let outcome = self
             .renderer
             .as_mut()
-            .map(|renderer| renderer.render(snapshot.as_ref(), status));
+            .map(|renderer| renderer.render(snapshot.as_ref(), Some(&sidebar_lines), status));
         match outcome {
             Some(RenderOutcome::DeviceLost) => {
                 self.status = "Noren renderer device lost";
@@ -786,8 +795,44 @@ impl ApplicationHandler for NorenApp {
     }
 }
 
-fn pty_size(grid: GridSize) -> Result<PtySize, noren_pty::PtyError> {
-    PtySize::from_raw(grid.rows(), grid.cols()).ok_or(noren_pty::PtyError::InvalidSize)
+fn pty_size(rows: u16, cols: u16) -> Result<PtySize, noren_pty::PtyError> {
+    PtySize::from_raw(rows, cols).ok_or(noren_pty::PtyError::InvalidSize)
+}
+
+/// Terminal column count for a given window column count, reserving
+/// [`renderer::SIDEBAR_COLS`] columns on the left for the sidebar. The PTY
+/// winsize, terminal state's column count, and the renderer's drawn region all
+/// use this value so they never disagree.
+fn terminal_cols(window_cols: u16) -> u16 {
+    window_cols
+        .saturating_sub(u16::try_from(renderer::SIDEBAR_COLS).unwrap_or(u16::MAX))
+        .max(1)
+}
+
+/// Convert the sidebar view into text lines the renderer can draw.
+///
+/// Each row is prefixed with `>` when selected, space otherwise, followed by
+/// the label and optional detail — using [`SidebarRow::label`] and
+/// [`SidebarRow::detail`] verbatim. When the sidebar is empty the
+/// empty-state message is returned as the sole line.
+fn sidebar_text_lines(sidebar: &SidebarView) -> Vec<String> {
+    if sidebar.is_empty() {
+        return sidebar
+            .empty_state()
+            .map(|state| vec![state.message().to_string()])
+            .unwrap_or_default();
+    }
+    sidebar
+        .rows()
+        .iter()
+        .map(|row| {
+            let marker = if row.is_selected() { '>' } else { ' ' };
+            match row.detail() {
+                Some(detail) => format!("{marker} {} {}", row.label(), detail),
+                None => format!("{marker} {}", row.label()),
+            }
+        })
+        .collect()
 }
 
 /// Index of the cell row containing a non-negative pixel coordinate, or

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -18,6 +18,15 @@ const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize) * (MAX_RENDER_COLS as usize) * 35 * 6;
 
+/// Width of the left sidebar in cell columns. The terminal occupies the
+/// remaining columns to the right, drawn at a pixel offset of
+/// `SIDEBAR_COLS * CELL_WIDTH`.
+///
+/// Exposed as `pub(crate)` so `main.rs` can subtract it from the PTY/terminal
+/// grid, and so the frame oracle (`renderer_capture.rs`) can render sidebar
+/// content through the same pipeline.
+pub(crate) const SIDEBAR_COLS: usize = 16;
+
 /// WGSL source for the PoC glyph pipeline.
 ///
 /// Exposed as `pub(crate)` solely so the offscreen frame-oracle
@@ -190,13 +199,20 @@ impl Renderer {
     pub(crate) fn render(
         &mut self,
         terminal: Option<&TerminalSnapshot>,
+        sidebar: Option<&[String]>,
         status: Option<&str>,
     ) -> RenderOutcome {
         if self.device_lost.load(Ordering::Acquire) {
             return RenderOutcome::DeviceLost;
         }
 
-        let vertices = glyph_vertices(terminal, status, self.config.width, self.config.height);
+        let vertices = glyph_vertices(
+            terminal,
+            sidebar,
+            status,
+            self.config.width,
+            self.config.height,
+        );
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
         if required > self.vertex_capacity {
@@ -287,8 +303,15 @@ fn block_on<F: Future>(future: F) -> F::Output {
 
 /// Exposed as `pub(crate)` for the offscreen frame-oracle (see
 /// `renderer_capture.rs`); no behaviour change.
+///
+/// When `sidebar` is `Some`, the first [`SIDEBAR_COLS`] columns are reserved
+/// for the sidebar text and the terminal is drawn starting at column
+/// `SIDEBAR_COLS`. When `sidebar` is `None`, the terminal occupies the full
+/// width starting at column 0 (preserving the pre-sidebar behaviour the frame
+/// oracle's existing tests rely on).
 pub(crate) fn glyph_vertices(
     terminal: Option<&TerminalSnapshot>,
+    sidebar: Option<&[String]>,
     status: Option<&str>,
     width: u32,
     height: u32,
@@ -302,6 +325,23 @@ pub(crate) fn glyph_vertices(
     let visible_cols = usize::try_from(width / CELL_WIDTH)
         .unwrap_or(usize::MAX)
         .clamp(1, usize::from(MAX_RENDER_COLS));
+
+    let has_sidebar = sidebar.is_some();
+    let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
+    let terminal_cols = visible_cols.saturating_sub(col_offset);
+    let mut vertices = Vec::new();
+
+    if let Some(lines) = sidebar {
+        for (row, line) in lines.iter().take(visible_rows).enumerate() {
+            for (col, character) in line.chars().take(SIDEBAR_COLS).enumerate() {
+                push_glyph(&mut vertices, character, col, row, width, height);
+                if vertices.len() >= MAX_VERTICES {
+                    return vertices;
+                }
+            }
+        }
+    }
+
     // display_lines preserves wide-character continuation columns, so the
     // character index below is the display column for every glyph.
     let lines = terminal
@@ -309,7 +349,6 @@ pub(crate) fn glyph_vertices(
         .unwrap_or_default();
     let total_lines = lines.len() + usize::from(status.is_some());
     let first_line = total_lines.saturating_sub(visible_rows);
-    let mut vertices = Vec::new();
 
     for (row, line_index) in (first_line..total_lines).enumerate() {
         let line = if line_index < lines.len() {
@@ -317,27 +356,47 @@ pub(crate) fn glyph_vertices(
         } else {
             status.unwrap_or_default()
         };
-        for (col, character) in line.chars().take(visible_cols).enumerate() {
-            let glyph = glyph_rows(character);
-            for (glyph_y, bits) in glyph.into_iter().enumerate() {
-                for glyph_x in 0..5 {
-                    if bits & (1 << (4 - glyph_x)) == 0 {
-                        continue;
-                    }
-                    let x = u32::try_from(col).unwrap_or(u32::MAX) * CELL_WIDTH
-                        + u32::try_from(glyph_x).unwrap_or(0) * GLYPH_SCALE;
-                    let y = u32::try_from(row).unwrap_or(u32::MAX) * CELL_HEIGHT
-                        + GLYPH_TOP
-                        + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
-                    push_rect(&mut vertices, x, y, GLYPH_SCALE, width, height);
-                    if vertices.len() >= MAX_VERTICES {
-                        return vertices;
-                    }
-                }
+        for (col, character) in line.chars().take(terminal_cols).enumerate() {
+            push_glyph(
+                &mut vertices,
+                character,
+                col_offset + col,
+                row,
+                width,
+                height,
+            );
+            if vertices.len() >= MAX_VERTICES {
+                return vertices;
             }
         }
     }
     vertices
+}
+
+/// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`,
+/// converting each lit pixel bit to a 2×2 rectangle of vertices.
+fn push_glyph(
+    vertices: &mut Vec<[f32; 2]>,
+    character: char,
+    col: usize,
+    row: usize,
+    width: u32,
+    height: u32,
+) {
+    let glyph = glyph_rows(character);
+    for (glyph_y, bits) in glyph.into_iter().enumerate() {
+        for glyph_x in 0..5 {
+            if bits & (1 << (4 - glyph_x)) == 0 {
+                continue;
+            }
+            let x = u32::try_from(col).unwrap_or(u32::MAX) * CELL_WIDTH
+                + u32::try_from(glyph_x).unwrap_or(0) * GLYPH_SCALE;
+            let y = u32::try_from(row).unwrap_or(u32::MAX) * CELL_HEIGHT
+                + GLYPH_TOP
+                + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
+            push_rect(vertices, x, y, GLYPH_SCALE, width, height);
+        }
+    }
 }
 
 fn push_rect(vertices: &mut Vec<[f32; 2]>, x: u32, y: u32, size: u32, width: u32, height: u32) {
@@ -456,7 +515,7 @@ mod tests {
     #[test]
     fn glyph_input_is_bounded_to_visible_poc_grid() {
         let terminal = snapshot(100, 500, &vec![b'A'; 50_000]);
-        let vertices = glyph_vertices(Some(&terminal), None, u32::MAX, u32::MAX);
+        let vertices = glyph_vertices(Some(&terminal), None, None, u32::MAX, u32::MAX);
         assert!(vertices.len() <= MAX_VERTICES);
     }
 
@@ -464,8 +523,8 @@ mod tests {
     fn empty_and_zero_sized_inputs_have_no_vertices() {
         let empty = snapshot(1, 1, b"");
         let text = snapshot(1, 8, b"text");
-        assert!(glyph_vertices(Some(&empty), None, 900, 600).is_empty());
-        assert!(glyph_vertices(Some(&text), None, 0, 600).is_empty());
+        assert!(glyph_vertices(Some(&empty), None, None, 900, 600).is_empty());
+        assert!(glyph_vertices(Some(&text), None, None, 0, 600).is_empty());
     }
 
     #[test]
@@ -478,7 +537,7 @@ mod tests {
     #[test]
     fn vertex_encoding_has_two_floats_per_vertex() {
         let terminal = snapshot(1, 2, b"A");
-        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
         assert_eq!(vertex_bytes(&vertices).len(), vertices.len() * 8);
     }
 
@@ -498,7 +557,7 @@ mod tests {
     #[test]
     fn wide_characters_place_following_glyphs_at_display_columns() {
         let terminal = snapshot(1, 6, "a日b".as_bytes());
-        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
 
         // a occupies column 0, 日 columns 1-2, so b must start at display
         // column 3 and nothing may draw at column 2's lead edge.
@@ -511,8 +570,8 @@ mod tests {
         let wide = snapshot(1, 6, "a日b".as_bytes());
         let aligned = snapshot(1, 6, b"a? b");
         assert_eq!(
-            glyph_vertices(Some(&wide), None, 900, 600),
-            glyph_vertices(Some(&aligned), None, 900, 600),
+            glyph_vertices(Some(&wide), None, None, 900, 600),
+            glyph_vertices(Some(&aligned), None, None, 900, 600),
             "the wide lead draws in column 1, its continuation column stays empty, and b lands in column 3"
         );
     }
@@ -520,7 +579,7 @@ mod tests {
     #[test]
     fn ascii_glyphs_keep_their_character_columns() {
         let terminal = snapshot(1, 4, b"BD");
-        let vertices = glyph_vertices(Some(&terminal), None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
         assert!(has_rect_top_left(&vertices, ndc_left(0)));
         assert!(has_rect_top_left(&vertices, ndc_left(1)));
         assert!(!has_rect_top_left(&vertices, ndc_left(2)));

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -322,13 +322,28 @@ pub(crate) fn glyph_vertices(
     let visible_rows = usize::try_from(height / CELL_HEIGHT)
         .unwrap_or(usize::MAX)
         .clamp(1, usize::from(MAX_RENDER_ROWS));
-    let visible_cols = usize::try_from(width / CELL_WIDTH)
-        .unwrap_or(usize::MAX)
-        .clamp(1, usize::from(MAX_RENDER_COLS));
+    let window_cols = usize::try_from(width / CELL_WIDTH).unwrap_or(usize::MAX);
 
     let has_sidebar = sidebar.is_some();
     let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
-    let terminal_cols = visible_cols.saturating_sub(col_offset);
+    // Reserve the sidebar, then clamp the terminal to the renderer's drawable
+    // budget (`MAX_RENDER_COLS - SIDEBAR_COLS`), floored at one. This is the
+    // same formula `main::terminal_cols` applies — kept independent rather than
+    // shared so the sidebar geometry test can still pin that the two sites
+    // agree (a single shared function would make their agreement structural and
+    // the sidebar subtraction itself un-testable). The sidebar lives *inside*
+    // the `MAX_RENDER_COLS` ceiling, so the terminal never owns more columns
+    // than the renderer can draw beside it.
+    let terminal_cols = if has_sidebar {
+        let budget = usize::from(MAX_RENDER_COLS)
+            .saturating_sub(SIDEBAR_COLS)
+            .max(1);
+        window_cols.saturating_sub(SIDEBAR_COLS).clamp(1, budget)
+    } else {
+        // No sidebar (offscreen oracle's pre-sidebar mode): the terminal fills
+        // the window, clamped to the renderer's column ceiling.
+        window_cols.clamp(1, usize::from(MAX_RENDER_COLS))
+    };
     let mut vertices = Vec::new();
 
     if let Some(lines) = sidebar {

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -188,13 +188,14 @@ impl OffscreenRenderer {
     pub(crate) fn capture(
         &self,
         terminal: Option<&TerminalSnapshot>,
+        sidebar: Option<&[String]>,
         status: Option<&str>,
         width: u32,
         height: u32,
     ) -> CapturedFrame {
         assert!(width > 0 && height > 0, "capture target must be non-zero");
 
-        let vertices = glyph_vertices(terminal, status, width, height);
+        let vertices = glyph_vertices(terminal, sidebar, status, width, height);
         let bytes = vertex_bytes(&vertices);
 
         let vertex_buffer = if bytes.is_empty() {

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -43,6 +43,7 @@ mod renderer_capture;
 
 use noren_app::{POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
 use noren_terminal::{TerminalSnapshot, TerminalState};
+use renderer_capture::renderer_source::SIDEBAR_COLS;
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// Construct a snapshot by feeding `bytes` through the real terminal state.
@@ -56,7 +57,7 @@ fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
 fn render(renderer: &OffscreenRenderer, snapshot: &TerminalSnapshot) -> CapturedFrame {
     let width = u32::from(snapshot.cols()) * CELL_WIDTH;
     let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
-    renderer.capture(Some(snapshot), None, width, height)
+    renderer.capture(Some(snapshot), None, None, width, height)
 }
 
 /// A pixel counts as "background" when it is close to the clear colour. Glyph
@@ -376,4 +377,134 @@ fn utf8_cell_is_at_least_lit_so_the_pipeline_handles_wide_input() {
     let frame = render(&renderer, &snap);
     // c, a, f are ASCII and lit; the final cell holds the non-ASCII 'é' lead.
     assert!(cell_is_lit(&frame, 0, 3), "non-ASCII cell drew nothing");
+}
+
+// ===========================================================================
+// Sidebar rendering: the sidebar is a fixed-width column on the left; the
+// terminal occupies the remaining columns to the right. These tests drive the
+// real wgpu pipeline offscreen and assert on rendered pixels — the same
+// approach as the core oracle above.
+// ===========================================================================
+
+/// Render a snapshot plus sidebar text at `(terminal_cols + SIDEBAR_COLS)` cell
+/// columns wide — mirroring how the real app partitions the window.
+fn render_with_sidebar(
+    renderer: &OffscreenRenderer,
+    snap: &TerminalSnapshot,
+    sidebar: &[String],
+) -> CapturedFrame {
+    let total_cols = u32::from(snap.cols()) + SIDEBAR_COLS as u32;
+    let width = total_cols * CELL_WIDTH;
+    let height = u32::from(snap.rows()) * CELL_HEIGHT;
+    renderer.capture(Some(snap), Some(sidebar), None, width, height)
+}
+
+#[test]
+fn sidebar_rows_appear_in_the_left_columns() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    // One selected session row: '>' marker, then label and detail.
+    let sidebar = vec!["> SESSION-1 LOCAL".to_string()];
+    let snap = snapshot(1, 20, b"");
+    let frame = render_with_sidebar(&renderer, &snap, &sidebar);
+
+    // The '>' selection marker at column 0 must be lit.
+    assert!(
+        cell_is_lit(&frame, 0, 0),
+        "selection marker '>' at column 0 should be lit"
+    );
+    // Column 1 is the space separator — blank.
+    assert!(
+        !cell_is_lit(&frame, 0, 1),
+        "space after marker at column 1 should be blank"
+    );
+    // 'S' of SESSION at column 2 must be lit.
+    assert!(
+        cell_is_lit(&frame, 0, 2),
+        "'S' of SESSION at column 2 should be lit"
+    );
+    // The lit pattern at (0,0) must differ from a blank cell to prove a real
+    // glyph was drawn, not noise.
+    let blank = vec![false; (CELL_WIDTH * CELL_HEIGHT) as usize];
+    assert_ne!(
+        cell_pattern(&frame, 0, 0),
+        blank,
+        "selection marker cell has a non-blank glyph pattern"
+    );
+}
+
+#[test]
+fn terminal_content_does_not_overlap_sidebar_columns() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    // No sidebar text — the sidebar region stays entirely blank.
+    let sidebar: Vec<String> = vec![];
+    // Terminal with 'A' at column 0.
+    let snap = snapshot(1, 10, b"A");
+    let frame = render_with_sidebar(&renderer, &snap, &sidebar);
+
+    let sc = SIDEBAR_COLS as u32;
+    // The terminal's column 0 maps to window column SIDEBAR_COLS — the 'A'
+    // must appear there, not inside the sidebar.
+    assert!(
+        cell_is_lit(&frame, 0, sc),
+        "terminal 'A' should be lit at window column SIDEBAR_COLS ({sc})"
+    );
+    // Every sidebar column must be blank.
+    for col in 0..sc {
+        assert!(
+            !cell_is_lit(&frame, 0, col),
+            "sidebar column {col} is lit — terminal bled into the sidebar"
+        );
+    }
+}
+
+#[test]
+fn sidebar_plus_terminal_columns_equal_window_columns() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let sidebar: Vec<String> = vec![];
+    let term_cols = 10u16;
+    // Fill every terminal column with 'A'.
+    let snap = snapshot(1, term_cols, b"AAAAAAAAAA");
+    let frame = render_with_sidebar(&renderer, &snap, &sidebar);
+
+    let sc = SIDEBAR_COLS as u32;
+    let total = sc + u32::from(term_cols);
+
+    // Sidebar region: columns 0..SIDEBAR_COLS must be blank.
+    for col in 0..sc {
+        assert!(
+            !cell_is_lit(&frame, 0, col),
+            "sidebar column {col} should be blank"
+        );
+    }
+    // Terminal region: columns SIDEBAR_COLS..total must be lit.
+    for col in sc..total {
+        assert!(
+            cell_is_lit(&frame, 0, col),
+            "terminal column {col} (window col {col}) should be lit"
+        );
+    }
+}
+
+#[test]
+fn empty_state_message_is_drawn_in_the_sidebar() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let sidebar = vec!["NO SESSIONS".to_string()];
+    let snap = snapshot(1, 10, b"");
+    let frame = render_with_sidebar(&renderer, &snap, &sidebar);
+
+    // 'N' at column 0 and 'O' at column 1 must both be lit.
+    assert!(
+        cell_is_lit(&frame, 0, 0),
+        "'N' of NO SESSIONS should be lit"
+    );
+    assert!(
+        cell_is_lit(&frame, 0, 1),
+        "'O' of NO SESSIONS should be lit"
+    );
+    // The patterns must differ — they are different glyphs.
+    assert_ne!(
+        cell_pattern(&frame, 0, 0),
+        cell_pattern(&frame, 0, 1),
+        "'N' and 'O' rendered the same pattern"
+    );
 }


### PR DESCRIPTION
縦切りの**3段階中2段階目**。**これが見た目の変化をもたらす段階**です。

## 起動したNorenで何が変わるか

**左に幅16セルのテキストカラムが現れ、稼働中のセッションが一覧表示される**（例：`> SESSION-1 LOCAL · STARTING`）。シェルのプロンプトとターミナル出力は右にずれ、残りの幅を占める。

これまではターミナルがウィンドウ全体を占め、サイドバーは存在しなかった。

正直な注記：ビットマップフォントが小文字を大文字に畳み込み、`·` のような非ASCII区切りは `?` になる。**読めるが、体裁は整っていない。**

## macOS実機で検証済み

```
$ ./target/release/noren-app &
$ stty -f /dev/ttys025 size
30 74
```

**以前は `30 90`。差の16は `SIDEBAR_COLS` と正確に一致する。** PTY の winsize・ターミナル状態の列数・描画領域の3つが合意していることの実機証拠。クリーン終了も確認。

## ジオメトリ不整合の罠への対処

最も壊れやすい箇所は「サイドバーが左を占めるのにターミナルが全列数のまま」で、これは描画バグに見えて実体はジオメトリ不整合になる。

`terminal_cols()` が `TerminalState`/`PtySize` の生成前に `SIDEBAR_COLS` を減算することで、3者が同一の値から導出される。テストでも `ターミナル列 + サイドバー列 == ウィンドウ列` を検証。

## 実装

- **`renderer.rs`**: `SIDEBAR_COLS = 16`、`push_glyph` ヘルパ、`glyph_vertices` に `Option<&[String]>` を追加。サイドバーがあれば列0-15に描画しターミナルを列16へオフセット、`None` なら列0から描画（**既存のオラクルテストを保つ**）
- **`main.rs`**: `sidebar_text_lines()` が `SidebarView` の行を `label()`/`detail()` から生成。選択マーカーは列0の `>`。**サイドバー領域内のクリックは `grid_point_at()` が拒否**するのでテキスト選択と干渉しない
- **`frame_oracle.rs`**: オフスクリーンのピクセル単位テスト4件を追加

## 選択表示について

レンダラに色も反転もないため、**描けない強調を発明せず**、列0の `>` で示している。

## 変異検証 2/2

| 変異 | 検出 |
|---|---|
| サイドバー原点を+1列ずらす | `sidebar_rows_appear_in_the_left_columns` が列0の `>` アサーションで FAILED |
| ターミナルのオフセットを0にする | `terminal_content_does_not_overlap_sidebar_columns` が、ターミナルの `A` が列0に現れて FAILED |

## 検証

fmt / clippy(-D warnings) 通過。`cargo test --workspace` **613 passed / 3 ignored / 0 failed**。`frame_oracle --ignored` はちょうど2件失敗（既存のフォント欠陥、変化なし）。

## 依存

PR #98（段階1、マージ済み）の `WorkspaceState` を描画対象として読む。