### PR TITLE
fix(app): thread configured cell size to the renderer at runtime (#76)

### DIFF
--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -138,6 +138,36 @@ impl GridSize {
     }
 }
 
+/// Runtime cell metrics: the configured width and height of one terminal grid
+/// cell in physical pixels.
+///
+/// `GridGeometry` produces this from configuration; every consumer — the
+/// renderer's `glyph_vertices`, the offscreen capture path, and the binary's
+/// click-to-grid mappers — reads width and height from this single value
+/// rather than from a compile-time constant. Bundling the two dimensions
+/// prevents width and height from drifting to different origins at a call
+/// site (the defect from issue #76: the renderer drew at the constant while
+/// the geometry used the configured value).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CellMetrics {
+    width: u32,
+    height: u32,
+}
+
+impl CellMetrics {
+    /// Cell width in physical pixels.
+    #[must_use]
+    pub const fn width(self) -> u32 {
+        self.width
+    }
+
+    /// Cell height in physical pixels.
+    #[must_use]
+    pub const fn height(self) -> u32 {
+        self.height
+    }
+}
+
 /// Deterministic fixed-cell geometry and resize coalescing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GridGeometry {
@@ -172,6 +202,35 @@ impl GridGeometry {
             cell_height,
             current: None,
         })
+    }
+
+    /// Configured cell width in physical pixels.
+    ///
+    /// This is the single runtime source of truth for cell width: the renderer,
+    /// the click-to-grid mapper, and the sidebar boundary all read it from here
+    /// rather than from a compile-time constant.
+    #[must_use]
+    pub const fn cell_width(self) -> u32 {
+        self.cell_width
+    }
+
+    /// Configured cell height in physical pixels.
+    ///
+    /// See [`cell_width`](Self::cell_width) for the single-source rationale.
+    #[must_use]
+    pub const fn cell_height(self) -> u32 {
+        self.cell_height
+    }
+
+    /// The configured [`CellMetrics`] — the single runtime source of truth
+    /// for cell size, threaded to the renderer and click-handling code so
+    /// every consumer reads the same width and height.
+    #[must_use]
+    pub const fn cell_metrics(self) -> CellMetrics {
+        CellMetrics {
+            width: self.cell_width,
+            height: self.cell_height,
+        }
     }
 
     /// Current last valid grid.

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -5,8 +5,7 @@ mod renderer;
 use noren_app::{
     Arrow, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key, KeyDropReason,
     KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode, MAX_RENDER_COLS,
-    MAX_RENDER_ROWS, Modifiers, PARSE_BUDGET_BYTES_PER_TURN, POC_CELL_HEIGHT, POC_CELL_WIDTH,
-    PasteReject, Resize, SystemClipboard,
+    MAX_RENDER_ROWS, Modifiers, PARSE_BUDGET_BYTES_PER_TURN, PasteReject, Resize, SystemClipboard,
     config::AppConfig,
     diagnostics::{self, PtyChildStatus},
     encode_paste,
@@ -324,7 +323,7 @@ impl NorenApp {
                     None
                 }
             };
-        self.renderer = match Renderer::new(Arc::clone(&window)) {
+        self.renderer = match Renderer::new(Arc::clone(&window), self.geometry.cell_metrics()) {
             Ok(renderer) => Some(renderer),
             Err(_) => {
                 self.status = "Noren renderer start failed";
@@ -710,12 +709,14 @@ impl NorenApp {
         let terminal = self.terminal.as_ref()?;
         let window = self.window.as_ref()?;
         let physical = window.inner_size();
+        let cell_width = self.geometry.cell_width();
+        let cell_height = self.geometry.cell_height();
         // The sidebar occupies the leftmost SIDEBAR_COLS cell columns; clicks
         // inside it do not address the terminal grid.
-        if position.x < sidebar_pixel_width() {
+        if position.x < sidebar_pixel_width(cell_width) {
             return None;
         }
-        let visible_rows = usize::try_from(physical.height / POC_CELL_HEIGHT)
+        let visible_rows = usize::try_from(physical.height / cell_height)
             .unwrap_or(0)
             .clamp(1, usize::from(MAX_RENDER_ROWS));
         let content_rows = visible_content_rows(terminal);
@@ -723,7 +724,7 @@ impl NorenApp {
         let displayed = total_lines.min(visible_rows);
         let top_blank_rows = visible_rows - displayed;
         let first_line = total_lines - displayed;
-        let row = pixel_row_index(position.y, POC_CELL_HEIGHT)?;
+        let row = pixel_row_index(position.y, cell_height)?;
         if row < top_blank_rows {
             return None;
         }
@@ -735,7 +736,7 @@ impl NorenApp {
         if line_index >= usize::from(rows) {
             return None;
         }
-        let column = terminal_column_at(position.x, cols)?;
+        let column = terminal_column_at(position.x, cols, cell_width)?;
         Some(GridPoint::new(
             terminal.scrollback_len() + line_index,
             column,
@@ -1216,8 +1217,8 @@ fn pixel_row_index(pixel: f64, cell_size: u32) -> Option<usize> {
 /// Pixel width of the sidebar's left strip: `SIDEBAR_COLS` cell columns. The
 /// terminal is drawn to the right of this edge, so a click at exactly this x is
 /// the first terminal column.
-fn sidebar_pixel_width() -> f64 {
-    f64::from((renderer::SIDEBAR_COLS as u32) * POC_CELL_WIDTH)
+fn sidebar_pixel_width(cell_width: u32) -> f64 {
+    f64::from((renderer::SIDEBAR_COLS as u32) * cell_width)
 }
 
 /// Terminal cell column under pixel x, or `None` when the click lands in the
@@ -1225,11 +1226,12 @@ fn sidebar_pixel_width() -> f64 {
 /// boundary is exclusive: x exactly at [`sidebar_pixel_width`] is the first
 /// terminal column and maps to cell 0; anything strictly left of it is the
 /// sidebar and is rejected.
-fn terminal_column_at(pixel_x: f64, terminal_cols: u16) -> Option<usize> {
-    if !pixel_x.is_finite() || pixel_x < sidebar_pixel_width() {
+fn terminal_column_at(pixel_x: f64, terminal_cols: u16, cell_width: u32) -> Option<usize> {
+    let edge = sidebar_pixel_width(cell_width);
+    if !pixel_x.is_finite() || pixel_x < edge {
         return None;
     }
-    pixel_row_index(pixel_x - sidebar_pixel_width(), POC_CELL_WIDTH)
+    pixel_row_index(pixel_x - edge, cell_width)
         .map(|raw| raw.min(usize::from(terminal_cols).saturating_sub(1)))
 }
 
@@ -1364,6 +1366,7 @@ mod tests {
     use noren_app::palette::CommandId;
     use noren_app::passthrough::{self, collisions};
     use noren_app::sidebar::EntryKind;
+    use noren_app::{CellMetrics, POC_CELL_WIDTH};
 
     #[test]
     fn winit_space_variants_encode_ascii_space() {
@@ -1857,11 +1860,11 @@ mod tests {
     /// arbitrary vertices would count that bleed as a drawn column and over-
     /// count by one. Each rect is emitted as a 6-vertex fan whose first vertex
     /// is its top-left corner, so the left edges are read from every 6th group.
-    fn rendered_terminal_columns(vertices: &[[f32; 2]], width: u32) -> usize {
+    fn rendered_terminal_columns(vertices: &[[f32; 2]], width: u32, cell_width: u32) -> usize {
         let rect_lefts: Vec<f32> = vertices.chunks_exact(6).map(|rect| rect[0][0]).collect();
         let mut drawn = 0;
         for col in renderer::SIDEBAR_COLS..usize::from(MAX_RENDER_COLS) {
-            let edge = ((col as u32) * POC_CELL_WIDTH) as f32 / width as f32 * 2.0 - 1.0;
+            let edge = ((col as u32) * cell_width) as f32 / width as f32 * 2.0 - 1.0;
             if rect_lefts.iter().any(|left| (left - edge).abs() < 1e-5) {
                 drawn += 1;
             } else {
@@ -1873,29 +1876,31 @@ mod tests {
 
     /// Drive the three terminal-width consumers — `TerminalState`'s stored
     /// column count, the PTY winsize, and the columns the renderer actually
-    /// draws — at one window width, asserting they all agree on
+    /// draws — at one window width and cell size, asserting they all agree on
     /// `terminal_cols(window_cols)`. Asserting `terminal_cols() == window_cols -
     /// 16` would merely restate the formula and pass any consistent-but-wrong
     /// value; instead this exercises the three real consumers and is shared by
     /// the swept agreement test below across every regime where they can drift
-    /// apart.
-    fn assert_three_consumers_agree_at(width: u32) {
+    /// apart — including non-default cell sizes.
+    fn assert_three_consumers_agree_at(width: u32, metrics: CellMetrics) {
         let height = 600_u32;
-        // Grid columns and the renderer's visible columns both derive
-        // `width / CELL_WIDTH`, so they share this `window_cols`.
-        let window_cols = u16::try_from(width / POC_CELL_WIDTH).expect("fits in u16");
+        let cell_width = metrics.width();
+        let cell_height = metrics.height();
+        let window_cols = u16::try_from(width / cell_width).expect("fits in u16");
         let cols = terminal_cols(window_cols);
 
         // Consumer 1: the terminal state stores the sidebar-adjusted width.
-        let rows = u16::try_from(height / POC_CELL_HEIGHT).expect("fits in u16");
+        let rows = u16::try_from(height / cell_height).expect("fits in u16");
         let mut terminal = TerminalState::new(rows, cols).expect("valid terminal");
-        // Fill every terminal column of row 0 so each drawn column is visible
-        // to `rendered_terminal_columns` via its left pixel edge.
         terminal.feed_bytes(&vec![b'B'; usize::from(cols)]);
         let (_, term_cols) = terminal.size();
         assert_eq!(
-            term_cols, cols,
-            "at {width}px: terminal must store terminal_cols({window_cols}) = {cols}"
+            term_cols,
+            cols,
+            "at {width}px cell {}x{}: terminal must store \
+             terminal_cols({window_cols}) = {cols}",
+            metrics.width(),
+            metrics.height(),
         );
 
         // Consumer 2: the PTY winsize carries the same column count.
@@ -1903,11 +1908,15 @@ mod tests {
         assert_eq!(
             pty.cols(),
             cols,
-            "at {width}px: PTY winsize must agree with the terminal"
+            "at {width}px cell {}x{}: PTY winsize must agree",
+            metrics.width(),
+            metrics.height(),
         );
 
         // Consumer 3: the renderer draws exactly that many terminal columns —
-        // measured from vertex output, independent of `terminal_cols`.
+        // measured from vertex output, independent of `terminal_cols`. The cell
+        // metrics are threaded through so a renderer still drawing at the
+        // compile-time default is exposed at a non-default size.
         let snapshot = terminal.snapshot();
         let sidebar: Vec<String> = Vec::new();
         let vertices = renderer::glyph_vertices(
@@ -1916,14 +1925,18 @@ mod tests {
             None,
             width,
             height,
+            metrics,
         );
-        let drawn = rendered_terminal_columns(&vertices, width);
+        let drawn = rendered_terminal_columns(&vertices, width, cell_width);
         assert_eq!(
             drawn,
             usize::from(cols),
-            "at {width}px (window_cols={window_cols}): renderer drew {drawn} terminal columns but \
-             terminal/PTY agree on {cols} — the sidebar width is not consistently subtracted or \
-             the upper clamp is missing"
+            "at {width}px cell {}x{} (window_cols={window_cols}): \
+             renderer drew {drawn} terminal columns but terminal/PTY agree on {cols} — \
+             the sidebar width is not consistently subtracted, the upper clamp is missing, \
+             or the renderer ignored the configured cell size",
+            metrics.width(),
+            metrics.height(),
         );
     }
 
@@ -1951,10 +1964,25 @@ mod tests {
     /// and it exists to hold that line. Mutating `terminal_cols` to drop the
     /// sidebar subtraction breaks the typical/above-max widths, and dropping
     /// the upper clamp breaks the 2000px width.
+    ///
+    /// The test is also swept across **cell sizes**. Issue #76: a configured
+    /// `cell_width = 20` flows to the geometry/PTY but the renderer ignored it,
+    /// drawing at the 10px compile-time constant. At 20px every width in the
+    /// sweep produces half the window_cols, so the renderer — if still on the
+    /// constant — would draw *twice* as many terminal columns as the terminal
+    /// and PTY agree on, and the three consumers diverge. This is the
+    /// acceptance criterion from the Issue.
     #[test]
     fn terminal_cols_pty_winsize_and_renderer_agree_across_the_width_range() {
+        let poc = GridGeometry::poc().cell_metrics();
         for width in [80_u32, 900, 1600, 2000] {
-            assert_three_consumers_agree_at(width);
+            assert_three_consumers_agree_at(width, poc);
+        }
+        let big = GridGeometry::with_cells(20, 40)
+            .expect("valid geometry")
+            .cell_metrics();
+        for width in [160_u32, 1800, 3200, 4000] {
+            assert_three_consumers_agree_at(width, big);
         }
     }
 
@@ -1984,8 +2012,9 @@ mod tests {
             None,
             width,
             height,
+            GridGeometry::poc().cell_metrics(),
         );
-        let drawn = rendered_terminal_columns(&vertices, width);
+        let drawn = rendered_terminal_columns(&vertices, width, POC_CELL_WIDTH);
         assert_eq!(
             drawn,
             usize::from(cols),
@@ -2055,32 +2084,37 @@ mod tests {
     #[test]
     fn terminal_column_at_rejects_the_sidebar_and_starts_the_terminal_at_zero() {
         let cols = 40_u16;
-        let sidebar_edge = sidebar_pixel_width();
+        let sidebar_edge = sidebar_pixel_width(POC_CELL_WIDTH);
 
         // The last sidebar column — just inside the sidebar's right edge — does
         // not address the terminal grid.
         assert_eq!(
-            terminal_column_at(sidebar_edge - 1.0, cols),
+            terminal_column_at(sidebar_edge - 1.0, cols, POC_CELL_WIDTH),
             None,
             "a click in the last sidebar column must be rejected"
         );
         // The first terminal column, exactly at the sidebar's right edge, maps
         // to terminal cell 0.
         assert_eq!(
-            terminal_column_at(sidebar_edge, cols),
+            terminal_column_at(sidebar_edge, cols, POC_CELL_WIDTH),
             Some(0),
             "the first terminal column must map to cell 0"
         );
         // One cell width further in lands in terminal cell 1.
         assert_eq!(
-            terminal_column_at(sidebar_edge + f64::from(POC_CELL_WIDTH), cols),
+            terminal_column_at(
+                sidebar_edge + f64::from(POC_CELL_WIDTH),
+                cols,
+                POC_CELL_WIDTH
+            ),
             Some(1)
         );
         // The last terminal column maps to the highest valid cell.
         assert_eq!(
             terminal_column_at(
                 sidebar_edge + f64::from(POC_CELL_WIDTH) * f64::from(cols - 1),
-                cols
+                cols,
+                POC_CELL_WIDTH
             ),
             Some(usize::from(cols - 1))
         );
@@ -2088,13 +2122,67 @@ mod tests {
         assert_eq!(
             terminal_column_at(
                 sidebar_edge + f64::from(POC_CELL_WIDTH) * f64::from(cols),
-                cols
+                cols,
+                POC_CELL_WIDTH
             ),
             Some(usize::from(cols - 1))
         );
         // Negative and non-finite clicks are rejected.
-        assert_eq!(terminal_column_at(-1.0, cols), None);
-        assert_eq!(terminal_column_at(f64::NAN, cols), None);
+        assert_eq!(terminal_column_at(-1.0, cols, POC_CELL_WIDTH), None);
+        assert_eq!(terminal_column_at(f64::NAN, cols, POC_CELL_WIDTH), None);
+    }
+
+    /// Issue #76: at a non-default cell width, the sidebar's drawn pixel
+    /// boundary and the click-handling boundary must agree. The renderer draws
+    /// the terminal starting at column `SIDEBAR_COLS`; `sidebar_pixel_width`
+    /// and `terminal_column_at` must use the same `cell_width` to locate that
+    /// boundary, or clicks land in the wrong region.
+    ///
+    /// At `cell_width = 20` the boundary is `16 * 20 = 320px`. If
+    /// `sidebar_pixel_width` still used `POC_CELL_WIDTH` (10), the boundary
+    /// would drift to 160px and clicks in the 160–320px strip would be
+    /// misattributed to the terminal instead of the sidebar.
+    #[test]
+    fn sidebar_boundary_and_click_boundary_agree_at_non_default_cell_width() {
+        let cell_width = 20_u32;
+        let cols = 40_u16;
+        let sidebar_edge = sidebar_pixel_width(cell_width);
+
+        // The drawn boundary is SIDEBAR_COLS * cell_width.
+        assert_eq!(
+            sidebar_edge,
+            f64::from((renderer::SIDEBAR_COLS as u32) * cell_width),
+            "sidebar pixel width must be SIDEBAR_COLS * cell_width"
+        );
+        assert_eq!(sidebar_edge, 320.0);
+
+        // A click at the boundary maps to terminal column 0.
+        assert_eq!(
+            terminal_column_at(sidebar_edge, cols, cell_width),
+            Some(0),
+            "at cell_width=20, the first terminal column is at the sidebar edge"
+        );
+        // A click one pixel left of the boundary is still the sidebar.
+        assert_eq!(
+            terminal_column_at(sidebar_edge - 1.0, cols, cell_width),
+            None,
+            "at cell_width=20, a click just left of the boundary is the sidebar"
+        );
+        // One cell width further maps to column 1.
+        assert_eq!(
+            terminal_column_at(sidebar_edge + f64::from(cell_width), cols, cell_width),
+            Some(1),
+            "at cell_width=20, one cell past the boundary is column 1"
+        );
+        // The last terminal column maps to the highest valid cell.
+        assert_eq!(
+            terminal_column_at(
+                sidebar_edge + f64::from(cell_width) * f64::from(cols - 1),
+                cols,
+                cell_width
+            ),
+            Some(usize::from(cols - 1)),
+        );
     }
 
     // ── Pass-through gate integration tests ──────────────────────────────

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -10,9 +10,7 @@ use wgpu::CurrentSurfaceTexture;
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
-use noren_app::{
-    MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH,
-};
+use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::TerminalSnapshot;
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
@@ -88,10 +86,11 @@ pub(crate) struct Renderer {
     vertex_buffer: wgpu::Buffer,
     vertex_capacity: u64,
     device_lost: Arc<AtomicBool>,
+    metrics: CellMetrics,
 }
 
 impl Renderer {
-    pub(crate) fn new(window: Arc<Window>) -> Result<Self, RendererError> {
+    pub(crate) fn new(window: Arc<Window>, metrics: CellMetrics) -> Result<Self, RendererError> {
         let size = window.inner_size();
         let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
         instance_descriptor.backends = wgpu::Backends::METAL;
@@ -184,6 +183,7 @@ impl Renderer {
             vertex_buffer,
             vertex_capacity,
             device_lost,
+            metrics,
         })
     }
 
@@ -212,6 +212,7 @@ impl Renderer {
             status,
             self.config.width,
             self.config.height,
+            self.metrics,
         );
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
@@ -315,14 +316,17 @@ pub(crate) fn glyph_vertices(
     status: Option<&str>,
     width: u32,
     height: u32,
+    metrics: CellMetrics,
 ) -> Vec<[f32; 2]> {
     if width == 0 || height == 0 {
         return Vec::new();
     }
-    let visible_rows = usize::try_from(height / CELL_HEIGHT)
+    let cell_width = metrics.width();
+    let cell_height = metrics.height();
+    let visible_rows = usize::try_from(height / cell_height)
         .unwrap_or(usize::MAX)
         .clamp(1, usize::from(MAX_RENDER_ROWS));
-    let window_cols = usize::try_from(width / CELL_WIDTH).unwrap_or(usize::MAX);
+    let window_cols = usize::try_from(width / cell_width).unwrap_or(usize::MAX);
 
     let has_sidebar = sidebar.is_some();
     let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
@@ -349,7 +353,7 @@ pub(crate) fn glyph_vertices(
     if let Some(lines) = sidebar {
         for (row, line) in lines.iter().take(visible_rows).enumerate() {
             for (col, character) in line.chars().take(SIDEBAR_COLS).enumerate() {
-                push_glyph(&mut vertices, character, col, row, width, height);
+                push_glyph(&mut vertices, character, col, row, width, height, metrics);
                 if vertices.len() >= MAX_VERTICES {
                     return vertices;
                 }
@@ -379,6 +383,7 @@ pub(crate) fn glyph_vertices(
                 row,
                 width,
                 height,
+                metrics,
             );
             if vertices.len() >= MAX_VERTICES {
                 return vertices;
@@ -397,16 +402,19 @@ fn push_glyph(
     row: usize,
     width: u32,
     height: u32,
+    metrics: CellMetrics,
 ) {
+    let cell_width = metrics.width();
+    let cell_height = metrics.height();
     let glyph = glyph_rows(character);
     for (glyph_y, bits) in glyph.into_iter().enumerate() {
         for glyph_x in 0..5 {
             if bits & (1 << (4 - glyph_x)) == 0 {
                 continue;
             }
-            let x = u32::try_from(col).unwrap_or(u32::MAX) * CELL_WIDTH
+            let x = u32::try_from(col).unwrap_or(u32::MAX) * cell_width
                 + u32::try_from(glyph_x).unwrap_or(0) * GLYPH_SCALE;
-            let y = u32::try_from(row).unwrap_or(u32::MAX) * CELL_HEIGHT
+            let y = u32::try_from(row).unwrap_or(u32::MAX) * cell_height
                 + GLYPH_TOP
                 + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
             push_rect(vertices, x, y, GLYPH_SCALE, width, height);
@@ -519,6 +527,7 @@ fn glyph_rows(character: char) -> [u8; 7] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noren_app::GridGeometry;
     use noren_terminal::TerminalState;
 
     fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
@@ -527,10 +536,22 @@ mod tests {
         terminal.snapshot()
     }
 
+    /// The PoC default cell metrics for tests that exercise the default path.
+    fn poc_metrics() -> CellMetrics {
+        GridGeometry::poc().cell_metrics()
+    }
+
     #[test]
     fn glyph_input_is_bounded_to_visible_poc_grid() {
         let terminal = snapshot(100, 500, &vec![b'A'; 50_000]);
-        let vertices = glyph_vertices(Some(&terminal), None, None, u32::MAX, u32::MAX);
+        let vertices = glyph_vertices(
+            Some(&terminal),
+            None,
+            None,
+            u32::MAX,
+            u32::MAX,
+            poc_metrics(),
+        );
         assert!(vertices.len() <= MAX_VERTICES);
     }
 
@@ -538,8 +559,8 @@ mod tests {
     fn empty_and_zero_sized_inputs_have_no_vertices() {
         let empty = snapshot(1, 1, b"");
         let text = snapshot(1, 8, b"text");
-        assert!(glyph_vertices(Some(&empty), None, None, 900, 600).is_empty());
-        assert!(glyph_vertices(Some(&text), None, None, 0, 600).is_empty());
+        assert!(glyph_vertices(Some(&empty), None, None, 900, 600, poc_metrics()).is_empty());
+        assert!(glyph_vertices(Some(&text), None, None, 0, 600, poc_metrics()).is_empty());
     }
 
     #[test]
@@ -552,9 +573,11 @@ mod tests {
     #[test]
     fn vertex_encoding_has_two_floats_per_vertex() {
         let terminal = snapshot(1, 2, b"A");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         assert_eq!(vertex_bytes(&vertices).len(), vertices.len() * 8);
     }
+
+    const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
 
     fn ndc_left(column: u32) -> f32 {
         (column * CELL_WIDTH) as f32 / 900.0 * 2.0 - 1.0
@@ -572,7 +595,7 @@ mod tests {
     #[test]
     fn wide_characters_place_following_glyphs_at_display_columns() {
         let terminal = snapshot(1, 6, "a日b".as_bytes());
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
 
         // a occupies column 0, 日 columns 1-2, so b must start at display
         // column 3 and nothing may draw at column 2's lead edge.
@@ -584,9 +607,10 @@ mod tests {
     fn wide_output_renders_like_the_equivalent_single_width_layout() {
         let wide = snapshot(1, 6, "a日b".as_bytes());
         let aligned = snapshot(1, 6, b"a? b");
+        let m = poc_metrics();
         assert_eq!(
-            glyph_vertices(Some(&wide), None, None, 900, 600),
-            glyph_vertices(Some(&aligned), None, None, 900, 600),
+            glyph_vertices(Some(&wide), None, None, 900, 600, m),
+            glyph_vertices(Some(&aligned), None, None, 900, 600, m),
             "the wide lead draws in column 1, its continuation column stays empty, and b lands in column 3"
         );
     }
@@ -594,9 +618,63 @@ mod tests {
     #[test]
     fn ascii_glyphs_keep_their_character_columns() {
         let terminal = snapshot(1, 4, b"BD");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600);
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         assert!(has_rect_top_left(&vertices, ndc_left(0)));
         assert!(has_rect_top_left(&vertices, ndc_left(1)));
         assert!(!has_rect_top_left(&vertices, ndc_left(2)));
+    }
+
+    /// Issue #76 acceptance criterion: a non-default configured cell size must
+    /// change what the renderer *draws*, not merely what the geometry computes.
+    ///
+    /// The shipped bug was that `glyph_vertices` imported the compile-time
+    /// `POC_CELL_WIDTH`/`POC_CELL_HEIGHT` constants and drew at 10×20 regardless
+    /// of the configured size. This test renders identical terminal content at
+    /// two different cell metrics and asserts (a) the vertex arrays differ, and
+    /// (b) specific vertex x-positions land at the configured cell-width stride.
+    ///
+    /// Mutation check: if `push_glyph` is reverted to use `POC_CELL_WIDTH` (the
+    /// constant) instead of `metrics.width()`, both vertex arrays become
+    /// identical and the `assert_ne!` fails.
+    #[test]
+    fn non_default_cell_metrics_change_what_the_renderer_draws() {
+        let terminal = snapshot(1, 4, b"BBBB");
+        let small = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let big = GridGeometry::with_cells(20, 40)
+            .expect("valid metrics")
+            .cell_metrics();
+        let big_verts = glyph_vertices(Some(&terminal), None, None, 900, 600, big);
+
+        assert_ne!(
+            small, big_verts,
+            "the renderer must produce different vertices at different cell sizes — \
+             identical arrays mean the configured metrics were ignored (issue #76)"
+        );
+
+        // Column 1 of 'B' has glyph row 1 = 0b10001 which lights glyph column 0,
+        // so a rect's left edge sits exactly at `1 * cell_width` pixels.
+        // At 10px that is NDC `20/900*2 - 1`; at 20px it is `40/900*2 - 1`.
+        let small_edge_1 = 10.0_f32 / 900.0 * 2.0 - 1.0;
+        let big_edge_1 = 20.0_f32 / 900.0 * 2.0 - 1.0;
+        assert!(
+            small
+                .chunks_exact(6)
+                .any(|rect| (rect[0][0] - small_edge_1).abs() < 1e-5),
+            "at default metrics, column 1's left edge must be at 10px"
+        );
+        assert!(
+            big_verts
+                .chunks_exact(6)
+                .any(|rect| (rect[0][0] - big_edge_1).abs() < 1e-5),
+            "at cell_width=20, column 1's left edge must be at 20px, not 10px"
+        );
+        // And conversely, the big-vertices must NOT have an edge at the 10px
+        // position — that is the shipped bug.
+        assert!(
+            !big_verts
+                .chunks_exact(6)
+                .any(|rect| (rect[0][0] - small_edge_1).abs() < 1e-5),
+            "at cell_width=20, no vertex should land at the 10px column boundary"
+        );
     }
 }

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread;
 
+use noren_app::CellMetrics;
 use noren_terminal::TerminalSnapshot;
 use renderer_source::{CLEAR_COLOR, SHADER, glyph_vertices, vertex_bytes};
 
@@ -192,10 +193,11 @@ impl OffscreenRenderer {
         status: Option<&str>,
         width: u32,
         height: u32,
+        metrics: CellMetrics,
     ) -> CapturedFrame {
         assert!(width > 0 && height > 0, "capture target must be non-zero");
 
-        let vertices = glyph_vertices(terminal, sidebar, status, width, height);
+        let vertices = glyph_vertices(terminal, sidebar, status, width, height, metrics);
         let bytes = vertex_bytes(&vertices);
 
         let vertex_buffer = if bytes.is_empty() {

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -41,10 +41,16 @@
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
 
-use noren_app::{POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
+use noren_app::{GridGeometry, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::SIDEBAR_COLS;
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
+
+/// The PoC default cell metrics, used by every frame-oracle capture call so
+/// the renderer draws at the same size the geometry computed.
+fn poc_metrics() -> noren_app::CellMetrics {
+    GridGeometry::poc().cell_metrics()
+}
 
 /// Construct a snapshot by feeding `bytes` through the real terminal state.
 fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
@@ -57,7 +63,7 @@ fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
 fn render(renderer: &OffscreenRenderer, snapshot: &TerminalSnapshot) -> CapturedFrame {
     let width = u32::from(snapshot.cols()) * CELL_WIDTH;
     let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
-    renderer.capture(Some(snapshot), None, None, width, height)
+    renderer.capture(Some(snapshot), None, None, width, height, poc_metrics())
 }
 
 /// A pixel counts as "background" when it is close to the clear colour. Glyph
@@ -396,7 +402,14 @@ fn render_with_sidebar(
     let total_cols = u32::from(snap.cols()) + SIDEBAR_COLS as u32;
     let width = total_cols * CELL_WIDTH;
     let height = u32::from(snap.rows()) * CELL_HEIGHT;
-    renderer.capture(Some(snap), Some(sidebar), None, width, height)
+    renderer.capture(
+        Some(snap),
+        Some(sidebar),
+        None,
+        width,
+        height,
+        poc_metrics(),
+    )
 }
 
 #[test]


### PR DESCRIPTION
Issue #76 を解消。**設定した `cell_width`/`cell_height` が実際の描画に反映されるようになります。**

`I76 runtime_metrics=yes call_sites_updated=14 single_source=yes sidebar_boundary_consistent=yes mutation_reproduces_bug=yes defaults_unchanged=yes tests=PASS total=634`

## 修正した欠陥

`[font] cell_width` はグリッドと PTY のサイズには反映されるが、**描画には反映されていなかった**。`renderer.rs` がコンパイル時定数 `POC_CELL_WIDTH`/`POC_CELL_HEIGHT` で描いていたため。

`cell_width = 20` に設定すると、シェルは20px想定のグリッドサイズを伝えられる一方、グリフは10pxで描かれる。**ターミナルが自分で描いていないサイズを報告している**状態だった。

## サイドバー導入で影響が拡大していた

Issue 起票後にサイドバーが入り、`SIDEBAR_COLS * CELL_WIDTH` がサイドバーのピクセル境界と `grid_point_at` のクリック判定の**両方**で使われるようになっていた。

セル幅が実行時値になる以上、**これらすべてが同じ情報源を読まないとクリックが別領域に落ちる**。指示書で全箇所の洗い出しを求め、**14箇所**が更新された（`single_source=yes`）。

## テストが実際に欠陥を再現する

`mutation_reproduces_bug=yes`。**ジオメトリ側を設定値にしたままレンダラを定数に残す変異**（＝出荷されていたバグそのもの）でテストが失敗することを確認済み。Issue の受け入れ条件「今日なら失敗するテスト」を満たしている。

検証項目：

- 非デフォルトのセルサイズで**レンダラが描くもの**が変わる（ジオメトリの計算値だけでなく）
- 非デフォルトサイズでサイドバーの描画境界とクリック境界が一致
- 非デフォルトサイズでもターミナル/PTY列数と描画列数が一致（既存の掃引テストを拡張）

## デフォルト不変

`defaults_unchanged=yes`。設定なしの既存挙動は変わらない。

## 検証（統括が実行）

fmt / clippy(-D warnings) / test すべて通過、`frame_oracle --ignored` はちょうど2件失敗。