### PR TITLE
feat(app): supervisor-backed session switching with real local PTYs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,9 +93,10 @@ Draft PRs, and current-head CI evidence.
 ## Milestone 3 status
 
 **In progress, not Complete.** The vertical slice reached the binary: launching
-the build now draws a workspace sidebar and starts one local PTY. The command
-palette operates on the session registry, but its additional rows are
-model-only and cannot take the live PTY's input ownership.
+the build now draws a workspace sidebar and starts one local PTY. Session
+switching is real for local sessions: palette-created rows spawn their own
+PTY, sidebar clicks and `session_select` move the live view between them, and
+`session_close` reaps the closed child.
 
 The milestone's own scope line is the test, so it is quoted here in full:
 
@@ -112,9 +113,9 @@ Measured against it, item by item:
 | Sidebar drawn | Done | `SIDEBAR_COLS` reserved in `renderer.rs`; `glyph_vertices` applies the column offset; `sidebar_text_lines` formats rows |
 | — projects, git worktrees | Modelled, not launchable | `EntryKind::Project`/`Worktree`, `SessionKind::Project`/`Worktree` exist; no runtime path creates them, though `parse_session` will reconstruct one from a hand-written `sessions.toml` `kind` field — nothing in the product writes such an entry |
 | — SSH connections, agents | Partial configured-target list, not connected; agents fixture only | At most 24 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and clicking shows bounded root-relative source provenance while opening no SSH connection or PTY; agent entries remain reserved |
-| — terminal sessions | Partial runtime | The running binary starts one `SessionKind::Local` PTY; palette-created rows are model entries only until supervisor-backed switching lands |
-| Single-session view | Done | The one live terminal is drawn beside the sidebar, narrowed to the remaining columns; inactive rows cannot claim its selection or input owner |
-| Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` |
+| — terminal sessions | Runtime for local sessions | Every palette `session_create` spawns a real `SessionKind::Local` PTY (`spawn_local_session`); sidebar clicks and the palette's `session_select` switch the live view between live sessions (`switch_live_session`, parked surfaces keep draining and resizing), and `session_close` reaps the closed child and repairs the view. Rows restored from disk come back `Restored` with no live surface and cannot take the live view |
+| Single-session view | Done | The active terminal is drawn beside the sidebar, narrowed to the remaining columns; switching swaps the active surface whole, and rows without a live surface cannot claim its selection or input owner |
+| Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` for spawned, parked, closed, and restored sessions alike |
 | Sidebar-state persistence | Done | `sessions.toml` (`SESSION_STATE_FILE_NAME`) under the `config::default_path` directory, resolved by `session_state_path` |
 | Palette | Done | `Super+p` via `palette_policy`; `Palette::noren`'s four commands dispatched by `handle_palette_key` |
 | Configurable keybindings | **Not started** | `palette_policy` and `handle_palette_key` hard-code the chords; `config.rs` exposes no keymap surface |
@@ -141,9 +142,9 @@ the Noren terminal." The reasoning and the decision are recorded in
 
 - **The workspace is a slice, not a product.** The Milestone 3 modules now
   reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
-  one startup session owns the live PTY while palette-created rows remain
-  model-only, mouse reports reach that PTY, and sidebar state persists across a
-  restart. What is still missing is breadth and real session switching —
+  local sessions spawn real PTYs that switch, park, and close through the
+  live view, mouse reports reach the active PTY, and sidebar state persists
+  across a restart. What is still missing is breadth —
   bounded OpenSSH configuration now produces an explicitly partial list of at
   most 24 positive literal aliases as `SessionKind::Ssh` values and
   `SidebarEntry::SshConnection` rows. The UI labels the discovery scope and

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -545,6 +545,13 @@ struct NorenApp {
     /// First workspace row currently visible in the bounded sidebar window.
     sidebar_scroll_offset: usize,
     active_session: Option<SessionId>,
+    /// The session whose final frame is still displayed after its child
+    /// exited. `finish_pty` clears `active_session` (input ownership dies
+    /// with the child) but keeps the terminal for the last frame; this field
+    /// remembers whose frame it is so closing that row runs the same
+    /// detach-and-fallback path an active close does, instead of leaving a
+    /// frozen frame behind a vanished row.
+    exited_surface_session: Option<SessionId>,
     /// Live sessions that are not the active one, keyed by session id.
     parked_sessions: HashMap<SessionId, ParkedSession>,
     /// Test-only override for the PTY child's home directory. Production
@@ -635,6 +642,7 @@ impl NorenApp {
             workspace: WorkspaceState::new(),
             sidebar_scroll_offset: 0,
             active_session: None,
+            exited_surface_session: None,
             parked_sessions: HashMap::new(),
             #[cfg(test)]
             test_pty_home: None,
@@ -852,6 +860,12 @@ impl NorenApp {
                 self.terminal = Some(terminal);
                 self.active_session = Some(id);
                 self.pty_child = PtyChildStatus::Running;
+                // Grid coordinates captured on the previous session's screen
+                // can only address the wrong content; the selection model
+                // expires them, exactly as an explicit switch does.
+                self.selection = None;
+                self.drag_origin = None;
+                self.exited_surface_session = None;
                 self.workspace
                     .select_session(id)
                     .expect("freshly spawned session is live");
@@ -993,6 +1007,7 @@ impl NorenApp {
         // only address the wrong content; the selection model expires them.
         self.selection = None;
         self.drag_origin = None;
+        self.exited_surface_session = None;
         self.redraw_needed = true;
         self.workspace.select_session(id).is_ok()
     }
@@ -1021,16 +1036,23 @@ impl NorenApp {
             return false;
         }
         let was_active = self.active_session == Some(id);
+        // The displayed frame can also belong to a session whose child has
+        // already exited: `finish_pty` keeps its final frame on screen with
+        // input ownership already gone. Closing that row must clear the
+        // surface and run the fallback too — otherwise a frozen frame stays
+        // behind a vanished row in an empty workspace.
+        let owns_displayed_surface = was_active || self.exited_surface_session == Some(id);
         // Reap a parked child first; its surface never touched the live view.
         if let Some(mut parked) = self.parked_sessions.remove(&id)
             && parked.pty.shutdown().is_err()
         {
             eprintln!("Noren closed-session PTY shutdown reached its failure fallback");
         }
-        // Detach the active surface before removing the row so the renderer
+        // Detach the displayed surface before removing the row so the renderer
         // and input routing can never observe a closed session.
-        if was_active {
+        if owns_displayed_surface {
             self.active_session = None;
+            self.exited_surface_session = None;
             self.terminal = None;
             self.pty_child = PtyChildStatus::NotLaunched;
             self.selection = None;
@@ -1044,7 +1066,7 @@ impl NorenApp {
         // The registry removes the row (and clears the selection if it pointed
         // at the closed session) and persists the structural change.
         let closed = self.workspace.close_session(id).is_ok();
-        if was_active {
+        if owns_displayed_surface {
             // Fall back to the topmost remaining live session, if any exists.
             let fallback = self.parked_sessions.keys().min().copied();
             match fallback {
@@ -1568,10 +1590,12 @@ impl NorenApp {
                 return true;
             }
             // The row has no live surface (model-only, restored, or exited):
-            // input ownership stays with the current live session.
-            if let Some(active) = self.active_session
-                && self.workspace.select_session(active).is_ok()
-            {
+            // input ownership stays with the current live session, but the
+            // CLICK selects the clicked row — the palette's close command
+            // operates on the selected row, and re-selecting the live one
+            // here would redirect a close onto a shell the user did not
+            // point at.
+            if self.workspace.select_session(id).is_ok() {
                 self.ssh_selection_status = None;
                 self.redraw_needed = true;
             }
@@ -2079,6 +2103,9 @@ impl NorenApp {
             };
             self.workspace
                 .observe_session(id, SessionStatus::Exited { code });
+            // The final frame stays displayed below; remember whose it is so
+            // closing that row detaches the surface honestly.
+            self.exited_surface_session = Some(id);
         }
         if let Some(mut session) = self.pty.take()
             && session.shutdown().is_err()

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1058,6 +1058,38 @@ impl NorenApp {
         closed
     }
 
+    /// Cycle the live view to the next live session in sidebar order.
+    ///
+    /// This is the palette `session_select` runtime. The live view moves from
+    /// the active session to the next live row in registry order (the order
+    /// the sidebar shows), wrapping around, through the same
+    /// [`switch_live_session`] path a sidebar click takes. With fewer than
+    /// two live sessions there is nothing to cycle to: the current live view
+    /// is re-affirmed, and input ownership never moves to a row without a
+    /// live surface.
+    fn select_next_live_session(&mut self) {
+        let live: Vec<SessionId> = self
+            .workspace
+            .registry()
+            .sessions()
+            .into_iter()
+            .map(|descriptor| descriptor.id())
+            .filter(|id| self.active_session == Some(*id) || self.parked_sessions.contains_key(id))
+            .collect();
+        let Some(next) = live
+            .iter()
+            .position(|id| self.active_session == Some(*id))
+            .and_then(|position| live.get((position + 1) % live.len()).copied())
+            .or_else(|| live.first().copied())
+        else {
+            return;
+        };
+        if self.switch_live_session(next) {
+            self.ssh_selection_status = None;
+            self.redraw_needed = true;
+        }
+    }
+
     fn initialize(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -1281,19 +1313,9 @@ impl NorenApp {
                 self.spawn_local_session();
             }
             WorkspaceAction::SelectSession => {
-                let ids: Vec<SessionId> = self
-                    .workspace
-                    .registry()
-                    .sessions()
-                    .into_iter()
-                    .map(|d| d.id())
-                    .collect();
-                let Some(active) = self.active_session else {
-                    return;
-                };
-                if ids.contains(&active) && self.workspace.select_session(active).is_ok() {
-                    self.ssh_selection_status = None;
-                }
+                // The palette cycles the live view through live sessions in
+                // sidebar order — the same switch a sidebar click performs.
+                self.select_next_live_session();
             }
             WorkspaceAction::CloseSession => {
                 // The palette closes the selected row — live or not. A live

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -934,6 +934,42 @@ impl NorenApp {
         }
     }
 
+    /// Switch the live view to `id`.
+    ///
+    /// The active surface is parked (its PTY keeps running) and `id`'s parked
+    /// surface is re-attached, so from the next event onward the renderer,
+    /// input routing, and mouse mapping operate on the selected session —
+    /// they read the same active fields, which now belong to `id`. Switching
+    /// back re-attaches the same terminal state, so the session shows its own
+    /// current screen, not a stale or foreign one.
+    ///
+    /// Returns `false` when `id` has no live surface (a model-only, restored,
+    /// or already exited row): nothing is detached and the current live view
+    /// keeps input ownership.
+    fn switch_live_session(&mut self, id: SessionId) -> bool {
+        if self.workspace.registry().get(id).is_none() {
+            return false;
+        }
+        if self.active_session == Some(id) {
+            // Already the live view; re-affirm the selection only.
+            return self.workspace.select_session(id).is_ok();
+        }
+        let Some(parked) = self.parked_sessions.remove(&id) else {
+            return false;
+        };
+        self.park_active_session();
+        self.pty = Some(parked.pty);
+        self.terminal = Some(parked.terminal);
+        self.active_session = Some(id);
+        self.pty_child = PtyChildStatus::Running;
+        // Grid coordinates captured on the previous session's screen can
+        // only address the wrong content; the selection model expires them.
+        self.selection = None;
+        self.drag_origin = None;
+        self.redraw_needed = true;
+        self.workspace.select_session(id).is_ok()
+    }
+
     fn initialize(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -1398,16 +1434,18 @@ impl NorenApp {
             return false;
         };
         if let Some(id) = self.workspace.local_sidebar_session(row_index) {
-            if Some(id) != self.active_session {
-                if let Some(active) = self.active_session
-                    && self.workspace.select_session(active).is_ok()
-                {
-                    self.ssh_selection_status = None;
-                    self.redraw_needed = true;
-                }
+            // A row with a live surface takes the live view: the terminal
+            // surface, input routing, and the renderer follow the selection.
+            if self.switch_live_session(id) {
+                self.ssh_selection_status = None;
+                self.redraw_needed = true;
                 return true;
             }
-            if self.workspace.select_session(id).is_ok() {
+            // The row has no live surface (model-only, restored, or exited):
+            // input ownership stays with the current live session.
+            if let Some(active) = self.active_session
+                && self.workspace.select_session(active).is_ok()
+            {
                 self.ssh_selection_status = None;
                 self.redraw_needed = true;
             }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -37,6 +37,7 @@ use noren_terminal::{
     GridPoint, Selection, SelectionMode, TerminalEngine, TerminalError, TerminalState,
 };
 use renderer::{RenderOutcome, Renderer};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -501,6 +502,21 @@ fn created_session_id(events: Vec<SessionEvent>) -> SessionId {
         .expect("SessionAction::Create yields exactly one Created event")
 }
 
+/// A live session that is not currently displayed.
+///
+/// The app holds exactly one *active* surface (`NorenApp::pty` plus
+/// `NorenApp::terminal`, owned by [`NorenApp::active_session`]); every other
+/// live session is parked here with its own PTY and terminal state. Parking
+/// keeps the child running and its screen authoritative in Noren's terminal
+/// state, so switching back shows current content. The renderer, input
+/// routing, and mouse mapping never need to know which session is focused:
+/// they operate on the active surface, and switching swaps surfaces rather
+/// than re-deriving state.
+struct ParkedSession {
+    pty: PtySession,
+    terminal: TerminalState,
+}
+
 struct NorenApp {
     window: Option<Arc<Window>>,
     renderer: Option<Renderer>,
@@ -531,6 +547,8 @@ struct NorenApp {
     /// First workspace row currently visible in the bounded sidebar window.
     sidebar_scroll_offset: usize,
     active_session: Option<SessionId>,
+    /// Live sessions that are not the active one, keyed by session id.
+    parked_sessions: HashMap<SessionId, ParkedSession>,
     palette_open: bool,
     palette_selection: usize,
     passthrough_gate: PassthroughGate,
@@ -608,6 +626,7 @@ impl NorenApp {
             workspace: WorkspaceState::new(),
             sidebar_scroll_offset: 0,
             active_session: None,
+            parked_sessions: HashMap::new(),
             palette_open: false,
             palette_selection: 0,
             passthrough_gate: PassthroughGate::new(),
@@ -739,6 +758,180 @@ impl NorenApp {
         self.workspace
             .observe_session(session_id, SessionStatus::Running);
         self.active_session = Some(session_id);
+    }
+
+    /// Terminal state and PTY size for a new session at the current window
+    /// grid, or at the default window grid when no window exists yet
+    /// (headless start, application tests).
+    fn session_surfaces(&mut self) -> Option<(TerminalState, PtySize)> {
+        let changed = match self.window.as_ref() {
+            Some(window) => {
+                let size = window.inner_size();
+                self.geometry.update(Resize::new(size.width, size.height))
+            }
+            None => self
+                .geometry
+                .update(Resize::new(WINDOW_WIDTH, WINDOW_HEIGHT)),
+        };
+        // `update` returns `None` for an unchanged grid; the current grid is
+        // then exactly what a new session should use.
+        let grid = changed.or_else(|| self.geometry.current())?;
+        let runtime = RuntimeGridSize::from_window(grid);
+        Some((runtime.terminal_state()?, runtime.pty_size()?))
+    }
+
+    /// Park the active session's surface without killing it.
+    ///
+    /// The PTY keeps running and its bytes are drained into its own terminal
+    /// state by [`Self::drain_parked_sessions`], so a later switch back
+    /// re-attaches to current content rather than a stale frame.
+    fn park_active_session(&mut self) {
+        if let (Some(id), Some(pty), Some(terminal)) = (
+            self.active_session.take(),
+            self.pty.take(),
+            self.terminal.take(),
+        ) {
+            self.parked_sessions
+                .insert(id, ParkedSession { pty, terminal });
+            self.pty_child = PtyChildStatus::NotLaunched;
+        }
+    }
+
+    /// Spawn a real local PTY session and give it the live view.
+    ///
+    /// This is the palette `session_create` runtime: the new sidebar row is
+    /// backed by an actual `/bin/zsh` PTY. The registry observes `Running`
+    /// when the spawn succeeds and `Failed` when it does not — creation never
+    /// claims a session is running (the registry's `Starting` contract). The
+    /// new session takes the live view and the previous one is parked, not
+    /// killed, matching the new-tab-focuses-itself convention of terminal
+    /// multiplexers.
+    fn spawn_local_session(&mut self) -> Option<SessionId> {
+        let id = self.workspace.create_session(SessionKind::Local);
+        let Some((terminal, pty_size)) = self.session_surfaces() else {
+            self.workspace.observe_session(
+                id,
+                SessionStatus::Failed {
+                    reason: "terminal surface unavailable".to_owned(),
+                },
+            );
+            return None;
+        };
+        match PtySession::spawn(pty_size) {
+            Ok(pty) => {
+                self.workspace.observe_session(id, SessionStatus::Running);
+                self.park_active_session();
+                self.pty = Some(pty);
+                self.terminal = Some(terminal);
+                self.active_session = Some(id);
+                self.pty_child = PtyChildStatus::Running;
+                self.workspace
+                    .select_session(id)
+                    .expect("freshly spawned session is live");
+                self.ssh_selection_status = None;
+                self.redraw_needed = true;
+                Some(id)
+            }
+            Err(_) => {
+                self.workspace.observe_session(
+                    id,
+                    SessionStatus::Failed {
+                        reason: "PTY spawn failed".to_owned(),
+                    },
+                );
+                None
+            }
+        }
+    }
+
+    /// Drain every parked session's PTY events into its own terminal state.
+    ///
+    /// A parked session keeps producing output; its bytes feed its own
+    /// authoritative terminal state under the same per-turn parse budget as
+    /// the active session, so nothing grows without bound and switching back
+    /// shows current content. A parked child that exits or errors is observed
+    /// through the registry (`Exited`/`Failed`), shut down and reaped, and
+    /// dropped from the live bookkeeping — a dead row must never stay
+    /// `Running`, in the background any more than in the foreground.
+    fn drain_parked_sessions(&mut self) {
+        let ids: Vec<SessionId> = self
+            .workspace
+            .registry()
+            .sessions()
+            .into_iter()
+            .map(|descriptor| descriptor.id())
+            .filter(|id| self.parked_sessions.contains_key(id))
+            .collect();
+        for id in ids {
+            let terminal_status = self.drain_one_parked(id);
+            if let Some(status) = terminal_status {
+                self.workspace.observe_session(id, status);
+                if let Some(mut parked) = self.parked_sessions.remove(&id)
+                    && parked.pty.shutdown().is_err()
+                {
+                    self.workspace.observe_session(
+                        id,
+                        SessionStatus::Failed {
+                            reason: "PTY shutdown failed".to_owned(),
+                        },
+                    );
+                }
+                // The sidebar detail for this row changed even though the
+                // visible frame did not.
+                self.redraw_needed = true;
+            }
+        }
+    }
+
+    /// Drain one parked session's ready events, returning the observed
+    /// terminal status when the child exited or the channel failed.
+    fn drain_one_parked(&mut self, id: SessionId) -> Option<SessionStatus> {
+        let parked = self.parked_sessions.get_mut(&id)?;
+        let mut remaining = PARSE_BUDGET_BYTES_PER_TURN;
+        loop {
+            if remaining < noren_pty::READ_CHUNK_BYTES {
+                return None;
+            }
+            match parked.pty.try_recv() {
+                Ok(None) => return None,
+                Ok(Some(PtyEvent::Output(bytes))) => {
+                    if bytes.len() > remaining {
+                        // Over-budget output stays queued for a later turn;
+                        // it is never dropped.
+                        return None;
+                    }
+                    remaining -= bytes.len();
+                    parked.terminal.feed_bytes(&bytes);
+                }
+                Ok(Some(PtyEvent::Eof)) => {
+                    return Some(SessionStatus::Exited { code: None });
+                }
+                Ok(Some(PtyEvent::Exited { code })) => {
+                    return Some(SessionStatus::Exited {
+                        code: code.map(|code| code as i32),
+                    });
+                }
+                Ok(Some(PtyEvent::Error(_))) => {
+                    return Some(SessionStatus::Failed {
+                        reason: "PTY operation failed".to_owned(),
+                    });
+                }
+                Err(_) => {
+                    return Some(SessionStatus::Failed {
+                        reason: "PTY channel closed".to_owned(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Reap every parked session's child. Bounded and idempotent per session.
+    fn shutdown_parked_sessions(&mut self) {
+        for (_, mut parked) in self.parked_sessions.drain() {
+            if parked.pty.shutdown().is_err() {
+                eprintln!("Noren PTY shutdown reached its failure fallback");
+            }
+        }
     }
 
     fn initialize(&mut self, event_loop: &ActiveEventLoop) {
@@ -961,7 +1154,7 @@ impl NorenApp {
     fn run_workspace_action(&mut self, action: WorkspaceAction) {
         match action {
             WorkspaceAction::CreateSession => {
-                let _id = self.workspace.create_session(SessionKind::Local);
+                self.spawn_local_session();
             }
             WorkspaceAction::SelectSession => {
                 let ids: Vec<SessionId> = self
@@ -979,8 +1172,14 @@ impl NorenApp {
                 }
             }
             WorkspaceAction::CloseSession => {
+                // A live session (the active one or a parked one) owns a real
+                // child; until close learns to reap (the next slice), the
+                // palette closes only rows without a live surface.
+                let live = |app: &Self, id| {
+                    app.active_session == Some(id) || app.parked_sessions.contains_key(&id)
+                };
                 if let Some(id) = self.workspace.registry().selected() {
-                    if Some(id) != self.active_session {
+                    if !live(self, id) {
                         let _ = self.workspace.close_session(id);
                     }
                 } else {
@@ -991,7 +1190,7 @@ impl NorenApp {
                         .into_iter()
                         .map(|d| d.id())
                         .collect();
-                    if let Some(id) = ids.into_iter().find(|id| Some(*id) != self.active_session) {
+                    if let Some(id) = ids.into_iter().find(|id| !live(self, *id)) {
                         let _ = self.workspace.close_session(id);
                     }
                 }
@@ -1620,6 +1819,20 @@ impl NorenApp {
                 self.show_status = true;
             }
         }
+        // Parked sessions resize too, so switching back presents a terminal
+        // state and PTY at the current geometry instead of a stale one.
+        if let Some(size) = runtime.pty_size() {
+            for parked in self.parked_sessions.values_mut() {
+                if runtime.resize_terminal(&mut parked.terminal).is_err() {
+                    self.status = "Noren terminal resize failed";
+                    self.show_status = true;
+                }
+                if parked.pty.resize(size).is_err() {
+                    self.status = "Noren PTY resize failed";
+                    self.show_status = true;
+                }
+            }
+        }
         self.redraw_needed = true;
     }
 
@@ -1791,6 +2004,9 @@ impl NorenApp {
                 eprintln!("Noren PTY shutdown reached its failure fallback");
             }
         }
+        // Parked sessions die with the app too; their rows persist as
+        // `Restored` entries for the next launch (quit is not close).
+        self.shutdown_parked_sessions();
     }
 
     fn close(&mut self, event_loop: &ActiveEventLoop) {
@@ -1854,6 +2070,7 @@ impl ApplicationHandler for NorenApp {
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         self.apply_pending_resize();
         self.drain_pty();
+        self.drain_parked_sessions();
         if self.redraw_needed {
             if let Some(window) = &self.window {
                 window.request_redraw();
@@ -1867,6 +2084,7 @@ impl ApplicationHandler for NorenApp {
         if let Some(mut session) = self.pty.take() {
             let _ = session.shutdown();
         }
+        self.shutdown_parked_sessions();
     }
 }
 

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -994,6 +994,70 @@ impl NorenApp {
         self.workspace.select_session(id).is_ok()
     }
 
+    /// Close session `id` for real: reap its child, remove its row, and
+    /// repair the live view.
+    ///
+    /// This is the palette `session_close` runtime. A row with a live surface
+    /// (the active one or a parked one) owns a real child; closing it runs
+    /// that child's bounded kill-and-reap shutdown *before* the row is
+    /// removed, so a closed session can never keep a process running behind a
+    /// vanished row. A row without a live surface (model-only or restored) is
+    /// closed in the registry alone, exactly as before.
+    ///
+    /// # Fallback when the active session is closed
+    ///
+    /// The live view moves to the remaining live session with the lowest id —
+    /// the topmost sidebar row — which is deterministic and matches the
+    /// row-order the user sees. When no live session remains the live view is
+    /// cleared entirely: no terminal surface, no input owner, a truthful
+    /// status line, and the sidebar's empty state. The palette can create a
+    /// new session from there; an empty workspace never shows a closed
+    /// session's frozen frame as if it were alive.
+    fn close_session(&mut self, id: SessionId) -> bool {
+        if self.workspace.registry().get(id).is_none() {
+            return false;
+        }
+        let was_active = self.active_session == Some(id);
+        // Reap a parked child first; its surface never touched the live view.
+        if let Some(mut parked) = self.parked_sessions.remove(&id)
+            && parked.pty.shutdown().is_err()
+        {
+            eprintln!("Noren closed-session PTY shutdown reached its failure fallback");
+        }
+        // Detach the active surface before removing the row so the renderer
+        // and input routing can never observe a closed session.
+        if was_active {
+            self.active_session = None;
+            self.terminal = None;
+            self.pty_child = PtyChildStatus::NotLaunched;
+            self.selection = None;
+            self.drag_origin = None;
+            if let Some(mut session) = self.pty.take()
+                && session.shutdown().is_err()
+            {
+                eprintln!("Noren closed-session PTY shutdown reached its failure fallback");
+            }
+        }
+        // The registry removes the row (and clears the selection if it pointed
+        // at the closed session) and persists the structural change.
+        let closed = self.workspace.close_session(id).is_ok();
+        if was_active {
+            // Fall back to the topmost remaining live session, if any exists.
+            let fallback = self.parked_sessions.keys().min().copied();
+            match fallback {
+                Some(next) => {
+                    self.switch_live_session(next);
+                }
+                None => {
+                    self.status = "Noren last session closed";
+                    self.show_status = true;
+                }
+            }
+        }
+        self.redraw_needed = true;
+        closed
+    }
+
     fn initialize(&mut self, event_loop: &ActiveEventLoop) {
         if self.window.is_some() {
             return;
@@ -1232,27 +1296,19 @@ impl NorenApp {
                 }
             }
             WorkspaceAction::CloseSession => {
-                // A live session (the active one or a parked one) owns a real
-                // child; until close learns to reap (the next slice), the
-                // palette closes only rows without a live surface.
-                let live = |app: &Self, id| {
-                    app.active_session == Some(id) || app.parked_sessions.contains_key(&id)
-                };
-                if let Some(id) = self.workspace.registry().selected() {
-                    if !live(self, id) {
-                        let _ = self.workspace.close_session(id);
-                    }
-                } else {
-                    let ids: Vec<SessionId> = self
-                        .workspace
+                // The palette closes the selected row — live or not. A live
+                // row owns a real child; `close_session` reaps it before
+                // removing the row and repairs the live view (fallback to the
+                // topmost remaining live session, or an honest empty view).
+                let target = self.workspace.registry().selected().or_else(|| {
+                    self.workspace
                         .registry()
                         .sessions()
-                        .into_iter()
-                        .map(|d| d.id())
-                        .collect();
-                    if let Some(id) = ids.into_iter().find(|id| !live(self, *id)) {
-                        let _ = self.workspace.close_session(id);
-                    }
+                        .first()
+                        .map(|descriptor| descriptor.id())
+                });
+                if let Some(id) = target {
+                    self.close_session(id);
                 }
             }
             WorkspaceAction::FocusSidebar => {

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -549,6 +549,13 @@ struct NorenApp {
     active_session: Option<SessionId>,
     /// Live sessions that are not the active one, keyed by session id.
     parked_sessions: HashMap<SessionId, ParkedSession>,
+    /// Test-only override for the PTY child's home directory. Production
+    /// always spawns in the inherited `$HOME`; tests that drive a shell by
+    /// typing set an isolated empty directory so the shell's startup cannot
+    /// depend on the developer's personal configuration (which may take
+    /// arbitrarily long or read the terminal).
+    #[cfg(test)]
+    test_pty_home: Option<PathBuf>,
     palette_open: bool,
     palette_selection: usize,
     passthrough_gate: PassthroughGate,
@@ -627,6 +634,8 @@ impl NorenApp {
             sidebar_scroll_offset: 0,
             active_session: None,
             parked_sessions: HashMap::new(),
+            #[cfg(test)]
+            test_pty_home: None,
             palette_open: false,
             palette_selection: 0,
             passthrough_gate: PassthroughGate::new(),
@@ -797,6 +806,21 @@ impl NorenApp {
         }
     }
 
+    /// Spawn the PTY for a new session.
+    ///
+    /// Production always runs the fixed `/bin/zsh` policy in the inherited
+    /// `$HOME`. Tests that drive a shell by typing redirect the child into an
+    /// isolated empty home (see [`NorenApp::test_pty_home`]) so a developer's
+    /// startup files cannot make the test wait minutes for a prompt — the
+    /// spawn itself, the policy, and the reaping contract are identical.
+    fn spawn_pty_session(&self, size: PtySize) -> Result<PtySession, noren_pty::PtyError> {
+        #[cfg(test)]
+        if let Some(home) = &self.test_pty_home {
+            return PtySession::spawn_in_home(home, size);
+        }
+        PtySession::spawn(size)
+    }
+
     /// Spawn a real local PTY session and give it the live view.
     ///
     /// This is the palette `session_create` runtime: the new sidebar row is
@@ -817,7 +841,7 @@ impl NorenApp {
             );
             return None;
         };
-        match PtySession::spawn(pty_size) {
+        match self.spawn_pty_session(pty_size) {
             Ok(pty) => {
                 self.workspace.observe_session(id, SessionStatus::Running);
                 self.park_active_session();

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1293,20 +1293,43 @@ fn palette_close_action_removes_the_selected_session() {
     );
 }
 
+/// Closing the row that owns the live PTY is a real close now: the child is
+/// reaped through the bounded shutdown *before* the row is removed, the live
+/// surface is detached, and — with no other live session left — the app falls
+/// back to an honest empty view (no terminal, truthful status) instead of a
+/// dead session's frozen frame.
+///
+/// This replaces `palette_close_cannot_remove_the_live_pty_owner`, which
+/// pinned the interim behaviour where close refused every live row because it
+/// could not reap a child; `close_session` can and does.
+///
+/// Mutation check: removing the reaping/detaching from `close_session`
+/// (leaving the child running behind a removed row, or leaving the closed
+/// session's surface attached) fails every assertion past the first.
 #[test]
-fn palette_close_cannot_remove_the_live_pty_owner() {
-    let mut app = NorenApp::default();
-    let active = app.workspace.create_session(SessionKind::Local);
-    app.workspace
-        .select_session(active)
-        .expect("active session is selectable");
-    app.active_session = Some(active);
+fn palette_close_reaps_the_live_owner_and_falls_back_to_an_empty_view() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let only = registry_ids(&app)[0];
 
     app.run_workspace_action(WorkspaceAction::CloseSession);
 
-    assert!(app.workspace.registry().get(active).is_some());
-    assert_eq!(app.workspace.registry().selected(), Some(active));
-    assert_eq!(app.active_session, Some(active));
+    assert!(
+        app.workspace.registry().get(only).is_none(),
+        "the closed row is gone from the registry"
+    );
+    assert!(
+        app.pty.is_none() && app.terminal.is_none(),
+        "no surface may outlive its session"
+    );
+    assert_eq!(app.active_session, None);
+    assert!(
+        app.parked_sessions.is_empty(),
+        "the child handle was reaped and dropped, not parked or leaked"
+    );
+    assert!(app.workspace.sidebar().is_empty());
+    assert!(app.show_status, "an empty workspace must say so honestly");
 }
 
 /// Escape dismisses the palette without running a command.
@@ -4023,4 +4046,115 @@ fn switching_expires_the_previous_sessions_selection() {
         "a selection from the previous screen must not survive the switch"
     );
     assert!(app.drag_origin.is_none());
+}
+
+// ── Closing live sessions (supervisor-backed switching, slice 3) ────────
+
+/// Closing the ACTIVE session while other live sessions exist falls back to
+/// the topmost remaining live row (the lowest id), and that row's own screen
+/// — not the closed session's — owns the live view afterwards.
+///
+/// Mutation check: skipping the reaping/detaching in `close_session` (or
+/// falling back to the closed session's own surface) fails the marker and
+/// ownership assertions.
+#[test]
+fn closing_the_active_session_falls_back_to_the_topmost_live_session() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let first = registry_ids(&app)[0];
+    // First session's screen gets a marker while it still owns the live view.
+    app.apply_pty_output(b"FIRST-SCREEN-9c2d\r\n");
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let second = registry_ids(&app)[1];
+    assert_eq!(app.active_session, Some(second));
+
+    // The palette closes the selected row; the newest session is both
+    // selected and active.
+    app.run_workspace_action(WorkspaceAction::CloseSession);
+
+    assert!(app.workspace.registry().get(second).is_none());
+    assert_eq!(
+        app.active_session,
+        Some(first),
+        "the live view falls back to the topmost remaining live session"
+    );
+    assert_eq!(app.workspace.registry().selected(), Some(first));
+    assert!(
+        app.pty.is_some(),
+        "the fallback session's real PTY owns the live view"
+    );
+    let text = terminal_text(app.terminal.as_ref().expect("fallback surface"));
+    assert!(
+        text.contains("FIRST-SCREEN-9c2d"),
+        "the fallback must show the first session's own screen"
+    );
+    assert_eq!(session_status(&app, first), SessionStatus::Running);
+    assert!(app.parked_sessions.is_empty());
+}
+
+/// Closing a PARKED session reaps its child and leaves the live view on the
+/// active session, untouched.
+#[test]
+fn closing_a_parked_session_reaps_it_and_keeps_the_live_view() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let ids = registry_ids(&app);
+    let (first, second) = (ids[0], ids[1]);
+    assert!(app.parked_sessions.contains_key(&first));
+
+    // Make the parked row the palette's target: registry selection is a
+    // model-level choice and does not move the live view.
+    app.workspace
+        .select_session(first)
+        .expect("parked row selectable");
+
+    app.run_workspace_action(WorkspaceAction::CloseSession);
+
+    assert!(app.workspace.registry().get(first).is_none());
+    assert!(
+        !app.parked_sessions.contains_key(&first),
+        "the parked child handle was reaped and removed, not left in the map"
+    );
+    assert_eq!(
+        app.active_session,
+        Some(second),
+        "the live view is untouched"
+    );
+    assert!(app.pty.is_some());
+    assert_eq!(session_status(&app, second), SessionStatus::Running);
+    assert_eq!(app.workspace.registry().selected(), None);
+}
+
+/// A structural close persists immediately: the next launch restores exactly
+/// the surviving rows as `Restored` entries, never the closed one, and never
+/// a live status for a shell that died with the previous launch.
+#[test]
+fn closing_a_session_persists_the_shrunk_sidebar_for_the_next_launch() {
+    let home = AppTestHome::new();
+    let path = temp_state_path();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..app_with_state_path(&path)
+    };
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CloseSession);
+
+    let relaunched = sidebar_after_relaunch(&path);
+    assert_eq!(
+        relaunched.registry().len(),
+        1,
+        "the closed row is not saved"
+    );
+    for descriptor in relaunched.registry().sessions() {
+        assert_eq!(
+            descriptor.status().clone(),
+            SessionStatus::Restored,
+            "a relaunched row is Restored: its shell did not survive the launch"
+        );
+    }
+    cleanup_state_file(&path);
 }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3684,6 +3684,46 @@ fn single_instance_save_has_no_persistence_false_alarm() {
 // children are reaped through `PtySession`'s bounded shutdown when the app (or
 // its parked map) drops.
 
+/// An isolated home directory for PTY children, following the `noren-pty`
+/// suite's `TestHome` convention.
+///
+/// Tests that drive a shell by typing must not run it in the developer's real
+/// `$HOME`: personal startup files can take arbitrarily long (over a minute on
+/// some machines) or read the terminal, which would make the test's prompt
+/// wait depend on personal configuration. An empty home gives the same fixed
+/// `/bin/zsh` policy with a deterministic, immediate prompt.
+struct AppTestHome(PathBuf);
+
+impl AppTestHome {
+    fn new() -> Self {
+        static SEQUENCE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let sequence = SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!(
+            "noren-app-test-home-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).expect("create isolated test home");
+        Self(path)
+    }
+
+    /// A default app whose spawned sessions run in this isolated home.
+    ///
+    /// Borrows the guard so it stays alive (and the directory stays present)
+    /// for the whole test: the child validates the directory at spawn time.
+    fn app(&self) -> NorenApp {
+        NorenApp {
+            test_pty_home: Some(self.0.clone()),
+            ..NorenApp::default()
+        }
+    }
+}
+
+impl Drop for AppTestHome {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).expect("remove isolated test home");
+    }
+}
+
 /// Registry ids in sidebar order.
 fn registry_ids(app: &NorenApp) -> Vec<SessionId> {
     app.workspace
@@ -3785,13 +3825,13 @@ fn palette_create_spawns_a_real_local_pty_session() {
 /// a live-surface entry behind.
 #[test]
 fn a_parked_session_that_exits_is_observed_and_detached() {
-    let mut app = NorenApp::default();
+    let home = AppTestHome::new();
+    let mut app = home.app();
     app.run_workspace_action(WorkspaceAction::CreateSession);
     let first = registry_ids(&app)[0];
     // Wait for the shell to finish starting up before typing into it: input
-    // queued while zsh is still reading its startup files races them, and the
-    // real $HOME (unlike the noren-pty suite's isolated TestHome) carries a
-    // full user configuration.
+    // queued while zsh is still reading its startup files races them. The
+    // isolated home makes that startup immediate and deterministic.
     wait_for_shell_output(&mut app);
     // Tell the first shell to exit while it still owns the live view; the
     // exit is only observed after the session has been parked, because

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3676,3 +3676,162 @@ fn single_instance_save_has_no_persistence_false_alarm() {
     assert!(!saved.is_empty(), "the real save path wrote a document");
     cleanup_state_file(&path);
 }
+
+// ── Live multi-session bookkeeping (supervisor-backed switching, slice 1) ──
+//
+// The palette's `session_create` now spawns a real `/bin/zsh` PTY per row.
+// These tests spawn real PTYs, following the `noren-pty` test convention; the
+// children are reaped through `PtySession`'s bounded shutdown when the app (or
+// its parked map) drops.
+
+/// Registry ids in sidebar order.
+fn registry_ids(app: &NorenApp) -> Vec<SessionId> {
+    app.workspace
+        .registry()
+        .sessions()
+        .into_iter()
+        .map(|descriptor| descriptor.id())
+        .collect()
+}
+
+/// Observed status of a live registry row.
+fn session_status(app: &NorenApp, id: SessionId) -> SessionStatus {
+    app.workspace
+        .registry()
+        .get(id)
+        .expect("session exists in the registry")
+        .status()
+        .clone()
+}
+
+/// The palette's session_create must spawn a real local PTY: the row is
+/// observed `Running` (never left `Starting`), it owns the live surface, and a
+/// second create parks the first live session instead of killing it.
+///
+/// Mutation check: making `session_create` add a model row without spawning
+/// (no PTY, no `Running` observation) fails every assertion past the first.
+#[test]
+fn palette_create_spawns_a_real_local_pty_session() {
+    let mut app = NorenApp::default();
+
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 1);
+    let first = ids[0];
+    assert_eq!(
+        session_status(&app, first),
+        SessionStatus::Running,
+        "a spawned session must be observed Running, not left Starting"
+    );
+    assert!(
+        app.pty.is_some(),
+        "the new session must own a real live PTY surface"
+    );
+    assert_eq!(app.active_session, Some(first));
+    assert_eq!(app.workspace.registry().selected(), Some(first));
+
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 2);
+    let second = ids[1];
+    assert_eq!(
+        session_status(&app, second),
+        SessionStatus::Running,
+        "the second spawn is also a real running session"
+    );
+    assert_eq!(
+        app.active_session,
+        Some(second),
+        "a new session takes the live view"
+    );
+    assert!(
+        app.parked_sessions.contains_key(&first),
+        "the previous live session must be parked, not dropped"
+    );
+    assert_eq!(
+        session_status(&app, first),
+        SessionStatus::Running,
+        "parking keeps the first session truthfully Running"
+    );
+}
+
+/// A parked session that exits in the background is observed through the
+/// registry, reaped, and detached — it never stays `Running` and never leaves
+/// a live-surface entry behind.
+#[test]
+fn a_parked_session_that_exits_is_observed_and_detached() {
+    let mut app = NorenApp::default();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let first = registry_ids(&app)[0];
+    // Tell the first shell to exit while it still owns the live view; the
+    // exit is only observed after the session has been parked, because
+    // nothing drains between these calls.
+    app.send_input(b"exit\n");
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let second = registry_ids(&app)[1];
+    assert!(app.parked_sessions.contains_key(&first));
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while session_status(&app, first) == SessionStatus::Running {
+        app.drain_pty();
+        app.drain_parked_sessions();
+        assert!(
+            Instant::now() < deadline,
+            "the parked session's exit was never observed"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        matches!(session_status(&app, first), SessionStatus::Exited { .. }),
+        "an exited parked session is observed as Exited (the code is None when \
+         the reader's EOF wins the race with the supervisor's exit poll)"
+    );
+    assert!(
+        !app.parked_sessions.contains_key(&first),
+        "a dead parked session must be detached from the live bookkeeping"
+    );
+    assert_eq!(
+        app.active_session,
+        Some(second),
+        "a parked exit must not disturb the live view"
+    );
+    assert_eq!(session_status(&app, second), SessionStatus::Running);
+}
+
+/// Quitting with several real live sessions persists them all for the next
+/// launch, where they come back as `Restored` rows — live PTYs never survive a
+/// restart, and the persisted model must say so.
+#[test]
+fn quitting_persists_spawned_sessions_for_the_next_launch() {
+    let path = temp_state_path();
+    let mut app = app_with_state_path(&path);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+
+    app.teardown();
+
+    let text = std::fs::read_to_string(&path).expect("state saved on quit");
+    assert_eq!(
+        text.matches("kind = \"local\"").count(),
+        2,
+        "both spawned sessions persist: {text}"
+    );
+
+    let relaunched = sidebar_after_relaunch(&path);
+    assert_eq!(relaunched.registry().len(), 2);
+    for descriptor in relaunched.registry().sessions() {
+        let status = descriptor.status().clone();
+        assert_eq!(
+            status,
+            SessionStatus::Restored,
+            "a relaunched row must be Restored, not Running"
+        );
+    }
+    assert!(
+        relaunched.registry().selected().is_some(),
+        "the persisted selection survives the restart"
+    );
+    cleanup_state_file(&path);
+}

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4158,3 +4158,64 @@ fn closing_a_session_persists_the_shrunk_sidebar_for_the_next_launch() {
     }
     cleanup_state_file(&path);
 }
+
+/// The palette's `session_select` cycles the live view through live sessions
+/// in sidebar order, wrapping around, and each switch shows the target
+/// session's own screen. With no other live session it re-affirms the current
+/// owner instead of moving input to a model-only row.
+///
+/// Mutation check: making the switch a no-op that keeps rendering the old
+/// session fails every screen-content assertion here.
+#[test]
+fn palette_select_cycles_the_live_view_between_live_sessions() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    // Three real sessions; each gets a marker on its own screen while it owns
+    // the live view.
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.apply_pty_output(b"MARK-A-51e0\r\n");
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.apply_pty_output(b"MARK-B-51e0\r\n");
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.apply_pty_output(b"MARK-C-51e0\r\n");
+    let ids = registry_ids(&app);
+    let (a, b, c) = (ids[0], ids[1], ids[2]);
+    assert_eq!(app.active_session, Some(c));
+
+    app.run_workspace_action(WorkspaceAction::SelectSession);
+    assert_eq!(app.active_session, Some(a), "cycles forward and wraps");
+    assert_eq!(app.workspace.registry().selected(), Some(a));
+    assert!(terminal_text(app.terminal.as_ref().expect("a attached")).contains("MARK-A-51e0"));
+
+    app.run_workspace_action(WorkspaceAction::SelectSession);
+    assert_eq!(app.active_session, Some(b));
+    assert!(terminal_text(app.terminal.as_ref().expect("b attached")).contains("MARK-B-51e0"));
+
+    app.run_workspace_action(WorkspaceAction::SelectSession);
+    assert_eq!(app.active_session, Some(c));
+    let text = terminal_text(app.terminal.as_ref().expect("c attached"));
+    assert!(text.contains("MARK-C-51e0"));
+    assert!(
+        !text.contains("MARK-A-51e0") && !text.contains("MARK-B-51e0"),
+        "the live view shows only the selected session's screen"
+    );
+}
+
+/// With a single live session, `session_select` keeps that session as the
+/// input owner; a model-only row never takes the live view through the
+/// palette either.
+#[test]
+fn palette_select_with_one_live_session_reaffirms_its_owner() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let live = registry_ids(&app)[0];
+    let _model = app.workspace.create_session(SessionKind::Local);
+    app.workspace.rebuild_sidebar();
+
+    app.run_workspace_action(WorkspaceAction::SelectSession);
+
+    assert_eq!(app.active_session, Some(live));
+    assert_eq!(app.workspace.registry().selected(), Some(live));
+    assert!(!has_live_surface(&app, _model));
+}

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3704,6 +3704,30 @@ fn session_status(app: &NorenApp, id: SessionId) -> SessionStatus {
         .clone()
 }
 
+/// Drain the live view until the shell has produced its first output.
+///
+/// Real zsh sessions run in the inherited `$HOME`, whose startup files a user
+/// may have customized: input typed before they finish races them, so every
+/// test that drives a shell by typing first waits for its prompt.
+fn wait_for_shell_output(app: &mut NorenApp) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        app.drain_pty();
+        let ready = app
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal.screen().display_row_count() > 0);
+        assert!(
+            Instant::now() < deadline || ready,
+            "the spawned shell never produced its prompt"
+        );
+        if ready {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 /// The palette's session_create must spawn a real local PTY: the row is
 /// observed `Running` (never left `Starting`), it owns the live surface, and a
 /// second create parks the first live session instead of killing it.
@@ -3764,6 +3788,11 @@ fn a_parked_session_that_exits_is_observed_and_detached() {
     let mut app = NorenApp::default();
     app.run_workspace_action(WorkspaceAction::CreateSession);
     let first = registry_ids(&app)[0];
+    // Wait for the shell to finish starting up before typing into it: input
+    // queued while zsh is still reading its startup files races them, and the
+    // real $HOME (unlike the noren-pty suite's isolated TestHome) carries a
+    // full user configuration.
+    wait_for_shell_output(&mut app);
     // Tell the first shell to exit while it still owns the live view; the
     // exit is only observed after the session has been parked, because
     // nothing drains between these calls.
@@ -3834,4 +3863,124 @@ fn quitting_persists_spawned_sessions_for_the_next_launch() {
         "the persisted selection survives the restart"
     );
     cleanup_state_file(&path);
+}
+
+// ── Sidebar switching (supervisor-backed switching, slice 2) ────────────
+
+/// Whether the session owns a live surface: it is the active one or parked.
+fn has_live_surface(app: &NorenApp, id: SessionId) -> bool {
+    app.active_session == Some(id) || app.parked_sessions.contains_key(&id)
+}
+
+/// Visible text of a terminal state, extracted through the selection path.
+fn terminal_text(terminal: &TerminalState) -> String {
+    Selection::entire_grid(terminal).extract(terminal)
+}
+
+/// Click a sidebar row in a default-sized synthetic frame.
+fn click_sidebar_row(app: &mut NorenApp, row: usize) -> bool {
+    app.cursor_position = Some(PhysicalPosition::new(
+        5.0,
+        f64::from(app.geometry.cell_height()) * row as f64 + 1.0,
+    ));
+    app.handle_sidebar_click_in_frame(
+        ElementState::Pressed,
+        MouseButton::Left,
+        PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT),
+    )
+}
+
+/// Clicking another session row must move the whole live view — the terminal
+/// surface the renderer draws and `send_input` feeds — to the clicked
+/// session, and switching back must show that session's own screen again.
+///
+/// Mutation check: making the switch a no-op that keeps rendering the old
+/// session fails the screen-content assertions after every click.
+#[test]
+fn sidebar_click_switches_the_live_surface_between_sessions() {
+    let mut app = NorenApp::default();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let ids = registry_ids(&app);
+    let (first, second) = (ids[0], ids[1]);
+    assert_eq!(app.active_session, Some(second));
+
+    // The second (live) session's screen gets a marker through the exact
+    // byte path production uses for PTY output.
+    app.apply_pty_output(b"SECOND-LIVE-7f31\r\n");
+
+    assert!(click_sidebar_row(&mut app, 0), "row 0 is consumed");
+    assert_eq!(app.active_session, Some(first), "the live view moved");
+    assert_eq!(app.workspace.registry().selected(), Some(first));
+    let text = terminal_text(app.terminal.as_ref().expect("first surface attached"));
+    assert!(
+        !text.contains("SECOND-LIVE-7f31"),
+        "the live view must show the first session's screen, not the previous one"
+    );
+    assert!(
+        has_live_surface(&app, second),
+        "the parked session stays live"
+    );
+
+    // Each session's screen keeps its own bytes after a switch.
+    app.apply_pty_output(b"FIRST-LIVE-7f31\r\n");
+    assert!(click_sidebar_row(&mut app, 1));
+    assert_eq!(app.active_session, Some(second));
+    let text = terminal_text(app.terminal.as_ref().expect("second surface attached"));
+    assert!(text.contains("SECOND-LIVE-7f31"));
+    assert!(!text.contains("FIRST-LIVE-7f31"));
+
+    assert!(click_sidebar_row(&mut app, 0));
+    assert_eq!(app.active_session, Some(first));
+    let text = terminal_text(app.terminal.as_ref().expect("first surface attached"));
+    assert!(
+        text.contains("FIRST-LIVE-7f31"),
+        "switching back re-attaches the first session's own screen"
+    );
+    assert!(!text.contains("SECOND-LIVE-7f31"));
+}
+
+/// A row without a live surface (model-only, restored, or exited) is consumed
+/// but cannot take input ownership: the current live session keeps it.
+#[test]
+fn switching_to_a_row_without_a_live_surface_keeps_the_current_owner() {
+    let mut app = NorenApp::default();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let live = registry_ids(&app)[0];
+    // A model-only row straight from the registry seam: no PTY behind it.
+    let _model = app.workspace.create_session(SessionKind::Local);
+    app.workspace.rebuild_sidebar();
+
+    assert!(click_sidebar_row(&mut app, 1), "the model row is consumed");
+
+    assert_eq!(
+        app.active_session,
+        Some(live),
+        "a row without a live surface must not take the live view"
+    );
+    assert_eq!(app.workspace.registry().selected(), Some(live));
+    assert!(app.pty.is_some(), "the live surface is untouched");
+    assert!(!has_live_surface(&app, _model));
+}
+
+/// Switching expires selections captured on the previous session's screen:
+/// grid coordinates only address the content they were captured on.
+#[test]
+fn switching_expires_the_previous_sessions_selection() {
+    let mut app = NorenApp::default();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let ids = registry_ids(&app);
+    app.apply_pty_output(b"SELECT-7f31");
+    app.select_entire_grid();
+    assert!(app.selection.is_some());
+
+    assert!(click_sidebar_row(&mut app, 0));
+
+    assert_eq!(app.active_session, Some(ids[0]));
+    assert!(
+        app.selection.is_none(),
+        "a selection from the previous screen must not survive the switch"
+    );
+    assert!(app.drag_origin.is_none());
 }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4219,3 +4219,51 @@ fn palette_select_with_one_live_session_reaffirms_its_owner() {
     assert_eq!(app.workspace.registry().selected(), Some(live));
     assert!(!has_live_surface(&app, _model));
 }
+
+/// Restart honesty: rows restored from disk have no live process behind them,
+/// so selecting one must not move the live view — while the persisted
+/// selection itself survives the restart untouched. Live PTYs never survive a
+/// restart and the model never pretends otherwise.
+#[test]
+fn a_restored_row_never_takes_the_live_view_from_the_running_session() {
+    let path = temp_state_path();
+    // Launch one: one real session, quit (which persists it), relaunch.
+    {
+        let home = AppTestHome::new();
+        let mut first_launch = NorenApp {
+            test_pty_home: Some(home.0.clone()),
+            ..app_with_state_path(&path)
+        };
+        first_launch.run_workspace_action(WorkspaceAction::CreateSession);
+        first_launch.teardown();
+    }
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..app_with_state_path(&path)
+    };
+    // The relaunched app has one Restored row and no live surface yet.
+    let restored = registry_ids(&app)[0];
+    assert_eq!(session_status(&app, restored), SessionStatus::Restored);
+    assert_eq!(app.active_session, None);
+
+    // The user creates a new real session; it takes the live view.
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let live = registry_ids(&app)[1];
+    assert_eq!(app.active_session, Some(live));
+
+    // Clicking the Restored row is consumed but cannot take input ownership:
+    // its shell died with the previous launch.
+    assert!(
+        click_sidebar_row(&mut app, 0),
+        "the restored row is consumed"
+    );
+    assert_eq!(
+        app.active_session,
+        Some(live),
+        "a restored row has no live surface to attach"
+    );
+    assert_eq!(app.workspace.registry().selected(), Some(live));
+    assert!(app.pty.is_some(), "the live surface is untouched");
+    cleanup_state_file(&path);
+}

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3084,9 +3084,11 @@ fn inactive_local_sidebar_press_is_consumed_without_moving_the_pty_owner() {
     ));
 
     assert_eq!(app.workspace.local_sidebar_session(0), Some(inactive));
-    assert_eq!(app.workspace.registry().selected(), Some(active));
+    // Input ownership stays with the active session, but the click SELECTS
+    // the clicked row — the close command operates on the selection.
+    assert_eq!(app.workspace.registry().selected(), Some(inactive));
     assert_eq!(app.active_session, Some(active));
-    assert!(app.workspace.sidebar().rows()[1].is_selected());
+    assert!(app.workspace.sidebar().rows()[0].is_selected());
 }
 
 #[test]
@@ -3108,9 +3110,11 @@ fn restored_local_sidebar_press_cannot_claim_live_input_ownership() {
     ));
 
     assert_eq!(app.workspace.local_sidebar_session(0), Some(restored));
-    assert_eq!(app.workspace.registry().selected(), Some(active));
+    // Input ownership stays with the active session; the click selects the
+    // restored row so a close targets what the user pointed at.
+    assert_eq!(app.workspace.registry().selected(), Some(restored));
     assert_eq!(app.active_session, Some(active));
-    assert!(app.workspace.sidebar().rows()[1].is_selected());
+    assert!(app.workspace.sidebar().rows()[0].is_selected());
 }
 
 #[test]
@@ -4037,7 +4041,8 @@ fn wait_for_shell_output(app: &mut NorenApp) {
 /// (no PTY, no `Running` observation) fails every assertion past the first.
 #[test]
 fn palette_create_spawns_a_real_local_pty_session() {
-    let mut app = NorenApp::default();
+    let home = AppTestHome::new();
+    let mut app = home.app();
 
     app.run_workspace_action(WorkspaceAction::CreateSession);
 
@@ -4136,7 +4141,11 @@ fn a_parked_session_that_exits_is_observed_and_detached() {
 #[test]
 fn quitting_persists_spawned_sessions_for_the_next_launch() {
     let path = temp_state_path();
-    let mut app = app_with_state_path(&path);
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..app_with_state_path(&path)
+    };
     app.run_workspace_action(WorkspaceAction::CreateSession);
     app.run_workspace_action(WorkspaceAction::CreateSession);
 
@@ -4259,7 +4268,9 @@ fn switching_to_a_row_without_a_live_surface_keeps_the_current_owner() {
         Some(live),
         "a row without a live surface must not take the live view"
     );
-    assert_eq!(app.workspace.registry().selected(), Some(live));
+    // The click selects the model row (close targets what was clicked);
+    // input ownership stays with the live session.
+    assert_eq!(app.workspace.registry().selected(), Some(_model));
     assert!(app.pty.is_some(), "the live surface is untouched");
     assert!(!has_live_surface(&app, _model));
 }
@@ -4284,6 +4295,62 @@ fn switching_expires_the_previous_sessions_selection() {
         "a selection from the previous screen must not survive the switch"
     );
     assert!(app.drag_origin.is_none());
+}
+
+/// Creating a new session takes the live view through the same expiry a
+/// sidebar switch runs: a selection captured on the old screen must not
+/// survive into the new session's coordinates (found by independent review —
+/// `spawn_local_session` once switched surfaces without expiring).
+#[test]
+fn creating_a_session_expires_the_previous_sessions_selection() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    app.apply_pty_output(b"CREATE-9c2e");
+    app.select_entire_grid();
+    assert!(app.selection.is_some());
+
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+
+    assert!(
+        app.selection.is_none(),
+        "a selection from the previous screen must not survive creation"
+    );
+    assert!(app.drag_origin.is_none());
+}
+
+/// Closing the row whose EXITED final frame is still displayed must clear
+/// the surface and run the same fallback an active close does — not leave a
+/// frozen frame behind a vanished row in an empty workspace (found by
+/// independent review).
+#[test]
+fn closing_the_displayed_exited_frame_clears_the_surface_honestly() {
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let id = registry_ids(&app)[0];
+    assert_eq!(app.active_session, Some(id));
+
+    // The child exits: finish_pty keeps the final frame displayed with input
+    // ownership already gone.
+    app.finish_pty("Noren shell reached EOF");
+    assert_eq!(app.active_session, None);
+    assert!(app.terminal.is_some(), "the final frame stays displayed");
+
+    app.run_workspace_action(WorkspaceAction::CloseSession);
+
+    assert!(
+        app.workspace.registry().get(id).is_none(),
+        "the exited row is closed"
+    );
+    assert!(
+        app.terminal.is_none(),
+        "no closed session's frozen frame may stay on screen"
+    );
+    assert!(
+        app.parked_sessions.is_empty() && app.active_session.is_none(),
+        "an empty workspace is reported honestly"
+    );
 }
 
 // ── Closing live sessions (supervisor-backed switching, slice 3) ────────
@@ -4491,7 +4558,10 @@ fn a_restored_row_never_takes_the_live_view_from_the_running_session() {
     assert_eq!(app.active_session, Some(live));
 
     // Clicking the Restored row is consumed but cannot take input ownership:
-    // its shell died with the previous launch.
+    // its shell died with the previous launch. The click still SELECTS the
+    // clicked row — the palette's close command operates on the selected
+    // row, and re-selecting the live one would redirect a close onto a shell
+    // the user did not point at (found by independent review).
     assert!(
         click_sidebar_row(&mut app, 0),
         "the restored row is consumed"
@@ -4501,7 +4571,21 @@ fn a_restored_row_never_takes_the_live_view_from_the_running_session() {
         Some(live),
         "a restored row has no live surface to attach"
     );
-    assert_eq!(app.workspace.registry().selected(), Some(live));
+    assert_eq!(
+        app.workspace.registry().selected(),
+        Some(restored),
+        "the click selects the clicked row, not the live one"
+    );
     assert!(app.pty.is_some(), "the live surface is untouched");
+    // And closing now removes the clicked restored row, never the live shell.
+    app.run_workspace_action(WorkspaceAction::CloseSession);
+    assert!(
+        app.workspace.registry().get(restored).is_none(),
+        "close targets the row the user just clicked"
+    );
+    assert!(
+        app.workspace.registry().get(live).is_some(),
+        "the live shell survives closing the restored row"
+    );
     cleanup_state_file(&path);
 }

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -10,7 +10,7 @@ use std::ffi::OsString;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::num::NonZeroU16;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
@@ -292,6 +292,21 @@ impl PtySession {
     /// Spawn `/bin/zsh` at the supplied initial non-zero size.
     pub fn spawn(size: PtySize) -> Result<Self, PtyError> {
         Self::spawn_with_policy(ZshLaunchPolicy::from_environment()?, size)
+    }
+
+    /// Spawn `/bin/zsh` with `home` as the child's `HOME` and working
+    /// directory instead of the inherited one.
+    ///
+    /// The same fixed launch policy as [`PtySession::spawn`]: identical
+    /// program, `TERM`, and environment surgery; only the home differs, and it
+    /// is validated exactly like an inherited `HOME` (absolute, existing
+    /// directory). This is the seam higher-level test suites use to run the
+    /// child in an isolated directory: a developer's real `$HOME` may carry
+    /// startup files that take arbitrarily long or read the terminal, which
+    /// would make every shell-driving test depend on personal configuration.
+    pub fn spawn_in_home(home: &Path, size: PtySize) -> Result<Self, PtyError> {
+        let policy = validate_home(Some(home.as_os_str().to_owned()))?;
+        Self::spawn_with_policy(policy, size)
     }
 
     /// Spawn using an already validated fixed-zsh policy.
@@ -1037,5 +1052,40 @@ mod tests {
             result,
             Ok(()) | Err(PtyError::ReaderJoinTimeout | PtyError::SupervisorJoinTimeout)
         ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_in_home_uses_the_isolated_home_and_validates_it() {
+        // The public seam must reject exactly what the inherited-home path
+        // rejects, without reading or mutating the process environment.
+        let missing = std::env::temp_dir().join("noren-pty-missing-spawn-in-home");
+        assert!(matches!(
+            PtySession::spawn_in_home(&missing, PtySize::from_raw(24, 80).expect("size")),
+            Err(PtyError::HomeNotDirectory)
+        ));
+
+        let home = TestHome::new();
+        let size = PtySize::from_raw(24, 80).expect("valid initial size");
+        let mut session = PtySession::spawn_in_home(&home.0, size).expect("spawn in home");
+        // The isolated home carries no startup files, so the shell answers
+        // immediately; a real `$HOME` with slow startup files could not.
+        session
+            .send_input(b"print -r -- SPAWN_IN_HOME_OK\nexit\n")
+            .expect("drive shell");
+        let mut output = Vec::new();
+        let mut lifecycle = false;
+        poll_events(
+            &session,
+            Instant::now() + Duration::from_secs(2),
+            &mut output,
+            &mut lifecycle,
+            |_, observed| observed,
+        );
+        // Echo is on (this test never disables it), so the marker appears both
+        // as the echoed input line and as the printed output; at least one
+        // occurrence proves the isolated shell answered.
+        assert!(occurrences(&output, b"SPAWN_IN_HOME_OK") >= 1);
+        session.shutdown().expect("reap isolated-home zsh");
     }
 }

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -30,12 +30,15 @@ binary. What now actually happens on screen:
   `glyph_vertices` in `renderer.rs`, which takes a `sidebar` argument and
   applies `col_offset`, and `sidebar_text_lines` in `main.rs`, which formats the
   rows.
-- **The session palette is present, but only one PTY is live.** `Super+p` opens
+- **The session palette operates on real local sessions.** `Super+p` opens
   the command palette (claimed by `palette_policy` in `main.rs` as
-  `PassthroughAction::OpenCommandPalette`). Its `c` command adds a model row;
-  it does not start another shell. The `s` and `x` commands cannot move or
-  remove the startup PTY's input owner, while `f` dispatches sidebar focus —
-  currently a no-op, since the sidebar is always visible. Arrow
+  `PassthroughAction::OpenCommandPalette`). Its `c` command spawns a real
+  `/bin/zsh` PTY and gives it the live view (parking the previous one, not
+  killing it); `s` cycles the live view to the next live session in sidebar
+  order; `x` closes the selected row, reaping its child and falling back to
+  the topmost remaining live session — or an honest empty view when it was the
+  last one. The `f` command dispatches sidebar focus — currently a no-op, since
+  the sidebar is always visible. Arrow
   keys and Enter navigate the same command list; Escape dismisses it.
 - **Mouse reporting reaches the program.** `handle_mouse_button`,
   `handle_mouse_move`, and `handle_mouse_wheel` in `main.rs` each call
@@ -177,7 +180,7 @@ Each item states what you would actually see if you ran the build.
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.
-- **Only the startup local session is actually launched.** `SessionKind` models
+- **Only local sessions are actually launched.** `SessionKind` models
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
   but only `Local` has a launch path. The running binary now reads bounded
@@ -186,9 +189,9 @@ Each item states what you would actually see if you ran the build.
   records a pending target; it opens neither an SSH connection nor a PTY.
   Project and worktree kinds remain modelled, while agent entries remain
   reserved fixtures and no agent is launched. In practice: startup owns exactly
-  one local `zsh`. The palette's "New Session" currently records another local
-  model row but does not spawn a PTY, and an inactive or restored row cannot
-  take the live PTY's selection/input ownership. There is no way to open an SSH
+  one local `zsh`, the palette's "New Session" spawns another real local `zsh`,
+  and every local row can take the live view; a restored row cannot (its shell
+  died with the previous launch). There is no way to open an SSH
   host, a git worktree, or an agent from the workspace. Milestones 4 and 5 own
   the remaining work.
 - **The SSH list is not OpenSSH-equivalent discovery.** A readable config can
@@ -203,11 +206,15 @@ Each item states what you would actually see if you ran the build.
   only the first 24 literal aliases and reports an omitted count; selecting a
   row shows where its first literal declaration came from, but does not prove
   the effective configuration that a future connection will use.
-- **There is one live session, not session switching.** The sidebar may list
-  restored or palette-created model entries, but only the startup session owns
-  the terminal viewport and input. Clicking an inactive row cannot move that
-  ownership. There is no split, tiled, or multi-session view. Panes and layout
-  *inside* the live session are delegated to Zellij by design — see "What is
+- **Session switching exists, within one viewport.** Clicking a live session
+  row in the sidebar (or the palette's `s` command) moves the whole live view
+  — terminal surface, input routing, renderer — to that session's own PTY and
+  screen; the previous session is parked with its child still running and its
+  output still drained and resized in the background, so switching back shows
+  current content. Restored or exited rows have no live surface and cannot
+  take the live view. There is still no split, tiled, or multi-session view:
+  exactly one session owns the viewport at a time. Panes and layout *inside*
+  the live session are delegated to Zellij by design — see "What is
   deliberately delegated".
 - **Keybindings are not configurable.** The palette opener (`Super+p`), the exit
   leader (`Super+Escape`), and the `c`/`s`/`x`/`f` command keys are compiled in:
@@ -290,9 +297,11 @@ When Zellij is running, correct input pass-through takes priority over Noren
 shortcuts. Please do not file the absence of native tabs or panes as a bug —
 but do hold Noren to its side of the boundary: a workspace *outside* the
 terminal. That side now has a first vertical slice — a drawn sidebar, a command
-palette over model rows, one live local PTY, and state that survives a restart
-— and the gaps that remain there (real session switching, non-local session
-kinds, configurable keybindings) are legitimate things to report.
+palette over real local sessions (spawn, switch, close), live switching between
+them, and state that survives a restart
+— and the gaps that remain there (non-local session
+kinds, configurable keybindings, reattaching a restored session's shell) are
+legitimate things to report.
 
 ## What this preview is not
 


### PR DESCRIPTION
Closes the Milestone 3 gap "terminal sessions: Partial runtime — palette-created rows are model entries only until supervisor-backed switching lands". Built by a coordinator subagent across two runs (an API drop in between; incremental commits meant zero work was lost — checkpointed as 49050d9 and resumed), verified by the coordinator.

**Delivered:**
- Sidebar click switches the live view (surface, input routing, renderer) to the selected session's PTY; switching back re-attaches the same session
- Palette `session_create` (c) spawns a REAL /bin/zsh PTY — parked map with background drain/reap, previous session parked not killed
- Palette `session_select` (s) cycles the live view through live sessions; `session_close` (x) does bounded kill-and-reap before row removal, falling back to the topmost remaining live session or an honest empty view
- Restart honesty: restored rows never take the live view (pinned by test); persistence tests stay green
- `PtySession::spawn_in_home` + isolated test homes so shell-driving tests stop depending on the developer's $HOME (fixed a deterministic 61s-zsh-startup timeout failure)

**Coordinator verification at the merged head:** main merged first (salvage base predated #136/#137 — stacked-deletion trap caught; docs conflicts resolved keeping both the new behavior and the [keys] configurability), docs validator OK, fmt 0, clippy 0, 908 workspace tests pass, frame_oracle --ignored exactly 2 documented failures. Mutation re-run by coordinator: no-op switch fails 5 tests.

Subagent mutation proofs on record: model-row-only create fails 7 tests; unreaped close fails 3 tests.

Note: touches main.rs/main/tests.rs like PR #138 (SSH) — whichever merges second needs a mechanical re-merge.