### PR TITLE
feat(app): real SSH connections from the sidebar via the system ssh client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
 > exactly one local session; additional palette rows do not launch or switch
 > PTYs yet. A bounded, explicitly partial list of positive literal aliases
 > from the user's OpenSSH config is displayed in the sidebar (at most 24 rows),
-> and selecting one shows its root-relative config source without opening an
-> SSH connection or PTY. Wildcard-only and dynamic OpenSSH destinations are not
+> and selecting one launches the system `/usr/bin/ssh` client for that alias in
+> the terminal's PTY (argv is exactly `ssh -- <alias>`; no credential is ever
+> passed on the command line), replacing the current session, with launch,
+> connect, and disconnect failures shown as visible states. Wildcard-only and dynamic OpenSSH destinations are not
 > a complete browseable list. Parsed `HostName` and `User` values retain
 > unresolved tokens such as `%h`, `%p`, and `%r` and are discovery metadata
 > only; a future connection path must resolve or reject them first. `Include`

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -707,6 +707,11 @@ struct NorenApp {
     /// disable the spawn so the click path is exercised without launching any
     /// process, keeping the unit suite deterministic.
     ssh_spawn_enabled: bool,
+    /// Test-only override that makes the ssh spawn attempt itself fail (the
+    /// `Err` arm of `PtySession::spawn_ssh`), which cannot be forced from a
+    /// valid destination on a healthy machine. Production never sets it.
+    #[cfg(test)]
+    ssh_spawn_force_failure: bool,
     redraw_needed: bool,
     // User-initiated selection state. The renderer does not highlight it yet;
     // copy still extracts it. Any PTY output or resize invalidates it because
@@ -812,6 +817,8 @@ impl NorenApp {
             ssh_selection_status: None,
             ssh_eof_since: None,
             ssh_spawn_enabled: true,
+            #[cfg(test)]
+            ssh_spawn_force_failure: false,
             redraw_needed: true,
             selection: None,
             drag_origin: None,
@@ -1031,8 +1038,18 @@ impl NorenApp {
             }
         };
         let spawned = self.ssh_spawn_enabled && {
-            match PtySession::spawn_ssh(SshLaunchPolicy::inherit(destination), self.live_pty_size())
-            {
+            #[cfg(test)]
+            let attempt = if self.ssh_spawn_force_failure {
+                Err(noren_pty::PtyError::Backend {
+                    operation: noren_pty::PtyOperation::SpawnChild,
+                })
+            } else {
+                PtySession::spawn_ssh(SshLaunchPolicy::inherit(destination), self.live_pty_size())
+            };
+            #[cfg(not(test))]
+            let attempt =
+                PtySession::spawn_ssh(SshLaunchPolicy::inherit(destination), self.live_pty_size());
+            match attempt {
                 Ok(session) => {
                     self.retire_live_terminal();
                     self.pty = Some(session);

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -32,11 +32,14 @@ use noren_app::{
     sidebar::{SidebarEntry, SidebarView},
     ssh_config::{HostDiscoveryKind, SshConfig},
 };
-use noren_pty::{PtyEvent, PtySession, PtySize};
+use noren_pty::{
+    PtyEvent, PtySession, PtySize, SshDestination, SshDestinationError, SshLaunchPolicy,
+};
 use noren_terminal::{
     GridPoint, Selection, SelectionMode, TerminalEngine, TerminalError, TerminalState,
 };
 use renderer::{RenderOutcome, Renderer};
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -65,6 +68,108 @@ const SSH_SIDEBAR_TARGET_CHARS: usize = SSH_SIDEBAR_LABEL_CHARS - SSH_SIDEBAR_LA
 const SSH_SIDEBAR_TRUNCATED_TARGET_CHARS: usize =
     SSH_SIDEBAR_TARGET_CHARS - SSH_SIDEBAR_TRUNCATION_MARKER_CHARS;
 const SSH_SIDEBAR_DETAIL: &str = "not connected";
+/// Sidebar prefix while an ssh child owns the terminal (8 ASCII chars, so
+/// the label arithmetic in [`ssh_state_label`] is unchanged).
+const SSH_SIDEBAR_PREFIX_CONNECTED: &str = "SSH-ON  ";
+/// Sidebar prefix after a launch or connection failure (8 ASCII chars).
+const SSH_SIDEBAR_PREFIX_FAILED: &str = "SSH-ERR ";
+/// How long an ssh session may sit between EOF and its reaped exit event
+/// before it is classified as an immediate disconnect.
+const SSH_EOF_REAP_GRACE: Duration = Duration::from_secs(2);
+/// Status-row text for each SSH connection phase. Fixed strings only: a
+/// destination may embed a secret-shaped value, so no phase message may ever
+/// name it.
+const SSH_STATUS_CONNECTING: &str = "Noren ssh connecting";
+const SSH_STATUS_CLOSED: &str = "Noren ssh session closed";
+const SSH_STATUS_CONNECT_FAILED: &str = "Noren ssh connection failed";
+const SSH_STATUS_DISCONNECTED: &str = "Noren ssh connection lost";
+const SSH_STATUS_LAUNCH_FAILED: &str = "Noren ssh launch failed";
+const SSH_STATUS_REFUSED: &str = "Noren ssh connect refused";
+
+/// Observed state of the one live SSH launch. This is application-local
+/// runtime state, deliberately outside the session registry: the registry
+/// persists to `sessions.toml`, and a destination — which may embed a
+/// secret-shaped value — must never be persisted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SshConnectionPhase {
+    /// The system ssh client was spawned and owns the terminal; no output
+    /// has been observed yet.
+    Connecting,
+    /// The remote side has produced output through the normal PTY path, so
+    /// an interactive session is under way.
+    Connected,
+    /// ssh exited cleanly (exit code 0); the terminal is back offline.
+    Closed,
+    /// The ssh child could not be spawned at all.
+    LaunchFailed,
+    /// ssh exited non-zero: unreachable host, authentication failure, or a
+    /// refused destination.
+    ConnectFailed,
+    /// The PTY closed without a reaped exit code: an immediate disconnect.
+    Disconnected,
+}
+
+impl SshConnectionPhase {
+    /// Whether this phase owns the terminal with a live ssh child.
+    const fn is_live(self) -> bool {
+        matches!(self, Self::Connecting | Self::Connected)
+    }
+
+    /// The bounded ASCII sidebar prefix (8 chars).
+    const fn sidebar_prefix(self) -> &'static str {
+        match self {
+            Self::Connecting | Self::Connected => SSH_SIDEBAR_PREFIX_CONNECTED,
+            Self::Closed => SSH_SIDEBAR_LABEL_PREFIX,
+            Self::LaunchFailed | Self::ConnectFailed | Self::Disconnected => {
+                SSH_SIDEBAR_PREFIX_FAILED
+            }
+        }
+    }
+
+    /// The bounded ASCII sidebar detail text.
+    const fn sidebar_detail(self) -> &'static str {
+        match self {
+            Self::Connecting => "connecting",
+            Self::Connected => "connected",
+            Self::Closed => SSH_SIDEBAR_DETAIL,
+            Self::LaunchFailed => "launch failed",
+            Self::ConnectFailed => "connection failed",
+            Self::Disconnected => "disconnected",
+        }
+    }
+
+    /// The status-row text for this phase.
+    const fn status_text(self) -> &'static str {
+        match self {
+            Self::Connecting => SSH_STATUS_CONNECTING,
+            Self::Connected => SSH_STATUS_CONNECTING,
+            Self::Closed => SSH_STATUS_CLOSED,
+            Self::LaunchFailed => SSH_STATUS_LAUNCH_FAILED,
+            Self::ConnectFailed => SSH_STATUS_CONNECT_FAILED,
+            Self::Disconnected => SSH_STATUS_DISCONNECTED,
+        }
+    }
+}
+
+/// Classify the terminal observation of an ended ssh child. This is the
+/// failure-mapping seam: every non-clean outcome is a visible failure phase,
+/// never a silent hang or a fake success.
+fn ssh_exit_observation(code: Option<u32>) -> SshConnectionPhase {
+    match code {
+        Some(0) => SshConnectionPhase::Closed,
+        Some(_) => SshConnectionPhase::ConnectFailed,
+        None => SshConnectionPhase::Disconnected,
+    }
+}
+
+/// Classify a spawn attempt for the fixed system ssh client.
+fn ssh_launch_observation(spawned: bool) -> SshConnectionPhase {
+    if spawned {
+        SshConnectionPhase::Connecting
+    } else {
+        SshConnectionPhase::LaunchFailed
+    }
+}
 /// Keep the complete source identity and the partial-discovery warning visible
 /// together on ordinary terminal widths. The stable source tag is placed first
 /// so path truncation cannot make two retained sources indistinguishable.
@@ -75,6 +180,14 @@ const SSH_STATUS_SOURCE_CHARS: usize = 40;
 /// so this helper does the same and looks at one scalar beyond the untruncated
 /// target budget solely to decide whether the ASCII marker is needed.
 fn ssh_sidebar_label(target: &str) -> String {
+    ssh_state_label(SshConnectionPhase::Closed, target)
+}
+
+/// Build the bounded sidebar label for an SSH target in `phase`.
+///
+/// The prefix encodes the connection state; the target text is bounded
+/// exactly like the offline label.
+fn ssh_state_label(phase: SshConnectionPhase, target: &str) -> String {
     let inspected: Vec<char> = target
         .chars()
         .take(SSH_SIDEBAR_TARGET_CHARS.saturating_add(1))
@@ -86,7 +199,7 @@ fn ssh_sidebar_label(target: &str) -> String {
         inspected.len()
     };
     let mut label = String::with_capacity(SSH_SIDEBAR_LABEL_CHARS.saturating_mul(4));
-    label.push_str(SSH_SIDEBAR_LABEL_PREFIX);
+    label.push_str(phase.sidebar_prefix());
     label.extend(inspected.into_iter().take(visible_target_chars));
     if truncated {
         label.push_str(SSH_SIDEBAR_TRUNCATION_MARKER);
@@ -199,6 +312,10 @@ struct WorkspaceState {
     ssh_hosts_omitted: usize,
     selected_ssh_target: Option<String>,
     selected_ssh_source_label: Option<String>,
+    /// The one live SSH launch's target and phase, mirrored here only so
+    /// [`Self::rebuild_sidebar`] can mark the matching configured row. The
+    /// target never enters the registry, so it is never persisted.
+    ssh_connection: Option<(String, SshConnectionPhase)>,
     /// Owned by the workspace; dispatched when the palette opens.
     palette: Palette<WorkspaceAction>,
     /// Where sidebar state is persisted. `None` in tests and when `HOME` is
@@ -208,6 +325,36 @@ struct WorkspaceState {
     /// Exact comparison baseline plus persistence diagnostics. Baseline
     /// validity is explicit so failures cannot reuse stale or assumed bytes.
     persistence: PersistenceState,
+}
+
+impl fmt::Debug for WorkspaceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The selected and connected SSH targets may embed secret-shaped
+        // values, so every debug surface redacts them. The provenance label
+        // is bounded root-relative display text and stays visible.
+        f.debug_struct("WorkspaceState")
+            .field("registry", &self.registry.len())
+            .field("registry_selection", &self.registry.selected())
+            .field("sidebar", &self.sidebar)
+            .field("ssh_hosts", &self.ssh_hosts.len())
+            .field("ssh_hosts_omitted", &self.ssh_hosts_omitted)
+            .field(
+                "selected_ssh_target",
+                &self.selected_ssh_target.as_deref().map(|_| "<redacted>"),
+            )
+            .field("selected_ssh_source_label", &self.selected_ssh_source_label)
+            .field(
+                "ssh_connection",
+                &self
+                    .ssh_connection
+                    .as_ref()
+                    .map(|(_, phase)| format!("<redacted target, phase={phase:?}>")),
+            )
+            .field("palette", &self.palette)
+            .field("state_path", &self.state_path)
+            .field("persistence", &self.persistence)
+            .finish()
+    }
 }
 
 impl Default for WorkspaceState {
@@ -234,6 +381,7 @@ impl WorkspaceState {
             ssh_hosts_omitted: 0,
             selected_ssh_target: None,
             selected_ssh_source_label: None,
+            ssh_connection: None,
             palette: Palette::noren(
                 WorkspaceAction::CreateSession,
                 WorkspaceAction::SelectSession,
@@ -399,6 +547,17 @@ impl WorkspaceState {
         true
     }
 
+    /// Record the phase of the one live SSH launch and refresh the sidebar.
+    ///
+    /// The target is compared against the configured host rows to mark the
+    /// matching row's state. It is held in memory only: the registry is the
+    /// only persisted state and it never sees an SSH launch, so the target
+    /// cannot reach `sessions.toml`.
+    fn set_ssh_connection(&mut self, target: &str, phase: SshConnectionPhase) {
+        self.ssh_connection = Some((target.to_owned(), phase));
+        self.rebuild_sidebar();
+    }
+
     /// Resolve the local session id at a stable sidebar position.
     ///
     /// Session rows precede SSH facts and are generated from the registry's
@@ -449,9 +608,20 @@ impl WorkspaceState {
             let selected =
                 !pending_marked && self.selected_ssh_target.as_deref() == Some(target.as_str());
             pending_marked |= selected;
+            // The one live connection, if any, is matched by exact target so
+            // colliding truncated labels cannot mark the wrong row.
+            let phase = self
+                .ssh_connection
+                .as_ref()
+                .filter(|(connected, _)| connected == target)
+                .map(|(_, phase)| *phase);
+            let (label, detail) = match phase {
+                Some(phase) => (ssh_state_label(phase, target), phase.sidebar_detail()),
+                None => (ssh_sidebar_label(target), SSH_SIDEBAR_DETAIL),
+            };
             Some(SidebarEntry::SshConnection {
-                label: ssh_sidebar_label(target),
-                host: SSH_SIDEBAR_DETAIL.to_string(),
+                label,
+                host: detail.to_owned(),
                 selected,
             })
         }));
@@ -474,8 +644,8 @@ impl WorkspaceState {
     }
 
     /// The configured host that was selected, if any. Selection is a pending
-    /// UI choice and deliberately does not imply a connection or viewport.
-    #[cfg(test)]
+    /// UI choice; when a launch follows, the click path also drives
+    /// [`Self::set_ssh_connection`] for the same target.
     fn selected_ssh_target(&self) -> Option<&str> {
         self.selected_ssh_target.as_deref()
     }
@@ -516,6 +686,13 @@ struct NorenApp {
     diagnostics_line: String,
     ssh_diagnostic: Option<String>,
     ssh_selection_status: Option<String>,
+    /// When EOF was observed on a live ssh child whose reaped exit event has
+    /// not arrived yet; drives the immediate-disconnect classification.
+    ssh_eof_since: Option<Instant>,
+    /// Production spawns the real system ssh client. The binary test seam can
+    /// disable the spawn so the click path is exercised without launching any
+    /// process, keeping the unit suite deterministic.
+    ssh_spawn_enabled: bool,
     redraw_needed: bool,
     // User-initiated selection state. The renderer does not highlight it yet;
     // copy still extracts it. Any PTY output or resize invalidates it because
@@ -599,6 +776,8 @@ impl NorenApp {
             diagnostics_line: String::new(),
             ssh_diagnostic: None,
             ssh_selection_status: None,
+            ssh_eof_since: None,
+            ssh_spawn_enabled: true,
             redraw_needed: true,
             selection: None,
             drag_origin: None,
@@ -724,6 +903,125 @@ impl NorenApp {
         self.ssh_diagnostic = Some(line);
         self.redraw_needed = true;
     }
+
+    /// Whether the live PTY is owned by an ssh child of a live launch.
+    fn ssh_live(&self) -> bool {
+        self.workspace
+            .ssh_connection
+            .as_ref()
+            .is_some_and(|(_, phase)| phase.is_live())
+    }
+
+    /// The PTY size for a new launch: the authoritative terminal grid, or a
+    /// safe default before a terminal exists.
+    fn live_pty_size(&self) -> PtySize {
+        self.terminal
+            .as_ref()
+            .and_then(|terminal| {
+                let (rows, cols) = terminal.size();
+                PtySize::from_raw(rows, cols)
+            })
+            .unwrap_or_else(|| PtySize::from_raw(24, 80).expect("24x80 is a valid size"))
+    }
+
+    /// Retire the current terminal owner: the local session is observed as
+    /// exited (its process is terminated) and its PTY is shut down bounded.
+    fn retire_live_terminal(&mut self) {
+        if let Some(id) = self.active_session.take() {
+            self.workspace
+                .observe_session(id, SessionStatus::Exited { code: None });
+        }
+        if let Some(mut previous) = self.pty.take() {
+            let _ = previous.shutdown();
+        }
+    }
+
+    /// Surface a typed destination refusal. The typed error names the OpenSSH
+    /// keyword and token for token-bearing destinations; it never carries the
+    /// destination itself, so a secret-shaped target cannot leak here.
+    fn report_ssh_connect_refusal(&mut self, error: SshDestinationError) {
+        self.ssh_selection_status = Some(format!("SSH connect refused: {error}"));
+        // Show the typed refusal in preference to the static runtime text.
+        self.status = SSH_STATUS_REFUSED;
+        self.show_status = false;
+        self.redraw_needed = true;
+    }
+
+    /// Record an observed phase of the live SSH launch and make it visible.
+    fn apply_ssh_phase(&mut self, phase: SshConnectionPhase) {
+        let Some(target) = self
+            .workspace
+            .ssh_connection
+            .as_ref()
+            .map(|(target, _)| target.clone())
+        else {
+            return;
+        };
+        self.workspace.set_ssh_connection(&target, phase);
+        if !phase.is_live() {
+            self.status = phase.status_text();
+            self.show_status = true;
+        } else if phase == SshConnectionPhase::Connected {
+            // The remote side is producing output through the normal PTY
+            // path; the terminal content is the interface now.
+            self.show_status = false;
+        }
+        self.redraw_needed = true;
+    }
+
+    /// Launch the system ssh client for `target` in the terminal's PTY.
+    ///
+    /// The destination is validated first: a refused destination never tears
+    /// down the running terminal and never spawns a child. A successful spawn
+    /// replaces the current terminal owner; a failed spawn leaves the current
+    /// terminal untouched and surfaces [`SshConnectionPhase::LaunchFailed`].
+    fn connect_ssh_target(&mut self, target: &str) -> SshConnectOutcome {
+        if self
+            .workspace
+            .ssh_connection
+            .as_ref()
+            .is_some_and(|(connected, phase)| connected == target && phase.is_live())
+        {
+            return SshConnectOutcome::AlreadyLive;
+        }
+        let destination = match SshDestination::new(target) {
+            Ok(destination) => destination,
+            Err(error) => {
+                self.report_ssh_connect_refusal(error);
+                return SshConnectOutcome::Refused;
+            }
+        };
+        let spawned = self.ssh_spawn_enabled && {
+            match PtySession::spawn_ssh(SshLaunchPolicy::inherit(destination), self.live_pty_size())
+            {
+                Ok(session) => {
+                    self.retire_live_terminal();
+                    self.pty = Some(session);
+                    self.pty_child = PtyChildStatus::Running;
+                    true
+                }
+                Err(_) => false,
+            }
+        };
+        let phase = ssh_launch_observation(spawned);
+        self.ssh_eof_since = None;
+        self.workspace.set_ssh_connection(target, phase);
+        self.status = phase.status_text();
+        self.show_status = true;
+        self.redraw_needed = true;
+        SshConnectOutcome::Launched(phase)
+    }
+}
+
+/// Result of a sidebar click's connect attempt, for status-row wording.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SshConnectOutcome {
+    /// A spawn was attempted; the phase says whether it took.
+    Launched(SshConnectionPhase),
+    /// The destination was refused; the typed refusal is already visible.
+    Refused,
+    /// The same target already owns the terminal with a live child.
+    AlreadyLive,
 }
 
 impl NorenApp {
@@ -1215,12 +1513,25 @@ impl NorenApp {
             return true;
         }
         if self.workspace.select_ssh_sidebar_row(row_index) {
+            let target = self.workspace.selected_ssh_target().map(str::to_owned);
             let source = self
                 .workspace
                 .selected_ssh_source_label()
                 .map(ssh_status_source_label)
                 .unwrap_or_else(|| "#? source unavailable".to_owned());
             self.ssh_selection_status = Some(format!("SSH partial source {source}; offline"));
+            let outcome = match target.as_deref() {
+                Some(target) => self.connect_ssh_target(target),
+                None => return true,
+            };
+            // A refusal keeps its typed message; otherwise refresh the
+            // provenance line with the launch's observed phase word.
+            if let SshConnectOutcome::Launched(phase) = outcome {
+                self.ssh_selection_status = Some(format!(
+                    "SSH partial source {source}; {}",
+                    phase.sidebar_detail()
+                ));
+            }
             self.redraw_needed = true;
             return true;
         }
@@ -1629,6 +1940,17 @@ impl NorenApp {
         if let Some(terminal) = &mut self.terminal {
             terminal.feed_bytes(bytes);
         }
+        // First output from an ssh child means the remote side is talking
+        // through the normal I/O path: the launch is interactive now.
+        if self.ssh_live()
+            && self
+                .workspace
+                .ssh_connection
+                .as_ref()
+                .is_some_and(|(_, phase)| matches!(phase, SshConnectionPhase::Connecting))
+        {
+            self.apply_ssh_phase(SshConnectionPhase::Connected);
+        }
         self.redraw_needed = true;
     }
 
@@ -1659,12 +1981,22 @@ impl NorenApp {
                 }
                 PtyEvent::Eof => {
                     self.pty_child = PtyChildStatus::Exited { code: None };
-                    terminal_status = Some("Noren shell reached EOF");
-                    break;
+                    if self.ssh_live() {
+                        // The reader hit EOF; the supervisor's reaped exit
+                        // event follows within one poll. Wait for it (and
+                        // its honest code) instead of guessing now.
+                        self.ssh_eof_since.get_or_insert(Instant::now());
+                    } else {
+                        terminal_status = Some("Noren shell reached EOF");
+                    }
                 }
                 PtyEvent::Exited { code } => {
                     self.pty_child = PtyChildStatus::Exited { code };
-                    terminal_status = Some(if code == Some(0) {
+                    terminal_status = Some(if self.ssh_live() {
+                        let phase = ssh_exit_observation(code);
+                        self.apply_ssh_phase(phase);
+                        phase.status_text()
+                    } else if code == Some(0) {
                         "Noren shell exited"
                     } else {
                         "Noren shell exited with failure"
@@ -1672,9 +2004,26 @@ impl NorenApp {
                     break;
                 }
                 PtyEvent::Error(_) => {
-                    terminal_status = Some("Noren PTY operation failed");
+                    terminal_status = Some(if self.ssh_live() {
+                        self.apply_ssh_phase(SshConnectionPhase::Disconnected);
+                        SSH_STATUS_DISCONNECTED
+                    } else {
+                        "Noren PTY operation failed"
+                    });
                     break;
                 }
+            }
+        }
+        // An ssh child whose reaped exit never arrived after EOF is an
+        // immediate disconnect; surface it rather than waiting forever.
+        if terminal_status.is_none()
+            && let Some(eof_since) = self.ssh_eof_since
+            && eof_since.elapsed() >= SSH_EOF_REAP_GRACE
+        {
+            self.ssh_eof_since = None;
+            if self.ssh_live() {
+                self.apply_ssh_phase(SshConnectionPhase::Disconnected);
+                terminal_status = Some(SSH_STATUS_DISCONNECTED);
             }
         }
         // Any output may have moved or overwritten the selected content; the
@@ -1695,6 +2044,7 @@ impl NorenApp {
         self.status = status;
         self.show_status = true;
         self.redraw_needed = true;
+        self.ssh_eof_since = None;
         if let Some(id) = self.active_session.take() {
             let code = match self.pty_child {
                 PtyChildStatus::Exited { code } => code.map(|c| c as i32),

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -2207,7 +2207,10 @@ fn included_ssh_host_selection_shows_bounded_root_relative_provenance() {
     fixture.write_new(b"Include included.conf\nHost root-only\n");
     fixture.write_sibling_new("included.conf", b"Host remote\n");
 
-    let mut app = NorenApp::default();
+    // The click attempts a real launch; the deterministic seam disables the
+    // spawn so this test observes the provenance line plus the observed
+    // launch phase without starting any process.
+    let mut app = app_with_deterministic_ssh_seam();
     app.load_ssh_hosts_from(fixture.path());
     assert_eq!(app.workspace.ssh_hosts[0].source_label, "included.conf #1");
     app.cursor_position = Some(PhysicalPosition::new(5.0, 1.0));
@@ -2219,7 +2222,7 @@ fn included_ssh_host_selection_shows_bounded_root_relative_provenance() {
     ));
     assert_eq!(
         app.ssh_selection_status.as_deref(),
-        Some("SSH partial source #1 included.conf; offline")
+        Some("SSH partial source #1 included.conf; launch failed")
     );
     assert!(
         !app.ssh_selection_status
@@ -2590,11 +2593,13 @@ fn ssh_rows_stay_distinguishable_from_local_rows() {
 }
 
 #[test]
-fn selecting_an_ssh_row_only_records_a_pending_non_connection_choice() {
+fn selecting_an_ssh_row_keeps_a_pending_choice_and_never_a_registry_connection() {
     let fixture = SshConfigFixture::new();
     fixture.write_new(b"Host staging\n");
 
-    let mut app = NorenApp::default();
+    // Deterministic seam: the click path attempts the launch, and the
+    // disabled spawn reports the attempt's failure without any process.
+    let mut app = app_with_deterministic_ssh_seam();
     app.load_ssh_hosts_from(fixture.path());
     app.workspace.create_session(SessionKind::Local);
     app.cursor_position = Some(PhysicalPosition::new(5.0, 25.0));
@@ -2607,7 +2612,10 @@ fn selecting_an_ssh_row_only_records_a_pending_non_connection_choice() {
     assert_eq!(app.workspace.selected_ssh_target(), Some("staging"));
     assert_eq!(app.workspace.registry().selected(), None);
     assert_eq!(app.workspace.registry().len(), 1);
-    assert!(app.pty.is_none(), "SSH selection must not open a PTY");
+    assert!(
+        app.pty.is_none(),
+        "the deterministic seam must leave no PTY behind"
+    );
     app.show_status = false;
     let source = app.status_row();
     assert_eq!(source, StatusRowSource::SshSelection);
@@ -2617,7 +2625,7 @@ fn selecting_an_ssh_row_only_records_a_pending_non_connection_choice() {
             app.ssh_selection_status.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
-        "SSH partial source #0 config; offline"
+        "SSH partial source #0 config; launch failed"
     );
     assert!(
         app.workspace.sidebar().viewport().is_none(),
@@ -2629,7 +2637,7 @@ fn selecting_an_ssh_row_only_records_a_pending_non_connection_choice() {
 fn ssh_selection_does_not_hide_a_runtime_failure() {
     let fixture = SshConfigFixture::new();
     fixture.write_new(b"Host staging\n");
-    let mut app = NorenApp::default();
+    let mut app = app_with_deterministic_ssh_seam();
     app.load_ssh_hosts_from(fixture.path());
     app.finish_pty("Noren PTY operation failed");
     app.cursor_position = Some(PhysicalPosition::new(5.0, 1.0));
@@ -2651,7 +2659,7 @@ fn partial_undrawn_sidebar_row_cannot_select_a_hidden_ssh_entry() {
     let fixture = SshConfigFixture::new();
     fixture.write_new(b"Host visible\nHost hidden\n");
 
-    let mut app = NorenApp::default();
+    let mut app = app_with_deterministic_ssh_seam();
     app.load_ssh_hosts_from(fixture.path());
     assert_eq!(app.workspace.sidebar().rows().len(), 2);
 
@@ -2704,7 +2712,7 @@ fn partial_undrawn_sidebar_row_cannot_select_a_hidden_ssh_entry() {
 fn sidebar_scroll_reveals_and_selects_ssh_without_terminal_mouse_output() {
     let fixture = SshConfigFixture::new();
     fixture.write_new(b"Host alpha\nHost beta\nHost gamma\n");
-    let mut app = NorenApp::default();
+    let mut app = app_with_deterministic_ssh_seam();
     for _ in 0..3 {
         let _ = app.workspace.registry.restore(SessionKind::Local);
     }
@@ -3675,4 +3683,335 @@ fn single_instance_save_has_no_persistence_false_alarm() {
     let saved = std::fs::read(&path).expect("read exact verified save");
     assert!(!saved.is_empty(), "the real save path wrote a document");
     cleanup_state_file(&path);
+}
+
+// ── SSH connect: real launches, refusals, and visible failure states ──
+
+/// Test constructor with the deterministic ssh spawn seam disabled: the
+/// click path runs its full validation and phase reporting without
+/// launching any process.
+fn app_with_deterministic_ssh_seam() -> NorenApp {
+    NorenApp {
+        ssh_spawn_enabled: false,
+        ..NorenApp::default()
+    }
+}
+
+/// Unique secret-shaped stand-in for a destination that could embed a
+/// credential. Any surface that prints it is a leak.
+fn ssh_secret_sentinel(tag: &str) -> String {
+    format!("NOREN-SSHCONN-{tag}-hunter2-{}", std::process::id())
+}
+
+#[test]
+fn ssh_click_surfaces_launch_failure_when_no_child_can_spawn() {
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host web\n");
+    let mut app = app_with_deterministic_ssh_seam();
+    app.load_ssh_hosts_from(fixture.path());
+    app.cursor_position = Some(PhysicalPosition::new(5.0, 1.0));
+
+    assert!(app.handle_sidebar_click_in_frame(
+        ElementState::Pressed,
+        MouseButton::Left,
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    ));
+
+    // The failure is first-class: runtime status row, provenance line, and
+    // the sidebar row all carry the launch failure.
+    assert_eq!(app.status, "Noren ssh launch failed");
+    assert!(app.show_status, "the launch failure must be visible");
+    assert_eq!(
+        app.ssh_selection_status.as_deref(),
+        Some("SSH partial source #0 config; launch failed")
+    );
+    let row = &app.workspace.sidebar().rows()[0];
+    assert_eq!(row.label(), "SSH-ERR web");
+    assert_eq!(row.detail(), Some("launch failed"));
+    assert!(
+        app.pty.is_none(),
+        "a failed launch must leave no PTY behind"
+    );
+    assert!(
+        app.workspace.registry().sessions().is_empty(),
+        "the refused registry must record no session"
+    );
+}
+
+#[test]
+fn ssh_click_refuses_a_raw_token_destination_without_spawning() {
+    let secret = ssh_secret_sentinel("TOKEN");
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(format!("Host %p-{secret}\n").as_bytes());
+    let mut app = app_with_deterministic_ssh_seam();
+    app.load_ssh_hosts_from(fixture.path());
+    app.cursor_position = Some(PhysicalPosition::new(5.0, 1.0));
+
+    assert!(app.handle_sidebar_click_in_frame(
+        ElementState::Pressed,
+        MouseButton::Left,
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    ));
+
+    let status = app
+        .ssh_selection_status
+        .as_deref()
+        .expect("the typed refusal is visible");
+    assert!(
+        status.contains("%p"),
+        "the refusal must name the token: {status}"
+    );
+    assert!(
+        status.contains("Port"),
+        "the refusal must name the keyword: {status}"
+    );
+    assert!(
+        !status.contains(&secret),
+        "the refusal must never carry destination content: {status}"
+    );
+    // The connect did not proceed.
+    assert!(app.pty.is_none(), "a refused destination must not spawn");
+    assert!(app.workspace.ssh_connection.is_none());
+    let row = &app.workspace.sidebar().rows()[0];
+    assert!(
+        row.label().starts_with("SSH-OFF "),
+        "the row must stay disconnected: {}",
+        row.label()
+    );
+    assert_eq!(row.detail(), Some("not connected"));
+    // No debug surface may print the destination either.
+    assert!(!format!("{:?}", app.workspace).contains(&secret));
+}
+
+#[test]
+fn ssh_exit_observation_maps_every_child_outcome_to_a_visible_phase() {
+    assert_eq!(
+        ssh_exit_observation(Some(0)),
+        SshConnectionPhase::Closed,
+        "a clean ssh exit is a close, not a failure"
+    );
+    for code in [1, 127, 255] {
+        assert_eq!(
+            ssh_exit_observation(Some(code)),
+            SshConnectionPhase::ConnectFailed,
+            "exit {code} is an unreachable-host/auth/disconnect failure"
+        );
+    }
+    assert_eq!(
+        ssh_exit_observation(None),
+        SshConnectionPhase::Disconnected,
+        "a code-less end is an immediate disconnect"
+    );
+    assert_eq!(ssh_launch_observation(true), SshConnectionPhase::Connecting);
+    assert_eq!(
+        ssh_launch_observation(false),
+        SshConnectionPhase::LaunchFailed,
+        "a failed spawn must never report success"
+    );
+
+    for phase in [
+        SshConnectionPhase::Connecting,
+        SshConnectionPhase::Connected,
+        SshConnectionPhase::Closed,
+        SshConnectionPhase::LaunchFailed,
+        SshConnectionPhase::ConnectFailed,
+        SshConnectionPhase::Disconnected,
+    ] {
+        assert!(!phase.status_text().is_empty());
+        assert!(!phase.sidebar_detail().is_empty());
+        assert_eq!(
+            phase.sidebar_prefix().chars().count(),
+            SSH_SIDEBAR_LABEL_PREFIX_CHARS,
+            "the prefix must keep the fixed label arithmetic"
+        );
+        assert!(phase.sidebar_prefix().starts_with("SSH-"));
+    }
+}
+
+#[test]
+fn ssh_sidebar_state_prefixes_encode_the_connection_phase() {
+    assert_eq!(
+        ssh_state_label(SshConnectionPhase::Connected, "abcdef"),
+        "SSH-ON  abcdef"
+    );
+    assert_eq!(
+        ssh_state_label(SshConnectionPhase::Connecting, "abcdefg"),
+        "SSH-ON  abc..."
+    );
+    assert_eq!(
+        ssh_state_label(SshConnectionPhase::ConnectFailed, "abcdefg"),
+        "SSH-ERR abc..."
+    );
+    assert_eq!(
+        ssh_state_label(SshConnectionPhase::Disconnected, "abcdef"),
+        "SSH-ERR abcdef"
+    );
+    assert_eq!(
+        ssh_state_label(SshConnectionPhase::Closed, "abcdefg"),
+        "SSH-OFF abc..."
+    );
+    // Long targets stay bounded in every phase.
+    for phase in [
+        SshConnectionPhase::Connecting,
+        SshConnectionPhase::Connected,
+        SshConnectionPhase::Closed,
+        SshConnectionPhase::LaunchFailed,
+        SshConnectionPhase::ConnectFailed,
+        SshConnectionPhase::Disconnected,
+    ] {
+        let label = ssh_state_label(phase, &"x".repeat(2048));
+        assert_eq!(label.chars().count(), SSH_SIDEBAR_LABEL_CHARS);
+    }
+}
+
+#[test]
+fn ssh_connection_marker_identifies_only_the_exact_connected_target() {
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host abcdef-first\nHost abcdef-second\n");
+    let mut workspace = WorkspaceState::new();
+    let config = SshConfig::read(fixture.path()).expect("bounded SSH fixture parses");
+    workspace.load_ssh_config(&config);
+
+    workspace.set_ssh_connection("abcdef-second", SshConnectionPhase::Connected);
+    let rows = workspace.sidebar().rows();
+    assert!(
+        rows[0].label().starts_with("SSH-OFF "),
+        "{}",
+        rows[0].label()
+    );
+    assert!(
+        rows[1].label().starts_with("SSH-ON  "),
+        "{}",
+        rows[1].label()
+    );
+    assert_eq!(rows[1].detail(), Some("connected"));
+
+    workspace.set_ssh_connection("abcdef-second", SshConnectionPhase::ConnectFailed);
+    let rows = workspace.sidebar().rows();
+    assert!(
+        rows[1].label().starts_with("SSH-ERR "),
+        "{}",
+        rows[1].label()
+    );
+    assert_eq!(rows[1].detail(), Some("connection failed"));
+}
+
+#[test]
+fn ssh_connect_flow_never_persists_or_debug_prints_the_destination() {
+    let secret = ssh_secret_sentinel("PERSIST");
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(format!("Host {secret}\n").as_bytes());
+    let path = temp_state_path();
+    let mut workspace = WorkspaceState::with_state_path(Some(path.clone()));
+    let local = workspace.create_session(SessionKind::Local);
+    workspace.observe_session(local, SessionStatus::Running);
+    let config = SshConfig::read(fixture.path()).expect("bounded SSH fixture parses");
+    workspace.load_ssh_config(&config);
+
+    // The full connect path's workspace writes: pending selection, live
+    // connection, observed failure. Row 1 is the host row: the local
+    // session occupies row 0.
+    assert!(workspace.select_ssh_sidebar_row(1));
+    workspace.set_ssh_connection(&secret, SshConnectionPhase::Connecting);
+    workspace.set_ssh_connection(&secret, SshConnectionPhase::ConnectFailed);
+    workspace.persist();
+
+    let written = std::fs::read_to_string(&path).expect("the real save path wrote a document");
+    assert!(
+        !written.contains(&secret),
+        "the persisted sessions.toml must never carry the destination: {written}"
+    );
+    assert!(
+        !written.contains("kind = \"ssh\""),
+        "an SSH launch must never enter the persisted registry: {written}"
+    );
+    assert!(
+        !format!("{workspace:?}").contains(&secret),
+        "no debug surface may carry the destination"
+    );
+    assert!(
+        workspace
+            .registry()
+            .sessions()
+            .iter()
+            .all(|descriptor| !matches!(descriptor.kind(), SessionKind::Ssh { .. })),
+        "the live registry records no SSH session for the launch"
+    );
+    cleanup_state_file(&path);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn ssh_click_connects_the_system_client_end_to_end() {
+    // The alias begins with `@`, which the system ssh client rejects during
+    // its own argument parsing: the launch, the interactive I/O path, and
+    // the failure mapping are all observed with no network access and no
+    // credential.
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host @noren-refuse\n");
+    let mut app = NorenApp::default();
+    app.load_ssh_hosts_from(fixture.path());
+    app.terminal = Some(TerminalState::new(24, 80).expect("valid grid"));
+    app.cursor_position = Some(PhysicalPosition::new(5.0, 1.0));
+
+    assert!(app.handle_sidebar_click_in_frame(
+        ElementState::Pressed,
+        MouseButton::Left,
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    ));
+
+    // The click spawned the real system ssh client in the terminal's PTY.
+    assert!(
+        app.pty.is_some(),
+        "the click must launch the system ssh client"
+    );
+    assert_eq!(
+        app.workspace.ssh_connection.as_ref().map(|(_, p)| *p),
+        Some(SshConnectionPhase::Connecting)
+    );
+    assert_eq!(app.status, "Noren ssh connecting");
+
+    // Pump the production drain loop until the child's failure surfaces.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        app.drain_pty();
+        let phase = app.workspace.ssh_connection.as_ref().map(|(_, p)| *p);
+        if matches!(
+            phase,
+            Some(
+                SshConnectionPhase::ConnectFailed
+                    | SshConnectionPhase::Disconnected
+                    | SshConnectionPhase::Closed
+            )
+        ) || std::time::Instant::now() >= deadline
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+
+    assert_eq!(
+        app.workspace
+            .ssh_connection
+            .as_ref()
+            .map(|(_, phase)| *phase),
+        Some(SshConnectionPhase::ConnectFailed),
+        "ssh's own error exit must surface as a connection failure"
+    );
+    assert_eq!(app.status, "Noren ssh connection failed");
+    assert!(app.show_status, "the failure must own the status row");
+    assert!(app.pty.is_none(), "the failed child's PTY is retired");
+
+    // ssh's own usage diagnostic flowed through the normal terminal path.
+    let snapshot = app.terminal.as_ref().expect("terminal present").snapshot();
+    let rendered: Vec<&str> = snapshot.lines().iter().map(String::as_str).collect();
+    assert!(
+        rendered.iter().any(|line| line.contains("usage:")),
+        "the ssh diagnostic must reach the terminal content"
+    );
+
+    // The sidebar row carries the failure state.
+    let row = &app.workspace.sidebar().rows()[0];
+    assert!(row.label().starts_with("SSH-ERR "), "{}", row.label());
+    assert_eq!(row.detail(), Some("connection failed"));
 }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4004,6 +4004,52 @@ fn ssh_click_surfaces_launch_failure_when_no_child_can_spawn() {
 }
 
 #[test]
+fn ssh_spawn_failure_never_retires_the_running_local_session() {
+    // Found by independent review: connect_ssh_target orders
+    // retire_live_terminal() inside the Ok arm only, but no test pinned it —
+    // a mutation moving the retire BEFORE the spawn attempt passed the whole
+    // suite. This seeds a real live session and forces the spawn's Err arm,
+    // so a failed ssh launch must leave the running local shell untouched.
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let live = registry_ids(&app)[0];
+    assert!(app.pty.is_some(), "a live local session is running");
+
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host web\n");
+    app.ssh_spawn_force_failure = true;
+    app.load_ssh_hosts_from(fixture.path());
+    // Row 0 is the live local session; the SSH host sits at row 1.
+    app.cursor_position = Some(PhysicalPosition::new(5.0, 25.0));
+
+    assert!(app.handle_sidebar_click_in_frame(
+        ElementState::Pressed,
+        MouseButton::Left,
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    ));
+
+    assert_eq!(
+        app.status, "Noren ssh launch failed",
+        "the failure is surfaced first-class"
+    );
+    assert!(
+        app.pty.is_some(),
+        "a failed ssh spawn must not tear down the running local shell"
+    );
+    assert_eq!(
+        app.active_session,
+        Some(live),
+        "the local session keeps the live view"
+    );
+    assert_eq!(
+        session_status(&app, live),
+        SessionStatus::Running,
+        "the local session is not observed Exiting behind a failed launch"
+    );
+}
+
+#[test]
 fn ssh_click_refuses_a_raw_token_destination_without_spawning() {
     let secret = ssh_secret_sentinel("TOKEN");
     let fixture = SshConfigFixture::new();
@@ -4201,6 +4247,10 @@ fn ssh_connect_flow_never_persists_or_debug_prints_the_destination() {
             .iter()
             .all(|descriptor| !matches!(descriptor.kind(), SessionKind::Ssh { .. })),
         "the live registry records no SSH session for the launch"
+    );
+    cleanup_state_file(&path);
+}
+
 // ── Live multi-session bookkeeping (supervisor-backed switching, slice 1) ──
 //
 // The palette's `session_create` now spawns a real `/bin/zsh` PTY per row.
@@ -4508,6 +4558,8 @@ fn ssh_click_connects_the_system_client_end_to_end() {
     let row = &app.workspace.sidebar().rows()[0];
     assert!(row.label().starts_with("SSH-ERR "), "{}", row.label());
     assert_eq!(row.detail(), Some("connection failed"));
+}
+
 // ── Sidebar switching (supervisor-backed switching, slice 2) ────────────
 
 /// Whether the session owns a live surface: it is the active one or parked.

--- a/crates/noren-app/tests/ssh_security_no_leak.rs
+++ b/crates/noren-app/tests/ssh_security_no_leak.rs
@@ -1,0 +1,227 @@
+//! SSH-connect sentinel verification: a destination that could embed a
+//! credential must never surface in an error `Display`, a `Debug` print, or
+//! the persisted `sessions.toml` document, and Noren's parsed model must
+//! never adopt `ProxyCommand` content.
+//!
+//! Modeled on `tests/security_no_leak.rs` (TM-08): one unique sentinel is
+//! planted into each named channel and every observable surface is scanned
+//! for it. The scanner is self-tested against a planted leak so the suite
+//! cannot pass vacuously. The channels here are the ones the SSH connect
+//! slice owns:
+//!
+//! - **Destination errors** — a secret-shaped destination is pushed through
+//!   every refusal class of `noren_pty::SshDestination`, and both `Display`
+//!   and `Debug` of the typed error are scanned.
+//! - **Launch policy debug** — `SshDestination` and `SshLaunchPolicy` debug
+//!   prints are redacted by construction and scanned here.
+//! - **Persisted session state** — `session_persistence::encode` output for
+//!   a registry that the connect flow could have produced is scanned; the
+//!   connect path records SSH launches outside the registry, so an encoder
+//!   that suddenly carried a destination would fail this test.
+//! - **Parsed SSH configuration** — a `ProxyCommand` (and a
+//!   `ProxyCommand`-bearing HostName) is parsed; the parsed model must keep
+//!   the host discoverable while retaining none of the command, and the
+//!   parser's error surfaces must not echo it either. Noren never executes
+//!   proxy commands: they remain the system ssh binary's own trust boundary.
+
+use noren_app::session::{SessionKind, SessionRegistry, SessionStatus};
+use noren_app::session_persistence;
+use noren_app::ssh_config::SshConfig;
+use noren_pty::{SshDestination, SshDestinationError, SshLaunchPolicy, SshPercentToken};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// The unique secret-shaped value planted into every channel.
+fn sentinel() -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("the clock advances")
+        .as_nanos();
+    let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
+    format!("NOREN-SSHCONN-hunter2-{pid}-{nanos:x}-{nonce}")
+}
+
+/// The test logger contract: reject any sentinel fragment in `haystack`.
+fn leaked(haystack: &str, secret: &str) -> bool {
+    haystack.contains(secret)
+}
+
+/// The scanner must detect a planted leak, or a clean result would be
+/// meaningless (mirrors `scanner_flags_planted_leaks_and_accepts_clean_output`).
+#[test]
+fn scanner_flags_planted_leaks_and_accepts_clean_output() {
+    let secret = sentinel();
+    let clean = "SSH destination contains the unexpanded OpenSSH token %h \
+                 (HostName keyword); the connect must not proceed";
+    assert!(!leaked(clean, &secret));
+    assert!(leaked(&format!("refused destination {secret}"), &secret));
+}
+
+/// Every destination-refusal class must reject a secret-shaped destination
+/// without echoing it in `Display` or `Debug`.
+#[test]
+fn destination_refusals_never_echo_the_destination() {
+    let secret = sentinel();
+    let refusals: Vec<(String, SshDestinationError)> = vec![
+        (String::new(), SshDestinationError::Empty),
+        (format!("-{secret}"), SshDestinationError::LeadingHyphen),
+        (
+            format!("{secret} has space"),
+            SshDestinationError::ControlOrWhitespace,
+        ),
+        (
+            format!("{secret}\t"),
+            SshDestinationError::ControlOrWhitespace,
+        ),
+        (
+            format!("{secret}%h"),
+            SshDestinationError::RawToken {
+                token: SshPercentToken::Host,
+            },
+        ),
+        (
+            format!("%p{secret}"),
+            SshDestinationError::RawToken {
+                token: SshPercentToken::Port,
+            },
+        ),
+        (
+            format!("%r{secret}"),
+            SshDestinationError::RawToken {
+                token: SshPercentToken::RemoteUser,
+            },
+        ),
+    ];
+    for (destination, expected) in refusals {
+        let error =
+            SshDestination::new(&destination).expect_err("every planted destination is refused");
+        assert_eq!(error, expected, "the planted destination must be refused");
+        let display = error.to_string();
+        let debug = format!("{error:?}");
+        assert!(
+            !leaked(&display, &secret),
+            "refusal Display leaked the destination: {display}"
+        );
+        assert!(
+            !leaked(&debug, &secret),
+            "refusal Debug leaked the destination: {debug}"
+        );
+    }
+
+    // The oversize class with a long secret-shaped payload.
+    let oversized = format!("{}{}", sentinel(), "x".repeat(2048));
+    let error = SshDestination::new(&oversized).expect_err("oversize is refused");
+    assert_eq!(error, SshDestinationError::Oversize);
+    assert!(!leaked(&error.to_string(), &oversized[..32]));
+}
+
+/// The token-bearing refusal names the OpenSSH keyword and token while
+/// carrying none of the surrounding destination content.
+#[test]
+fn token_refusal_names_keyword_and_token_without_content() {
+    let secret = sentinel();
+    let cases = [
+        (
+            format!("user@%h.{secret}"),
+            SshPercentToken::Host,
+            "HostName",
+        ),
+        (format!("host:%p-{secret}"), SshPercentToken::Port, "Port"),
+        (
+            format!("%r.{secret}@host"),
+            SshPercentToken::RemoteUser,
+            "User",
+        ),
+    ];
+    for (destination, token, keyword) in cases {
+        let error =
+            SshDestination::new(&destination).expect_err("token-bearing destinations are refused");
+        let text = error.to_string();
+        assert!(text.contains(token.as_str()), "names the token: {text}");
+        assert!(text.contains(keyword), "names the keyword: {text}");
+        assert!(
+            !leaked(&text, &secret),
+            "carries no destination content: {text}"
+        );
+    }
+}
+
+/// A validated destination (and any policy over it) never prints itself:
+/// `Debug` is redacted by construction, scanned here with a secret-shaped
+/// target.
+#[test]
+fn destination_and_policy_debug_stay_redacted_for_secret_shaped_targets() {
+    let secret = sentinel();
+    let destination =
+        SshDestination::new(&format!("{secret}@web1.example")).expect("shape is valid");
+    let policy = SshLaunchPolicy::inherit(destination);
+    for inspected in [format!("{:?}", policy.destination()), format!("{policy:?}")] {
+        assert!(
+            !leaked(&inspected, &secret),
+            "debug surface leaked the destination: {inspected}"
+        );
+    }
+    // The accessor exists for argv construction; it is not a debug surface,
+    // and this assertion pins that nothing else grew content-bearing Debug.
+    assert_eq!(
+        policy.destination().as_str().len(),
+        secret.len() + "@web1.example".len()
+    );
+}
+
+/// The persisted sessions document never carries an SSH launch destination:
+/// the connect flow records launches outside the registry, so encoding the
+/// registry state the flow produces cannot mention the target.
+#[test]
+fn encoded_session_state_never_carries_an_ssh_launch_destination() {
+    let secret = sentinel();
+    let mut registry = SessionRegistry::new();
+    // The registry shape a connect flow leaves behind: the previous local
+    // session observed to a terminal status, and nothing else.
+    let local = registry.create(SessionKind::Local);
+    registry
+        .observe(local, SessionStatus::Exited { code: Some(0) })
+        .expect("a monotonic observation");
+    let encoded = session_persistence::encode(&registry).expect("the registry encodes");
+    assert!(
+        !leaked(&encoded, &secret),
+        "sessions.toml content leaked the destination: {encoded}"
+    );
+    assert!(
+        !encoded.contains("kind = \"ssh\""),
+        "no SSH launch may enter the persisted document: {encoded}"
+    );
+}
+
+/// Noren's parsed SSH model never adopts ProxyCommand content: the host stays
+/// discoverable, no fact carries the command, and no error surface echoes it.
+/// Executing a proxy command remains the system ssh binary's own trust
+/// boundary over the user's own configuration; Noren only passes the alias.
+#[test]
+fn parsed_model_never_adopts_proxycommand_content() {
+    let secret = sentinel();
+    let text = format!(
+        "Host proxied\n  ProxyCommand /bin/sh -c '{secret} %h %p'\n  HostName proxied.example\n"
+    );
+    let config = SshConfig::parse(&text).expect("ProxyCommand remains syntactically opaque");
+    let hosts = config.hosts();
+    assert_eq!(hosts.len(), 1, "the host stays discoverable");
+    assert_eq!(hosts[0].alias(), "proxied");
+    assert_eq!(hosts[0].host_name(), Some("proxied.example"));
+    // No fact of the parsed model carries the command text.
+    let model = format!("{config:?}");
+    assert!(
+        !leaked(&model, &secret),
+        "the parsed model leaked ProxyCommand content: {model}"
+    );
+
+    // The parser's own failure path (a malformed directive beside a
+    // ProxyCommand) never echoes the command either.
+    let broken = format!("Host broken\nPort nope\nProxyCommand {secret}\n");
+    let error = SshConfig::parse(&broken).expect_err("the malformed Port fails the parse");
+    assert!(!leaked(&error.to_string(), &secret));
+    assert!(!leaked(&format!("{error:?}"), &secret));
+}

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -9,7 +9,9 @@
 //! The SSH launch path drives the system `ssh` binary only. Noren never
 //! reimplements the SSH protocol and never passes a credential, key, or
 //! password on the command line: argv is exactly `ssh -- <destination>`, and
-//! authentication relies on ssh's own agent and configuration resolution.
+//! authentication relies on ssh's own agent and configuration resolution. A
+//! destination is accepted only through [`SshDestination`], whose typed
+//! refusals carry no destination content.
 
 use portable_pty::{CommandBuilder, PtySize as PortablePtySize, native_pty_system};
 use std::ffi::OsString;
@@ -180,39 +182,155 @@ fn build_zsh_command(policy: &ZshLaunchPolicy) -> CommandBuilder {
     command
 }
 
+/// An unexpanded OpenSSH percent token found in a destination.
+///
+/// OpenSSH expands these inside configuration keywords (never in the
+/// destination argument), so a token that survived into the destination
+/// string is by definition unexpanded. Each token names the keyword whose
+/// value could have carried it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SshPercentToken {
+    /// `%h`: the remote hostname, as written in a `HostName` value.
+    Host,
+    /// `%p`: the remote port, as written in a `Port`-derived value.
+    Port,
+    /// `%r`: the remote username, as written in a `User` value.
+    RemoteUser,
+}
+
+impl SshPercentToken {
+    /// The literal OpenSSH token spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Host => "%h",
+            Self::Port => "%p",
+            Self::RemoteUser => "%r",
+        }
+    }
+
+    /// The configuration keyword whose value could have carried this token.
+    #[must_use]
+    pub const fn keyword(self) -> &'static str {
+        match self {
+            Self::Host => "HostName",
+            Self::Port => "Port",
+            Self::RemoteUser => "User",
+        }
+    }
+
+    /// The first token `destination` contains, if any.
+    ///
+    /// The scan is deliberately conservative: it does not honour OpenSSH's
+    /// `%%` escaping, because a destination that merely contains a token
+    /// spelling has no legitimate origin in this application.
+    fn first_in(destination: &str) -> Option<Self> {
+        [Self::Host, Self::Port, Self::RemoteUser]
+            .into_iter()
+            .find(|token| destination.contains(token.as_str()))
+    }
+}
+
+impl fmt::Display for SshPercentToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Typed refusal of a destination string, carrying no destination content.
+///
+/// Every message is a fixed string: the rejected bytes never appear in an
+/// error, so a destination that happens to embed a secret cannot leak through
+/// `Display`, `Debug`, or a log line that prints either.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SshDestinationError {
+    /// The destination was empty.
+    Empty,
+    /// The destination exceeded [`MAX_SSH_DESTINATION_BYTES`].
+    Oversize,
+    /// The destination began with `-`, so ssh could parse it as an option.
+    LeadingHyphen,
+    /// The destination contained an ASCII control character or whitespace.
+    ControlOrWhitespace,
+    /// The destination contained an unexpanded OpenSSH percent token. The
+    /// connect must not proceed.
+    RawToken {
+        /// Which token was found.
+        token: SshPercentToken,
+    },
+}
+
+impl fmt::Display for SshDestinationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("SSH destination must not be empty"),
+            Self::Oversize => f.write_str("SSH destination exceeds its byte limit"),
+            Self::LeadingHyphen => f.write_str(
+                "SSH destination must not begin with a hyphen; ssh would parse it as an option",
+            ),
+            Self::ControlOrWhitespace => {
+                f.write_str("SSH destination must not contain control characters or whitespace")
+            }
+            Self::RawToken { token } => write!(
+                f,
+                "SSH destination contains the unexpanded OpenSSH token {} ({} keyword); \
+                 the connect must not proceed",
+                token.as_str(),
+                token.keyword()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SshDestinationError {}
+
 /// A validated SSH destination (`ssh -- <destination>` final argument).
 ///
 /// Validation is the argv-injection boundary, so it is deliberately stricter
 /// than what OpenSSH would accept: the destination must be non-empty, at most
 /// [`MAX_SSH_DESTINATION_BYTES`] bytes, free of ASCII control characters and
-/// whitespace, and must not begin with `-` (an alias like `-oProxyCommand=…`
+/// whitespace, must not begin with `-` (an alias like `-oProxyCommand=…`
 /// parsed out of a hostile `Host` directive must never reach argv as an
-/// option). Combined with the fixed `--` end-of-options marker, no accepted
-/// destination can be interpreted as an ssh option.
+/// option), and must not contain an unexpanded `%h`/`%p`/`%r` token (see
+/// [`SshPercentToken`]). Combined with the fixed `--` end-of-options marker,
+/// no accepted destination can be interpreted as an ssh option.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SshDestination {
     destination: String,
 }
 
 impl SshDestination {
-    /// Validate `destination` for the fixed ssh argv, or reject it.
-    #[must_use]
-    pub fn new(destination: &str) -> Option<Self> {
-        if destination.is_empty()
-            || destination.len() > MAX_SSH_DESTINATION_BYTES
-            || destination.starts_with('-')
-            || destination
-                .chars()
-                .any(|c| c.is_ascii_control() || c.is_whitespace())
-        {
-            return None;
+    /// Validate `destination` for the fixed ssh argv, or reject it with a
+    /// typed, content-free error.
+    pub fn new(destination: &str) -> Result<Self, SshDestinationError> {
+        if destination.is_empty() {
+            return Err(SshDestinationError::Empty);
         }
-        Some(Self {
+        if destination.len() > MAX_SSH_DESTINATION_BYTES {
+            return Err(SshDestinationError::Oversize);
+        }
+        if let Some(token) = SshPercentToken::first_in(destination) {
+            return Err(SshDestinationError::RawToken { token });
+        }
+        if destination.starts_with('-') {
+            return Err(SshDestinationError::LeadingHyphen);
+        }
+        if destination
+            .chars()
+            .any(|c| c.is_ascii_control() || c.is_whitespace())
+        {
+            return Err(SshDestinationError::ControlOrWhitespace);
+        }
+        Ok(Self {
             destination: destination.to_owned(),
         })
     }
 
     /// The validated destination string.
+    ///
+    /// This accessor exists to build the child argv, not for display: the
+    /// [`fmt::Debug`] implementation is redacted so a destination that embeds
+    /// a secret can never reach a log through a debug print.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.destination
@@ -221,27 +339,26 @@ impl SshDestination {
 
 impl fmt::Debug for SshDestination {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The destination is the public connection target shown in the UI;
-        // it is not a credential. Bound the Debug form so an oversized value
-        // can never flood a log line even if the length cap changes.
-        let inspected: Vec<char> = self.destination.chars().take(80).collect();
+        // The destination may embed a secret-shaped value and has no business
+        // in any debug surface, so it is redacted exactly like the zsh
+        // policy's home directory.
         f.debug_struct("SshDestination")
-            .field("destination", &inspected.into_iter().collect::<String>())
+            .field("destination", &"<redacted>")
             .finish()
     }
 }
 
 /// Fixed system-ssh launch policy.
 ///
-/// Production inherits the caller's environment unchanged (except the fixed
-/// `TERM`/`TERM_PROGRAM` overrides below) so ssh performs its own agent,
-/// key, and config resolution. The optional home override exists only for the
-/// crate-local test harness, mirroring [`ZshLaunchPolicy`]'s isolated-home
-/// seam; it never mutates process-global environment.
+/// The child inherits the caller's environment unchanged (except the fixed
+/// `TERM`/`TERM_PROGRAM` overrides below) so ssh performs its own agent, key,
+/// and config resolution. There is deliberately no home-override seam like
+/// [`ZshLaunchPolicy`]'s: OpenSSH resolves its per-user configuration through
+/// the passwd database rather than `$HOME`, so an env override would not
+/// isolate anything while suggesting it does.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SshLaunchPolicy {
     destination: SshDestination,
-    home: Option<PathBuf>,
 }
 
 impl SshLaunchPolicy {
@@ -249,10 +366,7 @@ impl SshLaunchPolicy {
     /// agent environment from this process.
     #[must_use]
     pub fn inherit(destination: SshDestination) -> Self {
-        Self {
-            destination,
-            home: None,
-        }
+        Self { destination }
     }
 
     /// The validated destination this policy connects to.
@@ -266,7 +380,6 @@ impl fmt::Debug for SshLaunchPolicy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SshLaunchPolicy")
             .field("destination", &self.destination)
-            .field("home", &"<inherited>")
             .finish()
     }
 }
@@ -281,9 +394,6 @@ fn build_ssh_command(policy: &SshLaunchPolicy) -> CommandBuilder {
     let mut command = CommandBuilder::new(SSH_PROGRAM);
     command.arg(SSH_END_OF_OPTIONS);
     command.arg(policy.destination.as_str());
-    if let Some(home) = &policy.home {
-        command.env("HOME", home);
-    }
     command.env("TERM", TERM_VALUE);
     command.env("TERM_PROGRAM", TERM_PROGRAM_VALUE);
     command.env_remove("COLUMNS");
@@ -580,7 +690,7 @@ fn validate_reply(bytes: &[u8]) -> Result<(), PtyError> {
 }
 
 fn supervisor_main(
-    policy: ZshLaunchPolicy,
+    command: CommandBuilder,
     size: PtySize,
     command_rx: Receiver<SupervisorCommand>,
     event_tx: SyncSender<PtyEvent>,
@@ -588,7 +698,7 @@ fn supervisor_main(
     done_tx: SyncSender<Result<(), PtyError>>,
     closing: Arc<AtomicBool>,
 ) {
-    let setup = setup_pty(&policy, size, &event_tx, Arc::clone(&closing));
+    let setup = setup_pty(command, size, &event_tx, Arc::clone(&closing));
     let (master, writer, mut child, reader, reader_done) = match setup {
         Ok(parts) => {
             let _ = ready_tx.send(Ok(()));
@@ -734,7 +844,7 @@ type PtyParts = (
 );
 
 fn setup_pty(
-    policy: &ZshLaunchPolicy,
+    command: CommandBuilder,
     size: PtySize,
     event_tx: &SyncSender<PtyEvent>,
     closing: Arc<AtomicBool>,
@@ -753,7 +863,6 @@ fn setup_pty(
     let writer = pair.master.take_writer().map_err(|_| PtyError::Backend {
         operation: PtyOperation::TakeWriter,
     })?;
-    let command = build_zsh_command(policy);
     let mut child = pair
         .slave
         .spawn_command(command)
@@ -1019,6 +1128,229 @@ mod tests {
         assert_eq!(command.get_env("COLUMNS"), None);
         assert_eq!(command.get_env("LINES"), None);
         fs::remove_dir(directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn ssh_destination_accepts_plain_targets_and_rejects_injection_classes() {
+        assert!(SshDestination::new("web1.example").is_ok());
+        assert!(SshDestination::new("user@10.0.0.9").is_ok());
+        assert!(SshDestination::new(&"a".repeat(MAX_SSH_DESTINATION_BYTES)).is_ok());
+
+        assert_eq!(SshDestination::new(""), Err(SshDestinationError::Empty));
+        assert_eq!(
+            SshDestination::new(&"a".repeat(MAX_SSH_DESTINATION_BYTES + 1)),
+            Err(SshDestinationError::Oversize)
+        );
+        assert_eq!(
+            SshDestination::new("-oProxyCommand=evil"),
+            Err(SshDestinationError::LeadingHyphen)
+        );
+        for rejected in [
+            "space here",
+            "tab\there",
+            "nl\nhere",
+            "nul\0here",
+            "esc\u{1b}here",
+        ] {
+            assert_eq!(
+                SshDestination::new(rejected),
+                Err(SshDestinationError::ControlOrWhitespace),
+                "control/whitespace destination must be rejected: {rejected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ssh_destination_rejects_every_unexpanded_percent_token_by_keyword() {
+        assert_eq!(
+            SshDestination::new("user@%h.example"),
+            Err(SshDestinationError::RawToken {
+                token: SshPercentToken::Host
+            })
+        );
+        assert_eq!(
+            SshDestination::new("host.example:%p"),
+            Err(SshDestinationError::RawToken {
+                token: SshPercentToken::Port
+            })
+        );
+        assert_eq!(
+            SshDestination::new("%r@host.example"),
+            Err(SshDestinationError::RawToken {
+                token: SshPercentToken::RemoteUser
+            })
+        );
+    }
+
+    #[test]
+    fn ssh_destination_error_messages_name_keyword_and_token_without_content() {
+        const SECRET: &str = "hunter2-token";
+
+        for (destination, token) in [
+            (format!("{SECRET}@%h.example"), SshPercentToken::Host),
+            (format!("host.example:%p-{SECRET}"), SshPercentToken::Port),
+            (
+                format!("%r-{SECRET}@host.example"),
+                SshPercentToken::RemoteUser,
+            ),
+        ] {
+            let error = SshDestination::new(&destination).expect_err("token-bearing destination");
+            let text = error.to_string();
+            assert!(
+                text.contains(token.as_str()),
+                "the message must name the token: {text}"
+            );
+            assert!(
+                text.contains(token.keyword()),
+                "the message must name the keyword: {text}"
+            );
+            assert!(
+                !text.contains(SECRET),
+                "the message must never carry destination content: {text}"
+            );
+            assert!(!format!("{error:?}").contains(SECRET));
+        }
+
+        for (destination, expected) in [
+            ("", SshDestinationError::Empty),
+            (
+                &"a".repeat(MAX_SSH_DESTINATION_BYTES + 1),
+                SshDestinationError::Oversize,
+            ),
+            ("-Wevil", SshDestinationError::LeadingHyphen),
+            ("a b", SshDestinationError::ControlOrWhitespace),
+        ] {
+            let error = SshDestination::new(destination).expect_err("rejected destination");
+            assert_eq!(error, expected);
+            assert!(error.to_string().starts_with("SSH destination"));
+            assert!(!error.to_string().contains("a".repeat(8).as_str()));
+        }
+    }
+
+    #[test]
+    fn ssh_destination_and_policy_debug_never_carry_the_destination() {
+        const SECRET: &str = "noren-debug-secret-9f21";
+
+        let destination =
+            SshDestination::new(&format!("{SECRET}@example.com")).expect("secret-shaped target");
+        assert!(!format!("{destination:?}").contains(SECRET));
+        assert!(format!("{destination:?}").contains("<redacted>"));
+
+        let policy = SshLaunchPolicy::inherit(destination);
+        let inspected = format!("{policy:?}");
+        assert!(
+            !inspected.contains(SECRET),
+            "debug must be redacted: {inspected}"
+        );
+        assert!(inspected.contains("<redacted>"));
+    }
+
+    #[test]
+    fn ssh_command_argv_is_exactly_the_fixed_program_marker_and_destination() {
+        let destination = SshDestination::new("deploy@web1.example").expect("valid destination");
+        let policy = SshLaunchPolicy::inherit(destination);
+        let command = build_ssh_command(&policy);
+
+        assert_eq!(
+            command.get_argv(),
+            &[
+                OsString::from(SSH_PROGRAM),
+                OsString::from(SSH_END_OF_OPTIONS),
+                OsString::from("deploy@web1.example"),
+            ]
+        );
+        assert!(
+            command.get_cwd().is_none(),
+            "the ssh launch must not pin a working directory"
+        );
+        assert_eq!(
+            command.get_env("TERM"),
+            Some(std::ffi::OsStr::new(TERM_VALUE))
+        );
+        assert_eq!(
+            command.get_env("TERM_PROGRAM"),
+            Some(std::ffi::OsStr::new(TERM_PROGRAM_VALUE))
+        );
+        assert_eq!(command.get_env("COLUMNS"), None);
+        assert_eq!(command.get_env("LINES"), None);
+        // The child's HOME is the caller's HOME, byte for byte: ssh's own
+        // agent and per-user configuration resolution must be inherited, not
+        // redirected.
+        assert_eq!(
+            command.get_env("HOME"),
+            std::env::var_os("HOME").as_deref(),
+            "the ssh launch must inherit HOME unchanged"
+        );
+    }
+
+    #[test]
+    fn ssh_command_argv_carries_no_credential_shaped_option() {
+        // Whatever the destination looks like, argv length is fixed at three
+        // and no argument can be interpreted as an option: the marker ends
+        // option parsing and the destination is the final argument.
+        for target in ["plain", "user@host", "host:2222", "equals=x", "quotes'q"] {
+            let destination = SshDestination::new(target).expect("valid destination");
+            let command = build_ssh_command(&SshLaunchPolicy::inherit(destination));
+            let argv = command.get_argv();
+            assert_eq!(argv.len(), 3, "argv must stay fixed for {target:?}");
+            assert_eq!(argv[0], OsString::from(SSH_PROGRAM));
+            assert_eq!(argv[1], OsString::from(SSH_END_OF_OPTIONS));
+            assert_eq!(argv[2], OsString::from(target));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_ssh_drives_the_system_client_and_surfaces_a_fast_failure() {
+        // Drive the real /usr/bin/ssh through the production argv. A
+        // destination beginning with `@` is rejected by ssh's own argument
+        // parsing before any name resolution or connection, so the process
+        // exits 255 with its usage diagnostic in milliseconds — deterministically,
+        // with no network access and no credential. The test observes the real
+        // fixed argv reaching the real binary and the failure flowing through
+        // the normal PTY output path.
+        const SSH_ARG_FAILURE: &str = "@noren-usage-refusal";
+
+        let destination = SshDestination::new(SSH_ARG_FAILURE).expect("valid destination");
+        let size = PtySize::from_raw(24, 80).expect("valid initial size");
+        let mut session = PtySession::spawn_ssh(SshLaunchPolicy::inherit(destination), size)
+            .expect("spawn the fixed system ssh client");
+
+        let mut output = Vec::new();
+        let mut saw_eof = false;
+        let mut exit_code: Option<u32> = None;
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && exit_code.is_none() {
+            match session.try_recv().expect("receive PTY event") {
+                Some(PtyEvent::Output(bytes)) => output.extend_from_slice(&bytes),
+                Some(PtyEvent::Eof) => saw_eof = true,
+                Some(PtyEvent::Exited { code }) => exit_code = code,
+                Some(PtyEvent::Error(error)) => panic!("unexpected typed PTY error: {error}"),
+                None => thread::sleep(Duration::from_millis(2)),
+            }
+        }
+
+        let code =
+            exit_code.unwrap_or_else(|| {
+                panic!(
+                    "the system ssh client must terminate after its usage refusal; eof={saw_eof} output={}",
+                    String::from_utf8_lossy(&output)
+                )
+            });
+        assert_eq!(
+            code, 255,
+            "ssh reports its own argument-parsing failure as its error exit"
+        );
+        assert!(
+            output.windows(b"usage:".len()).any(|w| w == b"usage:"),
+            "the ssh client's own diagnostic must flow through the normal PTY output path"
+        );
+        assert!(
+            saw_eof,
+            "the reader must observe EOF after the child terminates"
+        );
+        session.shutdown().expect("bounded shutdown after ssh exit");
+        session.shutdown().expect("shutdown remains idempotent");
     }
 
     #[test]

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -1,9 +1,15 @@
 //! Noren-owned process and PTY boundary for the macOS local-shell PoC.
 //!
 //! The public API deliberately exposes no `portable-pty` types. A session
-//! always launches `/bin/zsh` without caller-controlled arguments or `-c`,
-//! moves blocking I/O off the UI thread, bounds every queue and payload, and
-//! owns child termination and reaping in one supervisor thread.
+//! launches either the fixed `/bin/zsh` shell or the fixed system SSH client
+//! (`/usr/bin/ssh`) — in both cases without caller-controlled arguments or
+//! `-c`, moves blocking I/O off the UI thread, bounds every queue and payload,
+//! and owns child termination and reaping in one supervisor thread.
+//!
+//! The SSH launch path drives the system `ssh` binary only. Noren never
+//! reimplements the SSH protocol and never passes a credential, key, or
+//! password on the command line: argv is exactly `ssh -- <destination>`, and
+//! authentication relies on ssh's own agent and configuration resolution.
 
 use portable_pty::{CommandBuilder, PtySize as PortablePtySize, native_pty_system};
 use std::ffi::OsString;
@@ -31,6 +37,14 @@ pub const REPLY_BYTES_PER_SECOND: usize = 64 * 1024;
 pub const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(2);
 
 const ZSH_PROGRAM: &str = "/bin/zsh";
+/// Fixed system SSH client. An absolute path deliberately bypasses `PATH`
+/// so a writable `PATH` entry cannot substitute a different binary.
+const SSH_PROGRAM: &str = "/usr/bin/ssh";
+/// End-of-options marker. Combined with the destination validation this makes
+/// option injection through a hostile alias impossible, not just unlikely.
+const SSH_END_OF_OPTIONS: &str = "--";
+/// Maximum accepted SSH destination bytes before the launch is refused.
+const MAX_SSH_DESTINATION_BYTES: usize = 1024;
 const TERM_VALUE: &str = "xterm-256color";
 const TERM_PROGRAM_VALUE: &str = "Noren-PoC";
 const SUPERVISOR_POLL: Duration = Duration::from_millis(10);
@@ -166,6 +180,117 @@ fn build_zsh_command(policy: &ZshLaunchPolicy) -> CommandBuilder {
     command
 }
 
+/// A validated SSH destination (`ssh -- <destination>` final argument).
+///
+/// Validation is the argv-injection boundary, so it is deliberately stricter
+/// than what OpenSSH would accept: the destination must be non-empty, at most
+/// [`MAX_SSH_DESTINATION_BYTES`] bytes, free of ASCII control characters and
+/// whitespace, and must not begin with `-` (an alias like `-oProxyCommand=…`
+/// parsed out of a hostile `Host` directive must never reach argv as an
+/// option). Combined with the fixed `--` end-of-options marker, no accepted
+/// destination can be interpreted as an ssh option.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SshDestination {
+    destination: String,
+}
+
+impl SshDestination {
+    /// Validate `destination` for the fixed ssh argv, or reject it.
+    #[must_use]
+    pub fn new(destination: &str) -> Option<Self> {
+        if destination.is_empty()
+            || destination.len() > MAX_SSH_DESTINATION_BYTES
+            || destination.starts_with('-')
+            || destination
+                .chars()
+                .any(|c| c.is_ascii_control() || c.is_whitespace())
+        {
+            return None;
+        }
+        Some(Self {
+            destination: destination.to_owned(),
+        })
+    }
+
+    /// The validated destination string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.destination
+    }
+}
+
+impl fmt::Debug for SshDestination {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The destination is the public connection target shown in the UI;
+        // it is not a credential. Bound the Debug form so an oversized value
+        // can never flood a log line even if the length cap changes.
+        let inspected: Vec<char> = self.destination.chars().take(80).collect();
+        f.debug_struct("SshDestination")
+            .field("destination", &inspected.into_iter().collect::<String>())
+            .finish()
+    }
+}
+
+/// Fixed system-ssh launch policy.
+///
+/// Production inherits the caller's environment unchanged (except the fixed
+/// `TERM`/`TERM_PROGRAM` overrides below) so ssh performs its own agent,
+/// key, and config resolution. The optional home override exists only for the
+/// crate-local test harness, mirroring [`ZshLaunchPolicy`]'s isolated-home
+/// seam; it never mutates process-global environment.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SshLaunchPolicy {
+    destination: SshDestination,
+    home: Option<PathBuf>,
+}
+
+impl SshLaunchPolicy {
+    /// Launch the system ssh client to `destination`, inheriting HOME and the
+    /// agent environment from this process.
+    #[must_use]
+    pub fn inherit(destination: SshDestination) -> Self {
+        Self {
+            destination,
+            home: None,
+        }
+    }
+
+    /// The validated destination this policy connects to.
+    #[must_use]
+    pub fn destination(&self) -> &SshDestination {
+        &self.destination
+    }
+}
+
+impl fmt::Debug for SshLaunchPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SshLaunchPolicy")
+            .field("destination", &self.destination)
+            .field("home", &"<inherited>")
+            .finish()
+    }
+}
+
+/// Build the fixed ssh command. Security invariants, pinned by tests:
+///
+/// - argv is exactly `[SSH_PROGRAM, "--", destination]` — no options, so no
+///   credential, identity, or command can ever appear in argv (`ps`-visible).
+/// - `HOME` is not overridden (ssh needs the real agent/config resolution);
+///   `COLUMNS`/`LINES` are dropped exactly like the zsh policy.
+fn build_ssh_command(policy: &SshLaunchPolicy) -> CommandBuilder {
+    let mut command = CommandBuilder::new(SSH_PROGRAM);
+    command.arg(SSH_END_OF_OPTIONS);
+    command.arg(policy.destination.as_str());
+    if let Some(home) = &policy.home {
+        command.env("HOME", home);
+    }
+    command.env("TERM", TERM_VALUE);
+    command.env("TERM_PROGRAM", TERM_PROGRAM_VALUE);
+    command.env_remove("COLUMNS");
+    command.env_remove("LINES");
+    command
+}
+
 /// PTY operations named by payload-free errors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PtyOperation {
@@ -294,8 +419,23 @@ impl PtySession {
         Self::spawn_with_policy(ZshLaunchPolicy::from_environment()?, size)
     }
 
+    /// Spawn the fixed system ssh client for `destination` at the supplied
+    /// initial non-zero size, so the remote shell is interactive.
+    ///
+    /// argv is exactly `ssh -- <destination>` (see [`build_ssh_command`]);
+    /// no credential is ever passed on the command line and authentication is
+    /// left to ssh's own agent and configuration resolution.
+    pub fn spawn_ssh(policy: SshLaunchPolicy, size: PtySize) -> Result<Self, PtyError> {
+        Self::spawn_session(build_ssh_command(&policy), size)
+    }
+
     /// Spawn using an already validated fixed-zsh policy.
     fn spawn_with_policy(policy: ZshLaunchPolicy, size: PtySize) -> Result<Self, PtyError> {
+        Self::spawn_session(build_zsh_command(&policy), size)
+    }
+
+    /// Common bounded supervisor wiring for every fixed launch policy.
+    fn spawn_session(command: CommandBuilder, size: PtySize) -> Result<Self, PtyError> {
         let (command_tx, command_rx) = mpsc::sync_channel(COMMAND_CHANNEL_CAPACITY);
         let (event_tx, event_rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
         let (ready_tx, ready_rx) = mpsc::sync_channel(1);
@@ -307,7 +447,7 @@ impl PtySession {
             .name("noren-pty-supervisor".to_owned())
             .spawn(move || {
                 supervisor_main(
-                    policy,
+                    command,
                     size,
                     command_rx,
                     event_tx,

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -97,9 +97,11 @@ binary. What now actually happens on screen:
   `included_fifo_sources_return_promptly`).
 
 It is still **not** the full workspace product that [ADR
-0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — one local
-shell at a time; configured SSH targets are now discovered and selectable in
-the sidebar, but no non-local session can launch. See "What does not work"
+0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — one live
+PTY at a time; configured SSH targets are now discoverable in the sidebar, and
+selecting one launches the system `ssh` client for that alias in the single
+terminal PTY (one non-local launch path exists; there is still no
+multi-session switching). See "What does not work"
 below, which remains the more useful list. Milestones 3–8 are open on the
 [roadmap](../ROADMAP.md).
 
@@ -180,17 +182,24 @@ Each item states what you would actually see if you ran the build.
 - **Only the startup local session is actually launched.** `SessionKind` models
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
-  but only `Local` has a launch path. The running binary now reads bounded
-  OpenSSH configuration facts, constructs `SessionKind::Ssh`, and displays
-  configured targets as `SidebarEntry::SshConnection` rows. Clicking one only
-  records a pending target; it opens neither an SSH connection nor a PTY.
+  `Local` and `Ssh` have launch paths. The running binary reads bounded
+  OpenSSH configuration facts and displays configured targets as
+  `SidebarEntry::SshConnection` rows. Clicking one validates the alias as an
+  `SshDestination` (raw `%h`/`%p`/`%r` tokens are refused with a typed error
+  naming the keyword and token) and, if accepted, launches the fixed system
+  `/usr/bin/ssh` client in the single terminal PTY — argv is exactly
+  `ssh -- <alias>`, so no credential, identity, or option is ever
+  `ps`-visible — replacing the previous session. Launch, connect, and
+  disconnect failures surface as visible per-row and status-row states; the
+  alias never enters the persisted registry, so `sessions.toml` cannot carry
+  it. Authentication, agent, and config resolution (including the user's own
+  `ProxyCommand`) remain entirely ssh's own, executed by the system binary.
   Project and worktree kinds remain modelled, while agent entries remain
-  reserved fixtures and no agent is launched. In practice: startup owns exactly
-  one local `zsh`. The palette's "New Session" currently records another local
-  model row but does not spawn a PTY, and an inactive or restored row cannot
-  take the live PTY's selection/input ownership. There is no way to open an SSH
-  host, a git worktree, or an agent from the workspace. Milestones 4 and 5 own
-  the remaining work.
+  reserved fixtures and no agent is launched. The palette's "New Session"
+  currently records another local model row but does not spawn a PTY, and an
+  inactive or restored row cannot take the live PTY's selection/input
+  ownership. There is no way to open a git worktree or an agent from the
+  workspace. Milestones 4 and 5 own the remaining work.
 - **The SSH list is not OpenSSH-equivalent discovery.** A readable config can
   legitimately name destinations that do not appear: wildcard or negated
   patterns are matching policy rather than concrete aliases, `Match` and token


### PR DESCRIPTION
Resumed from `wip/sshconn-rl` by a coordinator subagent, then verified by the coordinator. Milestone 4 step 3 — the first slice that talks to the network. Note: the salvaged 144-line wip did not even compile (half-finished supervisor refactor); it was audited and finished, not trusted.

**Security boundary (both spec consultations' conclusions enforced):**
- argv is exactly `[/usr/bin/ssh, --, alias]` — no options, no credentials, ever. TERM/TERM_PROGRAM fixed, HOME inherited; ssh's own agent/config resolution does the rest. No crypto dependencies.
- ProxyCommand: never stored, never reconstructed, never executed by Noren (pinned by sentinel test; the user's own ssh config is the documented trust boundary, SEC-02).
- Raw %h/%p/%r tokens: typed destination refusal naming keyword and token; the connect does not proceed.
- No secret surfaces: fixed-constant error strings, redacted Debug on destination/policy types, SSH launches kept out of sessions.toml. Sentinel suite `tests/ssh_security_no_leak.rs` (modeled on #133's, self-tested scanner) + app-side sentinels.

**Visible failure states (4):** LaunchFailed, ConnectFailed (non-zero ssh exit — covers unreachable/auth), Disconnected (code-less EOF after a 2s reap grace so exit 255 is not misreported), and the typed destination refusal. Each marks the sidebar row (SSH-ERR + detail). First remote output promotes Connecting→Connected; the previous session is retired only after a successful spawn.

**Known blocked:** a successful interactive session against a real remote host is untestable here (no test credentials; sandbox DNS hangs verified). Live tests drive the REAL /usr/bin/ssh failing locally through the full production path (exit 255 in ~20ms, no network).

**Coordinator verification:** merged with current main first (the salvage base predated #136/#137 — the stacked-deletion trap, caught and resolved); fmt 0, clippy 0, 915 workspace tests pass, frame_oracle --ignored exactly 2 documented failures; mutation re-run by the coordinator — failed-spawn-reports-success fails 4 tests across the workspace.