### PR TITLE
feat(app): wire per-cell foreground colour through the GPU pipeline (#107)

### DIFF
--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -2272,8 +2272,15 @@ mod tests {
     /// arbitrary vertices would count that bleed as a drawn column and over-
     /// count by one. Each rect is emitted as a 6-vertex fan whose first vertex
     /// is its top-left corner, so the left edges are read from every 6th group.
-    fn rendered_terminal_columns(vertices: &[[f32; 2]], width: u32, cell_width: u32) -> usize {
-        let rect_lefts: Vec<f32> = vertices.chunks_exact(6).map(|rect| rect[0][0]).collect();
+    fn rendered_terminal_columns(
+        vertices: &[renderer::Vertex],
+        width: u32,
+        cell_width: u32,
+    ) -> usize {
+        let rect_lefts: Vec<f32> = vertices
+            .chunks_exact(6)
+            .map(|rect| rect[0].position[0])
+            .collect();
         let mut drawn = 0;
         for col in renderer::SIDEBAR_COLS..usize::from(MAX_RENDER_COLS) {
             let edge = ((col as u32) * cell_width) as f32 / width as f32 * 2.0 - 1.0;

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -1,4 +1,15 @@
 //! Minimal, bounded `wgpu` terminal view for the PoC.
+//!
+//! Per-cell foreground colour recorded by the terminal state reaches drawing
+//! here: [`resolve_foreground`] runs a cell's `Color` selection through the
+//! default palette (or passes `Rgb` through directly) and the result rides on
+//! every vertex the cell's glyph emits, which the fragment shader returns.
+//! A cell with no SGR colour resolves to [`DEFAULT_FOREGROUND`] — the exact
+//! shade the shader previously returned as a constant — so unstyled output is
+//! unchanged.
+//!
+//! Background colour is not drawn yet: that needs a filled rect behind each
+//! glyph rather than colour on the glyph's own vertices. See issue #107.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -11,7 +22,7 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
-use noren_terminal::TerminalSnapshot;
+use noren_terminal::{CellAttributes, Color, TerminalSnapshot};
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize) * (MAX_RENDER_COLS as usize) * 35 * 6;
@@ -33,20 +44,167 @@ pub(crate) const SIDEBAR_COLS: usize = 16;
 pub(crate) const SHADER: &str = r#"
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
 };
 
 @vertex
-fn vs_main(@location(0) position: vec2<f32>) -> VertexOutput {
+fn vs_main(
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec3<f32>,
+) -> VertexOutput {
     var output: VertexOutput;
     output.position = vec4<f32>(position, 0.0, 1.0);
+    output.color = color;
     return output;
 }
 
 @fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    return vec4<f32>(0.80, 0.92, 0.82, 1.0);
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(input.color, 1.0);
 }
 "#;
+
+/// One GPU vertex: an NDC position plus the resolved draw colour of the cell
+/// whose glyph emitted it.
+///
+/// The colour is per-vertex rather than per-draw because a frame mixes cells
+/// of many colours in one buffer and one `draw` call; the alternative (a draw
+/// call per colour run) would reorder glyphs and complicate the vertex budget
+/// for no visual gain at this scale.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct Vertex {
+    pub(crate) position: [f32; 2],
+    pub(crate) color: [f32; 3],
+}
+
+/// Bytes per [`Vertex`]: two position floats plus three colour floats.
+pub(crate) const VERTEX_BYTES: usize = 20;
+
+/// The vertex buffer layout for [`Vertex`], shared by the shipped renderer's
+/// pipeline and the offscreen frame-oracle's, so the two cannot drift apart on
+/// stride or attribute offsets.
+pub(crate) const VERTEX_ATTRIBUTES: [wgpu::VertexAttribute; 2] = [
+    wgpu::VertexAttribute {
+        format: wgpu::VertexFormat::Float32x2,
+        offset: 0,
+        shader_location: 0,
+    },
+    wgpu::VertexAttribute {
+        format: wgpu::VertexFormat::Float32x3,
+        offset: 8,
+        shader_location: 1,
+    },
+];
+
+/// Default terminal foreground — the concrete colour behind a `Color::Default`
+/// foreground selection, the sidebar, and the status line.
+///
+/// These are exactly the floats the fragment shader previously returned as a
+/// constant for every pixel. Keeping the value here rather than re-deriving it
+/// from an 8-bit triple is deliberate: rounding `0.80` through `u8` and back
+/// would shift the default shade slightly, and an unstyled prompt must look
+/// identical to how it looked before colour existed (issue #107).
+pub(crate) const DEFAULT_FOREGROUND: [f32; 3] = [0.80, 0.92, 0.82];
+
+/// The sixteen ANSI colours of the default theme as `(red, green, blue)` in
+/// palette-index order: standard colours `0..=7`, bright colours `8..=15`.
+///
+/// This table is the single theme seam. The values are the xterm defaults; a
+/// future configurable theme replaces this table and every palette-derived
+/// draw colour follows without touching the resolution logic.
+pub(crate) const DEFAULT_ANSI_PALETTE: [[u8; 3]; 16] = [
+    [0, 0, 0],
+    [205, 0, 0],
+    [0, 205, 0],
+    [205, 205, 0],
+    [0, 0, 238],
+    [205, 0, 205],
+    [0, 205, 205],
+    [229, 229, 229],
+    [127, 127, 127],
+    [255, 0, 0],
+    [0, 255, 0],
+    [255, 255, 0],
+    [92, 92, 255],
+    [255, 0, 255],
+    [0, 255, 255],
+    [255, 255, 255],
+];
+
+/// One channel of the xterm 6×6×6 colour cube: level zero is zero, and the
+/// remaining five levels are `55 + 40 * level`.
+const fn cube_channel(level: u8) -> u8 {
+    if level == 0 { 0 } else { level * 40 + 55 }
+}
+
+/// Derive the full xterm 256-colour palette once, at compile time.
+const fn build_default_palette() -> [[u8; 3]; 256] {
+    let mut palette = [[0_u8; 3]; 256];
+    let mut index = 0_usize;
+    while index < 256 {
+        palette[index] = if index < 16 {
+            DEFAULT_ANSI_PALETTE[index]
+        } else if index < 232 {
+            let cube = (index - 16) as u32;
+            [
+                cube_channel((cube / 36) as u8),
+                cube_channel(((cube / 6) % 6) as u8),
+                cube_channel((cube % 6) as u8),
+            ]
+        } else {
+            let gray = (8 + (index - 232) * 10) as u8;
+            [gray, gray, gray]
+        };
+        index += 1;
+    }
+    palette
+}
+
+/// The xterm 256-colour default palette: entries `0..=15` from
+/// [`DEFAULT_ANSI_PALETTE`], `16..=231` the 6×6×6 colour cube, and
+/// `232..=255` the 24-step grayscale ramp.
+///
+/// The 16 ANSI colours and the 256-colour indexes resolve through this one
+/// table, so `SGR 31` and `SGR 38;5;1` cannot disagree about what red is.
+pub(crate) const DEFAULT_PALETTE: [[u8; 3]; 256] = build_default_palette();
+
+/// Convert an 8-bit-per-channel colour to the shader's `0.0..=1.0` floats.
+const fn channels_to_floats([red, green, blue]: [u8; 3]) -> [f32; 3] {
+    [
+        red as f32 / 255.0,
+        green as f32 / 255.0,
+        blue as f32 / 255.0,
+    ]
+}
+
+/// Resolve one renderer-independent colour selection to a concrete draw colour.
+///
+/// [`Color::Default`] yields `default` (the caller supplies the contextual
+/// default for the slot), [`Color::Ansi`] and [`Color::Indexed`] both resolve
+/// through [`DEFAULT_PALETTE`] — one path, so the 16-colour and 256-colour
+/// forms of the same colour agree — and [`Color::Rgb`] passes through as
+/// direct 24-bit truecolor.
+#[must_use]
+pub(crate) fn resolve_color(color: Color, default: [f32; 3]) -> [f32; 3] {
+    match color {
+        Color::Default => default,
+        Color::Ansi(ansi) => channels_to_floats(DEFAULT_PALETTE[ansi.palette_index() as usize]),
+        Color::Indexed(index) => channels_to_floats(DEFAULT_PALETTE[index as usize]),
+        Color::Rgb(red, green, blue) => channels_to_floats([red, green, blue]),
+    }
+}
+
+/// The colour a cell's glyph is drawn in.
+///
+/// Background rectangles are deliberately out of scope for this foreground
+/// pass. In particular, do not resolve reverse video to the background here:
+/// without a rectangle behind it that would draw the glyph in the clear colour
+/// and make reversed text disappear. Reverse/background composition belongs in
+/// the later background pass.
+#[must_use]
+pub(crate) fn resolve_foreground(attributes: &CellAttributes) -> [f32; 3] {
+    resolve_color(attributes.foreground(), DEFAULT_FOREGROUND)
+}
 
 /// Clear colour used by the glyph pipeline's load op.
 ///
@@ -141,13 +299,9 @@ impl Renderer {
                 entry_point: Some("vs_main"),
                 compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[Some(wgpu::VertexBufferLayout {
-                    array_stride: 8,
+                    array_stride: VERTEX_BYTES as u64,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Float32x2,
-                        offset: 0,
-                        shader_location: 0,
-                    }],
+                    attributes: &VERTEX_ATTRIBUTES,
                 })],
             },
             primitive: wgpu::PrimitiveState::default(),
@@ -317,7 +471,7 @@ pub(crate) fn glyph_vertices(
     width: u32,
     height: u32,
     metrics: CellMetrics,
-) -> Vec<[f32; 2]> {
+) -> Vec<Vertex> {
     if width == 0 || height == 0 {
         return Vec::new();
     }
@@ -349,11 +503,25 @@ pub(crate) fn glyph_vertices(
         window_cols.clamp(1, usize::from(MAX_RENDER_COLS))
     };
     let mut vertices = Vec::new();
+    let target = Target {
+        width,
+        height,
+        metrics,
+    };
 
+    // The sidebar is chrome, not terminal content: it carries no cell
+    // attributes, so it draws in the default foreground.
     if let Some(lines) = sidebar {
         for (row, line) in lines.iter().take(visible_rows).enumerate() {
             for (col, character) in line.chars().take(SIDEBAR_COLS).enumerate() {
-                push_glyph(&mut vertices, character, col, row, width, height, metrics);
+                push_glyph(
+                    &mut vertices,
+                    character,
+                    DEFAULT_FOREGROUND,
+                    col,
+                    row,
+                    target,
+                );
                 if vertices.len() >= MAX_VERTICES {
                     return vertices;
                 }
@@ -361,51 +529,90 @@ pub(crate) fn glyph_vertices(
         }
     }
 
-    // display_lines preserves wide-character continuation columns, so the
-    // character index below is the display column for every glyph.
-    let lines = terminal
-        .map(TerminalSnapshot::display_lines)
+    // `display_cells` is the per-cell parallel of `display_lines`: it selects
+    // the same rows and gives a wide character's continuation cell its own
+    // column, so the cell index below is the display column for every glyph —
+    // the same coordinate model the string path used, now carrying the
+    // attributes that path threw away.
+    let rows: Vec<&[noren_terminal::Cell]> = terminal
+        .map(|snapshot| snapshot.display_cells().collect())
         .unwrap_or_default();
-    let total_lines = lines.len() + usize::from(status.is_some());
+    let total_lines = rows.len() + usize::from(status.is_some());
     let first_line = total_lines.saturating_sub(visible_rows);
 
     for (row, line_index) in (first_line..total_lines).enumerate() {
-        let line = if line_index < lines.len() {
-            lines[line_index].as_str()
+        if let Some(cells) = rows.get(line_index) {
+            for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
+                // A continuation cell draws nothing but still owns its column,
+                // exactly as the placeholder space did in `display_lines`.
+                if cell.is_continuation() {
+                    continue;
+                }
+                let color = resolve_foreground(cell.attributes());
+                for character in cell.text().chars() {
+                    push_glyph(
+                        &mut vertices,
+                        character,
+                        color,
+                        col_offset + col,
+                        row,
+                        target,
+                    );
+                    if vertices.len() >= MAX_VERTICES {
+                        return vertices;
+                    }
+                }
+            }
         } else {
-            status.unwrap_or_default()
-        };
-        for (col, character) in line.chars().take(terminal_cols).enumerate() {
-            push_glyph(
-                &mut vertices,
-                character,
-                col_offset + col,
-                row,
-                width,
-                height,
-                metrics,
-            );
-            if vertices.len() >= MAX_VERTICES {
-                return vertices;
+            // The status line is renderer chrome with no cell backing.
+            for (col, character) in status
+                .unwrap_or_default()
+                .chars()
+                .take(terminal_cols)
+                .enumerate()
+            {
+                push_glyph(
+                    &mut vertices,
+                    character,
+                    DEFAULT_FOREGROUND,
+                    col_offset + col,
+                    row,
+                    target,
+                );
+                if vertices.len() >= MAX_VERTICES {
+                    return vertices;
+                }
             }
         }
     }
     vertices
 }
 
-/// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`,
-/// converting each lit pixel bit to a 2×2 rectangle of vertices.
-fn push_glyph(
-    vertices: &mut Vec<[f32; 2]>,
-    character: char,
-    col: usize,
-    row: usize,
+/// The draw surface a frame is laid out against: pixel dimensions plus the
+/// cell size the grid is drawn at.
+///
+/// These three travel together through every emit call and are constant for a
+/// frame, so passing them as one value keeps the glyph/rect helpers to a
+/// readable arity now that each also carries a colour.
+#[derive(Clone, Copy, Debug)]
+struct Target {
     width: u32,
     height: u32,
     metrics: CellMetrics,
+}
+
+/// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`,
+/// converting each lit pixel bit to a 2×2 rectangle of vertices in `color`.
+fn push_glyph(
+    vertices: &mut Vec<Vertex>,
+    character: char,
+    color: [f32; 3],
+    col: usize,
+    row: usize,
+    target: Target,
 ) {
-    let cell_width = metrics.width();
-    let cell_height = metrics.height();
+    let cell_width = target.metrics.width();
+    let cell_height = target.metrics.height();
     let glyph = glyph_rows(character);
     for (glyph_y, bits) in glyph.into_iter().enumerate() {
         for glyph_x in 0..5 {
@@ -417,33 +624,63 @@ fn push_glyph(
             let y = u32::try_from(row).unwrap_or(u32::MAX) * cell_height
                 + GLYPH_TOP
                 + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
-            push_rect(vertices, x, y, GLYPH_SCALE, width, height);
+            push_rect(vertices, x, y, GLYPH_SCALE, color, target);
         }
     }
 }
 
-fn push_rect(vertices: &mut Vec<[f32; 2]>, x: u32, y: u32, size: u32, width: u32, height: u32) {
+fn push_rect(
+    vertices: &mut Vec<Vertex>,
+    x: u32,
+    y: u32,
+    size: u32,
+    color: [f32; 3],
+    target: Target,
+) {
+    let (width, height) = (target.width, target.height);
     let left = x as f32 / width as f32 * 2.0 - 1.0;
     let right = x.saturating_add(size) as f32 / width as f32 * 2.0 - 1.0;
     let top = 1.0 - y as f32 / height as f32 * 2.0;
     let bottom = 1.0 - y.saturating_add(size) as f32 / height as f32 * 2.0;
     vertices.extend_from_slice(&[
-        [left, top],
-        [left, bottom],
-        [right, bottom],
-        [left, top],
-        [right, bottom],
-        [right, top],
+        Vertex {
+            position: [left, top],
+            color,
+        },
+        Vertex {
+            position: [left, bottom],
+            color,
+        },
+        Vertex {
+            position: [right, bottom],
+            color,
+        },
+        Vertex {
+            position: [left, top],
+            color,
+        },
+        Vertex {
+            position: [right, bottom],
+            color,
+        },
+        Vertex {
+            position: [right, top],
+            color,
+        },
     ]);
 }
 
 /// Exposed as `pub(crate)` for the offscreen frame-oracle (see
 /// `renderer_capture.rs`); no behaviour change.
-pub(crate) fn vertex_bytes(vertices: &[[f32; 2]]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(vertices.len().saturating_mul(8));
+pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(vertices.len().saturating_mul(VERTEX_BYTES));
     for vertex in vertices {
-        bytes.extend_from_slice(&vertex[0].to_ne_bytes());
-        bytes.extend_from_slice(&vertex[1].to_ne_bytes());
+        for value in vertex.position {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
+        for value in vertex.color {
+            bytes.extend_from_slice(&value.to_ne_bytes());
+        }
     }
     bytes
 }
@@ -567,6 +804,57 @@ mod tests {
         assert!(glyph_vertices(Some(&text), None, None, 0, 600, poc_metrics()).is_empty());
     }
 
+    /// The 16-colour and 256-colour forms of the same colour must resolve
+    /// through one path, and truecolor must pass through untouched.
+    #[test]
+    fn ansi_indexed_and_rgb_resolve_through_one_palette() {
+        use noren_terminal::AnsiColor;
+
+        // `SGR 31` (ANSI red) and `SGR 38;5;1` (indexed 1) name the same
+        // colour and must produce identical draw colours.
+        assert_eq!(
+            resolve_color(Color::Ansi(AnsiColor::Red), DEFAULT_FOREGROUND),
+            resolve_color(Color::Indexed(1), DEFAULT_FOREGROUND),
+        );
+        // Truecolor passes through as exact 24-bit channels.
+        assert_eq!(
+            resolve_color(Color::Rgb(255, 0, 0), DEFAULT_FOREGROUND),
+            [1.0, 0.0, 0.0]
+        );
+        // Default takes the contextual default the caller supplied.
+        assert_eq!(
+            resolve_color(Color::Default, DEFAULT_FOREGROUND),
+            DEFAULT_FOREGROUND
+        );
+        // Spot-check the xterm cube and grayscale derivations: index 196 is
+        // cube (5,0,0) = pure red, and 232 is the darkest gray step.
+        assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
+        assert_eq!(DEFAULT_PALETTE[232], [8, 8, 8]);
+        assert_eq!(DEFAULT_PALETTE[255], [238, 238, 238]);
+        // Distinct palette entries must stay distinct.
+        assert_ne!(DEFAULT_PALETTE[1], DEFAULT_PALETTE[4]);
+    }
+
+    /// A cell's resolved colour must reach the vertices its glyph emits —
+    /// this is the wiring issue #107 is about.
+    #[test]
+    fn sgr_foreground_reaches_the_vertex_colour() {
+        // Red 'A' then default-coloured 'B'.
+        let terminal = snapshot(1, 4, b"\x1b[31mA\x1b[0mB");
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let red = channels_to_floats(DEFAULT_ANSI_PALETTE[1]);
+        assert!(
+            vertices.iter().any(|vertex| vertex.color == red),
+            "the SGR-31 cell must emit vertices in palette red"
+        );
+        assert!(
+            vertices
+                .iter()
+                .any(|vertex| vertex.color == DEFAULT_FOREGROUND),
+            "the unstyled cell must emit vertices in the default foreground"
+        );
+    }
+
     #[test]
     fn ascii_glyphs_are_distinct_and_unknown_is_question_mark() {
         assert_ne!(glyph_rows('A'), glyph_rows('B'));
@@ -574,11 +862,41 @@ mod tests {
         assert_eq!(glyph_rows('界'), glyph_rows('?'));
     }
 
+    /// The encoded vertex stride must match what the pipeline's vertex buffer
+    /// layout declares, or the GPU reads position and colour from the wrong
+    /// offsets and every glyph is mispositioned or miscoloured.
     #[test]
-    fn vertex_encoding_has_two_floats_per_vertex() {
+    fn vertex_encoding_matches_the_declared_buffer_layout() {
         let terminal = snapshot(1, 2, b"A");
         let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
-        assert_eq!(vertex_bytes(&vertices).len(), vertices.len() * 8);
+        assert!(!vertices.is_empty(), "'A' emitted no vertices");
+        assert_eq!(
+            vertex_bytes(&vertices).len(),
+            vertices.len() * VERTEX_BYTES,
+            "encoded size must equal vertex count times the declared stride"
+        );
+        // Two position floats plus three colour floats.
+        assert_eq!(VERTEX_BYTES, (2 + 3) * size_of::<f32>());
+        // The colour attribute must start immediately after the position pair,
+        // which is where `vertex_bytes` writes it.
+        assert_eq!(VERTEX_ATTRIBUTES[1].offset, 2 * size_of::<f32>() as u64);
+    }
+
+    /// The default foreground must be the exact shade the fragment shader
+    /// returned as a constant before colour existed, so an unstyled prompt
+    /// does not change appearance (issue #107).
+    #[test]
+    fn unstyled_cells_draw_in_the_previous_constant_foreground() {
+        let terminal = snapshot(1, 4, b"AB");
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        assert!(!vertices.is_empty(), "unstyled text emitted no vertices");
+        assert!(
+            vertices
+                .iter()
+                .all(|vertex| vertex.color == [0.80, 0.92, 0.82]),
+            "unstyled cells must draw in the historical constant 0.80/0.92/0.82"
+        );
+        assert_eq!(DEFAULT_FOREGROUND, [0.80, 0.92, 0.82]);
     }
 
     const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
@@ -592,9 +910,11 @@ mod tests {
         1.0 - GLYPH_TOP as f32 / 600.0 * 2.0
     }
 
-    fn has_rect_top_left(vertices: &[[f32; 2]], left: f32) -> bool {
+    fn has_rect_top_left(vertices: &[Vertex], left: f32) -> bool {
         let top = ndc_top_row_zero();
-        vertices.chunks_exact(6).any(|rect| rect[0] == [left, top])
+        vertices
+            .chunks_exact(6)
+            .any(|rect| rect[0].position == [left, top])
     }
 
     #[test]
@@ -664,13 +984,13 @@ mod tests {
         assert!(
             small
                 .chunks_exact(6)
-                .any(|rect| (rect[0][0] - small_edge_1).abs() < 1e-5),
+                .any(|rect| (rect[0].position[0] - small_edge_1).abs() < 1e-5),
             "at default metrics, column 1's left edge must be at 10px"
         );
         assert!(
             big_verts
                 .chunks_exact(6)
-                .any(|rect| (rect[0][0] - big_edge_1).abs() < 1e-5),
+                .any(|rect| (rect[0].position[0] - big_edge_1).abs() < 1e-5),
             "at cell_width=20, column 1's left edge must be at 20px, not 10px"
         );
         // And conversely, the big-vertices must NOT have an edge at the 10px
@@ -678,7 +998,7 @@ mod tests {
         assert!(
             !big_verts
                 .chunks_exact(6)
-                .any(|rect| (rect[0][0] - small_edge_1).abs() < 1e-5),
+                .any(|rect| (rect[0].position[0] - small_edge_1).abs() < 1e-5),
             "at cell_width=20, no vertex should land at the 10px column boundary"
         );
     }

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -50,7 +50,9 @@ use std::thread;
 
 use noren_app::CellMetrics;
 use noren_terminal::TerminalSnapshot;
-use renderer_source::{CLEAR_COLOR, SHADER, glyph_vertices, vertex_bytes};
+use renderer_source::{
+    CLEAR_COLOR, SHADER, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices, vertex_bytes,
+};
 
 /// Linear RGBA8 (non-sRGB) offscreen target.
 ///
@@ -146,14 +148,15 @@ impl OffscreenRenderer {
                 module: &shader,
                 entry_point: Some("vs_main"),
                 compilation_options: wgpu::PipelineCompilationOptions::default(),
+                // The shipped renderer's own layout constants, not a parallel
+                // copy: a stride or attribute-offset change in `renderer.rs`
+                // reaches the oracle's pipeline automatically, so the oracle
+                // cannot keep passing against a layout the binary no longer
+                // uses.
                 buffers: &[Some(wgpu::VertexBufferLayout {
-                    array_stride: 8,
+                    array_stride: VERTEX_BYTES as u64,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[wgpu::VertexAttribute {
-                        format: wgpu::VertexFormat::Float32x2,
-                        offset: 0,
-                        shader_location: 0,
-                    }],
+                    attributes: &VERTEX_ATTRIBUTES,
                 })],
             },
             primitive: wgpu::PrimitiveState::default(),

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -19,7 +19,21 @@
 //!   likely real defect;
 //! - the drawn grid dimensions match the state's dimensions;
 //! - per-cell, lit/blank agrees with `TerminalSnapshot` across the FR-005
-//!   fixture classes (prompt, ASCII, UTF-8, control, scrolling).
+//!   fixture classes (prompt, ASCII, UTF-8, control, scrolling);
+//! - two cells carrying different SGR foreground colours draw *different*
+//!   pixel colours, each matching the palette; a cell with no SGR colour keeps
+//!   the unchanged default; truecolor and 256-colour both resolve to their
+//!   expected values (issue #107).
+//!
+//! ## The lit/blank gate
+//!
+//! `is_background` originally thresholded on brightness, which was sufficient
+//! only while every glyph was one bright-green constant — as the earlier
+//! version of this file noted. It now compares against the renderer's
+//! `CLEAR_COLOR` instead. That is strictly stronger, not weaker: a dark
+//! foreground (ANSI black, a dark truecolor shade) is correctly read as lit
+//! where the threshold would have called it background and thereby agreed with
+//! a renderer that dropped the cell.
 //!
 //! ## Faithfulness
 //!
@@ -43,7 +57,9 @@ mod renderer_capture;
 
 use noren_app::{GridGeometry, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
 use noren_terminal::{TerminalSnapshot, TerminalState};
-use renderer_capture::renderer_source::SIDEBAR_COLS;
+use renderer_capture::renderer_source::{
+    CLEAR_COLOR, DEFAULT_ANSI_PALETTE, DEFAULT_FOREGROUND, DEFAULT_PALETTE, SIDEBAR_COLS,
+};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// The PoC default cell metrics, used by every frame-oracle capture call so
@@ -66,12 +82,47 @@ fn render(renderer: &OffscreenRenderer, snapshot: &TerminalSnapshot) -> Captured
     renderer.capture(Some(snapshot), None, None, width, height, poc_metrics())
 }
 
-/// A pixel counts as "background" when it is close to the clear colour. Glyph
-/// pixels are drawn at the fragment shader's constant `0.80/0.92/0.82` (bright
-/// green), the clear at `0.035/0.045/0.04` (near-black), so a brightness gate
-/// is robust across minor driver rounding.
+/// The clear colour as captured bytes, derived from the renderer's own
+/// [`CLEAR_COLOR`] rather than a literal, so a change to the clear colour
+/// cannot silently invalidate every lit/blank assertion below.
+fn clear_rgb() -> [u8; 3] {
+    [CLEAR_COLOR.r, CLEAR_COLOR.g, CLEAR_COLOR.b].map(|channel| (channel * 255.0).round() as u8)
+}
+
+/// Per-channel tolerance for comparing a captured pixel to an expected colour.
+///
+/// The offscreen target is linear `Rgba8Unorm` and the shader writes the
+/// colour through unchanged, so the only error is float-to-byte rounding in
+/// the GPU's blend/store stage: at most one unit. Two units gives a margin for
+/// driver rounding-mode differences while staying far tighter than the gap
+/// between any two palette entries (the closest pair differs by 10).
+const CHANNEL_TOLERANCE: u8 = 2;
+
+/// Whether two colours match within [`CHANNEL_TOLERANCE`] on every channel.
+fn colors_match(actual: [u8; 3], expected: [u8; 3]) -> bool {
+    actual
+        .iter()
+        .zip(expected.iter())
+        .all(|(a, e)| a.abs_diff(*e) <= CHANNEL_TOLERANCE)
+}
+
+/// A pixel counts as "background" when it is exactly the clear colour.
+///
+/// This is deliberately an *equality* test against the clear colour, not the
+/// brightness threshold this oracle used before colour existed. That gate
+/// (`all channels < 48`) assumed every glyph was the shader's bright-green
+/// constant; it was flagged in this file as insufficient once colour landed,
+/// and it is: a cell drawn in ANSI black or in a dark truecolor shade is lit
+/// but has every channel under 48, so the brightness gate would report it
+/// blank and the lit/blank agreement checks would silently pass on a renderer
+/// that dropped those cells entirely.
+///
+/// Comparing to the clear colour instead is strictly stronger — it accepts
+/// only the one byte colour nothing was drawn in — and it is what lets
+/// [`cell_colors`] below distinguish *which* colour a lit cell holds rather
+/// than merely that something is lit.
 fn is_background(rgba: [u8; 4]) -> bool {
-    rgba[0] < 48 && rgba[1] < 48 && rgba[2] < 48
+    [rgba[0], rgba[1], rgba[2]] == clear_rgb()
 }
 
 /// Whether any lit (non-background) pixel falls inside cell `(row, col)`.
@@ -101,6 +152,52 @@ fn cell_pattern(frame: &CapturedFrame, row: u32, col: u32) -> Vec<bool> {
         }
     }
     pattern
+}
+
+/// The distinct lit (non-background) colours inside cell `(row, col)`.
+///
+/// This is the colour-aware counterpart of [`cell_pattern`]: where that
+/// records only *which* pixels are lit, this records *what colour* they are,
+/// which is what makes "two cells with different SGR colours differ" an
+/// assertion about colour rather than about glyph shape.
+fn cell_colors(frame: &CapturedFrame, row: u32, col: u32) -> Vec<[u8; 3]> {
+    let mut colors: Vec<[u8; 3]> = Vec::new();
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y);
+            if is_background(pixel) {
+                continue;
+            }
+            let rgb = [pixel[0], pixel[1], pixel[2]];
+            if !colors.iter().any(|seen| colors_match(*seen, rgb)) {
+                colors.push(rgb);
+            }
+        }
+    }
+    colors
+}
+
+/// The single colour a cell's glyph is drawn in.
+///
+/// Panics if the cell is unlit or holds more than one distinct colour — a
+/// glyph is drawn in exactly one foreground colour, so either case means the
+/// renderer is not doing what the test assumes and the test must fail loudly
+/// rather than silently pick a colour.
+fn cell_color(frame: &CapturedFrame, row: u32, col: u32) -> [u8; 3] {
+    let colors = cell_colors(frame, row, col);
+    assert_eq!(
+        colors.len(),
+        1,
+        "cell ({row},{col}) should hold exactly one lit colour, found {colors:?}"
+    );
+    colors[0]
+}
+
+/// The default foreground as captured bytes, derived from the renderer's own
+/// [`DEFAULT_FOREGROUND`] so the "unstyled cells are unchanged" assertion
+/// tracks the renderer rather than a literal copied here.
+fn default_foreground_rgb() -> [u8; 3] {
+    DEFAULT_FOREGROUND.map(|channel| (channel * 255.0).round() as u8)
 }
 
 /// State-driven blankness: a cell is blank when the row is absent, the column
@@ -310,6 +407,181 @@ fn state_and_render_agree_across_the_fr005_fixtures() {
     assert!(
         checked >= 4 * 2 * 6,
         "agreement checks covered {checked} cells"
+    );
+}
+
+// ===========================================================================
+// Colour (issue #107): colour was modelled in terminal state but never reached
+// drawing, so every cell rendered in one shade of green. These assertions read
+// the *colour* of drawn pixels, not merely whether they are lit — the
+// distinction the brightness gate above could not make.
+// ===========================================================================
+
+#[test]
+fn cells_with_different_sgr_foregrounds_render_different_colours() {
+    // The headline defect: before colour was wired, these two cells drew the
+    // same green and this test could not exist. Both cells hold 'A', so the
+    // glyph shape is identical and only the colour can differ.
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let snap = snapshot(1, 4, b"\x1b[31mA\x1b[32mA");
+    let frame = render(&renderer, &snap);
+
+    let red_cell = cell_color(&frame, 0, 0);
+    let green_cell = cell_color(&frame, 0, 1);
+
+    // Not merely both lit — actually different colours.
+    assert!(
+        !colors_match(red_cell, green_cell),
+        "SGR 31 and SGR 32 cells rendered the same colour {red_cell:?} — \
+         colour is not reaching the renderer (issue #107)"
+    );
+    // And each is the colour the palette says it is.
+    assert!(
+        colors_match(red_cell, DEFAULT_ANSI_PALETTE[1]),
+        "SGR 31 should draw palette red {:?}, drew {red_cell:?}",
+        DEFAULT_ANSI_PALETTE[1]
+    );
+    assert!(
+        colors_match(green_cell, DEFAULT_ANSI_PALETTE[2]),
+        "SGR 32 should draw palette green {:?}, drew {green_cell:?}",
+        DEFAULT_ANSI_PALETTE[2]
+    );
+}
+
+#[test]
+fn a_cell_with_no_sgr_colour_keeps_the_default_appearance() {
+    // The compatibility half of issue #107: wiring colour must not change how
+    // an unstyled prompt looks.
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let snap = snapshot(1, 4, b"$ A");
+    let frame = render(&renderer, &snap);
+
+    let expected = default_foreground_rgb();
+    for col in [0_u32, 2] {
+        let drawn = cell_color(&frame, 0, col);
+        assert!(
+            colors_match(drawn, expected),
+            "unstyled cell ({col}) drew {drawn:?}, expected the unchanged \
+             default foreground {expected:?}"
+        );
+    }
+    // Pin the default to the exact shade the fragment shader returned as a
+    // constant before colour existed: 0.80/0.92/0.82 -> 204/235/209.
+    assert_eq!(expected, [204, 235, 209]);
+}
+
+#[test]
+fn truecolor_and_256_colour_both_resolve_to_their_expected_pixels() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+
+    // Truecolor: SGR 38;2;R;G;B must produce exactly those channels. The
+    // value is deliberately not a palette entry, so only a real truecolor
+    // path can produce it.
+    let truecolor = snapshot(1, 4, b"\x1b[38;2;17;119;221mA");
+    let truecolor_frame = render(&renderer, &truecolor);
+    let drawn = cell_color(&truecolor_frame, 0, 0);
+    assert!(
+        colors_match(drawn, [17, 119, 221]),
+        "truecolor 38;2;17;119;221 drew {drawn:?}, expected [17, 119, 221] \
+         within ±{CHANNEL_TOLERANCE} per channel"
+    );
+
+    // 256-colour: index 196 is the colour cube's pure red (5,0,0).
+    let indexed = snapshot(1, 4, b"\x1b[38;5;196mA");
+    let indexed_frame = render(&renderer, &indexed);
+    let drawn_indexed = cell_color(&indexed_frame, 0, 0);
+    assert!(
+        colors_match(drawn_indexed, DEFAULT_PALETTE[196]),
+        "256-colour index 196 drew {drawn_indexed:?}, expected {:?}",
+        DEFAULT_PALETTE[196]
+    );
+    assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
+
+    // A grayscale-ramp index resolves too, and differs from both above.
+    let gray = snapshot(1, 4, b"\x1b[38;5;244mA");
+    let gray_frame = render(&renderer, &gray);
+    let drawn_gray = cell_color(&gray_frame, 0, 0);
+    assert!(
+        colors_match(drawn_gray, DEFAULT_PALETTE[244]),
+        "256-colour index 244 drew {drawn_gray:?}, expected {:?}",
+        DEFAULT_PALETTE[244]
+    );
+    assert!(!colors_match(drawn_gray, drawn_indexed));
+}
+
+#[test]
+fn the_16_colour_and_256_colour_forms_of_one_colour_agree() {
+    // `SGR 31` and `SGR 38;5;1` name the same colour. If they resolved through
+    // different tables they could drift apart; both must reach one palette.
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let snap = snapshot(1, 4, b"\x1b[31mA\x1b[38;5;1mA");
+    let frame = render(&renderer, &snap);
+
+    let ansi_form = cell_color(&frame, 0, 0);
+    let indexed_form = cell_color(&frame, 0, 1);
+    assert!(
+        colors_match(ansi_form, indexed_form),
+        "SGR 31 drew {ansi_form:?} but SGR 38;5;1 drew {indexed_form:?} — \
+         the two forms of ANSI red must resolve through one palette"
+    );
+}
+
+#[test]
+fn a_dark_coloured_cell_is_still_seen_as_lit() {
+    // This is the case the old brightness gate got wrong: ANSI black is a
+    // legitimate foreground whose channels are all far below the old `< 48`
+    // threshold, so a threshold-based oracle would call the cell blank and
+    // agree with a renderer that dropped it. `is_background` now compares to
+    // the clear colour, so the cell reads as lit and the colour is checked.
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let snap = snapshot(1, 4, b"\x1b[30mA");
+    let frame = render(&renderer, &snap);
+
+    assert!(
+        cell_is_lit(&frame, 0, 0),
+        "an ANSI-black 'A' must count as lit — it is drawn, just dark"
+    );
+    let drawn = cell_color(&frame, 0, 0);
+    assert!(
+        colors_match(drawn, DEFAULT_ANSI_PALETTE[0]),
+        "SGR 30 should draw palette black {:?}, drew {drawn:?}",
+        DEFAULT_ANSI_PALETTE[0]
+    );
+    // The old gate would have mistaken this for background; the new one must not.
+    assert!(drawn.iter().all(|channel| *channel < 48));
+}
+
+#[test]
+fn colour_follows_the_cell_across_wide_characters_and_rows() {
+    // Colour must be addressed per cell in the renderer's coordinate model,
+    // not per character of a flattened string: a wide lead's continuation
+    // column must not shift the colour of the glyph that follows it.
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    // 'a' default, then a red wide char (columns 1-2), then green 'b' at
+    // display column 3.
+    let snap = snapshot(2, 6, "a\x1b[31m日\x1b[32mb\r\n\x1b[34mc".as_bytes());
+    let frame = render(&renderer, &snap);
+
+    assert!(
+        colors_match(cell_color(&frame, 0, 0), default_foreground_rgb()),
+        "the unstyled 'a' must keep the default foreground"
+    );
+    assert!(
+        colors_match(cell_color(&frame, 0, 1), DEFAULT_ANSI_PALETTE[1]),
+        "the wide lead at column 1 must be red"
+    );
+    assert!(
+        !cell_is_lit(&frame, 0, 2),
+        "the wide continuation column must stay unlit"
+    );
+    assert!(
+        colors_match(cell_color(&frame, 0, 3), DEFAULT_ANSI_PALETTE[2]),
+        "'b' at display column 3 must be green — colour tracked the cell \
+         across the continuation column"
+    );
+    assert!(
+        colors_match(cell_color(&frame, 1, 0), DEFAULT_ANSI_PALETTE[4]),
+        "'c' on row 1 must be blue"
     );
 }
 

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1508,6 +1508,30 @@ impl TerminalSnapshot {
         &self.display_lines
     }
 
+    /// Display-positioned cell rows of the visible screen, parallel to
+    /// [`display_lines`](Self::display_lines).
+    ///
+    /// Rows are contiguous slices of exactly [`cols`](Self::cols) cells,
+    /// selected exactly like `display_lines` (trailing all-blank rows are
+    /// dropped, so both accessors always agree on the row count and on which
+    /// screen row each entry represents). Enumerating a row yields one cell
+    /// per display column: a width-two character's continuation cell keeps
+    /// its own column with empty text ([`Cell::is_continuation`]), encoding
+    /// the same column rule that `display_lines` encodes with one placeholder
+    /// character — so both accessors agree where every following glyph lands.
+    /// Within a row, trailing blank cells are retained (only whole rows are
+    /// dropped) so per-cell attributes stay addressable to the end of the
+    /// row.
+    #[must_use]
+    pub fn display_cells(&self) -> impl ExactSizeIterator<Item = &[Cell]> {
+        let cols = usize::from(self.screen.cols);
+        let mut rows: Vec<&[Cell]> = self.screen.cells.chunks_exact(cols).collect();
+        while rows.last().is_some_and(|row| row_is_display_blank(row)) {
+            rows.pop();
+        }
+        rows.into_iter()
+    }
+
     /// Retained scrollback rows in eviction order (oldest first, newest last).
     ///
     /// Each row is the full cell content of a primary-screen line that scrolled
@@ -1640,6 +1664,20 @@ fn cells_to_display_line(cells: &[Cell]) -> String {
         line.pop();
     }
     line
+}
+
+/// Whether a cell row renders as a blank display line.
+///
+/// This is exactly the condition under which
+/// [`visible_display_lines`] drops a trailing row: every cell contributes
+/// only spaces (blank cells) or placeholders (continuation cells). Keeping
+/// the predicate here — next to the line builder it mirrors — is what lets
+/// [`TerminalSnapshot::display_cells`] select the same rows as
+/// [`TerminalSnapshot::display_lines`].
+fn row_is_display_blank(cells: &[Cell]) -> bool {
+    cells
+        .iter()
+        .all(|cell| cell.is_blank() || cell.is_continuation())
 }
 
 #[cfg(test)]
@@ -1859,6 +1897,77 @@ mod tests {
         assert_eq!(row_widths(&state, 0), vec![1, 2, 0, 2, 0, 1, 1, 1, 1, 1]);
         assert_eq!(state.snapshot().lines(), ["a日😀b"]);
         assert_eq!(state.cursor(), Cursor { row: 0, column: 6 });
+    }
+
+    #[test]
+    fn display_cells_match_display_lines_column_positions() {
+        let mut state = TerminalState::new(2, 6).expect("valid terminal");
+        state.feed_bytes("a日b".as_bytes());
+        let snapshot = state.snapshot();
+
+        // One cell per display column: the continuation keeps column 2, so
+        // the cell index equals the placeholder character index of
+        // display_lines and `b` sits at display column 3 in both.
+        let cells: &[Cell] = snapshot.display_cells().next().expect("row");
+        assert_eq!(
+            cells.iter().map(|cell| cell.text()).collect::<Vec<_>>(),
+            ["a", "日", "", "b", " ", " "]
+        );
+        assert!(!cells[0].is_continuation());
+        assert!(!cells[1].is_continuation());
+        assert!(cells[2].is_continuation());
+        assert_eq!(snapshot.display_lines()[0].chars().count(), 4);
+        assert_eq!(
+            snapshot.display_lines()[0].chars().nth(3),
+            Some('b'),
+            "the cell index and the display-line character index agree"
+        );
+        // Row selection matches display_lines: identical counts at every
+        // trailing-blank height.
+        assert_eq!(
+            snapshot.display_cells().len(),
+            snapshot.display_lines().len()
+        );
+        let mut more = TerminalState::new(3, 6).expect("valid terminal");
+        more.feed_bytes("x\r\n\r\n".as_bytes());
+        assert_eq!(
+            more.snapshot().display_cells().len(),
+            more.snapshot().display_lines().len()
+        );
+    }
+
+    #[test]
+    fn display_cells_keep_attributes_through_continuations_and_trailing_blanks() {
+        let mut state = TerminalState::new(3, 6).expect("valid terminal");
+        // A printed blank keeps the pen's background; display_lines would
+        // trim it, so cell access is the only way to see it.
+        state.feed_bytes("\x1b[42ma日 \r\nX".as_bytes());
+        let snapshot = state.snapshot();
+
+        let row: Vec<CellAttributes> = snapshot
+            .display_cells()
+            .next()
+            .expect("row")
+            .iter()
+            .map(|cell| *cell.attributes())
+            .collect();
+        // The green background covers the lead, its continuation, and the
+        // printed blank, but not the untouched blanks ahead of the cursor.
+        let green_background =
+            CellAttributes::default().with_background(Color::Ansi(AnsiColor::Green));
+        assert_eq!(row[0], green_background);
+        assert_eq!(row[1], green_background);
+        assert_eq!(row[2], green_background);
+        assert_eq!(row[3], green_background);
+        assert_eq!(row[4], CellAttributes::default());
+        assert_eq!(row[5], CellAttributes::default());
+        assert_eq!(snapshot.display_lines(), ["a日", "X"]);
+        // Trailing blank cells within a row stay addressable, and row
+        // selection still matches display_lines.
+        assert_eq!(
+            snapshot.display_cells().len(),
+            snapshot.display_lines().len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Issue #107 を解消。**D-M8-001 が「これ単独で 0.1.0-preview を名乗れない理由になる」と位置づけた欠陥**の解消です。

`I107B compiles=yes foreground=yes background=deferred shader_uses_vertex_colour=yes oracle_distinguishes_colours=yes default_unchanged=yes mutations_caught=3/3 tests=PASS total=695`

## 起動したNorenで何が変わるか

**色が出ます。** これまでフラグメントシェーダが定数を返していたため、`ls --color`・`vim` のシンタックスハイライト・Zellij のステータスバーが**すべて同じ緑**でした。

truecolor（`38;2;R;G;B`）と256色（`38;5;N`）が単一経路で解決されます。

## 実装の経緯（2エンジン協働）

**codex** が中断された `wip/terminal-cell-accessor` をレビューした上で頂点レイアウトを再設計し、**GLM** が `push_glyph` の呼び出し側を修正して完成させました。

codex の設計判断で特に良い点：`VERTEX_BYTES`/`VERTEX_ATTRIBUTES` を `renderer.rs` と `renderer_capture.rs` で**共有**したこと。コメントに理由が書かれています — ストライドや属性の変更が片方だけに入ると、**オラクルがバイナリの持たないレイアウトに対して通過し続けてしまう**。共有により構造的に防いでいます。

## デフォルト外観は不変

`default_unchanged=yes`。SGR 色が設定されていないセルは従来通りの見え方を保ちます。色なしのプロンプトが突然変わることはありません。

## フレームオラクルが色を判別できるようになった

`oracle_distinguishes_colours=yes`。**異なる SGR 前景色のセルが異なるピクセル値を持つこと**を検証します（両方が「点灯している」だけでは不十分）。

`is_background()` の輝度閾値は、色が入ると不十分になることがオラクル自身のコメントで予告されていました。**弱めるのではなく、色を判別できるよう強化**しています。

変異3/3捕捉（頂点へ渡す途中で色を落とす変異を含む）。

## 背景色は繰り延べ

`background=deferred`。背景色はグリフ頂点だけでなくセル矩形の描画が必要で、より大きな変更になります。**前景色を完全に動かす方を優先**しました。

## 検証（統括が実行）

fmt / clippy(-D warnings) / test すべて通過（**695 passed**）、`frame_oracle --ignored` はちょうど2件失敗（既知のフォント欠陥）。

**macOS 実機**: 起動 → 子zsh `30 74` → クリーン終了。