### PR TITLE
feat(app): draw SGR background colour behind glyphs (#114)

### DIFF
--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -8,8 +8,8 @@
 //! shade the shader previously returned as a constant — so unstyled output is
 //! unchanged.
 //!
-//! Background colour is not drawn yet: that needs a filled rect behind each
-//! glyph rather than colour on the glyph's own vertices. See issue #107.
+//! Explicit SGR backgrounds emit one filled cell rectangle immediately before
+//! that cell's glyph, so the glyph remains legible over the background.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -25,7 +25,14 @@ use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::{CellAttributes, Color, TerminalSnapshot};
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
-const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize) * (MAX_RENDER_COLS as usize) * 35 * 6;
+const MAX_GLYPH_PIXELS: usize = 35;
+const VERTICES_PER_RECT: usize = 6;
+/// One cell can emit one background rectangle plus the largest 5x7 glyph.
+/// The bound is `MAX_RENDER_ROWS * MAX_RENDER_COLS * (1 + 35) * 6`.
+const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize)
+    * (MAX_RENDER_COLS as usize)
+    * (1 + MAX_GLYPH_PIXELS)
+    * VERTICES_PER_RECT;
 
 /// Width of the left sidebar in cell columns. The terminal occupies the
 /// remaining columns to the right, drawn at a pixel offset of
@@ -105,6 +112,11 @@ pub(crate) const VERTEX_ATTRIBUTES: [wgpu::VertexAttribute; 2] = [
 /// would shift the default shade slightly, and an unstyled prompt must look
 /// identical to how it looked before colour existed (issue #107).
 pub(crate) const DEFAULT_FOREGROUND: [f32; 3] = [0.80, 0.92, 0.82];
+
+/// Default terminal background as shader colour. Explicit backgrounds resolve
+/// through [`resolve_color`]; `Color::Default` emits no rectangle and leaves
+/// the render target's clear colour untouched.
+pub(crate) const DEFAULT_BACKGROUND: [f32; 3] = [0.035, 0.045, 0.04];
 
 /// The sixteen ANSI colours of the default theme as `(red, green, blue)` in
 /// palette-index order: standard colours `0..=7`, bright colours `8..=15`.
@@ -195,15 +207,20 @@ pub(crate) fn resolve_color(color: Color, default: [f32; 3]) -> [f32; 3] {
 }
 
 /// The colour a cell's glyph is drawn in.
-///
-/// Background rectangles are deliberately out of scope for this foreground
-/// pass. In particular, do not resolve reverse video to the background here:
-/// without a rectangle behind it that would draw the glyph in the clear colour
-/// and make reversed text disappear. Reverse/background composition belongs in
-/// the later background pass.
 #[must_use]
 pub(crate) fn resolve_foreground(attributes: &CellAttributes) -> [f32; 3] {
     resolve_color(attributes.foreground(), DEFAULT_FOREGROUND)
+}
+
+/// Resolve an explicit cell background through the same palette/truecolor path
+/// as foreground. `None` is intentional: an unstyled cell must remain exactly
+/// the clear colour, with no rectangle changing its rasterisation.
+#[must_use]
+pub(crate) fn resolve_background(attributes: &CellAttributes) -> Option<[f32; 3]> {
+    match attributes.background() {
+        Color::Default => None,
+        background => Some(resolve_color(background, DEFAULT_BACKGROUND)),
+    }
 }
 
 /// Clear colour used by the glyph pipeline's load op.
@@ -543,8 +560,23 @@ pub(crate) fn glyph_vertices(
     for (row, line_index) in (first_line..total_lines).enumerate() {
         if let Some(cells) = rows.get(line_index) {
             for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
-                // A continuation cell draws nothing but still owns its column,
-                // exactly as the placeholder space did in `display_lines`.
+                if let Some(color) = resolve_background(cell.attributes()) {
+                    push_rect(
+                        &mut vertices,
+                        u32::try_from(col_offset + col).unwrap_or(u32::MAX) * cell_width,
+                        u32::try_from(row).unwrap_or(u32::MAX) * cell_height,
+                        cell_width,
+                        cell_height,
+                        color,
+                        target,
+                    );
+                }
+                if vertices.len() >= MAX_VERTICES {
+                    return vertices;
+                }
+                // A continuation cell draws no glyph but still owns its
+                // column, exactly as the placeholder space did in
+                // `display_lines`.
                 if cell.is_continuation() {
                     continue;
                 }
@@ -624,7 +656,7 @@ fn push_glyph(
             let y = u32::try_from(row).unwrap_or(u32::MAX) * cell_height
                 + GLYPH_TOP
                 + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
-            push_rect(vertices, x, y, GLYPH_SCALE, color, target);
+            push_rect(vertices, x, y, GLYPH_SCALE, GLYPH_SCALE, color, target);
         }
     }
 }
@@ -633,15 +665,16 @@ fn push_rect(
     vertices: &mut Vec<Vertex>,
     x: u32,
     y: u32,
-    size: u32,
+    width: u32,
+    height: u32,
     color: [f32; 3],
     target: Target,
 ) {
-    let (width, height) = (target.width, target.height);
-    let left = x as f32 / width as f32 * 2.0 - 1.0;
-    let right = x.saturating_add(size) as f32 / width as f32 * 2.0 - 1.0;
-    let top = 1.0 - y as f32 / height as f32 * 2.0;
-    let bottom = 1.0 - y.saturating_add(size) as f32 / height as f32 * 2.0;
+    let (target_width, target_height) = (target.width, target.height);
+    let left = x as f32 / target_width as f32 * 2.0 - 1.0;
+    let right = x.saturating_add(width) as f32 / target_width as f32 * 2.0 - 1.0;
+    let top = 1.0 - y as f32 / target_height as f32 * 2.0;
+    let bottom = 1.0 - y.saturating_add(height) as f32 / target_height as f32 * 2.0;
     vertices.extend_from_slice(&[
         Vertex {
             position: [left, top],
@@ -843,6 +876,87 @@ mod tests {
                 .any(|vertex| vertex.color == DEFAULT_FOREGROUND),
             "the unstyled cell must emit vertices in the default foreground"
         );
+    }
+
+    #[test]
+    fn explicit_background_emits_a_full_rect_before_the_glyph() {
+        let terminal = snapshot(1, 1, b"\x1b[38;2;241;207;33;48;2;12;98;201mA");
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let background = channels_to_floats([12, 98, 201]);
+        let foreground = channels_to_floats([241, 207, 33]);
+
+        assert!(
+            vertices.len() > VERTICES_PER_RECT,
+            "background and glyph missing"
+        );
+        assert!(
+            vertices[..VERTICES_PER_RECT]
+                .iter()
+                .all(|vertex| vertex.color == background),
+            "the first primitive must be the cell background"
+        );
+        assert_eq!(
+            vertices[VERTICES_PER_RECT].color, foreground,
+            "the glyph must follow its background"
+        );
+        assert_eq!(
+            vertices[0].position,
+            [-1.0, 1.0],
+            "the background must start at the cell's top-left"
+        );
+        assert_eq!(
+            vertices[2].position,
+            [(-1.0 + 20.0 / 900.0), 1.0 - 40.0 / 600.0],
+            "the background must cover one configured cell"
+        );
+    }
+
+    #[test]
+    fn default_background_emits_no_extra_vertices() {
+        let terminal = snapshot(1, 1, b"A");
+        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let glyph_pixels = glyph_rows('A')
+            .iter()
+            .map(|row| row.count_ones() as usize)
+            .sum::<usize>();
+
+        assert_eq!(
+            vertices.len(),
+            glyph_pixels * VERTICES_PER_RECT,
+            "a default-background cell must keep the historical glyph vertex count"
+        );
+    }
+
+    #[test]
+    fn clamp_coordinates_keep_markers_inside_the_render_grid() {
+        let terminal = snapshot(
+            MAX_RENDER_ROWS + 1,
+            MAX_RENDER_COLS + 1,
+            b"\x1b[61;1HA\x1b[31;161HA\x1b[31;31HA",
+        );
+        let width = u32::from(MAX_RENDER_COLS + 1) * 10;
+        let height = u32::from(MAX_RENDER_ROWS + 1) * 20;
+        let vertices = glyph_vertices(Some(&terminal), None, None, width, height, poc_metrics());
+
+        let contains = |row: usize, col: usize| {
+            let left = col as f32 * 10.0 / width as f32 * 2.0 - 1.0;
+            let right = (col as f32 + 1.0) * 10.0 / width as f32 * 2.0 - 1.0;
+            let top = 1.0 - row as f32 * 20.0 / height as f32 * 2.0;
+            let bottom = 1.0 - (row as f32 + 1.0) * 20.0 / height as f32 * 2.0;
+            vertices.iter().any(|vertex| {
+                vertex.position[0] >= left
+                    && vertex.position[0] < right
+                    && vertex.position[1] <= top
+                    && vertex.position[1] > bottom
+            })
+        };
+
+        assert!(
+            contains(29, 30) || contains(30, 30),
+            "interior marker vanished"
+        );
+        assert!(!contains(usize::from(MAX_RENDER_ROWS), 0));
+        assert!(!contains(29, usize::from(MAX_RENDER_COLS)));
     }
 
     #[test]

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -778,23 +778,13 @@ mod tests {
         GridGeometry::poc().cell_metrics()
     }
 
-    #[test]
-    fn glyph_input_is_bounded_to_visible_poc_grid() {
-        // Grid dimensions one past the renderer limits exercise the same
-        // dimension clamps as u32::MAX: visible_rows clamps to
-        // MAX_RENDER_ROWS and terminal_cols clamps to MAX_RENDER_COLS.
-        // No overflow path exists — all dimension arithmetic uses
-        // saturating_add and clamp — so u32::MAX adds no coverage beyond
-        // these values.
-        let rows = MAX_RENDER_ROWS + 1;
-        let cols = MAX_RENDER_COLS + 1;
-        let bytes = vec![b'A'; usize::from(rows) * usize::from(cols)];
-        let terminal = snapshot(rows, cols, &bytes);
-        let width = u32::from(cols) * CELL_WIDTH + CELL_WIDTH;
-        let height = u32::from(rows) * CELL_HEIGHT + CELL_HEIGHT;
-        let vertices = glyph_vertices(Some(&terminal), None, None, width, height, poc_metrics());
-        assert!(vertices.len() <= MAX_VERTICES);
-    }
+    // NOTE: the renderer's row/column clamp coverage used to live here as
+    // `glyph_input_is_bounded_to_visible_poc_grid`, a count-based test that
+    // could not distinguish the clamps from the `MAX_VERTICES` backstop (issue
+    // #109). It is replaced by `frame_oracle::glyphs_stay_inside_the_render_clamp_grid`,
+    // which reads pixels back from the real pipeline and asserts on *where*
+    // glyphs land — the property a vertex-count assertion is structurally
+    // unable to pin.
 
     #[test]
     fn empty_and_zero_sized_inputs_have_no_vertices() {
@@ -900,7 +890,6 @@ mod tests {
     }
 
     const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
-    const CELL_HEIGHT: u32 = noren_app::POC_CELL_HEIGHT;
 
     fn ndc_left(column: u32) -> f32 {
         (column * CELL_WIDTH) as f32 / 900.0 * 2.0 - 1.0

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -55,7 +55,10 @@
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
 
-use noren_app::{GridGeometry, POC_CELL_HEIGHT as CELL_HEIGHT, POC_CELL_WIDTH as CELL_WIDTH};
+use noren_app::{
+    GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
+    POC_CELL_WIDTH as CELL_WIDTH,
+};
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::{
     CLEAR_COLOR, DEFAULT_ANSI_PALETTE, DEFAULT_FOREGROUND, DEFAULT_PALETTE, SIDEBAR_COLS,
@@ -408,6 +411,92 @@ fn state_and_render_agree_across_the_fr005_fixtures() {
         checked >= 4 * 2 * 6,
         "agreement checks covered {checked} cells"
     );
+}
+
+// ===========================================================================
+// Render clamps (issue #109): the renderer's `MAX_RENDER_ROWS` and
+// `MAX_RENDER_COLS` clamps must keep every glyph inside the drawable grid.
+//
+// The old guard — `renderer.rs::glyph_input_is_bounded_to_visible_poc_grid` —
+// asserted `vertices.len() <= MAX_VERTICES`. That cannot tell a clamp from the
+// `MAX_VERTICES` early-return backstop: both cap vertex output at the same
+// ceiling, and the fixture only ever reached ~half the cap (1,036,800 of
+// 2,016,000), so deleting any one guard left it green — confirmed by deletion
+// before this test was written. A count-based test is structurally unable to
+// pin this property.
+//
+// What needs guarding is *where glyphs land*, so this test reads pixels back
+// from the real pipeline and asserts directly that no cell past either clamp
+// boundary is lit. The fixture places three single-cell markers via CUP on a
+// grid one past each clamp limit, rather than filling it: a row detector at the
+// overflow display row, a column detector at the overflow column, and a stable
+// interior marker. Three glyphs keep the capture at small-grid cost (the full
+// 61×161 fill took ~4.5s; this takes ~0.1s).
+//
+// Mutation protocol (run before trusting this test): removing the row clamp
+// lights grid row `MAX_RENDER_ROWS`; removing the column clamp lights grid
+// column `MAX_RENDER_COLS`. The `MAX_VERTICES` backstop cannot produce a visual
+// change while the clamps hold (it is a memory guard, not a geometry guard), so
+// this test does not catch its removal — see the report line.
+// ===========================================================================
+
+#[test]
+fn glyphs_stay_inside_the_render_clamp_grid() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+
+    // A grid one past each clamp limit in both dimensions. Three CUP-placed
+    // markers carry the only lit content:
+    //   - row detector  at display (60, 0):   maps to grid row 59 with the row
+    //                                         clamp, grid row 60 (out of bounds)
+    //                                         without it;
+    //   - column detector at display (30, 160): column 160 is inside the grid
+    //                                         but past the MAX_RENDER_COLS cut,
+    //                                         so it draws only without the
+    //                                         column clamp;
+    //   - interior marker at display (30, 30): always drawn in bounds, at grid
+    //                                         row 29 or 30 depending on the row
+    //                                         clamp — a stable positive control.
+    let rows = MAX_RENDER_ROWS + 1;
+    let cols = MAX_RENDER_COLS + 1;
+    let bytes = "\x1b[61;1HA\x1b[31;161HA\x1b[31;31HA".as_bytes().to_vec();
+    let snap = snapshot(rows, cols, &bytes);
+    // Rendered at the terminal's own grid size: one cell larger than the clamp
+    // grid each way, so overflow content has pixel room to land in.
+    let frame = render(&renderer, &snap);
+
+    let max_row = u32::from(MAX_RENDER_ROWS);
+    let max_col = u32::from(MAX_RENDER_COLS);
+
+    // Positive control: the interior marker lands at grid row 29 or 30
+    // (depending on the row clamp), never outside the budget. If neither is
+    // lit the renderer drew nothing and the boundary checks below are vacuous.
+    assert!(
+        cell_is_lit(&frame, 29, 30) || cell_is_lit(&frame, 30, 30),
+        "interior marker must light grid (29,30) or (30,30) — \
+         otherwise the render produced nothing and the boundary checks are vacuous"
+    );
+
+    // Row clamp: no lit cell at row MAX_RENDER_ROWS. With the clamp the row
+    // detector sits at grid row 59; without it, it spills into row max_row.
+    // Neither the column clamp nor the MAX_VERTICES backstop can light this
+    // row, so a lit cell here pins a row-clamp regression.
+    for col in 0..max_col {
+        assert!(
+            !cell_is_lit(&frame, max_row, col),
+            "cell ({max_row},{col}) is lit at MAX_RENDER_ROWS — \
+             the row clamp failed to contain the grid"
+        );
+    }
+
+    // Column clamp: no lit cell at column MAX_RENDER_COLS. Symmetric to the
+    // row check; only a column-clamp regression lights any cell here.
+    for row in 0..max_row {
+        assert!(
+            !cell_is_lit(&frame, row, max_col),
+            "cell ({row},{max_col}) is lit at MAX_RENDER_COLS — \
+             the column clamp failed to contain the grid"
+        );
+    }
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -27,13 +27,13 @@
 //!
 //! ## The lit/blank gate
 //!
-//! `is_background` originally thresholded on brightness, which was sufficient
-//! only while every glyph was one bright-green constant — as the earlier
-//! version of this file noted. It now compares against the renderer's
-//! `CLEAR_COLOR` instead. That is strictly stronger, not weaker: a dark
-//! foreground (ANSI black, a dark truecolor shade) is correctly read as lit
-//! where the threshold would have called it background and thereby agreed with
-//! a renderer that dropped the cell.
+//! The oracle distinguishes an untouched clear pixel from a terminal-painted
+//! background pixel. `is_clear` is exact and drives lit/blank and neighbour
+//! assertions; `is_background` means that a pixel matches the specific
+//! expected terminal background for its cell (or the clear colour when the
+//! cell has no explicit background). Neither predicate accepts arbitrary dark
+//! pixels, so dropping a glyph, leaking into a neighbour, or skipping a
+//! background rectangle remains observable.
 //!
 //! ## Faithfulness
 //!
@@ -109,23 +109,19 @@ fn colors_match(actual: [u8; 3], expected: [u8; 3]) -> bool {
         .all(|(a, e)| a.abs_diff(*e) <= CHANNEL_TOLERANCE)
 }
 
-/// A pixel counts as "background" when it is exactly the clear colour.
-///
-/// This is deliberately an *equality* test against the clear colour, not the
-/// brightness threshold this oracle used before colour existed. That gate
-/// (`all channels < 48`) assumed every glyph was the shader's bright-green
-/// constant; it was flagged in this file as insufficient once colour landed,
-/// and it is: a cell drawn in ANSI black or in a dark truecolor shade is lit
-/// but has every channel under 48, so the brightness gate would report it
-/// blank and the lit/blank agreement checks would silently pass on a renderer
-/// that dropped those cells entirely.
-///
-/// Comparing to the clear colour instead is strictly stronger — it accepts
-/// only the one byte colour nothing was drawn in — and it is what lets
-/// [`cell_colors`] below distinguish *which* colour a lit cell holds rather
-/// than merely that something is lit.
-fn is_background(rgba: [u8; 4]) -> bool {
+/// Whether a pixel is untouched by every draw primitive.
+fn is_clear(rgba: [u8; 4]) -> bool {
     [rgba[0], rgba[1], rgba[2]] == clear_rgb()
+}
+
+/// Whether a pixel matches the expected background of its cell.
+///
+/// `None` means the cell has no SGR background, so the only valid background
+/// is the exact clear colour. `Some` names one concrete terminal colour and is
+/// compared with the same tight tolerance used for shader output.
+fn is_background(rgba: [u8; 4], expected: Option<[u8; 3]>) -> bool {
+    let actual = [rgba[0], rgba[1], rgba[2]];
+    expected.map_or_else(|| is_clear(rgba), |color| colors_match(actual, color))
 }
 
 /// Whether any lit (non-background) pixel falls inside cell `(row, col)`.
@@ -134,7 +130,7 @@ fn cell_is_lit(frame: &CapturedFrame, row: u32, col: u32) -> bool {
     let y0 = row * CELL_HEIGHT;
     for y in y0..y0 + CELL_HEIGHT {
         for x in x0..x0 + CELL_WIDTH {
-            if !is_background(frame.pixel(x, y)) {
+            if !is_clear(frame.pixel(x, y)) {
                 return true;
             }
         }
@@ -149,7 +145,7 @@ fn cell_pattern(frame: &CapturedFrame, row: u32, col: u32) -> Vec<bool> {
     let mut pattern = Vec::with_capacity((CELL_WIDTH * CELL_HEIGHT) as usize);
     for y in 0..CELL_HEIGHT {
         for x in 0..CELL_WIDTH {
-            pattern.push(!is_background(
+            pattern.push(!is_clear(
                 frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y),
             ));
         }
@@ -168,7 +164,7 @@ fn cell_colors(frame: &CapturedFrame, row: u32, col: u32) -> Vec<[u8; 3]> {
     for y in 0..CELL_HEIGHT {
         for x in 0..CELL_WIDTH {
             let pixel = frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y);
-            if is_background(pixel) {
+            if is_clear(pixel) {
                 continue;
             }
             let rgb = [pixel[0], pixel[1], pixel[2]];
@@ -612,6 +608,96 @@ fn the_16_colour_and_256_colour_forms_of_one_colour_agree() {
         colors_match(ansi_form, indexed_form),
         "SGR 31 drew {ansi_form:?} but SGR 38;5;1 drew {indexed_form:?} — \
          the two forms of ANSI red must resolve through one palette"
+    );
+}
+
+#[test]
+fn truecolor_background_paints_the_whole_cell_and_keeps_glyph_foreground() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let background = [12, 98, 201];
+    let foreground = [241, 207, 33];
+    let snap = snapshot(1, 1, b"\x1b[38;2;241;207;33;48;2;12;98;201mA");
+    let frame = render(&renderer, &snap);
+
+    let mut background_pixels = 0;
+    let mut foreground_pixels = 0;
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = frame.pixel(x, y);
+            if is_background(pixel, Some(background)) {
+                background_pixels += 1;
+            } else if colors_match([pixel[0], pixel[1], pixel[2]], foreground) {
+                foreground_pixels += 1;
+            } else {
+                panic!("cell pixel ({x},{y}) is neither background nor foreground: {pixel:?}");
+            }
+        }
+    }
+
+    assert!(
+        background_pixels > 0,
+        "the cell rectangle must paint pixels outside glyph strokes"
+    );
+    assert!(
+        foreground_pixels > 0,
+        "the glyph must remain visible over its background"
+    );
+    // The glyph starts three pixels below the cell top and never reaches the
+    // final row, so these corners must be painted by the full-cell rectangle.
+    for (x, y) in [
+        (0, 0),
+        (CELL_WIDTH - 1, 0),
+        (0, CELL_HEIGHT - 1),
+        (CELL_WIDTH - 1, CELL_HEIGHT - 1),
+    ] {
+        assert!(
+            is_background(frame.pixel(x, y), Some(background)),
+            "cell corner ({x},{y}) was not painted by the background rectangle"
+        );
+    }
+}
+
+#[test]
+fn background_on_a_space_paints_even_without_glyph_strokes() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let background = [73, 18, 146];
+    let snap = snapshot(1, 1, b"\x1b[48;2;73;18;146m ");
+    let frame = render(&renderer, &snap);
+
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            assert!(
+                is_background(frame.pixel(x, y), Some(background)),
+                "background-painted space leaked clear colour at ({x},{y})"
+            );
+        }
+    }
+}
+
+#[test]
+fn indexed_background_matches_its_truecolor_palette_entry() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let truecolor = snapshot(1, 1, b"\x1b[48;2;255;0;0mA");
+    let indexed = snapshot(1, 1, b"\x1b[48;5;196mA");
+
+    let truecolor_frame = render(&renderer, &truecolor);
+    let indexed_frame = render(&renderer, &indexed);
+    assert_eq!(
+        truecolor_frame.rgba, indexed_frame.rgba,
+        "truecolor red and indexed palette entry 196 must render identically"
+    );
+    assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
+}
+
+#[test]
+fn no_background_keeps_the_existing_pixel_exact_appearance() {
+    let renderer = OffscreenRenderer::new().expect("offscreen renderer");
+    let plain = render(&renderer, &snapshot(1, 1, b"A"));
+    let reset_background = render(&renderer, &snapshot(1, 1, b"\x1b[49mA"));
+
+    assert_eq!(
+        plain.rgba, reset_background.rgba,
+        "default background must not alter the historical glyph frame"
     );
 }
 

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -1662,6 +1662,12 @@ fn visible_display_lines(screen: &ScreenBuffer) -> Vec<String> {
         lines.push(cells_to_display_line(&screen.cells[start..end]));
     }
     while lines.last().is_some_and(String::is_empty) {
+        let row = lines.len() - 1;
+        let start = row * usize::from(screen.cols);
+        let end = start + usize::from(screen.cols);
+        if !row_is_display_blank(&screen.cells[start..end]) {
+            break;
+        }
         lines.pop();
     }
     lines
@@ -1689,14 +1695,15 @@ fn cells_to_display_line(cells: &[Cell]) -> String {
 ///
 /// This is exactly the condition under which
 /// [`visible_display_lines`] drops a trailing row: every cell contributes
-/// only spaces (blank cells) or placeholders (continuation cells). Keeping
-/// the predicate here — next to the line builder it mirrors — is what lets
-/// [`TerminalSnapshot::display_cells`] select the same rows as
-/// [`TerminalSnapshot::display_lines`].
+/// only spaces (blank cells) or placeholders (continuation cells), and no cell
+/// carries an explicit background. Keeping the predicate here — next to the
+/// line builder it mirrors — is what lets [`TerminalSnapshot::display_cells`]
+/// select the same rows as [`TerminalSnapshot::display_lines`] while retaining
+/// background-only rows for rendering.
 fn row_is_display_blank(cells: &[Cell]) -> bool {
-    cells
-        .iter()
-        .all(|cell| cell.is_blank() || cell.is_continuation())
+    cells.iter().all(|cell| {
+        (cell.is_blank() || cell.is_continuation()) && cell.attributes().background().is_default()
+    })
 }
 
 #[cfg(test)]
@@ -1986,6 +1993,23 @@ mod tests {
         assert_eq!(
             snapshot.display_cells().len(),
             snapshot.display_lines().len()
+        );
+    }
+
+    #[test]
+    fn display_rows_retain_a_background_only_space() {
+        let mut state = TerminalState::new(1, 1).expect("valid terminal");
+        state.feed_bytes(b"\x1b[48;2;73;18;146m ");
+        let snapshot = state.snapshot();
+
+        assert_eq!(snapshot.display_lines(), [""]);
+        assert_eq!(snapshot.display_cells().len(), 1);
+        assert_eq!(snapshot.display_cells().next().unwrap()[0].text(), " ");
+        assert!(
+            !snapshot.display_cells().next().unwrap()[0]
+                .attributes()
+                .background()
+                .is_default()
         );
     }
 


### PR DESCRIPTION
Issue #114 を解消。#112（前景色）で意図的に繰り延べた部分です。

`I114 background_drawn=yes draw_order=bg_first shares_resolve_path=yes new_vertex_bound=2073600 clamp_test_still_bites=yes default_unchanged=yes mutations_caught=3/3`

背景色付きセルが**セル全体を塗り**、グリフがその上で読めます。解決は前景と同じ `resolve_color`/`DEFAULT_PALETTE` 経路（truecolor と256色が乖離しない）。

`MAX_VERTICES` を新しい最悪ケース **2,073,600** に再計算しました。**Issue #118 が警告していた「バックストップが無防備な状態で頂点予算を変える危険」**に対し、#109 のクランプテストが依然として効くことを統括が変異で確認済み。

`is_background()` を再定義しています。セルが正当に背景色を持てるようになると「背景か」と「クリアカラーか」が別の問いになるため。**緩めてはおらず**、空セル・隣接漏れのアサーションは精度に依存したままです。

SGR 背景を持たないセルは従来通りの見え方（`default_unchanged=yes`）。

fmt / clippy / test すべて通過、`--ignored` はちょうど2件失敗。