### PR TITLE
refactor(app): extract mouse mode scanner

### DIFF
--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1,7 +1,9 @@
 //! macOS entry point for the bounded local-zsh PTY PoC.
 
+mod mouse_mode_scanner;
 mod renderer;
 
+use mouse_mode_scanner::MouseModeScanner;
 use noren_app::{
     Arrow, CellMetrics, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key,
     KeyDropReason, KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode,
@@ -477,103 +479,6 @@ fn created_session_id(events: Vec<SessionEvent>) -> SessionId {
             _ => None,
         })
         .expect("SessionAction::Create yields exactly one Created event")
-}
-
-/// Passive scanner that observes DECSET (`CSI ? Pn h`) and DECRST
-/// (`CSI ? Pn l`) sequences in PTY *output* and updates the app's
-/// [`MouseModes`].
-///
-/// TerminalState's parser recognises only modes 1, 1049, and 2004; mouse
-/// tracking and encoding modes (1000/1002/1003/1005/1006/1015) are dropped at
-/// `private_action` and never reach `TerminalModes`. This scanner sits on the
-/// output side as a read-only observer — it consumes no bytes and alters no
-/// parsing — so the terminal's own state machine is undisturbed. It exists
-/// because the alternative (a second parser) is what the project keeps filing
-/// as a bug; this is the narrowest possible seam.
-///
-/// Cross-chunk boundaries: the DFA retains its state across calls, so a
-/// `CSI ? 1000 h` split across two `PtyEvent::Output` chunks is still detected.
-#[derive(Default)]
-struct MouseModeScanner {
-    state: ScanState,
-    /// Parsed parameter values; supports multi-param sequences
-    /// (`CSI ? 1000 ; 1006 h`).
-    params: Vec<u16>,
-}
-
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
-enum ScanState {
-    #[default]
-    Ground,
-    Esc,
-    Csi,
-    /// After `ESC [ ?` or after a `;` separator — expecting the first digit
-    /// of the next parameter.
-    CsiQuestion,
-    /// Accumulating digits of the current parameter.
-    Param,
-}
-
-impl MouseModeScanner {
-    /// Feed one PTY output byte. Updates `modes` when a complete DECSET/DECRST
-    /// for a recognized mouse mode is observed.
-    fn feed(&mut self, byte: u8, modes: &mut MouseModes) {
-        // ESC always starts a fresh sequence regardless of current state.
-        if byte == 0x1b {
-            self.params.clear();
-            self.state = ScanState::Esc;
-            return;
-        }
-        match (self.state, byte) {
-            (ScanState::Esc, b'[') => {
-                self.state = ScanState::Csi;
-            }
-            (ScanState::Csi, b'?') => {
-                self.params.clear();
-                self.state = ScanState::CsiQuestion;
-            }
-            (ScanState::CsiQuestion, digit @ b'0'..=b'9') => {
-                self.params.push(u16::from(digit - b'0'));
-                self.state = ScanState::Param;
-            }
-            (ScanState::Param, digit @ b'0'..=b'9') => {
-                if let Some(last) = self.params.last_mut() {
-                    *last = last
-                        .saturating_mul(10)
-                        .saturating_add(u16::from(digit - b'0'));
-                }
-            }
-            (ScanState::Param, b';') => {
-                // Multi-parameter: wait for the next digit.
-                self.state = ScanState::CsiQuestion;
-            }
-            (ScanState::Param, b'h') => {
-                for &mode in &self.params {
-                    *modes = modes.set(mode, true);
-                }
-                self.params.clear();
-                self.state = ScanState::Ground;
-            }
-            (ScanState::Param, b'l') => {
-                for &mode in &self.params {
-                    *modes = modes.set(mode, false);
-                }
-                self.params.clear();
-                self.state = ScanState::Ground;
-            }
-            _ => {
-                self.params.clear();
-                self.state = ScanState::Ground;
-            }
-        }
-    }
-
-    /// Convenience: feed an entire byte slice.
-    fn scan(&mut self, bytes: &[u8], modes: &mut MouseModes) {
-        for &byte in bytes {
-            self.feed(byte, modes);
-        }
-    }
 }
 
 struct NorenApp {

--- a/crates/noren-app/src/mouse_mode_scanner.rs
+++ b/crates/noren-app/src/mouse_mode_scanner.rs
@@ -1,0 +1,96 @@
+use noren_app::mouse::MouseModes;
+
+/// Passive scanner that observes DECSET (`CSI ? Pn h`) and DECRST
+/// (`CSI ? Pn l`) sequences in PTY *output* and updates the app's
+/// [`MouseModes`].
+///
+/// This is a legacy compatibility observer while the application still keeps
+/// its encoder-facing [`MouseModes`] separately. `TerminalState::modes()` now
+/// exposes the authoritative terminal mode state, so later wiring should read
+/// that state and remove this scanner. Until then, this observer consumes no
+/// bytes and alters no terminal parsing.
+///
+/// Cross-chunk boundaries: the DFA retains its state across calls, so a
+/// `CSI ? 1000 h` split across two `PtyEvent::Output` chunks is still detected.
+#[derive(Default)]
+pub(super) struct MouseModeScanner {
+    state: ScanState,
+    /// Parsed parameter values; supports multi-param sequences
+    /// (`CSI ? 1000 ; 1006 h`).
+    params: Vec<u16>,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+enum ScanState {
+    #[default]
+    Ground,
+    Esc,
+    Csi,
+    /// After `ESC [ ?` or after a `;` separator — expecting the first digit
+    /// of the next parameter.
+    CsiQuestion,
+    /// Accumulating digits of the current parameter.
+    Param,
+}
+
+impl MouseModeScanner {
+    /// Feed one PTY output byte. Updates `modes` when a complete DECSET/DECRST
+    /// for a recognized mouse mode is observed.
+    fn feed(&mut self, byte: u8, modes: &mut MouseModes) {
+        // ESC always starts a fresh sequence regardless of current state.
+        if byte == 0x1b {
+            self.params.clear();
+            self.state = ScanState::Esc;
+            return;
+        }
+        match (self.state, byte) {
+            (ScanState::Esc, b'[') => {
+                self.state = ScanState::Csi;
+            }
+            (ScanState::Csi, b'?') => {
+                self.params.clear();
+                self.state = ScanState::CsiQuestion;
+            }
+            (ScanState::CsiQuestion, digit @ b'0'..=b'9') => {
+                self.params.push(u16::from(digit - b'0'));
+                self.state = ScanState::Param;
+            }
+            (ScanState::Param, digit @ b'0'..=b'9') => {
+                if let Some(last) = self.params.last_mut() {
+                    *last = last
+                        .saturating_mul(10)
+                        .saturating_add(u16::from(digit - b'0'));
+                }
+            }
+            (ScanState::Param, b';') => {
+                // Multi-parameter: wait for the next digit.
+                self.state = ScanState::CsiQuestion;
+            }
+            (ScanState::Param, b'h') => {
+                for &mode in &self.params {
+                    *modes = modes.set(mode, true);
+                }
+                self.params.clear();
+                self.state = ScanState::Ground;
+            }
+            (ScanState::Param, b'l') => {
+                for &mode in &self.params {
+                    *modes = modes.set(mode, false);
+                }
+                self.params.clear();
+                self.state = ScanState::Ground;
+            }
+            _ => {
+                self.params.clear();
+                self.state = ScanState::Ground;
+            }
+        }
+    }
+
+    /// Convenience: feed an entire byte slice.
+    pub(super) fn scan(&mut self, bytes: &[u8], modes: &mut MouseModes) {
+        for &byte in bytes {
+            self.feed(byte, modes);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Refs #123
Follow-up authority migration: #125

## Summary

Extract the binary-private `MouseModeScanner` DFA from `main.rs` into its own sibling module without changing runtime behavior.

- `main.rs`: 2,344 → 2,249 lines
- scanner implementation: unchanged after the minimal child-module visibility adjustment
- exact binary/workspace test inventories: unchanged

## Design decisions

`MouseModeScanner` and `scan` are only `pub(super)`; `ScanState`, fields, and `feed` remain private. The module is declared only by the binary and is absent from `lib.rs`.

The six scanner tests intentionally remain in `src/main/tests.rs`. Moving them under `mouse_mode_scanner::tests` would change their fully-qualified names and break Issue #123's stricter requirement to preserve existing test filters. Their bodies, names, and namespace remain byte-identical.

PR #113 made `TerminalState::modes()` authoritative. This PR stays mechanical; #125 separately tracks deleting the legacy observer and its unbounded parameter vector after application consumers migrate.

## Changed files and forbidden scope

Changed only:

- `crates/noren-app/src/main.rs`
- `crates/noren-app/src/mouse_mode_scanner.rs`

Forbidden and unchanged: runtime ordering, terminal parsing, mouse policy/encoding, PTY bytes, tests, public APIs, dependencies, SSH logic, docs, and feature claims.

## Verification

- scanner normalized implementation SHA-256 before/after: `3f8a97f73231f13528bbffb538e1ecfd2eb9c44d700b713d52f93502e4fe1ee0`
- binary test inventory: 133, unchanged hash `e9870e96e4074ad671b533850994bd9b960cc23a376bd5acd8ac867a12e77ccc`
- six exact `tests::scanner_*` filters preserved and passing
- workspace test inventory preserved; `cargo test --workspace`: PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: PASS
- `cargo build --release -p noren-app`: PASS
- `cargo fmt --all -- --check`: PASS
- `cargo deny check`: advisories/bans/licenses/sources PASS
- `python3 scripts/check_docs.py`: PASS
- `git diff --check`: PASS

No screenshot applies because this is a source-layout-only change.

## Performance impact

None intended; the same DFA runs at the same call site before terminal parsing.

## Security and privacy impact

No new runtime behavior or data access. The legacy scanner's pre-existing unbounded parameter vector and duplicate state authority are explicitly tracked by #125 rather than hidden or expanded here.

## Compatibility impact

None. Mouse tracking/encoding, Shift bypass, PTY routing, Zellij pass-through, macOS, and Linux code paths are unchanged.

## Known limitations

This extracts one responsibility but intentionally does not make the legacy scanner the long-term authority. #125 removes it in favor of bounded `TerminalState::modes()`.

## Rollback

Revert commit `0563a7a`.

## Independent review

- Implementer: Codex sub-agent
- Reviewing agents: two independent Codex lanes
- Independent QA: OpenCode GLM 5.2 exact-diff review

All three reviews reported BLOCKER 0 / MAJOR 0 / MINOR 0.

## Checklist

- [x] This change is scoped to its Issue and uses a non-`main` branch.
- [x] Requirements/RFCs/ADRs are linked and updated where needed.
- [x] Exact existing tests and inventories pass unchanged.
- [x] No unimplemented feature is advertised as supported.
- [x] No credential, token, cookie, SSH key, passphrase, or private data is present.
- [x] Documentation and release claims match current evidence.
- [x] Commits include DCO sign-off.