### PR TITLE
perf(ssh_config): first-character filter closes the mixed literal+wildcard quadratic

### DIFF
--- a/crates/noren-app/src/ssh_config.rs
+++ b/crates/noren-app/src/ssh_config.rs
@@ -627,6 +627,11 @@ impl HeadMask {
         };
         for pattern in patterns {
             let Some(head) = pattern.chars().next() else {
+                // An empty positive pattern matches only the empty alias
+                // (`wildcard_match("", "")`), and the empty alias has no head
+                // character to bucket by — admit the block everywhere rather
+                // than lose it for that one alias.
+                mask.any = true;
                 continue;
             };
             if head == '!' {

--- a/crates/noren-app/src/ssh_config.rs
+++ b/crates/noren-app/src/ssh_config.rs
@@ -433,6 +433,7 @@ impl SshConfig {
         let mut seen_aliases = HashSet::new();
         let mut literal_blocks = HashMap::<String, Vec<usize>>::new();
         let mut fallback_blocks = Vec::new();
+        let mut fallback_head_masks = Vec::new();
         let mut fallback_pattern_work = 0_u128;
         let mut fallback_setting_work = 0_u128;
 
@@ -443,6 +444,7 @@ impl SshConfig {
         for (block_index, block) in blocks.iter().enumerate() {
             let Some(patterns) = &block.patterns else {
                 fallback_blocks.push(block_index);
+                fallback_head_masks.push(HeadMask::ANY);
                 fallback_setting_work = fallback_setting_work.saturating_add(block.settings_work());
                 continue;
             };
@@ -497,6 +499,8 @@ impl SshConfig {
                 }
             } else {
                 fallback_blocks.push(block_index);
+                fallback_head_masks
+                    .push(HeadMask::for_patterns(patterns.iter().map(String::as_str)));
                 fallback_setting_work = fallback_setting_work.saturating_add(block.settings_work());
                 for pattern in patterns {
                     let match_pattern = pattern.strip_prefix('!').unwrap_or(pattern);
@@ -517,63 +521,139 @@ impl SshConfig {
         resolution_work.fallback_setting_work = fallback_setting_work.saturating_mul(alias_count);
         ensure_resolution_work(resolution_work, limits.resolution_work)?;
 
-        let hosts = aliases
-            .into_iter()
-            .map(|(alias, declared_source)| {
-                let mut host = SshHost {
-                    alias: alias.clone(),
-                    host_name: None,
-                    user: None,
-                    port: None,
-                    declared_source,
-                };
-
-                let indexed = literal_blocks
-                    .get(&alias.to_ascii_lowercase())
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]);
-                let mut indexed_position = 0;
-                let mut fallback_position = 0;
-                // Merge both ordered views so per-keyword first-value-wins
-                // precedence remains identical to scanning all blocks.
-                while indexed_position < indexed.len() || fallback_position < fallback_blocks.len()
-                {
-                    let (block_index, needs_match) = match (
-                        indexed.get(indexed_position),
-                        fallback_blocks.get(fallback_position),
-                    ) {
-                        (Some(indexed), Some(fallback)) if indexed < fallback => {
-                            indexed_position += 1;
-                            (*indexed, false)
-                        }
-                        (Some(_), Some(fallback)) => {
-                            fallback_position += 1;
-                            (*fallback, true)
-                        }
-                        (Some(indexed), None) => {
-                            indexed_position += 1;
-                            (*indexed, false)
-                        }
-                        (None, Some(fallback)) => {
-                            fallback_position += 1;
-                            (*fallback, true)
-                        }
-                        (None, None) => unreachable!(),
+        let hosts = {
+            // Filtering the fallback list by the alias's first character skips
+            // exactly the blocks `applies_to` would reject: a block is dropped
+            // only when none of its positive patterns can match that alias, so
+            // the merged order — and with it first-value-wins precedence — is
+            // identical to scanning every block. The list is built once per
+            // distinct first character, not once per alias.
+            let mut fallback_for_head: HashMap<Option<u8>, Vec<usize>> = HashMap::new();
+            aliases
+                .into_iter()
+                .map(|(alias, declared_source)| {
+                    let mut host = SshHost {
+                        alias: alias.clone(),
+                        host_name: None,
+                        user: None,
+                        port: None,
+                        declared_source,
                     };
-                    let block = &blocks[block_index];
-                    if needs_match && !block.applies_to(&alias) {
-                        continue;
+
+                    let indexed = literal_blocks
+                        .get(&alias.to_ascii_lowercase())
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    let head = alias
+                        .chars()
+                        .next()
+                        .map(|c| c.to_ascii_lowercase())
+                        .filter(char::is_ascii);
+                    let fallbacks: &Vec<usize> = fallback_for_head
+                        .entry(head.map(|c| c as u8))
+                        .or_insert_with(|| {
+                            fallback_blocks
+                                .iter()
+                                .zip(&fallback_head_masks)
+                                .filter(|(_, mask)| mask.admits(head))
+                                .map(|(&block_index, _)| block_index)
+                                .collect()
+                        });
+                    let mut indexed_position = 0;
+                    let mut fallback_position = 0;
+                    // Merge both ordered views so per-keyword first-value-wins
+                    // precedence remains identical to scanning all blocks.
+                    while indexed_position < indexed.len() || fallback_position < fallbacks.len() {
+                        let (block_index, needs_match) = match (
+                            indexed.get(indexed_position),
+                            fallbacks.get(fallback_position),
+                        ) {
+                            (Some(indexed), Some(fallback)) if indexed < fallback => {
+                                indexed_position += 1;
+                                (*indexed, false)
+                            }
+                            (Some(_), Some(fallback)) => {
+                                fallback_position += 1;
+                                (*fallback, true)
+                            }
+                            (Some(indexed), None) => {
+                                indexed_position += 1;
+                                (*indexed, false)
+                            }
+                            (None, Some(fallback)) => {
+                                fallback_position += 1;
+                                (*fallback, true)
+                            }
+                            (None, None) => unreachable!(),
+                        };
+                        let block = &blocks[block_index];
+                        if needs_match && !block.applies_to(&alias) {
+                            continue;
+                        }
+                        apply_settings(&mut host, block);
                     }
-                    apply_settings(&mut host, block);
-                }
-                host
-            })
-            .collect();
+                    host
+                })
+                .collect()
+        };
         Ok(Self {
             hosts,
             sources,
             discovery_kind: HostDiscoveryKind::PartialLiteralPatterns,
         })
+    }
+}
+
+/// The set of ASCII first characters an alias can have for any positive
+/// pattern of a fallback block to match it. `any` is set when a positive
+/// pattern starts with `*` or `?` (or the block is global), in which case the
+/// block must be tested against every alias. Non-ASCII first characters match
+/// no ASCII pattern head, so `admits(None)` falls back to `any` alone — the
+/// same conclusion `wildcard_match` would reach, just without walking the
+/// pattern.
+#[derive(Clone, Copy)]
+struct HeadMask {
+    any: bool,
+    bits: u128,
+}
+
+impl HeadMask {
+    const ANY: Self = Self { any: true, bits: 0 };
+
+    fn for_patterns<'a>(patterns: impl Iterator<Item = &'a str>) -> Self {
+        let mut mask = Self {
+            any: false,
+            bits: 0,
+        };
+        for pattern in patterns {
+            let Some(head) = pattern.chars().next() else {
+                continue;
+            };
+            if head == '!' {
+                // Only positive patterns decide whether the block can apply.
+                continue;
+            }
+            let head = head.to_ascii_lowercase();
+            if head == '*' || head == '?' || !head.is_ascii() {
+                mask.any = true;
+            } else {
+                mask.bits |= 1_u128 << (head as u8);
+            }
+        }
+        mask
+    }
+
+    fn admits(self, head: Option<char>) -> bool {
+        if self.any {
+            return true;
+        }
+        match head {
+            Some(c) => {
+                let c = c.to_ascii_lowercase();
+                c.is_ascii() && (self.bits & (1_u128 << (c as u8))) != 0
+            }
+            None => false,
+        }
     }
 }
 

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -2385,11 +2385,8 @@ fn baseline_mixed_quadratic_measurement() {
         ..DEFAULT_LIMITS
     };
     let started = std::time::Instant::now();
-    let lifted_result = SshConfig::from_blocks_with_limit(
-        &blocks,
-        vec![inline_source(SshSourceId(0))],
-        lifted,
-    );
+    let lifted_result =
+        SshConfig::from_blocks_with_limit(&blocks, vec![inline_source(SshSourceId(0))], lifted);
     let lifted_elapsed = started.elapsed();
     eprintln!(
         "BASELINE lifted budget (true resolution): {:?} ({})",
@@ -2408,11 +2405,8 @@ fn baseline_mixed_quadratic_measurement() {
             parse_blocks_for_test(&text, 0, SshSourceId(0), &mut token_items, MAX_TOKEN_ITEMS)
                 .expect("baseline blocks parse");
         let started = std::time::Instant::now();
-        let result = SshConfig::from_blocks_with_limit(
-            &blocks,
-            vec![inline_source(SshSourceId(0))],
-            lifted,
-        );
+        let result =
+            SshConfig::from_blocks_with_limit(&blocks, vec![inline_source(SshSourceId(0))], lifted);
         let elapsed = started.elapsed();
         eprintln!(
             "BASELINE lifted budget {pairs} pairs: {elapsed:?} ({})",

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -2417,3 +2417,98 @@ fn baseline_mixed_quadratic_measurement() {
         );
     }
 }
+
+#[test]
+fn mixed_quadratic_config_is_rejected_promptly_at_default_limits() {
+    // The 1 MiB mixed literal+wildcard file from the DoS report. The
+    // resolution-work budget must reject it as complexity, not spend
+    // minutes resolving it: measured 18-22 ms, ceiling has two orders of
+    // headroom.
+    let text = baseline_mixed_text(14_189);
+    let started = std::time::Instant::now();
+    let result = SshConfig::parse(&text);
+    let elapsed = started.elapsed();
+    assert!(
+        matches!(
+            result,
+            Err(SshConfigError {
+                kind: SshConfigErrorKind::ResolutionComplexityExceeded,
+                ..
+            })
+        ),
+        "expected ResolutionComplexityExceeded, got {result:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "rejection took {elapsed:?}; the budget wall must fail fast"
+    );
+}
+
+#[test]
+fn mixed_wildcard_resolution_is_tractable_under_lifted_budget() {
+    // The same file with the resolution budget lifted must resolve in
+    // near-linear time. Measured 9.1 ms at 14,189 pairs after the
+    // first-character fallback filter; the ceiling keeps three orders of
+    // headroom so it cannot flake on a slow machine while still catching
+    // any return of the quadratic walk (which measured 72.6 s here).
+    let text = baseline_mixed_text(14_189);
+    let mut token_items = 0usize;
+    let blocks = parse_blocks_for_test(&text, 0, SshSourceId(0), &mut token_items, MAX_TOKEN_ITEMS)
+        .expect("baseline blocks parse");
+    let lifted = ParserLimits {
+        resolution_work: u128::MAX,
+        ..DEFAULT_LIMITS
+    };
+    let started = std::time::Instant::now();
+    let config =
+        SshConfig::from_blocks_with_limit(&blocks, vec![inline_source(SshSourceId(0))], lifted)
+            .expect("lifted budget resolves the mixed file");
+    let elapsed = started.elapsed();
+    assert_eq!(config.hosts().len(), 14_189);
+    for host in config.hosts() {
+        // Every literal block precedes its wildcard pair and sets HostName
+        // first, so first-value-wins must keep the literal value.
+        assert_eq!(host.host_name(), Some("x"));
+    }
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "resolution took {elapsed:?}; the quadratic fallback walk is back"
+    );
+}
+
+#[test]
+fn first_character_filter_preserves_wildcard_semantics() {
+    // Adversarial shapes for the first-character fallback filter: a wildcard
+    // sharing the alias's first character must still be matched; a case-folded
+    // pattern head must admit the alias; nested same-head blocks must apply in
+    // file order; and a non-ASCII alias must not be matched by any
+    // ASCII-headed wildcard.
+    let config = SshConfig::parse(
+        "Host l*\nHostName outer\nUser o\n\
+         Host lnx\nHostName literal\nPort 33\n\
+         Host l?x*\nHostName wildcard\nUser w\n\
+         Host LNX\nHostName casefold-head\nUser c\n\
+         Host ünïcode\nHostName unicode\n",
+    )
+    .expect("mixed shapes parse");
+    let lnx = config
+        .hosts()
+        .iter()
+        .find(|host| host.alias() == "lnx")
+        .expect("literal alias present");
+    // In file order: `l*` first (outer/o), the literal block is the only one
+    // that sets a Port, `l?x*` and `LNX` match but set nothing new.
+    assert_eq!(lnx.host_name(), Some("outer"));
+    assert_eq!(lnx.user(), Some("o"));
+    assert_eq!(lnx.port(), Some(33));
+    // The non-ASCII alias resolves against its own literal block only; the
+    // ASCII-headed wildcards above it must not match.
+    let unicode = config
+        .hosts()
+        .iter()
+        .find(|host| host.alias() == "ünïcode")
+        .expect("unicode alias present");
+    assert_eq!(unicode.host_name(), Some("unicode"));
+    assert_eq!(unicode.user(), None);
+    assert_eq!(unicode.port(), None);
+}

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -2347,3 +2347,79 @@ fn keywords_are_case_insensitive_and_values_are_preserved() {
     assert_eq!(host.user(), Some("DeployUser"));
     assert_eq!(host.port(), Some(2201));
 }
+
+fn baseline_mixed_text(pairs: usize) -> String {
+    let mut text = String::new();
+    for index in 0..pairs {
+        writeln!(text, "Host literal-alias-{index:05}").expect("write to string");
+        text.push_str("HostName x\n");
+        writeln!(text, "Host impossible-{index:05}*").expect("write to string");
+        text.push_str("HostName y\n");
+    }
+    text
+}
+
+#[test]
+#[ignore = "temporary baseline measurement for the mixed DoS remediation"]
+fn baseline_mixed_quadratic_measurement() {
+    let text = baseline_mixed_text(14_189);
+    assert!((900 * 1024..=1024 * 1024).contains(&text.len()));
+
+    let started = std::time::Instant::now();
+    let default_result = SshConfig::parse(&text);
+    let default_elapsed = started.elapsed();
+    eprintln!(
+        "BASELINE default limits: {:?} ({})",
+        default_elapsed,
+        match &default_result {
+            Ok(config) => format!("Ok({} hosts)", config.hosts().len()),
+            Err(error) => format!("{error:?}"),
+        }
+    );
+
+    let mut token_items = 0usize;
+    let blocks = parse_blocks_for_test(&text, 0, SshSourceId(0), &mut token_items, MAX_TOKEN_ITEMS)
+        .expect("baseline blocks parse");
+    let lifted = ParserLimits {
+        resolution_work: u128::MAX,
+        ..DEFAULT_LIMITS
+    };
+    let started = std::time::Instant::now();
+    let lifted_result = SshConfig::from_blocks_with_limit(
+        &blocks,
+        vec![inline_source(SshSourceId(0))],
+        lifted,
+    );
+    let lifted_elapsed = started.elapsed();
+    eprintln!(
+        "BASELINE lifted budget (true resolution): {:?} ({})",
+        lifted_elapsed,
+        match &lifted_result {
+            Ok(config) => format!("Ok({} hosts)", config.hosts().len()),
+            Err(error) => format!("{error:?}"),
+        }
+    );
+    drop(lifted_result);
+
+    for pairs in [1_000usize, 4_000, 8_000] {
+        let text = baseline_mixed_text(pairs);
+        let mut token_items = 0usize;
+        let blocks =
+            parse_blocks_for_test(&text, 0, SshSourceId(0), &mut token_items, MAX_TOKEN_ITEMS)
+                .expect("baseline blocks parse");
+        let started = std::time::Instant::now();
+        let result = SshConfig::from_blocks_with_limit(
+            &blocks,
+            vec![inline_source(SshSourceId(0))],
+            lifted,
+        );
+        let elapsed = started.elapsed();
+        eprintln!(
+            "BASELINE lifted budget {pairs} pairs: {elapsed:?} ({})",
+            match &result {
+                Ok(config) => format!("Ok({} hosts)", config.hosts().len()),
+                Err(error) => format!("{error:?}"),
+            }
+        );
+    }
+}

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -2512,3 +2512,35 @@ fn first_character_filter_preserves_wildcard_semantics() {
     assert_eq!(unicode.user(), None);
     assert_eq!(unicode.port(), None);
 }
+
+#[test]
+fn empty_positive_pattern_still_reaches_the_empty_alias() {
+    // Found by independent review of the first-character filter: a mixed
+    // block whose positive pattern is the empty string matches the empty
+    // alias under wildcard_match("", ""), but the empty alias has no head
+    // character to bucket by — the block must still be walked, or the
+    // later wildcard block's value would win instead of the first block's.
+    let config = SshConfig::parse(
+        "Host \"\" !z*\nHostName first\nPort 29\n\
+         Host other\nHostName literal\n\
+         Host *\nHostName last\nPort 99\n",
+    )
+    .expect("empty-pattern config parses");
+    let empty = config
+        .hosts()
+        .iter()
+        .find(|host| host.alias().is_empty())
+        .expect("empty alias discovered");
+    assert_eq!(empty.host_name(), Some("first"));
+    assert_eq!(empty.port(), Some(29));
+    // A non-empty alias is never matched by the empty pattern; its own
+    // literal block precedes `*`, so first-value-wins keeps `literal` while
+    // `*` contributes the port the literal block left unset.
+    let other = config
+        .hosts()
+        .iter()
+        .find(|host| host.alias() == "other")
+        .expect("literal alias present");
+    assert_eq!(other.host_name(), Some("literal"));
+    assert_eq!(other.port(), Some(99));
+}


### PR DESCRIPTION
Resumed from `wip/perf-rl`; rebased onto current main. Implemented directly by the coordinator.

**Measured baseline (release, this machine):** the 41.5 s report reproduced as **72.6 s** under a lifted resolution budget for the 1 MiB / 14,189-pair mixed file — quadratic (1k=0.3s, 4k=5.4s, 8k=21.5s). Important correction to the review claim: at **default** limits the file is rejected in ~20 ms with `ResolutionComplexityExceeded` — it was never reachable in production; the budget wall already stopped it. The remaining cost of that wall is rejecting configs OpenSSH accepts, which this PR's filter removes the need for in practice.

**Fix:** each fallback block carries a u128 bitmask of the ASCII first characters its positive patterns can match (`any` when a pattern starts with `*`/`?`). Per-alias fallback lists are filtered by first character, built once per distinct head — skipping exactly the blocks `applies_to` would reject, so merge order and first-value-wins precedence are untouched (verified by the existing order/precedence suites plus a new adversarial shapes test).

**After:** 14,189 pairs resolve in **9.1 ms**; scaling linear (1k=0.5ms, 4k=2.2ms, 8k=4.7ms).

**Mutation proofs:** removing the `host_name.is_none()` guard fails 7 tests; the new tractability ceiling test fails if the quadratic walk returns.

Gates: fmt 0, clippy 0, 871 tests pass, frame_oracle --ignored keeps exactly 2 documented failures.