### PR TITLE
fix(app): distinguish restored sessions and warn on external state changes (#110 #111)

### DIFF
--- a/crates/noren-app/src/diagnostics.rs
+++ b/crates/noren-app/src/diagnostics.rs
@@ -57,6 +57,7 @@ pub struct DiagnosticsInput {
     scrollback_len: usize,
     scrollback_cap: usize,
     pty: PtyChildStatus,
+    persistence_conflict: bool,
 }
 
 /// Build diagnostics input from the live terminal snapshot.
@@ -75,6 +76,7 @@ pub fn from_snapshot(snapshot: Option<&TerminalSnapshot>, pty: PtyChildStatus) -
             scrollback_len: snapshot.scrollback().len(),
             scrollback_cap: MAX_SCROLLBACK_LINES,
             pty,
+            persistence_conflict: false,
         },
         None => DiagnosticsInput {
             grid_rows: None,
@@ -83,7 +85,17 @@ pub fn from_snapshot(snapshot: Option<&TerminalSnapshot>, pty: PtyChildStatus) -
             scrollback_len: 0,
             scrollback_cap: MAX_SCROLLBACK_LINES,
             pty,
+            persistence_conflict: false,
         },
+    }
+}
+
+impl DiagnosticsInput {
+    /// Add the workspace's best-effort external-state warning to the report.
+    #[must_use]
+    pub const fn with_persistence_conflict(mut self, conflict: bool) -> Self {
+        self.persistence_conflict = conflict;
+        self
     }
 }
 
@@ -116,8 +128,15 @@ pub fn report(input: &DiagnosticsInput) -> String {
     }
     let _ = write!(
         out,
-        " scrollback={}/{} child={}",
-        input.scrollback_len, input.scrollback_cap, input.pty
+        " scrollback={}/{} child={} state={}",
+        input.scrollback_len,
+        input.scrollback_cap,
+        input.pty,
+        if input.persistence_conflict {
+            "changed-underneath"
+        } else {
+            "ok"
+        }
     );
     out
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -24,7 +24,9 @@ use noren_app::{
         SessionAction, SessionError, SessionEvent, SessionId, SessionKind, SessionRegistry,
         SessionStatus,
     },
-    session_persistence::{SESSION_STATE_FILE_NAME, SessionPersistenceError, load, save},
+    session_persistence::{
+        SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save, snapshot,
+    },
     sidebar::{SidebarEntry, SidebarView},
 };
 use noren_pty::{PtyEvent, PtySession, PtySize};
@@ -118,6 +120,12 @@ struct WorkspaceState {
     /// unset; in both cases the workspace is in-memory only and [`persist`]
     /// is a no-op.
     state_path: Option<PathBuf>,
+    /// Exact state-file bytes observed at restore or after the last save.
+    /// `None` also represents a normally absent first-run file.
+    loaded_snapshot: Option<Vec<u8>>,
+    /// Sticky warning for the diagnostics overlay when another instance has
+    /// replaced the file since this workspace loaded it.
+    persistence_conflict: bool,
 }
 
 impl Default for WorkspaceState {
@@ -147,6 +155,8 @@ impl WorkspaceState {
                 WorkspaceAction::FocusSidebar,
             ),
             state_path,
+            loaded_snapshot: None,
+            persistence_conflict: false,
         }
     }
 
@@ -163,7 +173,7 @@ impl WorkspaceState {
         let Some(path) = &self.state_path else {
             return Ok(());
         };
-        load(path, &mut self.registry)?;
+        self.loaded_snapshot = load_snapshot(path, &mut self.registry)?;
         self.rebuild_sidebar();
         Ok(())
     }
@@ -175,13 +185,30 @@ impl WorkspaceState {
     /// never bypasses it. A failure is surfaced through stderr and swallowed
     /// so the app keeps running — losing a save is preferable to crashing the
     /// terminal.
-    fn persist(&self) {
+    fn persist(&mut self) {
         let Some(path) = &self.state_path else {
             return;
         };
+        match snapshot(path) {
+            Ok(current) if current != self.loaded_snapshot => {
+                self.persistence_conflict = true;
+            }
+            Err(error) => {
+                eprintln!("Noren could not inspect sidebar state before saving: {error}");
+            }
+            _ => {}
+        }
         if let Err(error) = save(path, &self.registry) {
             eprintln!("Noren could not save sidebar state: {error}");
+        } else if let Ok(current) = snapshot(path) {
+            self.loaded_snapshot = current;
         }
+    }
+
+    /// Whether a save observed state written by another instance since the
+    /// last restore or successful save.
+    fn persistence_conflict(&self) -> bool {
+        self.persistence_conflict
     }
 
     /// Create a new session and rebuild the sidebar.
@@ -1101,7 +1128,8 @@ impl NorenApp {
             return;
         }
         let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
-        let input = diagnostics::from_snapshot(snapshot.as_ref(), self.pty_child);
+        let input = diagnostics::from_snapshot(snapshot.as_ref(), self.pty_child)
+            .with_persistence_conflict(self.workspace.persistence_conflict());
         let line = diagnostics::report(&input);
         eprintln!("{line}");
         if let Some(window) = &self.window {
@@ -1777,6 +1805,7 @@ mod tests {
     use super::*;
     use noren_app::palette::CommandId;
     use noren_app::passthrough::{self, collisions};
+    use noren_app::session_persistence::load;
     use noren_app::sidebar::EntryKind;
 
     #[test]
@@ -3844,10 +3873,17 @@ mod tests {
             .and_then(|r| r.detail())
             .unwrap_or_default();
         assert!(
-            detail.contains("starting"),
-            "detail says starting: {detail}"
+            detail.contains("restored") && detail.contains("not running"),
+            "detail identifies a restored, non-running session: {detail}"
         );
-        assert!(!detail.contains("running"), "detail must not say running");
+        assert!(
+            !detail.ends_with("· running"),
+            "detail must not claim running: {detail}"
+        );
+        assert!(
+            relaunched.sidebar().viewport().is_none(),
+            "a restored selected session must not imply an attachment"
+        );
         cleanup_state_file(&path);
     }
 
@@ -3944,5 +3980,48 @@ mod tests {
         assert!(state.restore().is_ok(), "no path → no-op restore");
         state.create_session(SessionKind::Local);
         assert_eq!(state.registry().len(), 1);
+    }
+
+    /// Mutation check for Issue #111: removing the baseline comparison makes
+    /// this cross-instance overwrite pass without setting the diagnostics
+    /// warning.
+    #[test]
+    fn second_instance_overwrite_is_detected_and_reported_by_diagnostics() {
+        let path = temp_state_path();
+        let mut first = WorkspaceState::with_state_path(Some(path.clone()));
+        first.create_session(SessionKind::Local);
+
+        let mut second = app_with_state_path(&path);
+        first.create_session(SessionKind::Local);
+        second.workspace.create_session(SessionKind::Local);
+
+        assert!(second.workspace.persistence_conflict());
+        second.toggle_diagnostics();
+        assert!(
+            second.diagnostics_line.contains("state=changed-underneath"),
+            "diagnostics: {}",
+            second.diagnostics_line
+        );
+        cleanup_state_file(&path);
+    }
+
+    #[test]
+    fn single_instance_save_has_no_persistence_false_alarm() {
+        let path = temp_state_path();
+        let mut app = app_with_state_path(&path);
+        app.workspace.create_session(SessionKind::Local);
+
+        app.toggle_diagnostics();
+        assert!(
+            app.diagnostics_line.contains("state=ok"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+        assert!(
+            !app.diagnostics_line.contains("changed-underneath"),
+            "diagnostics: {}",
+            app.diagnostics_line
+        );
+        cleanup_state_file(&path);
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1297,9 +1297,8 @@ impl NorenApp {
         // entry rather than marking it stopped, so closing here would persist
         // a deletion and hand back an empty sidebar on the next launch. The
         // session stays in the registry; only its PTY goes away. On the next
-        // launch it is restored as `SessionStatus::Starting`, which is what
-        // this PR already decided a restored session means: a visible entry
-        // whose shell is not running.
+        // launch it is restored as `SessionStatus::Restored`: a visible entry
+        // whose shell is not running and cannot be reattached implicitly.
         //
         // This also protects the non-quit caller: `redraw` invokes `close` on
         // `RenderOutcome::DeviceLost`. A lost GPU device must not delete the
@@ -3600,9 +3599,11 @@ mod tests {
         cleanup_state_file(&path);
     }
 
-    /// Required: a restored session's status does not claim to be running.
+    /// Required: a restored session is distinct from a shell that is starting.
+    /// Mutation check for Issue #110: changing `load_snapshot`'s restoration
+    /// path back to `create` makes the status and sidebar assertions fail.
     #[test]
-    fn restored_sessions_start_at_starting_not_running() {
+    fn restored_sessions_are_restored_not_starting_or_running() {
         let path = temp_state_path();
         let mut state = WorkspaceState::with_state_path(Some(path.clone()));
         let id = state.create_session(SessionKind::Local);
@@ -3614,8 +3615,8 @@ mod tests {
         for descriptor in restored.registry().sessions() {
             assert_eq!(
                 descriptor.status(),
-                &SessionStatus::Starting,
-                "restored session must not claim to be running"
+                &SessionStatus::Restored,
+                "restored session must identify its no-process state"
             );
         }
         let detail = restored
@@ -3625,10 +3626,17 @@ mod tests {
             .and_then(|r| r.detail())
             .unwrap_or_default();
         assert!(
-            detail.contains("starting"),
-            "detail says starting: {detail}"
+            detail.contains("restored") && detail.contains("not running"),
+            "detail identifies a restored, non-running session: {detail}"
         );
-        assert!(!detail.contains("running"), "detail must not say running");
+        assert!(
+            !detail.ends_with("· running"),
+            "detail must not claim running: {detail}"
+        );
+        assert!(
+            restored.sidebar().viewport().is_none(),
+            "selecting a restored session must not imply an attachment"
+        );
         cleanup_state_file(&path);
     }
 
@@ -3807,11 +3815,11 @@ mod tests {
     }
 
     /// Quitting must not silently downgrade the session's status claim either:
-    /// the shell is gone, so the restored entry is `Starting`, never `Running`.
-    /// Consistent with `restored_sessions_start_at_starting_not_running`, but
+    /// the shell is gone, so the restored entry is `Restored`, never `Running`.
+    /// Consistent with `restored_sessions_are_restored_not_starting_or_running`, but
     /// reached through the quit path rather than a direct workspace mutation.
     #[test]
-    fn session_restored_after_quitting_is_starting_not_running() {
+    fn session_restored_after_quitting_is_restored_not_running() {
         let path = temp_state_path();
         let mut app = app_with_state_path(&path);
         let id = app.workspace.create_session(SessionKind::Local);
@@ -3825,7 +3833,7 @@ mod tests {
         for descriptor in relaunched.registry().sessions() {
             assert_eq!(
                 descriptor.status(),
-                &SessionStatus::Starting,
+                &SessionStatus::Restored,
                 "a session whose PTY was torn down must not claim to be running"
             );
         }

--- a/crates/noren-app/src/session.rs
+++ b/crates/noren-app/src/session.rs
@@ -127,6 +127,8 @@ pub enum SessionStatus {
     /// The entry exists but no runtime observation has been reported.
     #[default]
     Starting,
+    /// A sidebar entry restored from disk with no live process attached.
+    Restored,
     /// Observed running.
     Running,
     /// Observed to have exited, carrying the exit code when known.
@@ -144,13 +146,14 @@ pub enum SessionStatus {
 impl SessionStatus {
     /// Lifecycle rank used to reject backwards observations.
     ///
-    /// `Starting` (0) < `Running` (1) < terminal `Exited`/`Failed` (2).
+    /// `Starting`/`Restored` (0) < `Running` (1) < terminal
+    /// `Exited`/`Failed` (2).
     /// Equal-rank terminal observations may refine their payload or variant,
     /// but a terminal session can never return to a live status.
     #[must_use]
     pub const fn rank(&self) -> u8 {
         match self {
-            Self::Starting => 0,
+            Self::Starting | Self::Restored => 0,
             Self::Running => 1,
             Self::Exited { .. } | Self::Failed { .. } => 2,
         }
@@ -357,6 +360,18 @@ impl SessionRegistry {
         id
     }
 
+    /// Restore a persisted session entry without claiming that its process
+    /// still exists.
+    #[must_use]
+    pub fn restore(&mut self, kind: SessionKind) -> SessionId {
+        let id = self.create(kind);
+        self.sessions
+            .get_mut(&id)
+            .expect("restored session was just created")
+            .status = SessionStatus::Restored;
+        id
+    }
+
     /// Remove a session, clearing the selection if it was selected.
     ///
     /// Returns [`SessionError::UnknownSession`] when `id` is not live.
@@ -512,6 +527,21 @@ mod tests {
     fn kinds_and_statuses_have_natural_defaults() {
         assert_eq!(SessionKind::default(), SessionKind::Local);
         assert_eq!(SessionStatus::default(), SessionStatus::Starting);
+    }
+
+    #[test]
+    fn status_ranks_pin_all_lifecycle_variants() {
+        assert_eq!(SessionStatus::Starting.rank(), 0);
+        assert_eq!(SessionStatus::Restored.rank(), 0);
+        assert_eq!(SessionStatus::Running.rank(), 1);
+        assert_eq!(SessionStatus::Exited { code: None }.rank(), 2);
+        assert_eq!(
+            SessionStatus::Failed {
+                reason: String::new()
+            }
+            .rank(),
+            2
+        );
     }
 
     #[test]

--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -209,12 +209,39 @@ pub fn save(path: &Path, registry: &SessionRegistry) -> Result<(), SessionPersis
 /// [`SessionRegistry::restore`], so they start at `Restored` with generated
 /// titles; this module spawns nothing.
 pub fn load(path: &Path, registry: &mut SessionRegistry) -> Result<(), SessionPersistenceError> {
+    load_snapshot(path, registry).map(drop)
+}
+
+/// Load the sidebar state and return the exact bounded bytes that were read.
+///
+/// The returned snapshot is a caller-owned baseline for detecting a later
+/// external replacement. It is captured from the same read that is decoded,
+/// so the baseline does not require a second filesystem observation during
+/// restore.
+pub fn load_snapshot(
+    path: &Path,
+    registry: &mut SessionRegistry,
+) -> Result<Option<Vec<u8>>, SessionPersistenceError> {
     let bytes = match read_bounded(path) {
         Ok(bytes) => bytes,
-        Err(SessionPersistenceError::NotFound) => return Ok(()),
+        Err(SessionPersistenceError::NotFound) => return Ok(None),
         Err(error) => return Err(error),
     };
-    load_bytes(&bytes, registry)
+    load_bytes(&bytes, registry)?;
+    Ok(Some(bytes))
+}
+
+/// Read the current bounded state-file bytes without decoding them.
+///
+/// A missing file is represented as `Ok(None)`, matching [`load`]. This is
+/// used only for the best-effort external-change check; the atomic save path
+/// remains responsible for writing the document.
+pub fn snapshot(path: &Path) -> Result<Option<Vec<u8>>, SessionPersistenceError> {
+    match read_bounded(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(SessionPersistenceError::NotFound) => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 /// Decode raw state file bytes and apply them to `registry`.

--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -46,8 +46,8 @@
 //! Per D-M3-001, [`SessionId`]s are registry-local and are **not**
 //! persistence keys, so no id is written. Entries are stored in registry
 //! order and the selection is stored as a positional index into that list.
-//! Restoration runs each loaded kind through [`SessionRegistry::create`],
-//! which records it as [`SessionStatus::Starting`] with a generated title;
+//! Restoration runs each loaded kind through [`SessionRegistry::restore`],
+//! which records it as [`SessionStatus::Restored`] with a generated title;
 //! runtime status is an observed fact and is never persisted. Titles are
 //! derived facts today (a rename feature may change that in a later format
 //! version), so they are not persisted either.
@@ -58,7 +58,7 @@
 //! nothing.
 //!
 //! [`SessionId`]: crate::session::SessionId
-//! [`SessionStatus::Starting`]: crate::session::SessionStatus::Starting
+//! [`SessionStatus::Restored`]: crate::session::SessionStatus::Restored
 
 use crate::session::{SessionKind, SessionRegistry};
 use std::fmt;
@@ -206,7 +206,7 @@ pub fn save(path: &Path, registry: &SessionRegistry) -> Result<(), SessionPersis
 /// returns `Ok`. Any file that exists must read, decode, and validate or the
 /// call errors — and because decoding validates before creating, an error
 /// also leaves `registry` exactly as it was. Entries re-enter through
-/// [`SessionRegistry::create`], so they start at `Starting` with generated
+/// [`SessionRegistry::restore`], so they start at `Restored` with generated
 /// titles; this module spawns nothing.
 pub fn load(path: &Path, registry: &mut SessionRegistry) -> Result<(), SessionPersistenceError> {
     let bytes = match read_bounded(path) {
@@ -468,7 +468,7 @@ fn apply(
     }
     let created: Vec<_> = kinds
         .into_iter()
-        .map(|kind| registry.create(kind))
+        .map(|kind| registry.restore(kind))
         .collect();
     if let Some(index) = selected {
         registry

--- a/crates/noren-app/src/sidebar.rs
+++ b/crates/noren-app/src/sidebar.rs
@@ -187,8 +187,9 @@ impl SessionViewport {
 ///
 /// 1. `empty_state` is `Some` exactly when there are no rows.
 /// 2. At most one row has [`SidebarRow::is_selected`] set.
-/// 3. `viewport` is `Some` exactly when one session row is selected, and it
-///    names that same session. Unselected sessions describe no viewport.
+/// 3. `viewport` is `Some` exactly when one non-restored session row is
+///    selected, and it names that same session. A restored entry has no live
+///    process to attach to, so selecting it does not create a viewport.
 /// 4. A selection that matches no entry is dropped, never rendered dangling.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SidebarView {
@@ -208,6 +209,7 @@ impl SidebarView {
     #[must_use]
     pub fn build(entries: &[SidebarEntry], selected: Option<SessionId>) -> Self {
         let mut viewport: Option<SessionViewport> = None;
+        let mut selected_row = false;
         let mut rows: Vec<SidebarRow> = Vec::with_capacity(entries.len());
         for entry in entries {
             rows.push(match entry {
@@ -236,8 +238,11 @@ impl SidebarView {
                     selected: false,
                 },
                 SidebarEntry::Session(descriptor) => {
-                    let is_selected = viewport.is_none() && selected == Some(descriptor.id());
+                    let is_selected = !selected_row && selected == Some(descriptor.id());
                     if is_selected {
+                        selected_row = true;
+                    }
+                    if is_selected && !matches!(descriptor.status(), SessionStatus::Restored) {
                         viewport = Some(SessionViewport {
                             session: descriptor.clone(),
                         });
@@ -321,6 +326,7 @@ fn session_kind_text(kind: &SessionKind) -> &'static str {
 fn session_status_text(status: &SessionStatus) -> &'static str {
     match status {
         SessionStatus::Starting => "starting",
+        SessionStatus::Restored => "restored (not running)",
         SessionStatus::Running => "running",
         SessionStatus::Exited { .. } => "exited",
         SessionStatus::Failed { .. } => "failed",

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -135,7 +135,7 @@ fn round_trip_preserves_every_entry_kind_and_the_selection() {
 }
 
 #[test]
-fn restored_entries_reenter_as_starting_with_generated_titles() {
+fn restored_entries_reenter_as_restored_with_generated_titles() {
     // Restoration re-spawns domain entries, not runtime facts: every entry
     // comes back through SessionRegistry::create, so it is Starting with a
     // generated display title, and the selected entry resolves live.
@@ -149,7 +149,7 @@ fn restored_entries_reenter_as_starting_with_generated_titles() {
     let mut restored = SessionRegistry::new();
     load(&path, &mut restored).expect("state loads");
     for (index, descriptor) in restored.sessions().iter().enumerate() {
-        assert_eq!(descriptor.status(), &SessionStatus::Starting);
+        assert_eq!(descriptor.status(), &SessionStatus::Restored);
         assert_eq!(descriptor.title(), format!("session-{}", index + 1));
     }
     let selected = registry_selected_descriptor(&restored);


### PR DESCRIPTION
Issue #110 と #111 を解消。**Issue ごとに1コミット**で個別に revert 可能。

`I110_111 restored_variant=Restored matches_updated=2 detection=bounded exact-content snapshot before atomic save false_alarms=no not_caught=read/compare/write race mutations_caught=2/2`

## #110 — 復元セッションが「起動中」と区別できなかった

前回実行から復元されたセッションが `SessionStatus::Starting` で表示されており、`Running` を偽らない点は正直でしたが、**いま起動しつつあるシェルと区別がつきません**でした。再アタッチ経路がないため、無期限に `starting` のまま留まります。

`SessionStatus::Restored` を追加しました。順序の意味論も正しく定義されています：

```rust
/// / (0) <  (1) < terminal
Self::Starting | Self::Restored => 0,
```

**復元されたエントリには生きたプロセスがありません。** サイドバーがそれを誤認させず、選択してもアタッチを装いません。

`matches_updated=2` — `SessionStatus` への網羅的 match をすべて更新（バリアント追加時の回帰リスクの本体はここ）。

## #111 — 多重起動の上書きが黙って起きていた

**ロック機構は作っていません。** Noren が単一インスタンス前提の製品かは M4/M5 に絡む未決の製品判断であり、ここで方針を先取りすべきではないためです。

このIssueが必要としていたのは、**損失が黙って起きなくなること**。atomic save の直前に、読み込み時点の内容スナップショットと照合し、外部で変わっていれば既存の diagnostics 経路へ通知します。

`false_alarms=no` — 通常の単一インスタンス動作では何も出ません。

### 捕捉できないケースを正直に報告

`not_caught=read/compare/write race`。**read/compare/write の間隙は残ります** — 安価な検出方式はいずれも競合を完全には塞げません。実装者がこれを自己申告している点を評価します。

## 検証（統括が実行）

fmt / clippy(-D warnings) / test すべて通過。変異2/2捕捉（Issue ごとに1件）。

終了時に消さずに保存する経路（PR #106）のテストも維持されています。

**実装: codex**（`codex-tatu`）。