### PR TITLE
test(app): make the renderer clamp test actually bite (#109)

### DIFF
--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -778,23 +778,13 @@ mod tests {
         GridGeometry::poc().cell_metrics()
     }
 
-    #[test]
-    fn glyph_input_is_bounded_to_visible_poc_grid() {
-        // Grid dimensions one past the renderer limits exercise the same
-        // dimension clamps as u32::MAX: visible_rows clamps to
-        // MAX_RENDER_ROWS and terminal_cols clamps to MAX_RENDER_COLS.
-        // No overflow path exists — all dimension arithmetic uses
-        // saturating_add and clamp — so u32::MAX adds no coverage beyond
-        // these values.
-        let rows = MAX_RENDER_ROWS + 1;
-        let cols = MAX_RENDER_COLS + 1;
-        let bytes = vec![b'A'; usize::from(rows) * usize::from(cols)];
-        let terminal = snapshot(rows, cols, &bytes);
-        let width = u32::from(cols) * CELL_WIDTH + CELL_WIDTH;
-        let height = u32::from(rows) * CELL_HEIGHT + CELL_HEIGHT;
-        let vertices = glyph_vertices(Some(&terminal), None, None, width, height, poc_metrics());
-        assert!(vertices.len() <= MAX_VERTICES);
-    }
+    // NOTE: the renderer's row/column clamp coverage used to live here as
+    // `glyph_input_is_bounded_to_visible_poc_grid`, a count-based test that
+    // could not distinguish the clamps from the `MAX_VERTICES` backstop (issue
+    // #109). It is replaced by `frame_oracle::glyphs_stay_inside_the_render_clamp_grid`,
+    // which reads pixels back from the real pipeline and asserts on *where*
+    // glyphs land — the property a vertex-count assertion is structurally
+    // unable to pin.
 
     #[test]
     fn empty_and_zero_sized_inputs_have_no_vertices() {
@@ -900,7 +890,6 @@ mod tests {
     }
 
     const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
-    const CELL_HEIGHT: u32 = noren_app::POC_CELL_HEIGHT;
 
     fn ndc_left(column: u32) -> f32 {
         (column * CELL_WIDTH) as f32 / 900.0 * 2.0 - 1.0

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -55,7 +55,10 @@
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
 
-use noren_app::{GridGeometry, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
+use noren_app::{
+    GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
+    POC_CELL_WIDTH as CELL_WIDTH,
+};
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::{
     CLEAR_COLOR, DEFAULT_ANSI_PALETTE, DEFAULT_FOREGROUND, DEFAULT_PALETTE, SIDEBAR_COLS,
@@ -408,6 +411,92 @@ fn state_and_render_agree_across_the_fr005_fixtures() {
         checked >= 4 * 2 * 6,
         "agreement checks covered {checked} cells"
     );
+}
+
+// ===========================================================================
+// Render clamps (issue #109): the renderer's `MAX_RENDER_ROWS` and
+// `MAX_RENDER_COLS` clamps must keep every glyph inside the drawable grid.
+//
+// The old guard — `renderer.rs::glyph_input_is_bounded_to_visible_poc_grid` —
+// asserted `vertices.len() <= MAX_VERTICES`. That cannot tell a clamp from the
+// `MAX_VERTICES` early-return backstop: both cap vertex output at the same
+// ceiling, and the fixture only ever reached ~half the cap (1,036,800 of
+// 2,016,000), so deleting any one guard left it green — confirmed by deletion
+// before this test was written. A count-based test is structurally unable to
+// pin this property.
+//
+// What needs guarding is *where glyphs land*, so this test reads pixels back
+// from the real pipeline and asserts directly that no cell past either clamp
+// boundary is lit. The fixture places three single-cell markers via CUP on a
+// grid one past each clamp limit, rather than filling it: a row detector at the
+// overflow display row, a column detector at the overflow column, and a stable
+// interior marker. Three glyphs keep the capture at small-grid cost (the full
+// 61×161 fill took ~4.5s; this takes ~0.1s).
+//
+// Mutation protocol (run before trusting this test): removing the row clamp
+// lights grid row `MAX_RENDER_ROWS`; removing the column clamp lights grid
+// column `MAX_RENDER_COLS`. The `MAX_VERTICES` backstop cannot produce a visual
+// change while the clamps hold (it is a memory guard, not a geometry guard), so
+// this test does not catch its removal — see the report line.
+// ===========================================================================
+
+#[test]
+fn glyphs_stay_inside_the_render_clamp_grid() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+
+    // A grid one past each clamp limit in both dimensions. Three CUP-placed
+    // markers carry the only lit content:
+    //   - row detector  at display (60, 0):   maps to grid row 59 with the row
+    //                                         clamp, grid row 60 (out of bounds)
+    //                                         without it;
+    //   - column detector at display (30, 160): column 160 is inside the grid
+    //                                         but past the MAX_RENDER_COLS cut,
+    //                                         so it draws only without the
+    //                                         column clamp;
+    //   - interior marker at display (30, 30): always drawn in bounds, at grid
+    //                                         row 29 or 30 depending on the row
+    //                                         clamp — a stable positive control.
+    let rows = MAX_RENDER_ROWS + 1;
+    let cols = MAX_RENDER_COLS + 1;
+    let bytes = "\x1b[61;1HA\x1b[31;161HA\x1b[31;31HA".as_bytes().to_vec();
+    let snap = snapshot(rows, cols, &bytes);
+    // Rendered at the terminal's own grid size: one cell larger than the clamp
+    // grid each way, so overflow content has pixel room to land in.
+    let frame = render(&renderer, &snap);
+
+    let max_row = u32::from(MAX_RENDER_ROWS);
+    let max_col = u32::from(MAX_RENDER_COLS);
+
+    // Positive control: the interior marker lands at grid row 29 or 30
+    // (depending on the row clamp), never outside the budget. If neither is
+    // lit the renderer drew nothing and the boundary checks below are vacuous.
+    assert!(
+        cell_is_lit(&frame, 29, 30) || cell_is_lit(&frame, 30, 30),
+        "interior marker must light grid (29,30) or (30,30) — \
+         otherwise the render produced nothing and the boundary checks are vacuous"
+    );
+
+    // Row clamp: no lit cell at row MAX_RENDER_ROWS. With the clamp the row
+    // detector sits at grid row 59; without it, it spills into row max_row.
+    // Neither the column clamp nor the MAX_VERTICES backstop can light this
+    // row, so a lit cell here pins a row-clamp regression.
+    for col in 0..max_col {
+        assert!(
+            !cell_is_lit(&frame, max_row, col),
+            "cell ({max_row},{col}) is lit at MAX_RENDER_ROWS — \
+             the row clamp failed to contain the grid"
+        );
+    }
+
+    // Column clamp: no lit cell at column MAX_RENDER_COLS. Symmetric to the
+    // row check; only a column-clamp regression lights any cell here.
+    for row in 0..max_row {
+        assert!(
+            !cell_is_lit(&frame, row, max_col),
+            "cell ({row},{max_col}) is lit at MAX_RENDER_COLS — \
+             the column clamp failed to contain the grid"
+        );
+    }
 }
 
 // ===========================================================================


### PR DESCRIPTION
Issue #109 を解消。**Issue #93 の削除根拠が偽だった**問題の是正です。

`I109 measured_before=1036800 row_clamp_caught=yes col_clamp_caught=yes backstop_caught=no old_test=replaced runtime_seconds=0 tests=PASS total=698`

## 何が壊れていたか

`glyph_input_is_bounded_to_visible_poc_grid` は頂点数が `MAX_VERTICES` を超えないことを守っているはずでしたが、**1,036,800頂点／上限2,016,000（51%）**しか生成せず、3つのガード（`MAX_VERTICES` 早期リターン、行クランプ、列クランプ）を**個別に削除しても通過**していました。

Issue #93 で恒真クランプテストを削除した根拠が「このテストが実カバレッジを提供している」でしたが、**提供していませんでした**。穴はそれ以来開いたままでした。

## なぜ素朴な修正では駄目か

頂点数に対する `<=` アサーションでは、**行・列クランプと `MAX_VERTICES` バックストップを区別できません**（どちらも同じ上限で抑えるため）。Issue #93 で実験的に確認済みです。

守るべきは**グリフがどこに着地するか**。クランプを外すと境界外に描画されるので、フレームオラクルがピクセルを読み戻して**クランプ境界の外に何も描かれないこと**を直接検証する形にしました。

## 統括による変異検証

```
行クランプ削除 (.clamp(1, MAX_RENDER_ROWS) → .max(1)):
  test result: FAILED. 28 passed; 1 failed

列クランプ削除 (window_cols.clamp(1, MAX_RENDER_COLS) → .max(1)):
  test result: FAILED. 28 passed; 1 failed
```

**両クランプが個別に捕捉される。** これが従来欠けていた性質です。

`backstop_caught=no` は正直な報告で、`MAX_VERTICES` 早期リターンは依然として別の守り方が要ります（ただしクランプが効いていれば到達しない）。

## 実行時間

`runtime_seconds=0`。31秒→1.4秒の短縮（Issue #101）を維持し、遅いフィクスチャを再導入していません。

## 検証

fmt / clippy(-D warnings) / test すべて通過（**698 passed**）、`frame_oracle --ignored` はちょうど2件失敗。

## 関連

**Issue #114（背景色）に着手する前にこれが必要**でした。セル矩形を足すと頂点予算が変わるのに、上限を守るテストが機能していない状態で予算を変えるのは危険なため。