### PR TITLE
feat(app): configurable keybindings with typed chord parsing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,20 +117,19 @@ Measured against it, item by item:
 | Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` |
 | Sidebar-state persistence | Done | `sessions.toml` (`SESSION_STATE_FILE_NAME`) under the `config::default_path` directory, resolved by `session_state_path` |
 | Palette | Done | `Super+p` via `palette_policy`; `Palette::noren`'s four commands dispatched by `handle_palette_key` |
-| Configurable keybindings | **Not started** | `palette_policy` and `handle_palette_key` hard-code the chords; `config.rs` exposes no keymap surface |
+| Configurable keybindings | Done for the palette surface | `[keys]` in `config.toml` (`KeymapConfig` in `config.rs`) rebinds the palette opener and the four palette command chords with the previous values as defaults; `palette_policy`/`handle_palette_key` in `main.rs` honor them, unparseable chords and unknown actions are typed errors, and the opener is validated against the pinned Zellij corpus and the exit leader. The exit leader, palette navigation keys, diagnostics chord, and clipboard shortcuts remain fixed |
 | Zellij pass-through | Done against a pinned corpus | `passthrough.rs` policy claims only Super-space chords that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds; no test drives a live Zellij |
 
-Two named scope items remain unsatisfied: **configurable keybindings do not
-exist at all**, and **SSH connections and agents do not run**. Positive literal
-aliases now appear in a bounded sidebar list and a click records a
-source-attributed pending target, but opens no SSH connection or PTY; wildcard
-or dynamic destinations are not presented as a complete host inventory, and
-agent entries remain fixtures and launch no agent. Since "Only evidence-backed
-work is marked complete" and the scope line
-names both, Milestone 3 stays **In progress**. The SSH and agent session kinds
-also depend on Milestones 4 and 5; whether they are retired from Milestone 3's
-scope or carried is an open scoping decision, not something to settle by
-relabelling the status.
+One named scope item remains unsatisfied: **SSH connections and agents do
+not run**. Positive literal aliases now appear in a bounded sidebar list and
+a click records a source-attributed pending target, but opens no SSH
+connection or PTY; wildcard or dynamic destinations are not presented as a
+complete host inventory, and agent entries remain fixtures and launch no
+agent. Since "Only evidence-backed work is marked complete" and the scope
+line names it, Milestone 3 stays **In progress**. The SSH and agent session
+kinds also depend on Milestones 4 and 5; whether they are retired from
+Milestone 3's scope or carried is an open scoping decision, not something to
+settle by relabelling the status.
 
 ## What blocks a public preview
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,8 +149,9 @@ the Noren terminal." The reasoning and the decision are recorded in
   shows bounded root-relative source provenance on selection, but selecting one
   only records a pending target and opens no connection or PTY. Only
   `SessionKind::Local` reaches a
-  launch path; git worktrees remain unreachable, agents remain fixture-only,
-  and keybindings are not configurable. See [Milestone 3 status](#milestone-3-status).
+  launch path; git worktrees remain unreachable, and agents remain
+  fixture-only; keybindings ARE configurable through the `[keys]` section
+  since this milestone (see [Milestone 3 status](#milestone-3-status)).
 - **Colour rendering exists, but themes are fixed.** `renderer.rs` resolves
   each cell's SGR foreground and any explicit background through its compiled-in
   ANSI/256-colour palette or as direct RGB truecolor. The vertex layout carries

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -336,12 +336,31 @@ fn parse_keys(table: &dyn TableLike, keys: &mut KeymapConfig) -> Result<(), Conf
 
 /// Parse one `[keys]` value into a chord, blaming the key and value on
 /// failure.
+///
+/// The binary claims Super+A/C/V (clipboard) and Super+D (diagnostics)
+/// ahead of every configured path — palette commands included, because
+/// `handle_key` consults them first even while the palette is open — and
+/// matches them with any combination of further modifiers held. A chord
+/// there would be dead configuration, so it is rejected here like every
+/// other unclaimable binding.
 fn parse_configured_chord(key: &str, value: &str) -> Result<Chord, ConfigError> {
-    parse_chord(value).map_err(|error| ConfigError::InvalidChord {
+    let chord = parse_chord(value).map_err(|error| ConfigError::InvalidChord {
         key: clip(key),
         value: clip(value),
         reason: clip(error.to_string()),
-    })
+    })?;
+    if chord.modifiers().is_super()
+        && matches!(
+            chord.code(),
+            KeyCode::Char('a') | KeyCode::Char('c') | KeyCode::Char('v') | KeyCode::Char('d')
+        )
+    {
+        return Err(ConfigError::ReservedChord {
+            key: clip(key),
+            value: clip(value),
+        });
+    }
+    Ok(chord)
 }
 
 /// Parse and validate one palette-command chord. The four command chords are
@@ -762,8 +781,9 @@ impl fmt::Display for ConfigError {
             ),
             Self::ReservedChord { key, value } => write!(
                 f,
-                "configuration key {key} binds chord {value} on a key the open palette \
-                 always interprets as navigation or dismissal"
+                "configuration key {key} binds chord {value} on a key the application \
+                 always claims first: the open palette reads it as navigation or dismissal, \
+                 and Super+A/C/V/D are fixed clipboard and diagnostics shortcuts"
             ),
             Self::DuplicateChord {
                 first,
@@ -1238,6 +1258,58 @@ mod tests {
                 AppConfig::parse(text),
                 Err(ConfigError::UnknownKey(name.to_owned())),
                 "{text:?} must not parse as a working setting"
+            );
+        }
+    }
+
+    /// Super+A/C/V (clipboard) and Super+D (diagnostics) are handled ahead of
+    /// every configured path, for every action, with further modifiers still
+    /// matching — a configured binding there would be dead, so it is a typed
+    /// `ReservedChord` error naming the key, never a silently shadowed accept.
+    #[test]
+    fn fixed_global_shortcuts_are_rejected_for_every_action() {
+        let actions = [
+            "palette_open",
+            "session_create",
+            "session_select",
+            "session_close",
+            "sidebar_focus",
+        ];
+        let reserved = [
+            ("super+a", 'a'),
+            ("super+c", 'c'),
+            ("super+v", 'v'),
+            ("super+d", 'd'),
+            // Shift (and any further modifier) still routes into the fixed
+            // handlers, so these are dead too.
+            ("super+shift+a", 'a'),
+            ("super+ctrl+d", 'd'),
+        ];
+        for action in actions {
+            for (chord, character) in reserved {
+                let text = format!("[keys]\n{action} = \"{chord}\"\n");
+                assert_eq!(
+                    AppConfig::parse(&text),
+                    Err(ConfigError::ReservedChord {
+                        key: action.to_owned(),
+                        value: chord.to_owned(),
+                    }),
+                    "{chord} must not be accepted for {action}"
+                );
+                let _ = character;
+            }
+        }
+        // The unmodified command keys and the default palette chord stay
+        // acceptable; only the fixed globals are refused.
+        for (action, chord) in [
+            ("session_create", "c"),
+            ("palette_open", "super+p"),
+            ("sidebar_focus", "f"),
+        ] {
+            let text = format!("[keys]\n{action} = \"{chord}\"\n");
+            assert!(
+                AppConfig::parse(&text).is_ok(),
+                "{chord} for {action} must stay accepted"
             );
         }
     }

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -17,6 +17,17 @@
 //! `docs/configuration.md` for the reserved settings and the lane work each
 //! one is waiting on.
 //!
+//! The `[keys]` table configures the workspace key chords (the palette
+//! opener and the four palette command shortcuts). It follows the same
+//! discipline: an absent table keeps the compiled-in defaults, an
+//! unparseable chord is a typed [`ConfigError::InvalidChord`] naming the
+//! offending key and value, an unknown action name is
+//! [`ConfigError::UnknownKey`], two actions on one chord is
+//! [`ConfigError::DuplicateChord`], and a palette chord the pass-through
+//! policy could never claim (a pinned Zellij default or the frozen
+//! `Super+Escape` exit leader) is [`ConfigError::UnclaimableChord`] rather
+//! than a silently dead binding.
+//!
 //! # Privacy
 //!
 //! Configuration carries no secrets: no supported key names a credential,
@@ -24,6 +35,10 @@
 //! keys at all. The shell program is **not** configurable: the threat model
 //! (TM-01) fixes the spawn at `/bin/zsh` with no configured additions.
 
+use crate::passthrough::{
+    CLAIM_ID_PALETTE, Chord, ChordError, ChordSeq, KeyCode, Modifiers, PassthroughAction,
+    PassthroughClaim, PassthroughPolicy, default_exit_claim,
+};
 use crate::{POC_CELL_HEIGHT, POC_CELL_WIDTH};
 use std::env;
 use std::fmt;
@@ -97,6 +112,72 @@ impl FontConfig {
     }
 }
 
+/// Configurable workspace key chords.
+///
+/// [`KeymapConfig::default`] is exactly the chord set the app shipped with
+/// before configuration existed: `super+p` opens the palette, and the bare
+/// characters `c`/`s`/`x`/`f` dispatch the four palette commands. Every
+/// chord is a normalized pass-through [`Chord`], so the binary compares
+/// configured bindings against live key events without re-parsing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KeymapConfig {
+    palette_open: Chord,
+    session_create: Chord,
+    session_select: Chord,
+    session_close: Chord,
+    sidebar_focus: Chord,
+}
+
+impl Default for KeymapConfig {
+    fn default() -> Self {
+        Self {
+            palette_open: default_chord(KeyCode::Char('p'), Modifiers::empty().super_key()),
+            session_create: default_chord(KeyCode::Char('c'), Modifiers::empty()),
+            session_select: default_chord(KeyCode::Char('s'), Modifiers::empty()),
+            session_close: default_chord(KeyCode::Char('x'), Modifiers::empty()),
+            sidebar_focus: default_chord(KeyCode::Char('f'), Modifiers::empty()),
+        }
+    }
+}
+
+impl KeymapConfig {
+    /// The chord opening the command palette; defaults to `super+p`.
+    #[must_use]
+    pub const fn palette_open(self) -> Chord {
+        self.palette_open
+    }
+
+    /// The palette command chord dispatching `session.create`; defaults to `c`.
+    #[must_use]
+    pub const fn session_create(self) -> Chord {
+        self.session_create
+    }
+
+    /// The palette command chord dispatching `session.select`; defaults to `s`.
+    #[must_use]
+    pub const fn session_select(self) -> Chord {
+        self.session_select
+    }
+
+    /// The palette command chord dispatching `session.close`; defaults to `x`.
+    #[must_use]
+    pub const fn session_close(self) -> Chord {
+        self.session_close
+    }
+
+    /// The palette command chord dispatching `sidebar.focus`; defaults to `f`.
+    #[must_use]
+    pub const fn sidebar_focus(self) -> Chord {
+        self.sidebar_focus
+    }
+}
+
+/// A default keymap chord constant; the values are printable characters and
+/// the Super modifier, which always normalize.
+fn default_chord(code: KeyCode, modifiers: Modifiers) -> Chord {
+    Chord::new(code, modifiers).expect("default keymap chords are normalized constants")
+}
+
 /// Validated application configuration.
 ///
 /// [`AppConfig::default`] is byte-for-byte the behavior the app had before
@@ -104,6 +185,7 @@ impl FontConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct AppConfig {
     font: FontConfig,
+    keys: KeymapConfig,
 }
 
 impl AppConfig {
@@ -111,6 +193,12 @@ impl AppConfig {
     #[must_use]
     pub const fn font(self) -> FontConfig {
         self.font
+    }
+
+    /// Workspace key chord settings.
+    #[must_use]
+    pub const fn keys(self) -> KeymapConfig {
+        self.keys
     }
 
     /// Load configuration from the standard path or the [`CONFIG_ENV_VAR`]
@@ -161,6 +249,7 @@ impl AppConfig {
                 .ok_or_else(|| ConfigError::WrongType { key: clip(key) })?;
             match key {
                 "font" => parse_font(table, &mut config.font)?,
+                "keys" => parse_keys(table, &mut config.keys)?,
                 // `[terminal]` historically attracted a `scrollback_lines` key.
                 // The terminal foundation has no configurable retention cap yet,
                 // so the table is rejected instead of parsed-and-ignored.
@@ -207,6 +296,326 @@ fn integer_in_range(key: &str, item: &Item, min: usize, max: usize) -> Result<us
         .ok_or_else(|| ConfigError::OutOfRange { key: clip(key) })?;
     Ok(value)
 }
+
+/// Apply the `[keys]` table to the keymap.
+/// Every TOML key must name a known action and every value must be a string
+/// holding one parseable chord. Palette-command chords must avoid the keys
+/// the open palette always interprets structurally (Escape, Enter, and the
+/// vertical arrows), the palette opener must stay claimable by the
+/// pass-through policy, and after applying the table all five chords must
+/// stay pairwise distinct — including the chords of actions the table left
+/// at their defaults.
+fn parse_keys(table: &dyn TableLike, keys: &mut KeymapConfig) -> Result<(), ConfigError> {
+    for (key, item) in table.iter() {
+        // Unknown action names are rejected before the value is examined,
+        // so a sub-table named by a typo reports the unknown action, not a
+        // value-type complaint.
+        let value = match key {
+            "palette_open" | "session_create" | "session_select" | "session_close"
+            | "sidebar_focus" => item
+                .as_str()
+                .ok_or_else(|| ConfigError::ChordNotAString { key: clip(key) })?,
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        };
+        match key {
+            "palette_open" => {
+                let chord = parse_configured_chord(key, value)?;
+                keys.palette_open = validate_palette_claim(chord, key, value)?;
+            }
+            "session_create" => keys.session_create = parse_command_chord(key, value)?,
+            "session_select" => keys.session_select = parse_command_chord(key, value)?,
+            "session_close" => keys.session_close = parse_command_chord(key, value)?,
+            "sidebar_focus" => keys.sidebar_focus = parse_command_chord(key, value)?,
+            // Unreachable in practice: the value match above rejected every
+            // other name as unknown.
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    ensure_distinct_chords(keys)
+}
+
+/// Parse one `[keys]` value into a chord, blaming the key and value on
+/// failure.
+fn parse_configured_chord(key: &str, value: &str) -> Result<Chord, ConfigError> {
+    parse_chord(value).map_err(|error| ConfigError::InvalidChord {
+        key: clip(key),
+        value: clip(value),
+        reason: clip(error.to_string()),
+    })
+}
+
+/// Parse and validate one palette-command chord. The four command chords are
+/// matched only while the palette is open, so they cannot steal a chord from
+/// Zellij or the child, but the open palette interprets Escape, Enter, and
+/// the vertical arrows structurally before chord dispatch — a command bound
+/// there would be dead configuration, so it is rejected.
+fn parse_command_chord(key: &str, value: &str) -> Result<Chord, ConfigError> {
+    let chord = parse_configured_chord(key, value)?;
+    if matches!(
+        chord.code(),
+        KeyCode::Escape | KeyCode::Enter | KeyCode::Up | KeyCode::Down
+    ) {
+        return Err(ConfigError::ReservedChord {
+            key: clip(key),
+            value: clip(value),
+        });
+    }
+    Ok(chord)
+}
+
+/// Validate that the pass-through policy could actually claim the configured
+/// palette chord, using the same enforcement point the live policy uses.
+///
+/// A chord colliding with a pinned Zellij default, or shadowed by / shadowing
+/// the frozen `Super+Escape` exit leader, could never open the palette;
+/// accepting it would be a silently dead binding.
+fn validate_palette_claim(chord: Chord, key: &str, value: &str) -> Result<Chord, ConfigError> {
+    let probe = PassthroughClaim {
+        id: CLAIM_ID_PALETTE,
+        action: PassthroughAction::OpenCommandPalette,
+        seq: ChordSeq::single(chord),
+        justification: "configuration validation probe",
+    };
+    match PassthroughPolicy::try_new(vec![default_exit_claim(), probe]) {
+        Ok(_) => Ok(chord),
+        Err(_) => Err(ConfigError::UnclaimableChord {
+            key: clip(key),
+            value: clip(value),
+        }),
+    }
+}
+
+/// Reject any chord bound to two of the five actions.
+///
+/// The check runs on the final keymap, so it also catches a configured value
+/// that silently collides with an action the table left at its default.
+fn ensure_distinct_chords(keys: &KeymapConfig) -> Result<(), ConfigError> {
+    let bindings = [
+        ("palette_open", keys.palette_open),
+        ("session_create", keys.session_create),
+        ("session_select", keys.session_select),
+        ("session_close", keys.session_close),
+        ("sidebar_focus", keys.sidebar_focus),
+    ];
+    for (index, (first_name, first)) in bindings.iter().enumerate() {
+        for (second_name, second) in bindings.iter().skip(index + 1) {
+            if first == second {
+                return Err(ConfigError::DuplicateChord {
+                    first: (*first_name).to_owned(),
+                    second: (*second_name).to_owned(),
+                    chord: chord_text(*first),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// One chord modifier recognized by the [`parse_chord`] grammar.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Modifier {
+    Ctrl,
+    Alt,
+    Shift,
+    Super,
+}
+
+/// Parse a modifier token, case-insensitively.
+fn parse_modifier(token: &str) -> Option<Modifier> {
+    match token.to_ascii_lowercase().as_str() {
+        "ctrl" => Some(Modifier::Ctrl),
+        "alt" => Some(Modifier::Alt),
+        "shift" => Some(Modifier::Shift),
+        "super" => Some(Modifier::Super),
+        _ => None,
+    }
+}
+
+/// Parse a final key token: one character (case-folded by [`Chord::new`]) or
+/// a named key, case-insensitively.
+fn parse_key_code(token: &str) -> Result<KeyCode, ChordParseError> {
+    let mut characters = token.chars();
+    let Some(first) = characters.next() else {
+        return Err(ChordParseError::EmptyToken);
+    };
+    if characters.next().is_none() {
+        return Ok(KeyCode::Char(first));
+    }
+    let lowered = token.to_ascii_lowercase();
+    let code = match lowered.as_str() {
+        "enter" => KeyCode::Enter,
+        "tab" => KeyCode::Tab,
+        "backspace" => KeyCode::Backspace,
+        "escape" => KeyCode::Escape,
+        "space" => KeyCode::Space,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" => KeyCode::PageUp,
+        "pagedown" => KeyCode::PageDown,
+        "insert" => KeyCode::Insert,
+        "delete" => KeyCode::Delete,
+        other => {
+            let Some(number) = other.strip_prefix('f') else {
+                return Err(ChordParseError::UnknownKey(token.to_owned()));
+            };
+            let Ok(number) = number.parse::<u8>() else {
+                return Err(ChordParseError::UnknownKey(token.to_owned()));
+            };
+            KeyCode::Function(number)
+        }
+    };
+    Ok(code)
+}
+
+/// Parse chord text such as `"super+p"` or `"ctrl+shift+t"` into a normalized
+/// [`Chord`].
+///
+/// The grammar is zero or more of the modifiers `super`, `ctrl`, `alt`, and
+/// `shift` (each at most once, case-insensitive) followed by exactly one key,
+/// all joined with `+`. The key is a single character or a named key
+/// (`enter`, `tab`, `backspace`, `escape`, `space`, arrows, `home`, `end`,
+/// `pageup`, `pagedown`, `insert`, `delete`, `f1`–`f24`). Characters fold to
+/// lowercase and whitespace or control characters are rejected, exactly as
+/// [`Chord::new`] normalizes. Every failure is a typed
+/// [`ChordParseError`]; there is no forgiving or default chord.
+///
+/// # Errors
+///
+/// Returns the first violation in left-to-right token order: an empty text,
+/// an empty `+`-separated token, a missing final key, a non-modifier token
+/// before the key, an unknown key name, a repeated modifier, or a key that
+/// [`Chord::new`] cannot normalize.
+pub fn parse_chord(text: &str) -> Result<Chord, ChordParseError> {
+    if text.is_empty() {
+        return Err(ChordParseError::Empty);
+    }
+    let tokens: Vec<&str> = text.split('+').collect();
+    if tokens.iter().any(|token| token.is_empty()) {
+        return Err(ChordParseError::EmptyToken);
+    }
+    let Some((key_token, modifier_tokens)) = tokens.split_last() else {
+        return Err(ChordParseError::Empty);
+    };
+    if parse_modifier(key_token).is_some() {
+        return Err(ChordParseError::MissingKey);
+    }
+    let mut modifiers = Modifiers::empty();
+    for token in modifier_tokens {
+        let token = *token;
+        let Some(modifier) = parse_modifier(token) else {
+            return Err(ChordParseError::NotAModifier(token.to_owned()));
+        };
+        let already = match modifier {
+            Modifier::Ctrl => modifiers.is_ctrl(),
+            Modifier::Alt => modifiers.is_alt(),
+            Modifier::Shift => modifiers.is_shift(),
+            Modifier::Super => modifiers.is_super(),
+        };
+        if already {
+            return Err(ChordParseError::RepeatedModifier(token.to_owned()));
+        }
+        modifiers = match modifier {
+            Modifier::Ctrl => modifiers.ctrl(),
+            Modifier::Alt => modifiers.alt(),
+            Modifier::Shift => modifiers.shift(),
+            Modifier::Super => modifiers.super_key(),
+        };
+    }
+    let code = parse_key_code(key_token)?;
+    Chord::new(code, modifiers).map_err(ChordParseError::InvalidKey)
+}
+
+/// Render a chord back to its canonical `parse_chord` text.
+///
+/// Used for error messages, so the text names exactly what two actions share.
+fn chord_text(chord: Chord) -> String {
+    let modifiers = chord.modifiers();
+    let mut parts: Vec<String> = Vec::new();
+    if modifiers.is_ctrl() {
+        parts.push("ctrl".to_owned());
+    }
+    if modifiers.is_alt() {
+        parts.push("alt".to_owned());
+    }
+    if modifiers.is_shift() {
+        parts.push("shift".to_owned());
+    }
+    if modifiers.is_super() {
+        parts.push("super".to_owned());
+    }
+    parts.push(key_code_text(chord.code()));
+    parts.join("+")
+}
+
+/// Canonical text of one key identity.
+fn key_code_text(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(character) => character.to_string(),
+        KeyCode::Function(number) => format!("f{number}"),
+        KeyCode::Enter => "enter".to_owned(),
+        KeyCode::Tab => "tab".to_owned(),
+        KeyCode::Backspace => "backspace".to_owned(),
+        KeyCode::Escape => "escape".to_owned(),
+        KeyCode::Space => "space".to_owned(),
+        KeyCode::Up => "up".to_owned(),
+        KeyCode::Down => "down".to_owned(),
+        KeyCode::Left => "left".to_owned(),
+        KeyCode::Right => "right".to_owned(),
+        KeyCode::Home => "home".to_owned(),
+        KeyCode::End => "end".to_owned(),
+        KeyCode::PageUp => "pageup".to_owned(),
+        KeyCode::PageDown => "pagedown".to_owned(),
+        KeyCode::Insert => "insert".to_owned(),
+        KeyCode::Delete => "delete".to_owned(),
+    }
+}
+
+/// Why chord text could not be parsed.
+///
+/// Every failure is typed; none falls back to a default chord.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChordParseError {
+    /// The chord text is empty.
+    Empty,
+    /// A `+`-separated token is empty (leading, trailing, or doubled `+`).
+    EmptyToken,
+    /// The text ends in a modifier, leaving no final key.
+    MissingKey,
+    /// A token before the final key is not one of the four modifiers.
+    NotAModifier(String),
+    /// The final token is not a character or known key name.
+    UnknownKey(String),
+    /// The same modifier appears more than once.
+    RepeatedModifier(String),
+    /// The key is valid grammar but not a normalizable [`Chord`] (a control
+    /// or whitespace character, or a function key outside F1–F24).
+    InvalidKey(ChordError),
+}
+
+impl fmt::Display for ChordParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("the chord is empty"),
+            Self::EmptyToken => f.write_str("a '+'-separated part of the chord is empty"),
+            Self::MissingKey => f.write_str("the chord has modifiers but no final key"),
+            Self::NotAModifier(token) => write!(
+                f,
+                "chord part {token} precedes the key but is not one of super, ctrl, alt, shift"
+            ),
+            Self::UnknownKey(token) => {
+                write!(f, "chord key {token} is not a recognized single key")
+            }
+            Self::RepeatedModifier(token) => write!(f, "modifier {token} appears more than once"),
+            Self::InvalidKey(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ChordParseError {}
 
 /// Standard per-user configuration path:
 /// `~/Library/Application Support/Noren/config.toml`.
@@ -299,6 +708,27 @@ pub enum ConfigError {
     WrongType { key: String },
     /// A value is outside its accepted range.
     OutOfRange { key: String },
+    /// A `[keys]` action is bound to a value that is not a TOML string.
+    ChordNotAString { key: String },
+    /// A `[keys]` value does not parse as a chord.
+    InvalidChord {
+        key: String,
+        value: String,
+        reason: String,
+    },
+    /// A `[keys]` palette chord parses but could never be claimed: it
+    /// collides with a pinned Zellij default or the frozen `Super+Escape`
+    /// exit leader.
+    UnclaimableChord { key: String, value: String },
+    /// A `[keys]` palette command chord uses a key the open palette always
+    /// interprets structurally, so the binding could never fire.
+    ReservedChord { key: String, value: String },
+    /// Two `[keys]` actions are bound to the same chord.
+    DuplicateChord {
+        first: String,
+        second: String,
+        chord: String,
+    },
 }
 
 impl fmt::Display for ConfigError {
@@ -317,6 +747,32 @@ impl fmt::Display for ConfigError {
             Self::OutOfRange { key } => {
                 write!(f, "configuration key {key} is outside its accepted range")
             }
+            Self::ChordNotAString { key } => write!(
+                f,
+                "configuration key {key} must be a chord string like \"super+p\""
+            ),
+            Self::InvalidChord { key, value, reason } => write!(
+                f,
+                "configuration key {key} has an unparseable chord {value}: {reason}"
+            ),
+            Self::UnclaimableChord { key, value } => write!(
+                f,
+                "configuration key {key} binds chord {value}, which collides with a pinned \
+                 Zellij default or the frozen Super+Escape exit leader"
+            ),
+            Self::ReservedChord { key, value } => write!(
+                f,
+                "configuration key {key} binds chord {value} on a key the open palette \
+                 always interprets as navigation or dismissal"
+            ),
+            Self::DuplicateChord {
+                first,
+                second,
+                chord,
+            } => write!(
+                f,
+                "configuration keys {first} and {second} are both bound to the chord {chord}"
+            ),
         }
     }
 }
@@ -662,5 +1118,364 @@ mod tests {
         let error = AppConfig::parse(&hostile).expect_err("malformed input fails");
         let message = error.to_string();
         assert!(message.len() < 1024, "message must stay bounded: {message}");
+    }
+
+    // ── [keys] keymap tests ────────────────────────────────────────────
+
+    fn chord(code: KeyCode, modifiers: Modifiers) -> Chord {
+        Chord::new(code, modifiers).expect("test chords are normalized constants")
+    }
+
+    /// With no `[keys]` surface at all, the keymap is exactly the chord set
+    /// the app shipped with before configuration existed.
+    #[test]
+    fn default_keymap_matches_the_pre_configuration_chords() {
+        let keys = KeymapConfig::default();
+        assert_eq!(
+            keys.palette_open(),
+            chord(KeyCode::Char('p'), Modifiers::empty().super_key()),
+            "palette opener defaults to super+p"
+        );
+        assert_eq!(
+            keys.session_create(),
+            chord(KeyCode::Char('c'), Modifiers::empty())
+        );
+        assert_eq!(
+            keys.session_select(),
+            chord(KeyCode::Char('s'), Modifiers::empty())
+        );
+        assert_eq!(
+            keys.session_close(),
+            chord(KeyCode::Char('x'), Modifiers::empty())
+        );
+        assert_eq!(
+            keys.sidebar_focus(),
+            chord(KeyCode::Char('f'), Modifiers::empty())
+        );
+        assert_eq!(AppConfig::default().keys(), keys);
+        assert_eq!(AppConfig::parse("# nothing\n").expect("valid").keys(), keys);
+    }
+
+    /// An empty `[keys]` table is presence without content: all defaults.
+    #[test]
+    fn empty_keys_table_keeps_every_default_chord() {
+        let config = AppConfig::parse("[keys]\n").expect("an empty table is valid");
+        assert_eq!(config.keys(), KeymapConfig::default());
+    }
+
+    #[test]
+    fn custom_palette_chord_overrides_only_the_opener() {
+        let config = AppConfig::parse("[keys]\npalette_open = \"super+k\"\n")
+            .expect("super+k is claimable and distinct");
+        assert_eq!(
+            config.keys().palette_open(),
+            chord(KeyCode::Char('k'), Modifiers::empty().super_key())
+        );
+        assert_eq!(
+            config.keys(),
+            KeymapConfig {
+                palette_open: config.keys().palette_open(),
+                ..KeymapConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn custom_command_chords_apply_to_their_own_actions() {
+        let config = AppConfig::parse(
+            "[keys]\nsession_create = \"ctrl+shift+t\"\nsession_select = \"n\"\n\
+             session_close = \"f2\"\nsidebar_focus = \"tab\"\n",
+        )
+        .expect("all four command chords are valid and distinct");
+        assert_eq!(
+            config.keys().session_create(),
+            chord(KeyCode::Char('t'), Modifiers::empty().ctrl().shift())
+        );
+        assert_eq!(
+            config.keys().session_select(),
+            chord(KeyCode::Char('n'), Modifiers::empty())
+        );
+        assert_eq!(
+            config.keys().session_close(),
+            chord(KeyCode::Function(2), Modifiers::empty())
+        );
+        assert_eq!(
+            config.keys().sidebar_focus(),
+            chord(KeyCode::Tab, Modifiers::empty())
+        );
+        assert_eq!(
+            config.keys().palette_open(),
+            KeymapConfig::default().palette_open()
+        );
+    }
+
+    #[test]
+    fn keys_apply_alongside_font_in_one_file() {
+        let config =
+            AppConfig::parse("[font]\ncell_width = 12\n[keys]\npalette_open = \"super+b\"\n")
+                .expect("both tables are valid");
+        assert_eq!(config.font().cell_width(), 12);
+        assert_eq!(
+            config.keys().palette_open(),
+            chord(KeyCode::Char('b'), Modifiers::empty().super_key())
+        );
+    }
+
+    /// Mutation proof (a): an action name the schema does not define must be
+    /// an error, never a silently ignored key. If unknown actions were
+    /// ignored, these files would parse as defaults and this test would fail.
+    #[test]
+    fn unknown_keys_actions_are_rejected_not_ignored() {
+        let cases = [
+            ("[keys]\npalette = \"super+p\"\n", "palette"),
+            ("[keys]\nsession_creat = \"c\"\n", "session_creat"),
+            ("[keys]\nzoom = \"super+z\"\n", "zoom"),
+            // A dotted action name becomes a sub-table, still unknown.
+            ("[keys.session]\ncreate = \"c\"\n", "session"),
+        ];
+        for (text, name) in cases {
+            assert_eq!(
+                AppConfig::parse(text),
+                Err(ConfigError::UnknownKey(name.to_owned())),
+                "{text:?} must not parse as a working setting"
+            );
+        }
+    }
+
+    /// Every unparseable chord is a typed error naming the offending key and
+    /// its value; none falls back to a default chord.
+    #[test]
+    fn unparseable_chords_are_typed_errors_naming_key_and_value() {
+        let cases = [
+            ("", ChordParseError::Empty),
+            ("+p", ChordParseError::EmptyToken),
+            ("super+", ChordParseError::EmptyToken),
+            ("super++p", ChordParseError::EmptyToken),
+            ("super", ChordParseError::MissingKey),
+            ("ctrl+shift", ChordParseError::MissingKey),
+            ("hyper+p", ChordParseError::NotAModifier("hyper".to_owned())),
+            ("p+q", ChordParseError::NotAModifier("p".to_owned())),
+            (
+                "ctrl+ctrl+t",
+                ChordParseError::RepeatedModifier("ctrl".to_owned()),
+            ),
+            ("foo", ChordParseError::UnknownKey("foo".to_owned())),
+            ("super+foo", ChordParseError::UnknownKey("foo".to_owned())),
+            ("fxy", ChordParseError::UnknownKey("fxy".to_owned())),
+            (
+                " ",
+                ChordParseError::InvalidKey(ChordError::ControlOrWhitespaceChar),
+            ),
+            (
+                "f25",
+                ChordParseError::InvalidKey(ChordError::FunctionKeyOutOfRange),
+            ),
+        ];
+        for (value, reason) in cases {
+            assert_eq!(
+                AppConfig::parse(&format!("[keys]\nsession_create = \"{value}\"\n")),
+                Err(ConfigError::InvalidChord {
+                    key: "session_create".to_owned(),
+                    value: value.to_owned(),
+                    reason: reason.to_string(),
+                }),
+                "chord {value:?} must be rejected with its key and value"
+            );
+        }
+    }
+
+    /// Hostile chord values are clipped in the error, like hostile keys.
+    #[test]
+    fn unparseable_chord_values_are_clipped_in_errors() {
+        let mut value = String::new();
+        value.extend(std::iter::repeat_n('a', 10_000));
+        let error = AppConfig::parse(&format!("[keys]\npalette_open = \"{value}\"\n"))
+            .expect_err("hostile chord value fails");
+        match error {
+            ConfigError::InvalidChord { value, .. } => {
+                assert!(
+                    value.chars().count() <= MAX_ERROR_DETAIL_CHARS + 1,
+                    "chord value must be clipped: {value}"
+                );
+            }
+            other => panic!("expected InvalidChord, got {other:?}"),
+        }
+    }
+
+    /// Two actions on one chord are rejected — including a configured value
+    /// that collides with an action the table left at its default.
+    #[test]
+    fn duplicate_chords_are_rejected_including_against_defaults() {
+        let explicit = AppConfig::parse("[keys]\nsession_create = \"n\"\nsession_select = \"n\"\n")
+            .expect_err("two actions on one chord");
+        assert_eq!(
+            explicit,
+            ConfigError::DuplicateChord {
+                first: "session_create".to_owned(),
+                second: "session_select".to_owned(),
+                chord: "n".to_owned(),
+            }
+        );
+
+        let against_default = AppConfig::parse("[keys]\nsession_create = \"f\"\n")
+            .expect_err("f is the sidebar_focus default");
+        assert_eq!(
+            against_default,
+            ConfigError::DuplicateChord {
+                first: "session_create".to_owned(),
+                second: "sidebar_focus".to_owned(),
+                chord: "f".to_owned(),
+            }
+        );
+
+        // Distinct-modifier chords on the same character are fine.
+        assert!(AppConfig::parse("[keys]\nsession_create = \"ctrl+c\"\n").is_ok());
+    }
+
+    /// A palette chord the pass-through policy could never claim is an
+    /// error, because the app could never honor it.
+    #[test]
+    fn unclaimable_palette_chords_are_rejected() {
+        for value in [
+            "p",            // bare p: Zellij pane mode binds it
+            "ctrl+t",       // Zellij shared_except_locked binds Ctrl t
+            "super+escape", // the frozen exit leader
+        ] {
+            assert_eq!(
+                AppConfig::parse(&format!("[keys]\npalette_open = \"{value}\"\n")),
+                Err(ConfigError::UnclaimableChord {
+                    key: "palette_open".to_owned(),
+                    value: value.to_owned(),
+                }),
+                "chord {value:?} must not parse as a claimable opener"
+            );
+        }
+        // Super-space chords stay outside the corpus and are accepted.
+        assert!(AppConfig::parse("[keys]\npalette_open = \"super+shift+p\"\n").is_ok());
+    }
+
+    /// Command chords on keys the open palette always interprets structurally
+    /// would be dead bindings, so they are rejected; the opener may use them.
+    #[test]
+    fn command_chords_on_palette_ui_keys_are_rejected() {
+        for value in ["escape", "enter", "up", "down"] {
+            assert_eq!(
+                AppConfig::parse(&format!("[keys]\nsession_create = \"{value}\"\n")),
+                Err(ConfigError::ReservedChord {
+                    key: "session_create".to_owned(),
+                    value: value.to_owned(),
+                }),
+                "command chord {value:?} could never fire"
+            );
+        }
+        assert!(AppConfig::parse("[keys]\nsession_create = \"left\"\n").is_ok());
+        assert!(AppConfig::parse("[keys]\npalette_open = \"super+enter\"\n").is_ok());
+    }
+
+    /// `[keys]` values must be TOML strings.
+    #[test]
+    fn keys_values_must_be_chord_strings() {
+        for text in [
+            "[keys]\nsession_create = 3\n",
+            "[keys]\npalette_open = true\n",
+            "[keys]\nsession_select = ['c']\n",
+        ] {
+            let error = AppConfig::parse(text).expect_err("non-string chord fails");
+            assert!(
+                matches!(error, ConfigError::ChordNotAString { .. }),
+                "{text:?} must be ChordNotAString, got {error:?}"
+            );
+        }
+    }
+
+    // ── chord parser unit tests ────────────────────────────────────────
+
+    #[test]
+    fn parse_chord_builds_modifiers_named_keys_and_folds_case() {
+        let cases = [
+            (
+                "super+p",
+                chord(KeyCode::Char('p'), Modifiers::empty().super_key()),
+            ),
+            (
+                "SUPER+P",
+                chord(KeyCode::Char('p'), Modifiers::empty().super_key()),
+            ),
+            (
+                "ctrl+shift+t",
+                chord(KeyCode::Char('t'), Modifiers::empty().ctrl().shift()),
+            ),
+            (
+                "alt+ctrl+shift+super+x",
+                chord(
+                    KeyCode::Char('x'),
+                    Modifiers::empty().alt().ctrl().shift().super_key(),
+                ),
+            ),
+            ("c", chord(KeyCode::Char('c'), Modifiers::empty())),
+            ("P", chord(KeyCode::Char('p'), Modifiers::empty())),
+            (
+                "super+f5",
+                chord(KeyCode::Function(5), Modifiers::empty().super_key()),
+            ),
+            ("enter", chord(KeyCode::Enter, Modifiers::empty())),
+            (
+                "alt+pageup",
+                chord(KeyCode::PageUp, Modifiers::empty().alt()),
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(parse_chord(text), Ok(expected), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn parse_chord_rejects_each_grammar_violation_directly() {
+        let cases = [
+            ("", ChordParseError::Empty),
+            ("+", ChordParseError::EmptyToken),
+            ("p+", ChordParseError::EmptyToken),
+            ("shift", ChordParseError::MissingKey),
+            (
+                "alt+hyper+p",
+                ChordParseError::NotAModifier("hyper".to_owned()),
+            ),
+            (
+                "super+super+p",
+                ChordParseError::RepeatedModifier("super".to_owned()),
+            ),
+            (
+                "f0",
+                ChordParseError::InvalidKey(ChordError::FunctionKeyOutOfRange),
+            ),
+            (
+                "\t",
+                ChordParseError::InvalidKey(ChordError::ControlOrWhitespaceChar),
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(parse_chord(text), Err(expected), "{text:?}");
+        }
+    }
+
+    /// Canonical text renders every chord back to its own parse input.
+    #[test]
+    fn chord_text_round_trips_through_parse_chord() {
+        let chords = [
+            chord(KeyCode::Char('p'), Modifiers::empty().super_key()),
+            chord(KeyCode::Char('t'), Modifiers::empty().ctrl().shift()),
+            chord(KeyCode::Char('c'), Modifiers::empty()),
+            chord(KeyCode::Function(12), Modifiers::empty().super_key()),
+            chord(KeyCode::Enter, Modifiers::empty()),
+            chord(KeyCode::PageUp, Modifiers::empty().alt()),
+        ];
+        for parsed in chords {
+            let text = chord_text(parsed);
+            assert_eq!(parse_chord(&text), Ok(parsed), "{text:?} must round-trip");
+        }
+        assert_eq!(
+            chord_text(KeymapConfig::default().palette_open()),
+            "super+p"
+        );
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -9,7 +9,7 @@ use noren_app::{
     Arrow, CellMetrics, CursorKeyMode, FunctionKey, GridGeometry, GridSize, InputMode, Key,
     KeyDropReason, KeyEncoder, KeyInput, KeyPhase, KeypadInput, KeypadKey, KeypadMode,
     MAX_RENDER_COLS, Modifiers, PARSE_BUDGET_BYTES_PER_TURN, PasteReject, Resize, SystemClipboard,
-    config::AppConfig,
+    config::{AppConfig, KeymapConfig},
     diagnostics::{self, PtyChildStatus},
     encode_paste,
     mouse::{
@@ -152,28 +152,26 @@ enum WorkspaceAction {
 /// registry's current sessions and selection, so the view and the model can
 /// never disagree.
 /// Build the pass-through policy claiming the exit leader (Super+Escape) and
-/// the palette opener (Super+p).
+/// the palette opener from the configured keymap.
 ///
-/// Both claimed chords live in the Super/Command modifier space, which the
-/// pinned Zellij v0.44.3 default corpus never binds. Super+Escape is the
-/// frozen exit leader from [`default_exit_claim`]; Super+p opens the command
-/// palette. This is the smallest set that works: one chord to open the
+/// The exit leader stays the frozen [`default_exit_claim`]. The palette claim
+/// is the configured [`KeymapConfig::palette_open`] chord, which
+/// configuration has already validated against the pinned Zellij v0.44.3
+/// corpus and the exit leader, so this claim steals no chord from Zellij or
+/// its panes. This is the smallest set that works: one chord to open the
 /// palette, one to exit to the workspace. No bare modifier chords, no
-/// Ctrl/Alt chords, nothing Zellij could ever use.
-fn palette_policy() -> PassthroughPolicy {
+/// chords the corpus binds.
+fn palette_policy(keys: KeymapConfig) -> PassthroughPolicy {
     let palette_claim = PassthroughClaim {
         id: CLAIM_ID_PALETTE,
         action: PassthroughAction::OpenCommandPalette,
-        seq: ChordSeq::single(
-            Chord::new(GateKeyCode::Char('p'), GateModifiers::empty().super_key())
-                .expect("normalized Super+p"),
-        ),
-        justification: "Super+p lives in the Super/Cmd modifier space which the \
-                        pinned Zellij v0.44.3 default corpus never binds, so claiming it \
-                        steals no chord from Zellij or its panes",
+        seq: ChordSeq::single(keys.palette_open()),
+        justification: "the configured palette chord is validated at load time against the \
+                        pinned Zellij v0.44.3 default corpus and the exit leader, so claiming \
+                        it steals no chord from Zellij or its panes",
     };
     PassthroughPolicy::try_new(vec![default_exit_claim(), palette_claim])
-        .expect("palette policy is valid and collision-free")
+        .expect("configuration validates the palette chord; the claim set is collision-free")
 }
 
 /// Resolve the sidebar state file path alongside the configuration file.
@@ -535,6 +533,10 @@ struct NorenApp {
     palette_selection: usize,
     passthrough_gate: PassthroughGate,
     passthrough_policy: PassthroughPolicy,
+    /// Configured key chords for the palette opener and the four palette
+    /// commands. The single source of truth for every workspace chord the
+    /// binary honors; no hard-coded chord remains on the key paths.
+    keys: KeymapConfig,
 }
 
 /// Which application-owned line, if any, occupies the renderer's status row.
@@ -611,7 +613,8 @@ impl NorenApp {
             palette_open: false,
             palette_selection: 0,
             passthrough_gate: PassthroughGate::new(),
-            passthrough_policy: palette_policy(),
+            passthrough_policy: palette_policy(config.keys()),
+            keys: config.keys(),
         }
     }
 
@@ -833,10 +836,10 @@ impl NorenApp {
 
     /// Route one key event through the pass-through gate.
     ///
-    /// The gate claims Super+Escape (exit) and Super+p (palette). Everything
-    /// else is forwarded byte-for-byte through the same encoder path as
-    /// before the gate existed, so a closed-palette key press is
-    /// byte-identical to the pre-gate behaviour.
+    /// The gate claims the exit leader (Super+Escape) and the configured
+    /// palette chord. Everything else is forwarded byte-for-byte through the
+    /// same encoder path as before the gate existed, so a closed-palette key
+    /// press is byte-identical to the pre-gate behaviour.
     fn handle_passthrough_key(&mut self, event: &KeyEvent) {
         let input_mode = self.current_input_mode();
         let encoded = if let Some(input) = translate_keypad_key(event) {
@@ -845,29 +848,11 @@ impl NorenApp {
             translate_key(event, self.modifiers)
                 .and_then(|input| KeyEncoder::encode_with(input, input_mode))
         };
-        if event.state == ElementState::Pressed {
-            if let Some(chord) = chord_from_event(event, self.modifiers) {
-                let decision = self.passthrough_gate.press(&self.passthrough_policy, chord);
-                match decision.kind {
-                    GateKind::Intercepted(PassthroughAction::OpenCommandPalette) => {
-                        self.open_palette();
-                        return;
-                    }
-                    GateKind::Intercepted(PassthroughAction::ExitToWorkspace) => {
-                        return;
-                    }
-                    GateKind::Pending => {
-                        return;
-                    }
-                    GateKind::Forwarded => {
-                        for replayed in &decision.replayed {
-                            if let Some(bytes) = encode_chord(replayed, input_mode) {
-                                self.send_input(&bytes);
-                            }
-                        }
-                    }
-                }
-            }
+        if event.state == ElementState::Pressed
+            && let Some(chord) = chord_from_event(event, self.modifiers)
+            && self.gate_pressed_chord(chord, input_mode)
+        {
+            return;
         }
         let Ok(bytes) = encoded else {
             return;
@@ -875,16 +860,55 @@ impl NorenApp {
         self.send_input(&bytes);
     }
 
+    /// Route one pressed chord through the gate.
+    ///
+    /// This is the seam the key-event path delegates to; it owns the palette
+    /// claim, so the configured opener chord — and nothing else — opens the
+    /// palette. Returns whether the chord was consumed (intercepted or held
+    /// pending); a forwarded chord replays any held leader bytes and falls
+    /// through to normal encoding.
+    fn gate_pressed_chord(&mut self, chord: Chord, input_mode: InputMode) -> bool {
+        let decision = self.passthrough_gate.press(&self.passthrough_policy, chord);
+        match decision.kind {
+            GateKind::Intercepted(PassthroughAction::OpenCommandPalette) => {
+                self.open_palette();
+                true
+            }
+            GateKind::Intercepted(PassthroughAction::ExitToWorkspace) => true,
+            GateKind::Pending => true,
+            GateKind::Forwarded => {
+                for replayed in &decision.replayed {
+                    if let Some(bytes) = encode_chord(replayed, input_mode) {
+                        self.send_input(&bytes);
+                    }
+                }
+                false
+            }
+        }
+    }
+
     /// Handle a key event while the palette is open.
     ///
-    /// Single-key shortcuts dispatch the four canonical commands; Escape
+    /// The four configured command chords dispatch their commands; Escape
     /// dismisses without running; Arrow Up/Down and Enter navigate and
-    /// confirm the selection.
+    /// confirm the selection. A single character that matches no command
+    /// chord dismisses the palette, as before configuration existed.
     fn handle_palette_key(&mut self, event: &KeyEvent) {
-        if event.state != ElementState::Pressed || event.repeat {
+        self.handle_palette_key_impl(&event.logical_key, event.state, event.repeat);
+    }
+
+    /// Window-independent seam for the palette key path: the real handler
+    /// with the winit event reduced to the parts it reads.
+    fn handle_palette_key_impl(
+        &mut self,
+        logical_key: &WinitKey,
+        state: ElementState,
+        repeat: bool,
+    ) {
+        if state != ElementState::Pressed || repeat {
             return;
         }
-        match &event.logical_key {
+        match logical_key {
             WinitKey::Named(NamedKey::Escape) => {
                 self.close_palette();
             }
@@ -908,19 +932,19 @@ impl NorenApp {
                 if text.chars().count() > 1 {
                     return;
                 }
-                let id = match ch.to_ascii_lowercase() {
-                    'c' => CommandId::SESSION_CREATE,
-                    's' => CommandId::SESSION_SELECT,
-                    'x' => CommandId::SESSION_CLOSE,
-                    'f' => CommandId::SIDEBAR_FOCUS,
-                    _ => {
-                        self.close_palette();
-                        return;
-                    }
-                };
-                self.dispatch_palette_command(id);
+                let pressed = chord_from_logical(logical_key, self.modifiers);
+                let bare = GateKeyCode::Char(ch.to_ascii_lowercase());
+                match palette_command_for(&self.keys, pressed, Some(bare)) {
+                    Some(id) => self.dispatch_palette_command(id),
+                    None => self.close_palette(),
+                }
             }
-            _ => {}
+            _ => {
+                let pressed = chord_from_logical(logical_key, self.modifiers);
+                if let Some(id) = palette_command_for(&self.keys, pressed, None) {
+                    self.dispatch_palette_command(id);
+                }
+            }
         }
     }
 
@@ -1732,7 +1756,8 @@ impl NorenApp {
             visible_rows,
         );
         let lines = if self.palette_open {
-            let mut lines = palette_text_lines(self.workspace.palette(), self.palette_selection);
+            let mut lines =
+                palette_text_lines(self.workspace.palette(), self.palette_selection, &self.keys);
             lines.extend(sidebar_lines);
             lines
         } else {
@@ -1969,17 +1994,41 @@ fn visible_sidebar_text_lines(
 /// Each command is one line: `]` marks the selected command, space otherwise,
 /// followed by a single-key shortcut and the label. The lines are uppercase
 /// to match the bitmap font's case-folding.
-fn palette_text_lines(palette: &Palette<WorkspaceAction>, selection: usize) -> Vec<String> {
-    let shortcuts = ['C', 'S', 'X', 'F'];
+fn palette_text_lines(
+    palette: &Palette<WorkspaceAction>,
+    selection: usize,
+    keys: &KeymapConfig,
+) -> Vec<String> {
     palette
         .iter()
         .enumerate()
         .map(|(idx, cmd)| {
             let marker = if idx == selection { ']' } else { ' ' };
-            let key = shortcuts.get(idx).copied().unwrap_or('?');
+            let key = command_shortcut(cmd.id(), keys);
             format!("{marker}{key} {label}", label = cmd.label())
         })
         .collect()
+}
+
+/// The one-character palette display shortcut for a command's configured
+/// chord.
+///
+/// A character binding shows its (upper-cased) character; any other chord —
+/// modifiers or a named key — has no single-glyph representation in the
+/// bitmap font and shows `?`. The label therefore never claims a shortcut
+/// the chord does not carry.
+fn command_shortcut(id: CommandId, keys: &KeymapConfig) -> char {
+    let binding = match id {
+        CommandId::SESSION_CREATE => keys.session_create(),
+        CommandId::SESSION_SELECT => keys.session_select(),
+        CommandId::SESSION_CLOSE => keys.session_close(),
+        CommandId::SIDEBAR_FOCUS => keys.sidebar_focus(),
+        _ => return '?',
+    };
+    match binding.code() {
+        GateKeyCode::Char(character) => character.to_ascii_uppercase(),
+        _ => '?',
+    }
 }
 
 /// Map a winit key event and app modifiers to a pass-through chord.
@@ -1988,9 +2037,48 @@ fn palette_text_lines(palette: &Palette<WorkspaceAction>, selection: usize) -> V
 /// (whitespace characters, dead keys, multi-codepoint IME sequences). Such
 /// keys bypass the gate and follow the normal encode-and-send path.
 fn chord_from_event(event: &KeyEvent, modifiers: Modifiers) -> Option<Chord> {
-    let code = winit_to_gate_key(&event.logical_key)?;
+    chord_from_logical(&event.logical_key, modifiers)
+}
+
+/// Map a logical key and app modifiers to a pass-through chord.
+///
+/// The window-free core of [`chord_from_event`], shared by the pass-through
+/// gate and the open palette's command-chord matching.
+fn chord_from_logical(key: &WinitKey, modifiers: Modifiers) -> Option<Chord> {
+    let code = winit_to_gate_key(key)?;
     let gate_mods = gate_modifiers(modifiers);
     Chord::new(code, gate_mods).ok()
+}
+
+/// Resolve a pressed key inside the open palette to its command.
+///
+/// An exact chord match honors configured modifiers. A modifier-free
+/// character binding additionally matches by logical character regardless of
+/// held modifiers, preserving the palette's pre-configuration behavior for
+/// the default `c`/`s`/`x`/`f` bindings; `bare` is `None` for non-character
+/// keys, which only ever match exactly.
+fn palette_command_for(
+    keys: &KeymapConfig,
+    pressed: Option<Chord>,
+    bare: Option<GateKeyCode>,
+) -> Option<CommandId> {
+    let bindings = [
+        (keys.session_create(), CommandId::SESSION_CREATE),
+        (keys.session_select(), CommandId::SESSION_SELECT),
+        (keys.session_close(), CommandId::SESSION_CLOSE),
+        (keys.sidebar_focus(), CommandId::SIDEBAR_FOCUS),
+    ];
+    for (binding, id) in bindings {
+        if pressed == Some(binding) {
+            return Some(id);
+        }
+        if binding.modifiers() == GateModifiers::empty()
+            && bare.is_some_and(|bare| binding.code() == bare)
+        {
+            return Some(id);
+        }
+    }
+    None
 }
 
 /// Encode a pass-through chord into PTY bytes for replay.
@@ -2030,6 +2118,32 @@ fn winit_to_gate_key(key: &WinitKey) -> Option<GateKeyCode> {
         WinitKey::Named(NamedKey::PageDown) => Some(GateKeyCode::PageDown),
         WinitKey::Named(NamedKey::Delete) => Some(GateKeyCode::Delete),
         WinitKey::Named(NamedKey::Insert) => Some(GateKeyCode::Insert),
+        // Function keys F1–F24 round out the chord vocabulary the keymap
+        // parser accepts (`f1`–`f24`); higher F-keys stay unmapped.
+        WinitKey::Named(NamedKey::F1) => Some(GateKeyCode::Function(1)),
+        WinitKey::Named(NamedKey::F2) => Some(GateKeyCode::Function(2)),
+        WinitKey::Named(NamedKey::F3) => Some(GateKeyCode::Function(3)),
+        WinitKey::Named(NamedKey::F4) => Some(GateKeyCode::Function(4)),
+        WinitKey::Named(NamedKey::F5) => Some(GateKeyCode::Function(5)),
+        WinitKey::Named(NamedKey::F6) => Some(GateKeyCode::Function(6)),
+        WinitKey::Named(NamedKey::F7) => Some(GateKeyCode::Function(7)),
+        WinitKey::Named(NamedKey::F8) => Some(GateKeyCode::Function(8)),
+        WinitKey::Named(NamedKey::F9) => Some(GateKeyCode::Function(9)),
+        WinitKey::Named(NamedKey::F10) => Some(GateKeyCode::Function(10)),
+        WinitKey::Named(NamedKey::F11) => Some(GateKeyCode::Function(11)),
+        WinitKey::Named(NamedKey::F12) => Some(GateKeyCode::Function(12)),
+        WinitKey::Named(NamedKey::F13) => Some(GateKeyCode::Function(13)),
+        WinitKey::Named(NamedKey::F14) => Some(GateKeyCode::Function(14)),
+        WinitKey::Named(NamedKey::F15) => Some(GateKeyCode::Function(15)),
+        WinitKey::Named(NamedKey::F16) => Some(GateKeyCode::Function(16)),
+        WinitKey::Named(NamedKey::F17) => Some(GateKeyCode::Function(17)),
+        WinitKey::Named(NamedKey::F18) => Some(GateKeyCode::Function(18)),
+        WinitKey::Named(NamedKey::F19) => Some(GateKeyCode::Function(19)),
+        WinitKey::Named(NamedKey::F20) => Some(GateKeyCode::Function(20)),
+        WinitKey::Named(NamedKey::F21) => Some(GateKeyCode::Function(21)),
+        WinitKey::Named(NamedKey::F22) => Some(GateKeyCode::Function(22)),
+        WinitKey::Named(NamedKey::F23) => Some(GateKeyCode::Function(23)),
+        WinitKey::Named(NamedKey::F24) => Some(GateKeyCode::Function(24)),
         _ => None,
     }
 }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1318,9 +1318,10 @@ fn escape_dismisses_palette_without_running_a_command() {
     let count_before = app.workspace.registry().len();
 
     // Simulate Escape key: handle_palette_key checks for NamedKey::Escape.
-    // We test the effect (close_palette) directly because constructing a
-    // full winit KeyEvent requires a DeviceId that is not safely creatable
-    // in a #[forbid(unsafe)] crate.
+    // We test the effect (close_palette) directly because a full winit
+    // KeyEvent cannot be fabricated outside winit: `KeyEvent::platform_specific`
+    // is private with no public constructor (DeviceId has `dummy()`, but the
+    // event cannot be completed without that field).
     app.close_palette();
 
     assert!(!app.palette_open, "palette must be dismissed");

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1090,7 +1090,7 @@ fn sidebar_boundary_and_click_boundary_agree_at_non_default_cell_width() {
 /// pinned Zellij v0.44.3 corpus never binds.
 #[test]
 fn palette_policy_claims_exactly_super_escape_and_super_p() {
-    let policy = palette_policy();
+    let policy = palette_policy(KeymapConfig::default());
     let claims = policy.claims();
     assert_eq!(claims.len(), 2, "exactly two claims");
     let corpus = passthrough::zellij_default_bindings();
@@ -1177,7 +1177,7 @@ fn leader_mismatch_replays_held_chord_bytes_in_order() {
 /// byte-identical to the pre-gate behaviour.
 #[test]
 fn closed_palette_forwarded_key_is_byte_identical_to_direct_encode() {
-    let policy = palette_policy();
+    let policy = palette_policy(KeymapConfig::default());
     let mode = InputMode::normal();
     let mut gate = PassthroughGate::new();
 
@@ -1209,7 +1209,7 @@ fn closed_palette_forwarded_key_is_byte_identical_to_direct_encode() {
 /// PTY bytes — confirming the palette claim works.
 #[test]
 fn super_p_is_intercepted_as_palette_open() {
-    let policy = palette_policy();
+    let policy = palette_policy(KeymapConfig::default());
     let mut gate = PassthroughGate::new();
     let chord =
         Chord::new(GateKeyCode::Char('p'), GateModifiers::empty().super_key()).expect("normalized");
@@ -1331,6 +1331,243 @@ fn escape_dismisses_palette_without_running_a_command() {
     );
 }
 
+// ── Configurable keybinding tests ────────────────────────────────────
+
+fn gate_chord(code: GateKeyCode, modifiers: GateModifiers) -> Chord {
+    Chord::new(code, modifiers).expect("normalized test chord")
+}
+
+fn super_chord(character: char) -> Chord {
+    gate_chord(
+        GateKeyCode::Char(character),
+        GateModifiers::empty().super_key(),
+    )
+}
+
+/// Mutation proof (b): the configured palette chord must reach the live
+/// pass-through policy. If `palette_policy` ignored the keymap and always
+/// claimed the hard-coded `super+p`, `super+k` would forward (never open)
+/// and this test would fail.
+#[test]
+fn custom_palette_chord_opens_the_palette_and_releases_the_default() {
+    let config = AppConfig::parse("[keys]\npalette_open = \"super+k\"\n")
+        .expect("super+k is a claimable, distinct opener chord");
+    let mut app = NorenApp::new(config);
+    assert!(!app.palette_open);
+
+    let consumed = app.gate_pressed_chord(super_chord('k'), InputMode::normal());
+    assert!(
+        consumed,
+        "the configured chord must be consumed by the gate"
+    );
+    assert!(
+        app.palette_open,
+        "the configured chord must open the palette"
+    );
+}
+
+#[test]
+fn custom_palette_chord_replaces_the_default_claim_in_the_policy() {
+    let config = AppConfig::parse("[keys]\npalette_open = \"super+k\"\n")
+        .expect("super+k is a claimable, distinct opener chord");
+    let app = NorenApp::new(config);
+    let mut gate = PassthroughGate::new();
+
+    let decision = gate.press(&app.passthrough_policy, super_chord('p'));
+    assert_eq!(
+        decision.kind,
+        GateKind::Forwarded,
+        "the default super+p must no longer be claimed"
+    );
+
+    let decision = gate.press(&app.passthrough_policy, super_chord('k'));
+    assert_eq!(
+        decision.kind,
+        GateKind::Intercepted(PassthroughAction::OpenCommandPalette),
+        "the configured super+k must be the palette claim"
+    );
+}
+
+/// With no `[keys]` section the binary behaves exactly as before: `super+p`
+/// opens the palette and the bare `c`/`s`/`x`/`f` characters dispatch the
+/// four commands — including under modifiers, which the pre-configuration
+/// palette ignored.
+#[test]
+fn default_keymap_keeps_the_pre_configuration_palette_behaviour() {
+    let mut app = NorenApp::default();
+    assert_eq!(app.keys, KeymapConfig::default());
+
+    assert!(app.gate_pressed_chord(super_chord('p'), InputMode::normal()));
+    assert!(
+        app.palette_open,
+        "the default super+p must still open the palette"
+    );
+
+    let before = app.workspace.registry().len();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("c".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert!(!app.palette_open, "dispatch closes the palette");
+    assert_eq!(
+        app.workspace.registry().len(),
+        before + 1,
+        "the default c must still create a session"
+    );
+
+    // The legacy modifier-insensitive character match survives: the palette
+    // matched logical characters regardless of held modifiers.
+    app.open_palette();
+    app.modifiers = Modifiers::empty().ctrl();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("c".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert_eq!(app.workspace.registry().len(), before + 2);
+
+    // An unbound single character still dismisses the palette.
+    app.open_palette();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("z".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert!(!app.palette_open, "an unbound character still dismisses");
+    assert_eq!(app.workspace.registry().len(), before + 2);
+}
+
+/// A configured command chord with modifiers dispatches only on the exact
+/// chord: the bare character neither dispatches nor runs the wrong command.
+#[test]
+fn custom_command_chord_dispatches_only_on_the_exact_chord() {
+    let config = AppConfig::parse("[keys]\nsession_create = \"ctrl+n\"\n")
+        .expect("ctrl+n is a valid command chord");
+    let mut app = NorenApp::new(config);
+    let before = app.workspace.registry().len();
+
+    // Exact chord dispatches even though the binding carries modifiers.
+    app.open_palette();
+    app.modifiers = Modifiers::empty().ctrl();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("n".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert!(!app.palette_open, "dispatch closes the palette");
+    assert_eq!(
+        app.workspace.registry().len(),
+        before + 1,
+        "the configured ctrl+n must create a session"
+    );
+
+    // The bare character does not dispatch: it dismisses without running.
+    app.open_palette();
+    app.modifiers = Modifiers::empty();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("n".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert!(!app.palette_open);
+    assert_eq!(app.workspace.registry().len(), before + 1);
+
+    // The default c binding was replaced, so bare c no longer creates.
+    app.open_palette();
+    app.handle_palette_key_impl(
+        &WinitKey::Character("c".into()),
+        ElementState::Pressed,
+        false,
+    );
+    assert!(!app.palette_open);
+    assert_eq!(
+        app.workspace.registry().len(),
+        before + 1,
+        "the replaced default must not dispatch"
+    );
+}
+
+/// A command chord bound to a named key dispatches when that key is pressed
+/// inside the open palette.
+#[test]
+fn named_key_command_chord_dispatches_in_the_open_palette() {
+    let config = AppConfig::parse("[keys]\nsession_select = \"f2\"\n")
+        .expect("f2 is a valid, distinct command chord");
+    let mut app = NorenApp::new(config);
+    app.open_palette();
+    let selected = app.workspace.registry().selected();
+
+    app.handle_palette_key_impl(&WinitKey::Named(NamedKey::F2), ElementState::Pressed, false);
+    assert!(!app.palette_open, "the bound named key dispatches");
+    assert_eq!(
+        app.workspace.registry().selected(),
+        selected,
+        "session_select on an empty active session keeps the selection"
+    );
+}
+
+/// The palette's one-glyph shortcut labels follow the configured chords
+/// rather than the compiled-in characters.
+#[test]
+fn palette_labels_follow_the_configured_command_chords() {
+    let config = AppConfig::parse("[keys]\nsession_create = \"n\"\nsession_close = \"f2\"\n")
+        .expect("valid, distinct command chords");
+    let app = NorenApp::new(config);
+    // Selection 1 keeps lines 0 and 2 unselected, so each begins with the
+    // marker, the shortcut glyph, and a space.
+    let lines = palette_text_lines(app.workspace.palette(), 1, &app.keys);
+    assert!(
+        lines[0].starts_with(" N "),
+        "create bound to n must show N, got {:?}",
+        lines[0]
+    );
+    assert!(
+        lines[2].starts_with(" ? "),
+        "close bound to f2 has no glyph and must show ?, got {:?}",
+        lines[2]
+    );
+
+    let default_lines = palette_text_lines(app.workspace.palette(), 1, &KeymapConfig::default());
+    for (index, key) in ['C', 'S', 'X', 'F'].into_iter().enumerate() {
+        let glyphs: Vec<char> = default_lines[index].chars().collect();
+        assert_eq!(
+            glyphs.first(),
+            Some(&(if index == 1 { ']' } else { ' ' })),
+            "line {index} marker"
+        );
+        assert_eq!(
+            glyphs.get(1),
+            Some(&key),
+            "default line {index} must still show {key}, got {:?}",
+            default_lines[index]
+        );
+    }
+}
+
+/// The pass-through seam is the live route for the palette claim: a
+/// forwarded chord is not consumed, an intercepted one is.
+#[test]
+fn gate_pressed_chord_reports_consumption_for_each_outcome() {
+    let mut app = NorenApp::default();
+    assert!(!app.gate_pressed_chord(
+        gate_chord(GateKeyCode::Char('a'), GateModifiers::empty()),
+        InputMode::normal()
+    ));
+    assert!(
+        !app.palette_open,
+        "unclaimed chords forward without opening"
+    );
+    assert!(app.gate_pressed_chord(
+        gate_chord(GateKeyCode::Escape, GateModifiers::empty().super_key()),
+        InputMode::normal()
+    ));
+    assert!(
+        !app.palette_open,
+        "the exit leader is consumed, not palette"
+    );
+}
+
 // ── Session status observation tests ─────────────────────────────────
 
 /// Observing Running after creation changes the sidebar detail from
@@ -1394,7 +1631,7 @@ fn observe_exited_after_running_updates_the_sidebar() {
 fn palette_text_lines_show_selection_marker() {
     let state = WorkspaceState::new();
     let palette = state.palette();
-    let lines = palette_text_lines(palette, 1);
+    let lines = palette_text_lines(palette, 1, &KeymapConfig::default());
     assert_eq!(lines.len(), 4, "four commands");
     assert!(
         lines[1].starts_with(']'),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,51 @@ grid (`MAX_RENDER_ROWS` by `MAX_RENDER_COLS`, 60 by 160), which is far inside
 the terminal foundation's `MAX_SCREEN_CELLS` bound, so no configuration value
 can push the grid past that ceiling.
 
+### `[keys]`
+
+Configurable key chords for workspace chrome. Every key is optional; an
+absent `[keys]` table keeps the compiled-in defaults, which are exactly the
+chords the app shipped with before configuration existed.
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `palette_open` | string | `"super+p"` | Chord that opens the command palette while it is closed. |
+| `session_create` | string | `"c"` | Palette command dispatching `session.create` (New Session). |
+| `session_select` | string | `"s"` | Palette command dispatching `session.select` (Switch Session). |
+| `session_close` | string | `"x"` | Palette command dispatching `session.close` (Close Session). |
+| `sidebar_focus` | string | `"f"` | Palette command dispatching `sidebar.focus` (Focus Sidebar). |
+
+A chord is zero or more modifiers followed by exactly one key, joined with
+`+`: the modifiers are `super`, `ctrl`, `alt`, and `shift` (each at most
+once, case-insensitive), and the key is a single character (case-folded) or
+a named key — `enter`, `tab`, `backspace`, `escape`, `space`, `up`, `down`,
+`left`, `right`, `home`, `end`, `pageup`, `pagedown`, `insert`, `delete`,
+`f1` through `f24`. Examples: `super+p`, `ctrl+shift+t`, `f2`.
+
+Rejections follow the same hard-error discipline as the rest of the schema —
+never a silent fallback and never a silently dead binding:
+
+- an unparseable chord (empty text, an empty `+` part, a non-modifier before
+  the key, an unknown key name, a repeated modifier, a control or whitespace
+  character, a function key outside F1–F24) is an error naming the key and
+  the offending value;
+- an unknown action name is an unknown-key error;
+- two actions bound to the same chord are an error, including a configured
+  value that collides with an action the table left at its default;
+- `palette_open` must stay claimable: a chord that collides with the pinned
+  Zellij v0.44.3 default corpus or with the frozen `Super+Escape` exit
+  leader is an error, because Noren could never honor it;
+- the four palette command chords must not use `escape`, `enter`, `up`, or
+  `down`, which the open palette always interprets as dismissal, confirm,
+  and navigation.
+
+The four command chords apply only while the palette is open — the palette
+intercepts all keys then, so command chords never steal input from Zellij or
+the terminal — which is why only `palette_open` is validated against the
+Zellij corpus. Chords with modifiers dispatch on the exact modifier set; a
+modifier-free character binding also matches the character with any
+modifiers held, as the pre-configuration palette did.
+
 ### Rejected keys, by design
 
 - **`[terminal]` / `scrollback_lines`.** Scrollback retention is enforced
@@ -65,6 +110,10 @@ can push the grid past that ceiling.
 [font]
 cell_width = 12
 cell_height = 24
+
+[keys]
+palette_open = "super+k"
+session_create = "ctrl+shift+t"
 ```
 
 ## Error behavior

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -30,9 +30,11 @@ binary. What now actually happens on screen:
   `glyph_vertices` in `renderer.rs`, which takes a `sidebar` argument and
   applies `col_offset`, and `sidebar_text_lines` in `main.rs`, which formats the
   rows.
-- **The session palette is present, but only one PTY is live.** `Super+p` opens
-  the command palette (claimed by `palette_policy` in `main.rs` as
-  `PassthroughAction::OpenCommandPalette`). Its `c` command adds a model row;
+- **The session palette is present, but only one PTY is live.** `super+p`
+  opens the command palette (claimed by `palette_policy` in `main.rs` as
+  `PassthroughAction::OpenCommandPalette`); the opener and the four command
+  chords are configurable through `[keys]` in `config.toml` with
+  `super+p`/`c`/`s`/`x`/`f` as the defaults. The `c` command adds a model row;
   it does not start another shell. The `s` and `x` commands cannot move or
   remove the startup PTY's input owner, while `f` focuses the sidebar. Arrow
   keys and Enter navigate the same command list; Escape dismisses it.
@@ -176,11 +178,16 @@ Each item states what you would actually see if you ran the build.
   ownership. There is no split, tiled, or multi-session view. Panes and layout
   *inside* the live session are delegated to Zellij by design — see "What is
   deliberately delegated".
-- **Keybindings are not configurable.** The palette opener (`Super+p`), the exit
-  leader (`Super+Escape`), and the `c`/`s`/`x`/`f` command keys are compiled in:
-  `palette_policy` and `handle_palette_key` in `main.rs` hard-code them, and the
-  config parser (`config.rs`) exposes no keybinding or keymap surface. Rebinding
-  requires editing source.
+- **Keybindings are configurable for the palette only, within bounds.** The
+  `[keys]` table in `config.toml` rebinds the palette opener and the four
+  palette command chords (`palette_policy` and `handle_palette_key` in
+  `main.rs` read them from `KeymapConfig`), with the pre-configuration
+  chords as defaults. The exit leader (`super+escape`), the palette's
+  structural keys (Escape, Enter, the vertical arrows), the diagnostics
+  chord (Super+D), and the clipboard shortcuts (Super+A/C/V) remain
+  compiled in; see [configuration](configuration.md) for the grammar and the
+  rejection rules, including the pinned-Zellij-corpus constraint on the
+  opener.
 - **A restored session's shell is not running.** Sidebar state persists across a
   restart, but a restored entry comes back as `SessionStatus::Restored` — a
   visible row whose PTY does not exist yet. The comment on `teardown` in

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -262,7 +262,8 @@ but do hold Noren to its side of the boundary: a workspace *outside* the
 terminal. That side now has a first vertical slice — a drawn sidebar, a command
 palette over model rows, one live local PTY, and state that survives a restart
 — and the gaps that remain there (real session switching, non-local session
-kinds, configurable keybindings) are legitimate things to report.
+kinds) are legitimate things to report; keybindings are configurable through
+`[keys]` now, with the live winit dispatch gap noted above.
 
 ## What this preview is not
 


### PR DESCRIPTION
Resumed from the rate-limit-salvaged `wip/keybind-rl` lane; rebased onto current main (the stale base would have reverted #132/#133).

- `[keys]` config section; chord parser (super/ctrl/alt/shift + key) with typed errors naming the offending key
- Unparseable chord, unknown action, duplicate binding → typed error, never silent fallback (config.rs discipline)
- Palette chord and its four commands come from config; today's values are defaults
- Binary wiring on the live key paths; 22 tests; docs/configuration.md updated
- Mutations proven: unknown-action silently ignored → test fails; hard-coded default wins → tests fail
- Gates: fmt 0, clippy 0, 890 tests pass, frame_oracle --ignored keeps exactly 2 documented failures