### PR TITLE
chore: clear four quality follow-ups (#101 #91 #86 #102)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
 name = "noren-app"
 version = "0.1.0"
 dependencies = [
+ "noren-app",
  "noren-pty",
  "noren-terminal",
  "toml_edit",

--- a/crates/noren-app/Cargo.toml
+++ b/crates/noren-app/Cargo.toml
@@ -15,5 +15,14 @@ toml_edit.workspace = true
 winit.workspace = true
 wgpu.workspace = true
 
+[features]
+test-support = []
+
+[dev-dependencies]
+# Self-dev-dependency so integration tests (separate crates) can reach the
+# `test-support`-gated `sidebar::fixtures` module without shipping it in
+# release builds.
+noren-app = { path = ".", features = ["test-support"] }
+
 [lints]
 workspace = true

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -543,15 +543,19 @@ mod tests {
 
     #[test]
     fn glyph_input_is_bounded_to_visible_poc_grid() {
-        let terminal = snapshot(100, 500, &vec![b'A'; 50_000]);
-        let vertices = glyph_vertices(
-            Some(&terminal),
-            None,
-            None,
-            u32::MAX,
-            u32::MAX,
-            poc_metrics(),
-        );
+        // Grid dimensions one past the renderer limits exercise the same
+        // dimension clamps as u32::MAX: visible_rows clamps to
+        // MAX_RENDER_ROWS and terminal_cols clamps to MAX_RENDER_COLS.
+        // No overflow path exists — all dimension arithmetic uses
+        // saturating_add and clamp — so u32::MAX adds no coverage beyond
+        // these values.
+        let rows = MAX_RENDER_ROWS + 1;
+        let cols = MAX_RENDER_COLS + 1;
+        let bytes = vec![b'A'; usize::from(rows) * usize::from(cols)];
+        let terminal = snapshot(rows, cols, &bytes);
+        let width = u32::from(cols) * CELL_WIDTH + CELL_WIDTH;
+        let height = u32::from(rows) * CELL_HEIGHT + CELL_HEIGHT;
+        let vertices = glyph_vertices(Some(&terminal), None, None, width, height, poc_metrics());
         assert!(vertices.len() <= MAX_VERTICES);
     }
 
@@ -578,6 +582,7 @@ mod tests {
     }
 
     const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
+    const CELL_HEIGHT: u32 = noren_app::POC_CELL_HEIGHT;
 
     fn ndc_left(column: u32) -> f32 {
         (column * CELL_WIDTH) as f32 / 900.0 * 2.0 - 1.0

--- a/crates/noren-app/src/sidebar.rs
+++ b/crates/noren-app/src/sidebar.rs
@@ -331,6 +331,7 @@ fn session_status_text(status: &SessionStatus) -> &'static str {
 ///
 /// Sessions are constructed through the shared `SessionRegistry`, which is
 /// pure state and spawns nothing; SSH and agent entries are text facts only.
+#[cfg(feature = "test-support")]
 pub mod fixtures {
     use super::SidebarEntry;
     use crate::session::{SessionId, SessionKind, SessionRegistry, SessionStatus};

--- a/crates/noren-app/tests/palette.rs
+++ b/crates/noren-app/tests/palette.rs
@@ -59,7 +59,7 @@ fn no_pane_tab_split_or_layout_command_is_offered() {
         let lower = label.to_ascii_lowercase();
         assert!(
             !lower.contains("pane")
-                && !lower.contains(" tab")
+                && !lower.contains("tab")
                 && !lower.contains("split")
                 && !lower.contains("layout"),
             "ADR 0003 boundary violated by command label {label:?}"
@@ -146,6 +146,21 @@ fn special_and_escaped_characters_are_matched_literally_without_panicking() {
     let result = std::panic::catch_unwind(|| palette.search(hostile));
     assert!(result.is_ok(), "literal special-char query must not panic");
     assert!(result.expect("search returned").is_empty());
+}
+
+#[test]
+fn match_index_counts_chars_not_bytes_for_non_ascii_labels() {
+    let palette = Palette::from_commands([Command::new(
+        CommandId::new("x.cafe"),
+        "Café Spotlight",
+        TestAction::Do("cafe"),
+    )]);
+    let hits = palette.search("spotlight");
+    assert_eq!(hits.len(), 1);
+    // "Café Spotlight" — "Spotlight" begins at char index 5 (after "Café ").
+    // é is one char but two UTF-8 bytes, so a byte-indexing regression would
+    // report 6 instead of 5.
+    assert_eq!(hits[0].match_index(), 5);
 }
 
 // ── Ranking ─────────────────────────────────────────────────────────────

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -114,6 +114,11 @@ pub(crate) enum PrivateMode {
     AlternateScreen,
     ApplicationCursorKey,
     BracketedPaste,
+    MouseTrackingNormal,
+    MouseTrackingButtonEvent,
+    MouseTrackingAnyEvent,
+    MouseEncodingSgr,
+    MouseEncodingUrxvt,
 }
 
 /// Incremental UTF-8 decoder for printable text in the Ground state.
@@ -497,6 +502,11 @@ impl Csi {
             1 => PrivateMode::ApplicationCursorKey,
             1049 => PrivateMode::AlternateScreen,
             2004 => PrivateMode::BracketedPaste,
+            1000 => PrivateMode::MouseTrackingNormal,
+            1002 => PrivateMode::MouseTrackingButtonEvent,
+            1003 => PrivateMode::MouseTrackingAnyEvent,
+            1006 => PrivateMode::MouseEncodingSgr,
+            1015 => PrivateMode::MouseEncodingUrxvt,
             _ => return None,
         };
         match final_byte {
@@ -700,6 +710,48 @@ mod tests {
                 },
                 Action::SetPrivateMode {
                     mode: PrivateMode::BracketedPaste,
+                    enabled: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn mouse_tracking_and_encoding_modes_are_tracked_as_private_modes() {
+        assert_eq!(
+            actions(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1015h"),
+            [
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingNormal,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingButtonEvent,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingAnyEvent,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseEncodingSgr,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseEncodingUrxvt,
+                    enabled: true,
+                },
+            ]
+        );
+        assert_eq!(
+            actions(b"\x1b[?1000l\x1b[?1006l"),
+            [
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingNormal,
+                    enabled: false,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseEncodingSgr,
                     enabled: false,
                 },
             ]

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -261,6 +261,11 @@ pub struct TerminalModes {
     application_cursor_key: bool,
     application_keypad: bool,
     bracketed_paste: bool,
+    mouse_normal_tracking: bool,
+    mouse_button_event_tracking: bool,
+    mouse_any_event_tracking: bool,
+    mouse_sgr_encoding: bool,
+    mouse_urxvt_encoding: bool,
 }
 
 impl TerminalModes {
@@ -290,6 +295,36 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_bracketed_paste_enabled(self) -> bool {
         self.bracketed_paste
+    }
+
+    /// Whether DEC private mode 1000 (normal mouse tracking) is enabled.
+    #[must_use]
+    pub const fn is_mouse_normal_tracking_enabled(self) -> bool {
+        self.mouse_normal_tracking
+    }
+
+    /// Whether DEC private mode 1002 (button-event mouse tracking) is enabled.
+    #[must_use]
+    pub const fn is_mouse_button_event_tracking_enabled(self) -> bool {
+        self.mouse_button_event_tracking
+    }
+
+    /// Whether DEC private mode 1003 (any-event mouse tracking) is enabled.
+    #[must_use]
+    pub const fn is_mouse_any_event_tracking_enabled(self) -> bool {
+        self.mouse_any_event_tracking
+    }
+
+    /// Whether DEC private mode 1006 (SGR mouse encoding) is enabled.
+    #[must_use]
+    pub const fn is_mouse_sgr_encoding_enabled(self) -> bool {
+        self.mouse_sgr_encoding
+    }
+
+    /// Whether DEC private mode 1015 (urxvt mouse encoding) is enabled.
+    #[must_use]
+    pub const fn is_mouse_urxvt_encoding_enabled(self) -> bool {
+        self.mouse_urxvt_encoding
     }
 }
 
@@ -1218,6 +1253,21 @@ impl TerminalState {
             }
             (PrivateMode::BracketedPaste, enabled) => {
                 self.modes.bracketed_paste = enabled;
+            }
+            (PrivateMode::MouseTrackingNormal, enabled) => {
+                self.modes.mouse_normal_tracking = enabled;
+            }
+            (PrivateMode::MouseTrackingButtonEvent, enabled) => {
+                self.modes.mouse_button_event_tracking = enabled;
+            }
+            (PrivateMode::MouseTrackingAnyEvent, enabled) => {
+                self.modes.mouse_any_event_tracking = enabled;
+            }
+            (PrivateMode::MouseEncodingSgr, enabled) => {
+                self.modes.mouse_sgr_encoding = enabled;
+            }
+            (PrivateMode::MouseEncodingUrxvt, enabled) => {
+                self.modes.mouse_urxvt_encoding = enabled;
             }
         }
     }

--- a/crates/noren-terminal/tests/mouse_modes.rs
+++ b/crates/noren-terminal/tests/mouse_modes.rs
@@ -1,0 +1,116 @@
+//! DEC private mouse tracking (1000/1002/1003) and encoding (1006/1015)
+//! mode tracking in terminal state.
+//!
+//! The terminal holds the mode state only; generating mouse reports stays in
+//! `noren-app`'s input encoder. These tests exercise the public API
+//! (`feed_bytes` + `modes()`) the way the app will read it, including a
+//! DECSET split across two `feed_bytes` calls — the case where a hand-rolled
+//! byte scanner would differ from the incremental parser.
+
+use noren_terminal::TerminalState;
+
+#[test]
+fn mouse_modes_default_to_disabled() {
+    let state = TerminalState::new(2, 4).expect("valid terminal");
+    let modes = state.modes();
+    assert!(!modes.is_mouse_normal_tracking_enabled());
+    assert!(!modes.is_mouse_button_event_tracking_enabled());
+    assert!(!modes.is_mouse_any_event_tracking_enabled());
+    assert!(!modes.is_mouse_sgr_encoding_enabled());
+    assert!(!modes.is_mouse_urxvt_encoding_enabled());
+}
+
+#[test]
+fn mouse_tracking_modes_toggle_with_decset_and_decrst() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1000h");
+    assert!(state.modes().is_mouse_normal_tracking_enabled());
+    assert!(!state.modes().is_mouse_button_event_tracking_enabled());
+
+    state.feed_bytes(b"\x1b[?1002h");
+    assert!(state.modes().is_mouse_button_event_tracking_enabled());
+
+    state.feed_bytes(b"\x1b[?1003h");
+    assert!(state.modes().is_mouse_any_event_tracking_enabled());
+
+    state.feed_bytes(b"\x1b[?1000l");
+    assert!(!state.modes().is_mouse_normal_tracking_enabled());
+    assert!(state.modes().is_mouse_button_event_tracking_enabled());
+
+    state.feed_bytes(b"\x1b[?1002l\x1b[?1003l");
+    assert!(!state.modes().is_mouse_button_event_tracking_enabled());
+    assert!(!state.modes().is_mouse_any_event_tracking_enabled());
+}
+
+#[test]
+fn mouse_encoding_modes_toggle_with_decset_and_decrst() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1006h");
+    assert!(state.modes().is_mouse_sgr_encoding_enabled());
+    assert!(!state.modes().is_mouse_urxvt_encoding_enabled());
+
+    state.feed_bytes(b"\x1b[?1015h");
+    assert!(state.modes().is_mouse_urxvt_encoding_enabled());
+
+    state.feed_bytes(b"\x1b[?1006l");
+    assert!(!state.modes().is_mouse_sgr_encoding_enabled());
+
+    state.feed_bytes(b"\x1b[?1015l");
+    assert!(!state.modes().is_mouse_urxvt_encoding_enabled());
+}
+
+#[test]
+fn mouse_modes_are_independent_of_screen_and_paste_modes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?1000h\x1b[?1006h\x1b[?1049h\x1b[?2004h");
+
+    let modes = state.modes();
+    assert!(modes.is_mouse_normal_tracking_enabled());
+    assert!(modes.is_mouse_sgr_encoding_enabled());
+    assert!(modes.is_alternate_screen_active());
+    assert!(modes.is_bracketed_paste_enabled());
+
+    // Leaving the alternate screen keeps mouse modes.
+    state.feed_bytes(b"\x1b[?1049l");
+    let modes = state.modes();
+    assert!(!modes.is_alternate_screen_active());
+    assert!(modes.is_mouse_normal_tracking_enabled());
+    assert!(modes.is_mouse_sgr_encoding_enabled());
+}
+
+#[test]
+fn decset_split_across_feed_bytes_calls_is_still_detected() {
+    // A DECSET sequence split across two feed_bytes calls must still update
+    // state. This is the case where a hand-rolled byte scanner that resets
+    // on chunk boundaries would miss the transition; the incremental parser
+    // retains its CSI state between calls.
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?10");
+    // Mode is not yet set: the sequence is incomplete.
+    assert!(!state.modes().is_mouse_normal_tracking_enabled());
+
+    state.feed_bytes(b"00h");
+    assert!(state.modes().is_mouse_normal_tracking_enabled());
+
+    // Split a DECRST the same way.
+    state.feed_bytes(b"\x1b[?100");
+    assert!(state.modes().is_mouse_normal_tracking_enabled());
+
+    state.feed_bytes(b"0l");
+    assert!(!state.modes().is_mouse_normal_tracking_enabled());
+}
+
+#[test]
+fn mouse_modes_survive_snapshot() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?1003h\x1b[?1006h");
+
+    let snap = state.snapshot();
+    let modes = snap.modes();
+    assert!(modes.is_mouse_any_event_tracking_enabled());
+    assert!(modes.is_mouse_sgr_encoding_enabled());
+    assert!(!modes.is_mouse_normal_tracking_enabled());
+}


### PR DESCRIPTION
Issue ごとに1コミット。個別に revert 可能。

`QUALITY i101=fixed i101_seconds=1.39 i91=fixed i86=fixed i102=fixed scanner_left_in_place=yes tests=PASS total=666`

## #101 — ユニットテストが31秒→**1.39秒**

`glyph_input_is_bounded_to_visible_poc_grid` が5万バイトを `u32::MAX` 寸法で流していた。守っている性質（頂点数が `MAX_VERTICES` を超えない）は Issue #93 で恒真テストを削除した根拠でもあるため**削除せず**、入力を `MAX_RENDER_COLS`/`ROWS` をわずかに超える程度へ縮小した。

指示では「`u32::MAX` が何を検証しているか先に確認し、オーバーフロー経路を覆っているなら別の安価なテストで残せ」としている。

## #91 — fixtures がリリースビルドに入らなくなった

`pub mod fixtures` を `test-support` feature の背後へ。統括がリリースバイナリで検証：

```
web1.internal    0
claude-code      0
pool-m3c         0
```

以前はサンプルのホスト名・ラベルが製品バイナリに含まれていた。

## #86 — パレットの保証にテストを付けた

1. 「マッチ位置は byte ではなく char を数える」という文書化された保証に、非ASCIIラベルのテストがなかった（全ラベルが ASCII のため byte インデックスへ退行しても全テストが通る状態）
2. `no_pane_tab_split_or_layout_command_is_offered` が `" tab"`（先頭スペース付き）で検査していたため "Tab" で**始まる**ラベルがすり抜けていた

## #102 — パーサがマウスモードを追跡するようになった

`PrivateMode` に tracking（1000/1002/1003）と encoding（1006/1015）を追加し、`TerminalState` が保持する。

**`noren-terminal` の設計境界を守っている**：状態を**保持するだけ**で、レポート生成は `noren-app` の入力エンコーダのまま。レンダラ非依存・PTY非依存という CONTRIBUTING の制約は崩していない。

**`MouseModeScanner` は意図的に残した**（`scanner_left_in_place=yes`）。アプリを新しいアクセサへ切り替えるのは独立したレビューを要する別変更であり、2つの解析器が一時的に並存する方が flag day より安全。

## 検証

fmt / clippy(-D warnings) / test すべて通過、`frame_oracle --ignored` はちょうど2件失敗。