### PR TITLE
fix(app): make persistence diagnostics evidence-based

### DIFF
--- a/crates/noren-app/src/diagnostics.rs
+++ b/crates/noren-app/src/diagnostics.rs
@@ -58,6 +58,7 @@ pub struct DiagnosticsInput {
     scrollback_cap: usize,
     pty: PtyChildStatus,
     persistence_conflict: bool,
+    persistence_unverified: bool,
 }
 
 /// Build diagnostics input from the live terminal snapshot.
@@ -77,6 +78,7 @@ pub fn from_snapshot(snapshot: Option<&TerminalSnapshot>, pty: PtyChildStatus) -
             scrollback_cap: MAX_SCROLLBACK_LINES,
             pty,
             persistence_conflict: false,
+            persistence_unverified: false,
         },
         None => DiagnosticsInput {
             grid_rows: None,
@@ -86,6 +88,7 @@ pub fn from_snapshot(snapshot: Option<&TerminalSnapshot>, pty: PtyChildStatus) -
             scrollback_cap: MAX_SCROLLBACK_LINES,
             pty,
             persistence_conflict: false,
+            persistence_unverified: false,
         },
     }
 }
@@ -95,6 +98,14 @@ impl DiagnosticsInput {
     #[must_use]
     pub const fn with_persistence_conflict(mut self, conflict: bool) -> Self {
         self.persistence_conflict = conflict;
+        self
+    }
+
+    /// Record that the last persistence attempt could not be fully inspected,
+    /// saved, or verified.
+    #[must_use]
+    pub const fn with_persistence_unverified(mut self, unverified: bool) -> Self {
+        self.persistence_unverified = unverified;
         self
     }
 }
@@ -132,7 +143,9 @@ pub fn report(input: &DiagnosticsInput) -> String {
         input.scrollback_len,
         input.scrollback_cap,
         input.pty,
-        if input.persistence_conflict {
+        if input.persistence_unverified {
+            "unverified"
+        } else if input.persistence_conflict {
             "changed-underneath"
         } else {
             "ok"
@@ -258,10 +271,24 @@ mod tests {
         let mut terminal = TerminalState::new(1024, 1024).expect("within MAX_SCREEN_CELLS");
         terminal.feed_bytes(b"\x1b[?1h\x1b=\x1b[?1049h");
         let state = terminal.snapshot();
-        let input = from_snapshot(Some(&state), PtyChildStatus::Exited { code: None });
+        let input = from_snapshot(Some(&state), PtyChildStatus::Exited { code: None })
+            .with_persistence_unverified(true);
         let line = report(&input);
         assert!(line.len() < 200, "report must stay bounded: {line}");
         assert!(line.is_ascii(), "no free text can reach the report");
+        assert!(line.ends_with("state=unverified"), "{line}");
+    }
+
+    /// A sticky historical conflict remains recorded, but it must never hide
+    /// the current attempt's unsafe outcome in the single diagnostics field.
+    #[test]
+    fn current_unverified_state_has_priority_over_sticky_conflict() {
+        let input = from_snapshot(None, PtyChildStatus::NotLaunched)
+            .with_persistence_conflict(true)
+            .with_persistence_unverified(true);
+        let line = report(&input);
+        assert!(line.ends_with("state=unverified"), "{line}");
+        assert!(!line.contains("state=changed-underneath"), "{line}");
     }
 
     /// The scrollback ceiling diagnostics reports is the terminal

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1,6 +1,9 @@
 //! macOS entry point for the bounded local-zsh PTY PoC.
 
+mod persistence_state;
 mod renderer;
+
+use persistence_state::{AttemptOutcome, Observation, PersistenceState, SaveOutcome};
 
 use noren_app::{
     Arrow, CellMetrics, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key,
@@ -24,7 +27,7 @@ use noren_app::{
         SessionStatus,
     },
     session_persistence::{
-        SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save, snapshot,
+        SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save_snapshot, snapshot,
     },
     sidebar::{SidebarEntry, SidebarView},
     ssh_config::{HostDiscoveryKind, SshConfig},
@@ -199,15 +202,12 @@ struct WorkspaceState {
     /// Owned by the workspace; dispatched when the palette opens.
     palette: Palette<WorkspaceAction>,
     /// Where sidebar state is persisted. `None` in tests and when `HOME` is
-    /// unset; in both cases the workspace is in-memory only and [`persist`]
-    /// is a no-op.
+    /// unset; in both cases the workspace is in-memory only and
+    /// [`Self::persist`] is a no-op.
     state_path: Option<PathBuf>,
-    /// Exact state-file bytes observed at restore or after the last save.
-    /// `None` also represents a normally absent first-run file.
-    loaded_snapshot: Option<Vec<u8>>,
-    /// Sticky warning for the diagnostics overlay when another instance has
-    /// replaced the file since this workspace loaded it.
-    persistence_conflict: bool,
+    /// Exact comparison baseline plus persistence diagnostics. Baseline
+    /// validity is explicit so failures cannot reuse stale or assumed bytes.
+    persistence: PersistenceState,
 }
 
 impl Default for WorkspaceState {
@@ -241,8 +241,7 @@ impl WorkspaceState {
                 WorkspaceAction::FocusSidebar,
             ),
             state_path,
-            loaded_snapshot: None,
-            persistence_conflict: false,
+            persistence: PersistenceState::default(),
         }
     }
 
@@ -259,7 +258,13 @@ impl WorkspaceState {
         let Some(path) = &self.state_path else {
             return Ok(());
         };
-        self.loaded_snapshot = load_snapshot(path, &mut self.registry)?;
+        match load_snapshot(path, &mut self.registry) {
+            Ok(snapshot) => self.persistence.restore_succeeded(snapshot),
+            Err(error) => {
+                self.persistence.restore_failed();
+                return Err(error);
+            }
+        }
         self.rebuild_sidebar();
         Ok(())
     }
@@ -267,34 +272,51 @@ impl WorkspaceState {
     /// Persist the current sidebar state to
     /// [`state_path`](Self::state_path), if one is set.
     ///
-    /// The write is atomic (temp-file rename) inside [`save`]; this method
-    /// never bypasses it. A failure is surfaced through stderr and swallowed
-    /// so the app keeps running — losing a save is preferable to crashing the
-    /// terminal.
+    /// The write is atomic (temp-file rename) inside [`save_snapshot`]; this
+    /// method never bypasses it. A failure is surfaced through stderr and
+    /// swallowed so the app keeps running — losing a save is preferable to
+    /// crashing the terminal.
     fn persist(&mut self) {
         let Some(path) = &self.state_path else {
             return;
         };
-        match snapshot(path) {
-            Ok(current) if current != self.loaded_snapshot => {
-                self.persistence_conflict = true;
-            }
+        let before = match snapshot(path) {
+            Ok(current) => Observation::Observed(current),
             Err(error) => {
                 eprintln!("Noren could not inspect sidebar state before saving: {error}");
+                Observation::Unavailable
             }
-            _ => {}
-        }
-        if let Err(error) = save(path, &self.registry) {
-            eprintln!("Noren could not save sidebar state: {error}");
-        } else if let Ok(current) = snapshot(path) {
-            self.loaded_snapshot = current;
-        }
+        };
+        let save = match save_snapshot(path, &self.registry) {
+            Ok(intended) => {
+                let observed = match snapshot(path) {
+                    Ok(current) => Observation::Observed(current),
+                    Err(error) => {
+                        eprintln!("Noren could not verify saved sidebar state: {error}");
+                        Observation::Unavailable
+                    }
+                };
+                SaveOutcome::Written { intended, observed }
+            }
+            Err(error) => {
+                eprintln!("Noren could not save sidebar state: {error}");
+                SaveOutcome::Failed
+            }
+        };
+        self.persistence
+            .apply_attempt(AttemptOutcome::new(before, save));
     }
 
     /// Whether a save observed state written by another instance since the
-    /// last restore or successful save.
+    /// last verified restore or save.
     fn persistence_conflict(&self) -> bool {
-        self.persistence_conflict
+        self.persistence.conflict()
+    }
+
+    /// Whether the latest persistence attempt completed without enough
+    /// evidence to call the on-disk state safe.
+    fn persistence_unverified(&self) -> bool {
+        self.persistence.unverified()
     }
 
     /// Create a new session and rebuild the sidebar.
@@ -1533,7 +1555,8 @@ impl NorenApp {
         }
         let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
         let input = diagnostics::from_snapshot(snapshot.as_ref(), self.pty_child)
-            .with_persistence_conflict(self.workspace.persistence_conflict());
+            .with_persistence_conflict(self.workspace.persistence_conflict())
+            .with_persistence_unverified(self.workspace.persistence_unverified());
         let line = diagnostics::report(&input);
         eprintln!("{line}");
         if let Some(window) = &self.window {

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use noren_app::palette::CommandId;
 use noren_app::passthrough::{self, collisions};
-use noren_app::session_persistence::load;
+use noren_app::session_persistence::{MAX_SESSION_STATE_BYTES, load};
 use noren_app::sidebar::EntryKind;
 
 #[test]
@@ -3056,6 +3056,10 @@ fn corrupt_state_file_surfaces_error_without_panicking() {
         state.sidebar().is_empty(),
         "corrupt file leaves empty sidebar"
     );
+    assert!(
+        state.persistence_unverified(),
+        "the restore error is the current unsafe persistence outcome"
+    );
     cleanup_state_file(&path);
 }
 
@@ -3472,6 +3476,180 @@ fn second_instance_overwrite_is_detected_and_reported_by_diagnostics() {
     cleanup_state_file(&path);
 }
 
+// Pure persistence-transition tests moved beside the binary-private state
+// machine in `persistence_state.rs`. Filesystem and diagnostics integration
+// coverage remains here.
+
+/// The diagnostic integration follows the state machine's two-stage outcome:
+/// a definitive post-save replacement is currently unverified, while a later
+/// exact retry clears that current flag and reveals the sticky conflict.
+#[test]
+fn post_save_absence_or_mismatch_then_exact_retry_moves_diagnostics_to_changed_underneath() {
+    for (case, replacement) in [
+        ("absence", Observation::Observed(None)),
+        (
+            "mismatch",
+            Observation::Observed(Some(b"peer replacement".to_vec())),
+        ),
+    ] {
+        let baseline = b"verified baseline".to_vec();
+        let first_write = b"first intended bytes".to_vec();
+        let retry_write = b"retry intended bytes".to_vec();
+        let mut app = NorenApp::new(AppConfig::default());
+        app.workspace
+            .persistence
+            .restore_succeeded(Some(baseline.clone()));
+        app.workspace.persistence.apply_attempt(AttemptOutcome::new(
+            Observation::Observed(Some(baseline)),
+            SaveOutcome::Written {
+                intended: first_write,
+                observed: replacement.clone(),
+            },
+        ));
+
+        assert!(app.workspace.persistence_conflict(), "case={case}");
+        assert!(app.workspace.persistence_unverified(), "case={case}");
+        app.toggle_diagnostics();
+        assert!(
+            app.diagnostics_line.ends_with("state=unverified"),
+            "case={case}: {}",
+            app.diagnostics_line
+        );
+        app.toggle_diagnostics();
+
+        app.workspace.persistence.apply_attempt(AttemptOutcome::new(
+            replacement,
+            SaveOutcome::Written {
+                intended: retry_write.clone(),
+                observed: Observation::Observed(Some(retry_write)),
+            },
+        ));
+
+        assert!(app.workspace.persistence_conflict(), "case={case}");
+        assert!(!app.workspace.persistence_unverified(), "case={case}");
+        app.toggle_diagnostics();
+        assert!(
+            app.diagnostics_line.ends_with("state=changed-underneath"),
+            "case={case}: {}",
+            app.diagnostics_line
+        );
+    }
+}
+
+/// Mutation check for Issue #122: if the `snapshot` error arm stops marking
+/// persistence unverified, an oversized external replacement falsely reports
+/// `state=ok` even though the conflict check could not inspect it.
+#[test]
+fn oversized_external_snapshot_never_reports_persistence_ok() {
+    let path = temp_state_path();
+    let mut app = app_with_state_path(&path);
+    std::fs::write(&path, vec![b'#'; MAX_SESSION_STATE_BYTES as usize + 1])
+        .expect("write oversized external replacement");
+
+    app.workspace.create_session(SessionKind::Local);
+
+    assert!(
+        app.workspace.persistence_unverified(),
+        "the failed external-change check must remain visible"
+    );
+    app.toggle_diagnostics();
+    assert!(
+        app.diagnostics_line.contains("state=unverified"),
+        "diagnostics: {}",
+        app.diagnostics_line
+    );
+    assert!(
+        !app.diagnostics_line.contains("state=ok"),
+        "diagnostics must not certify an uninspected save: {}",
+        app.diagnostics_line
+    );
+
+    let mut saved = SessionRegistry::new();
+    load(&path, &mut saved).expect("the atomic save itself still succeeds");
+    assert_eq!(
+        saved.len(),
+        1,
+        "the warning is about verification, not loss"
+    );
+    cleanup_state_file(&path);
+}
+
+/// Mutation check for Issue #122: replacing the state file with a directory
+/// makes both inspection and atomic rename fail. Dropping failure propagation
+/// would leave two in-memory sessions behind a false `state=ok` diagnostic.
+#[test]
+fn directory_replacement_save_failure_never_reports_persistence_ok() {
+    let path = temp_state_path();
+    let mut app = app_with_state_path(&path);
+    app.workspace.create_session(SessionKind::Local);
+    std::fs::remove_file(&path).expect("remove saved state fixture");
+    std::fs::create_dir(&path).expect("replace the state path with a directory");
+
+    app.workspace.create_session(SessionKind::Local);
+
+    assert_eq!(app.workspace.registry().len(), 2, "memory did mutate");
+    assert!(
+        path.is_dir(),
+        "the failed save did not replace the directory"
+    );
+    assert!(
+        app.workspace.persistence_unverified(),
+        "the failed save must remain visible"
+    );
+    app.toggle_diagnostics();
+    assert!(
+        app.diagnostics_line.contains("state=unverified"),
+        "diagnostics: {}",
+        app.diagnostics_line
+    );
+    assert!(
+        !app.diagnostics_line.contains("state=ok"),
+        "diagnostics must not certify unsaved state: {}",
+        app.diagnostics_line
+    );
+
+    std::fs::remove_dir(&path).expect("remove directory replacement fixture");
+}
+
+/// Isolate the save-error arm from the pre-save inspection arm. The existing
+/// file is readable and unchanged, but the new in-memory document is too large
+/// to encode; removing save-error propagation therefore makes this test fail.
+#[test]
+fn save_failure_after_clean_inspection_never_reports_persistence_ok() {
+    let path = temp_state_path();
+    let mut app = app_with_state_path(&path);
+    app.workspace.create_session(SessionKind::Local);
+    let before = std::fs::read(&path).expect("read the clean baseline");
+
+    app.workspace.create_session(SessionKind::Ssh {
+        target: "x".repeat(MAX_SESSION_STATE_BYTES as usize + 1),
+    });
+
+    assert_eq!(
+        std::fs::read(&path).expect("the baseline remains readable"),
+        before,
+        "a refused save must leave the prior safe state intact"
+    );
+    assert!(
+        app.workspace.persistence_unverified(),
+        "a save error after clean inspection must remain visible"
+    );
+    app.toggle_diagnostics();
+    assert!(
+        app.diagnostics_line.contains("state=unverified"),
+        "diagnostics: {}",
+        app.diagnostics_line
+    );
+    assert!(
+        !app.diagnostics_line.contains("state=ok"),
+        "diagnostics must not certify unsaved state: {}",
+        app.diagnostics_line
+    );
+    cleanup_state_file(&path);
+}
+
+/// Clean persistence must remain distinguishable from both Issue #122 error
+/// paths; making either the default or successful path unverified breaks this.
 #[test]
 fn single_instance_save_has_no_persistence_false_alarm() {
     let path = temp_state_path();
@@ -3489,5 +3667,12 @@ fn single_instance_save_has_no_persistence_false_alarm() {
         "diagnostics: {}",
         app.diagnostics_line
     );
+    assert!(
+        !app.diagnostics_line.contains("unverified"),
+        "diagnostics: {}",
+        app.diagnostics_line
+    );
+    let saved = std::fs::read(&path).expect("read exact verified save");
+    assert!(!saved.is_empty(), "the real save path wrote a document");
     cleanup_state_file(&path);
 }

--- a/crates/noren-app/src/persistence_state.rs
+++ b/crates/noren-app/src/persistence_state.rs
@@ -1,0 +1,332 @@
+//! Pure binary-private state transitions for sidebar persistence evidence.
+//!
+//! Filesystem I/O and diagnostic rendering stay in `main.rs`; this module
+//! records only what those boundaries proved about the latest save and any
+//! external replacement observed along the way.
+
+/// One bounded state-file observation. Errors carry no untrusted details
+/// here; the I/O boundary reports the typed error before using `Unavailable`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Observation {
+    Observed(Option<Vec<u8>>),
+    Unavailable,
+}
+
+/// The write and exact post-write observation from one persistence attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SaveOutcome {
+    Failed,
+    Written {
+        intended: Vec<u8>,
+        observed: Observation,
+    },
+}
+
+/// Inputs to the state-only transition applied after the I/O boundary has
+/// completed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct AttemptOutcome {
+    before: Observation,
+    save: SaveOutcome,
+}
+
+impl AttemptOutcome {
+    pub(super) fn new(before: Observation, save: SaveOutcome) -> Self {
+        Self { before, save }
+    }
+}
+
+/// Whether an exact comparison baseline has been established for the state
+/// file. `Verified(None)` is a real, observed first-run absence; `Invalid` is
+/// deliberately distinct so failed verification cannot reuse stale bytes.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum Baseline {
+    #[default]
+    Invalid,
+    Verified(Option<Vec<u8>>),
+}
+
+/// Persistence diagnostics and the exact baseline that makes conflict
+/// comparisons meaningful.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct PersistenceState {
+    baseline: Baseline,
+    /// Sticky once an external replacement is definitively observed.
+    conflict: bool,
+    /// Describes only the latest restore or persistence attempt.
+    unverified: bool,
+}
+
+impl PersistenceState {
+    pub(super) fn restore_succeeded(&mut self, observed: Option<Vec<u8>>) {
+        self.baseline = Baseline::Verified(observed);
+        self.unverified = false;
+    }
+
+    pub(super) fn restore_failed(&mut self) {
+        self.baseline = Baseline::Invalid;
+        self.unverified = true;
+    }
+
+    /// Apply one persistence attempt without performing I/O.
+    ///
+    /// A changed pre-save observation against a valid baseline proves a
+    /// conflict. After a successful write, definitive absence or bytes other
+    /// than the intended document also prove that a peer replaced the file.
+    /// `Unavailable` cannot prove replacement, so it is unverified-only.
+    /// Only an exact post-save match establishes the next valid baseline.
+    pub(super) fn apply_attempt(&mut self, outcome: AttemptOutcome) {
+        let mut unverified = matches!(&outcome.before, Observation::Unavailable);
+
+        if let (Baseline::Verified(baseline), Observation::Observed(current)) =
+            (&self.baseline, &outcome.before)
+        {
+            if current != baseline {
+                self.conflict = true;
+            }
+        }
+
+        match outcome.save {
+            SaveOutcome::Written {
+                intended,
+                observed: Observation::Observed(Some(observed)),
+            } if observed == intended => {
+                self.baseline = Baseline::Verified(Some(intended));
+            }
+            SaveOutcome::Written {
+                observed: Observation::Observed(_),
+                ..
+            } => {
+                self.baseline = Baseline::Invalid;
+                self.conflict = true;
+                unverified = true;
+            }
+            SaveOutcome::Failed
+            | SaveOutcome::Written {
+                observed: Observation::Unavailable,
+                ..
+            } => {
+                self.baseline = Baseline::Invalid;
+                unverified = true;
+            }
+        }
+
+        self.unverified = unverified;
+    }
+
+    pub(super) const fn conflict(&self) -> bool {
+        self.conflict
+    }
+
+    pub(super) const fn unverified(&self) -> bool {
+        self.unverified
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observed(bytes: &[u8]) -> Observation {
+        Observation::Observed(Some(bytes.to_vec()))
+    }
+
+    fn exact_save(intended: &[u8]) -> SaveOutcome {
+        SaveOutcome::Written {
+            intended: intended.to_vec(),
+            observed: observed(intended),
+        }
+    }
+
+    fn attempt(before: Observation, save: SaveOutcome) -> AttemptOutcome {
+        AttemptOutcome::new(before, save)
+    }
+
+    #[test]
+    fn missing_post_save_snapshot_sets_conflict_and_unverified_then_exact_retry_recovers_only_verification()
+     {
+        let baseline = b"verified baseline";
+        let first_write = b"first intended bytes";
+        let retry_write = b"retry intended bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(
+            observed(baseline),
+            SaveOutcome::Written {
+                intended: first_write.to_vec(),
+                observed: Observation::Observed(None),
+            },
+        ));
+
+        assert!(state.conflict());
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Invalid);
+
+        state.apply_attempt(attempt(observed(first_write), exact_save(retry_write)));
+
+        assert!(state.conflict(), "conflict is sticky across an exact retry");
+        assert!(!state.unverified(), "the latest save is now verified");
+        assert_eq!(
+            state.baseline,
+            Baseline::Verified(Some(retry_write.to_vec()))
+        );
+    }
+
+    #[test]
+    fn mismatched_post_save_snapshot_sets_conflict_and_unverified_then_exact_retry_recovers_only_verification()
+     {
+        let baseline = b"verified baseline";
+        let first_write = b"first intended bytes";
+        let peer = b"peer replacement bytes";
+        let retry_write = b"retry intended bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(
+            observed(baseline),
+            SaveOutcome::Written {
+                intended: first_write.to_vec(),
+                observed: observed(peer),
+            },
+        ));
+
+        assert!(state.conflict());
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Invalid);
+
+        state.apply_attempt(attempt(observed(peer), exact_save(retry_write)));
+
+        assert!(state.conflict(), "conflict is sticky across an exact retry");
+        assert!(!state.unverified(), "the latest save is now verified");
+        assert_eq!(
+            state.baseline,
+            Baseline::Verified(Some(retry_write.to_vec()))
+        );
+    }
+
+    #[test]
+    fn sticky_conflict_survives_a_later_clean_save() {
+        let baseline = b"verified baseline";
+        let peer = b"peer bytes";
+        let first_write = b"first write";
+        let clean_write = b"clean write";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(observed(peer), exact_save(first_write)));
+        assert!(state.conflict());
+        assert!(!state.unverified());
+
+        state.apply_attempt(attempt(observed(first_write), exact_save(clean_write)));
+
+        assert!(state.conflict());
+        assert!(!state.unverified());
+        assert_eq!(
+            state.baseline,
+            Baseline::Verified(Some(clean_write.to_vec()))
+        );
+    }
+
+    #[test]
+    fn pre_save_deletion_against_verified_some_sets_sticky_conflict() {
+        let baseline = b"verified baseline";
+        let intended = b"intended bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(Observation::Observed(None), exact_save(intended)));
+
+        assert!(state.conflict());
+        assert!(!state.unverified());
+        assert_eq!(state.baseline, Baseline::Verified(Some(intended.to_vec())));
+    }
+
+    #[test]
+    fn save_failure_then_exact_retry_clears_unverified_without_inventing_conflict() {
+        let baseline = b"verified baseline";
+        let retry_write = b"retry bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(observed(baseline), SaveOutcome::Failed));
+        assert!(!state.conflict());
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Invalid);
+
+        state.apply_attempt(attempt(observed(baseline), exact_save(retry_write)));
+
+        assert!(!state.conflict());
+        assert!(!state.unverified());
+        assert_eq!(
+            state.baseline,
+            Baseline::Verified(Some(retry_write.to_vec()))
+        );
+    }
+
+    #[test]
+    fn unavailable_pre_inspection_plus_exact_save_is_unverified_only() {
+        let baseline = b"verified baseline";
+        let intended = b"intended bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(Observation::Unavailable, exact_save(intended)));
+
+        assert!(!state.conflict());
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Verified(Some(intended.to_vec())));
+    }
+
+    #[test]
+    fn unavailable_post_save_observation_is_unverified_only_and_invalidates_baseline() {
+        let baseline = b"verified baseline";
+        let intended = b"intended bytes";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(baseline.to_vec()));
+
+        state.apply_attempt(attempt(
+            observed(baseline),
+            SaveOutcome::Written {
+                intended: intended.to_vec(),
+                observed: Observation::Unavailable,
+            },
+        ));
+
+        assert!(!state.conflict());
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Invalid);
+    }
+
+    #[test]
+    fn failed_restore_can_recover_without_comparing_an_invalid_baseline() {
+        let old = b"previously verified document";
+        let corrupt = b"readable but invalid restore input";
+        let recovered = b"recovered exact document";
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(old.to_vec()));
+        state.restore_failed();
+
+        assert!(state.unverified());
+        assert_eq!(state.baseline, Baseline::Invalid);
+
+        state.apply_attempt(attempt(observed(corrupt), exact_save(recovered)));
+
+        assert!(!state.conflict());
+        assert!(!state.unverified());
+        assert_eq!(state.baseline, Baseline::Verified(Some(recovered.to_vec())));
+    }
+
+    #[test]
+    fn successful_restore_replaces_invalid_baseline_and_clears_unverified() {
+        let restored = b"restored exact document";
+        let mut state = PersistenceState::default();
+        state.restore_failed();
+
+        state.restore_succeeded(Some(restored.to_vec()));
+
+        assert!(!state.conflict());
+        assert!(!state.unverified());
+        assert_eq!(state.baseline, Baseline::Verified(Some(restored.to_vec())));
+    }
+}

--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -195,8 +195,30 @@ impl std::error::Error for SessionPersistenceError {}
 /// more than [`MAX_SESSIONS`] entries or a document larger than
 /// [`MAX_SESSION_STATE_BYTES`]. Parent directories are created when absent.
 pub fn save(path: &Path, registry: &SessionRegistry) -> Result<(), SessionPersistenceError> {
-    let text = encode(registry)?;
-    write_atomic(path, text.as_bytes())
+    save_snapshot(path, registry).map(drop)
+}
+
+/// Save the sidebar state and return the exact bounded bytes handed to the
+/// atomic writer.
+///
+/// This function is public only because this package's library and binary are
+/// separate crates: the binary needs the exact write bytes for post-save
+/// verification and cannot call a library-private item. The returned buffer
+/// is no larger than [`MAX_SESSION_STATE_BYTES`], enforced by [`encode`].
+///
+/// Callers that verify a save must compare their post-save observation with
+/// this value. Merely observing that some file exists after the rename is not
+/// evidence that it contains this process's document: another process may
+/// have replaced it between the write and the observation. The returned
+/// buffer is therefore the intended document, not a claim about later disk
+/// contents.
+pub fn save_snapshot(
+    path: &Path,
+    registry: &SessionRegistry,
+) -> Result<Vec<u8>, SessionPersistenceError> {
+    let bytes = encode(registry)?.into_bytes();
+    write_atomic(path, &bytes)?;
+    Ok(bytes)
 }
 
 /// Load the sidebar state from `path` into `registry`, creating one entry

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -18,7 +18,7 @@
 use noren_app::session::{SessionDescriptor, SessionKind, SessionRegistry, SessionStatus};
 use noren_app::session_persistence::{
     MAX_SESSION_STATE_BYTES, MAX_SESSIONS, SESSION_STATE_VERSION, SessionPersistenceError, encode,
-    load, load_bytes, save,
+    load, load_bytes, save, save_snapshot,
 };
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -227,6 +227,24 @@ fn encoding_is_deterministic_across_saves() {
     );
     cleanup(&first);
     cleanup(&second);
+}
+
+#[test]
+fn save_snapshot_returns_the_exact_bounded_bytes_written() {
+    let source = sidebar_registry();
+    let path = temp_path("returned-save-snapshot.toml");
+
+    let intended = save_snapshot(&path, &source).expect("state saves with exact bytes");
+
+    assert_eq!(
+        intended,
+        std::fs::read(&path).expect("saved state remains readable")
+    );
+    assert!(
+        intended.len() <= MAX_SESSION_STATE_BYTES as usize,
+        "the returned verification buffer shares the serialization bound"
+    );
+    cleanup(&path);
 }
 
 #[test]


### PR DESCRIPTION
Closes #122.\n\n## Summary\n- replace ambiguous persistence booleans with an explicit binary-private evidence state machine\n- report failed or unverifiable persistence as state=unverified instead of false state=ok\n- keep definitive external replacement sticky and reveal it after a later exact retry\n- return the exact bounded bytes written by save_snapshot for post-write verification\n- add mutation-sensitive restore, save-failure, post-save mismatch/absence, retry, and diagnostics tests\n\n## Verification\n- cargo test --workspace --all-features: PASS\n- cargo clippy --workspace --all-targets --all-features with warnings denied: PASS\n- cargo fmt --all --check: PASS\n- cargo build --workspace --release: PASS\n- independent exact-head review: PASS (blockers=0, majors=0, minors=0)\n