### PR TITLE
fix(terminal): handle multi-parameter DEC private modes (#108)

### DIFF
--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -100,6 +100,11 @@ pub(crate) enum Action {
         mode: PrivateMode,
         enabled: bool,
     },
+    SetPrivateModes {
+        modes: [Option<PrivateMode>; MAX_CSI_PARAMS],
+        enabled: bool,
+        len: usize,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -117,6 +122,7 @@ pub(crate) enum PrivateMode {
     MouseTrackingNormal,
     MouseTrackingButtonEvent,
     MouseTrackingAnyEvent,
+    MouseEncodingUtf8,
     MouseEncodingSgr,
     MouseEncodingUrxvt,
 }
@@ -495,29 +501,41 @@ impl Csi {
     }
 
     fn private_action(&self, final_byte: u8) -> Option<Action> {
-        if self.len != 1 {
-            return None;
-        }
-        let mode = match self.params[0] {
-            1 => PrivateMode::ApplicationCursorKey,
-            1049 => PrivateMode::AlternateScreen,
-            2004 => PrivateMode::BracketedPaste,
-            1000 => PrivateMode::MouseTrackingNormal,
-            1002 => PrivateMode::MouseTrackingButtonEvent,
-            1003 => PrivateMode::MouseTrackingAnyEvent,
-            1006 => PrivateMode::MouseEncodingSgr,
-            1015 => PrivateMode::MouseEncodingUrxvt,
+        let enabled = match final_byte {
+            b'h' => true,
+            b'l' => false,
             _ => return None,
         };
-        match final_byte {
-            b'h' => Some(Action::SetPrivateMode {
-                mode,
-                enabled: true,
-            }),
-            b'l' => Some(Action::SetPrivateMode {
-                mode,
-                enabled: false,
-            }),
+        if self.len == 1 {
+            return self
+                .private_mode(self.params[0])
+                .map(|mode| Action::SetPrivateMode { mode, enabled });
+        }
+
+        let mut modes = [None; MAX_CSI_PARAMS];
+        let mut known = false;
+        for (index, mode) in modes.iter_mut().enumerate().take(self.len) {
+            *mode = self.private_mode(self.params[index]);
+            known |= mode.is_some();
+        }
+        known.then_some(Action::SetPrivateModes {
+            modes,
+            enabled,
+            len: self.len,
+        })
+    }
+
+    fn private_mode(&self, param: u16) -> Option<PrivateMode> {
+        match param {
+            1 => Some(PrivateMode::ApplicationCursorKey),
+            1049 => Some(PrivateMode::AlternateScreen),
+            2004 => Some(PrivateMode::BracketedPaste),
+            1000 => Some(PrivateMode::MouseTrackingNormal),
+            1002 => Some(PrivateMode::MouseTrackingButtonEvent),
+            1003 => Some(PrivateMode::MouseTrackingAnyEvent),
+            1005 => Some(PrivateMode::MouseEncodingUtf8),
+            1006 => Some(PrivateMode::MouseEncodingSgr),
+            1015 => Some(PrivateMode::MouseEncodingUrxvt),
             _ => None,
         }
     }
@@ -719,7 +737,7 @@ mod tests {
     #[test]
     fn mouse_tracking_and_encoding_modes_are_tracked_as_private_modes() {
         assert_eq!(
-            actions(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?1015h"),
+            actions(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1005h\x1b[?1006h\x1b[?1015h"),
             [
                 Action::SetPrivateMode {
                     mode: PrivateMode::MouseTrackingNormal,
@@ -731,6 +749,10 @@ mod tests {
                 },
                 Action::SetPrivateMode {
                     mode: PrivateMode::MouseTrackingAnyEvent,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseEncodingUtf8,
                     enabled: true,
                 },
                 Action::SetPrivateMode {
@@ -851,6 +873,15 @@ mod tests {
                 },
             ]
         );
-        assert!(actions(b"\x1b[?9999h\x1b[?1049;1h\x1b[>1049h").is_empty());
+        assert!(actions(b"\x1b[?9999h").is_empty());
+        assert!(actions(b"\x1b[>1049h").is_empty());
+        assert!(matches!(
+            actions(b"\x1b[?1049;1h").as_slice(),
+            [Action::SetPrivateModes {
+                enabled: true,
+                len: 2,
+                ..
+            }]
+        ));
     }
 }

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -264,6 +264,7 @@ pub struct TerminalModes {
     mouse_normal_tracking: bool,
     mouse_button_event_tracking: bool,
     mouse_any_event_tracking: bool,
+    mouse_utf8_encoding: bool,
     mouse_sgr_encoding: bool,
     mouse_urxvt_encoding: bool,
 }
@@ -319,6 +320,12 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_mouse_sgr_encoding_enabled(self) -> bool {
         self.mouse_sgr_encoding
+    }
+
+    /// Whether DEC private mode 1005 (UTF-8 mouse encoding) is enabled.
+    #[must_use]
+    pub const fn is_mouse_utf8_encoding_enabled(self) -> bool {
+        self.mouse_utf8_encoding
     }
 
     /// Whether DEC private mode 1015 (urxvt mouse encoding) is enabled.
@@ -937,6 +944,15 @@ impl TerminalState {
                 self.modes.application_keypad = enabled;
             }
             Action::SetPrivateMode { mode, enabled } => self.set_private_mode(mode, enabled),
+            Action::SetPrivateModes {
+                modes,
+                enabled,
+                len,
+            } => {
+                for mode in modes[..len].iter().flatten() {
+                    self.set_private_mode(*mode, enabled);
+                }
+            }
         }
         debug_assert!(self.active.screen.wide_cells_intact());
         if let Some(primary) = &self.primary_screen {
@@ -1262,6 +1278,9 @@ impl TerminalState {
             }
             (PrivateMode::MouseTrackingAnyEvent, enabled) => {
                 self.modes.mouse_any_event_tracking = enabled;
+            }
+            (PrivateMode::MouseEncodingUtf8, enabled) => {
+                self.modes.mouse_utf8_encoding = enabled;
             }
             (PrivateMode::MouseEncodingSgr, enabled) => {
                 self.modes.mouse_sgr_encoding = enabled;

--- a/crates/noren-terminal/tests/application_modes.rs
+++ b/crates/noren-terminal/tests/application_modes.rs
@@ -80,13 +80,18 @@ fn application_modes_survive_resize_and_alternate_screen_switching() {
 }
 
 #[test]
-fn unsupported_private_mode_lists_do_not_mutate_or_poison_modes() {
+fn unsupported_private_modes_do_not_mutate_but_known_lists_still_apply() {
     let mut state = TerminalState::new(2, 4).expect("valid terminal");
 
-    state.feed_bytes(b"\x1b[?999h\x1b[?1;1049h");
+    state.feed_bytes(b"\x1b[?999h");
     assert_modes(&state, false, false);
     assert!(!state.modes().is_alternate_screen_active());
 
-    state.feed_bytes(b"\x1b[?1h\x1b=");
-    assert_modes(&state, true, true);
+    state.feed_bytes(b"\x1b[?1;1049h");
+    assert_modes(&state, true, false);
+    assert!(state.modes().is_alternate_screen_active());
+
+    state.feed_bytes(b"\x1b[?1;1049l");
+    assert_modes(&state, false, false);
+    assert!(!state.modes().is_alternate_screen_active());
 }

--- a/crates/noren-terminal/tests/bracketed_paste.rs
+++ b/crates/noren-terminal/tests/bracketed_paste.rs
@@ -45,3 +45,20 @@ fn bracketed_paste_is_independent_of_cursor_and_screen_modes() {
     assert!(state.modes().is_bracketed_paste_enabled());
     assert!(!state.modes().is_alternate_screen_active());
 }
+
+#[test]
+fn multi_param_private_modes_preserve_existing_mode_behavior() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1;1049;2004h");
+    let modes = state.modes();
+    assert!(modes.is_application_cursor_key_mode());
+    assert!(modes.is_alternate_screen_active());
+    assert!(modes.is_bracketed_paste_enabled());
+
+    state.feed_bytes(b"\x1b[?1;1049;2004l");
+    let modes = state.modes();
+    assert!(!modes.is_application_cursor_key_mode());
+    assert!(!modes.is_alternate_screen_active());
+    assert!(!modes.is_bracketed_paste_enabled());
+}

--- a/crates/noren-terminal/tests/mouse_modes.rs
+++ b/crates/noren-terminal/tests/mouse_modes.rs
@@ -1,4 +1,4 @@
-//! DEC private mouse tracking (1000/1002/1003) and encoding (1006/1015)
+//! DEC private mouse tracking (1000/1002/1003) and encoding (1005/1006/1015)
 //! mode tracking in terminal state.
 //!
 //! The terminal holds the mode state only; generating mouse reports stays in
@@ -16,6 +16,7 @@ fn mouse_modes_default_to_disabled() {
     assert!(!modes.is_mouse_normal_tracking_enabled());
     assert!(!modes.is_mouse_button_event_tracking_enabled());
     assert!(!modes.is_mouse_any_event_tracking_enabled());
+    assert!(!modes.is_mouse_utf8_encoding_enabled());
     assert!(!modes.is_mouse_sgr_encoding_enabled());
     assert!(!modes.is_mouse_urxvt_encoding_enabled());
 }
@@ -59,6 +60,44 @@ fn mouse_encoding_modes_toggle_with_decset_and_decrst() {
 
     state.feed_bytes(b"\x1b[?1015l");
     assert!(!state.modes().is_mouse_urxvt_encoding_enabled());
+
+    state.feed_bytes(b"\x1b[?1005h");
+    assert!(state.modes().is_mouse_utf8_encoding_enabled());
+    state.feed_bytes(b"\x1b[?1005l");
+    assert!(!state.modes().is_mouse_utf8_encoding_enabled());
+}
+
+#[test]
+fn multi_param_mouse_modes_set_and_clear_in_order() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1002;1006h");
+    assert!(state.modes().is_mouse_button_event_tracking_enabled());
+    assert!(state.modes().is_mouse_sgr_encoding_enabled());
+
+    state.feed_bytes(b"\x1b[?1002;1006l");
+    assert!(!state.modes().is_mouse_button_event_tracking_enabled());
+    assert!(!state.modes().is_mouse_sgr_encoding_enabled());
+}
+
+#[test]
+fn multi_param_private_modes_keep_known_modes_when_unknown_is_mixed_in() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?9999;1002h");
+    assert!(state.modes().is_mouse_button_event_tracking_enabled());
+}
+
+#[test]
+fn multi_param_sequence_split_across_feed_bytes_calls_still_applies() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1002;");
+    assert!(!state.modes().is_mouse_button_event_tracking_enabled());
+    state.feed_bytes(b"1006h");
+
+    assert!(state.modes().is_mouse_button_event_tracking_enabled());
+    assert!(state.modes().is_mouse_sgr_encoding_enabled());
 }
 
 #[test]


### PR DESCRIPTION
Issue #108 を解消。**Zellij がアタッチ時に実際に送る形式**をパーサが扱えるようになります。

`I108 multiparam=yes general_case=yes mode_1005=yes existing_modes_pinned=yes split_sequence=yes scanner_untouched=yes mutations_caught=2/2`

## 修正した欠陥

`private_action` の `if self.len != 1 { return None; }` により、**複数パラメータの DECSET/DECRST が丸ごと捨てられていた**：

- `CSI ? 1002;1006 h` → どちらのモードも設定されない
- `CSI ? 1049;2004 h` → 同様（マウスに限らない一般的な欠陥）

Noren のテスト自身が理由を書いています：**Zellij はアタッチ時に tracking と encoding を単一シーケンスで有効化する**。ADR 0003 が Zellij を全 Noren ターミナルの内側に置く以上、パーサは最も可能性の高い実世界シーケンスに対して盲目でした。

## なぜ今直すか

現時点で実害はありません（アプリは自前の `MouseModeScanner` を使っており、パーサ側の getter を誰も読んでいない）。

しかし**アプリをパーサ側に切り替えた瞬間、Zellij のマウスが黙って壊れます**。切り替えの前提条件として先に直しました。

モード **1005**（UTF-8拡張）の欠落も解消（スキャナは追跡、パーサは省略という乖離がありました）。

## `MouseModeScanner` は残置

`scanner_untouched=yes`。アプリをパーサ側へ切り替えるのは独立したレビューを要する別変更です。2つのトラッカーが一時的に並存する方が flag day より安全。

## 既存モードの固定

`existing_modes_pinned=yes`。モード1・1049・2004 の挙動が従来通りであることをテストで固定しています（`PrivateMode` にバリアントを追加すると既存の match が変わりうるため、これが回帰リスクの本体）。

## 統括による変異検証

```
# private_action に if self.len != 1 { return None; } を戻す
test result: FAILED. 45 passed; 1 failed
```

## 検証

fmt / clippy(-D warnings) / test すべて通過、`frame_oracle --ignored` はちょうど2件失敗。分割シーケンス（`feed_bytes` を跨ぐ）も検証済み。

**実装: codex**（`codex-tatu`）。