### PR TITLE
feat(renderer): distinct ASCII glyphs, Latin-1, and box drawing — retire both font defects

### DIFF
--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -748,8 +748,11 @@ struct Target {
     metrics: CellMetrics,
 }
 
-/// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`,
-/// converting each lit pixel bit to a 2×2 rectangle of vertices in `color`.
+/// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`.
+///
+/// Text glyphs keep the historical 2×2 pixels and top inset. Box-drawing
+/// glyphs instead scale their bitmap across the whole cell: a line ending at a
+/// cell edge must meet the next frame cell without the text glyph's padding.
 fn push_glyph(
     vertices: &mut Vec<Vertex>,
     character: char,
@@ -760,20 +763,41 @@ fn push_glyph(
 ) {
     let cell_width = target.metrics.width();
     let cell_height = target.metrics.height();
+    let cell_x = u32::try_from(col).unwrap_or(u32::MAX) * cell_width;
+    let cell_y = u32::try_from(row).unwrap_or(u32::MAX) * cell_height;
+    let fills_cell = is_box_drawing(character);
     let glyph = glyph_rows(character);
     for (glyph_y, bits) in glyph.into_iter().enumerate() {
         for glyph_x in 0..5 {
             if bits & (1 << (4 - glyph_x)) == 0 {
                 continue;
             }
-            let x = u32::try_from(col).unwrap_or(u32::MAX) * cell_width
-                + u32::try_from(glyph_x).unwrap_or(0) * GLYPH_SCALE;
-            let y = u32::try_from(row).unwrap_or(u32::MAX) * cell_height
-                + GLYPH_TOP
-                + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE;
-            push_rect(vertices, x, y, GLYPH_SCALE, GLYPH_SCALE, color, target);
+            let (x, y, width, height) = if fills_cell {
+                let (x, width) = scaled_bitmap_segment(glyph_x, 5, cell_width);
+                let (y, height) = scaled_bitmap_segment(glyph_y, 7, cell_height);
+                (cell_x + x, cell_y + y, width, height)
+            } else {
+                (
+                    cell_x + u32::try_from(glyph_x).unwrap_or(0) * GLYPH_SCALE,
+                    cell_y + GLYPH_TOP + u32::try_from(glyph_y).unwrap_or(0) * GLYPH_SCALE,
+                    GLYPH_SCALE,
+                    GLYPH_SCALE,
+                )
+            };
+            push_rect(vertices, x, y, width, height, color, target);
         }
     }
+}
+
+/// Return one proportional bitmap segment without overflowing at `u32::MAX`.
+fn scaled_bitmap_segment(index: usize, segments: u32, length: u32) -> (u32, u32) {
+    let boundary = |position: usize| {
+        (u64::try_from(position).unwrap_or(u64::MAX) * u64::from(length) / u64::from(segments))
+            as u32
+    };
+    let start = boundary(index);
+    let end = boundary(index + 1);
+    (start, end - start)
 }
 
 fn push_rect(
@@ -831,6 +855,209 @@ pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
         }
     }
     bytes
+}
+
+const QUESTION_MARK_GLYPH: [u8; 7] = [14, 17, 1, 2, 4, 0, 4];
+
+fn is_box_drawing(character: char) -> bool {
+    matches!(character, '\u{2500}'..='\u{257f}')
+}
+
+#[derive(Clone, Copy)]
+enum BoxStroke {
+    None,
+    Light,
+    Heavy,
+    Double,
+}
+
+/// Rasterize up/right/down/left box-drawing arms around the bitmap centre.
+///
+/// Light strokes occupy one pixel, heavy strokes occupy three, and double
+/// strokes occupy the two pixels either side of the centre. The bitmap is
+/// stretched across the whole terminal cell by [`push_glyph`], so every arm
+/// reaches and joins the corresponding edge of an adjacent cell.
+fn box_stroke_rows(up: BoxStroke, right: BoxStroke, down: BoxStroke, left: BoxStroke) -> [u8; 7] {
+    fn vertical_arm(rows: &mut [u8; 7], stroke: BoxStroke, start: usize, end: usize) {
+        let mask = match stroke {
+            BoxStroke::None => 0,
+            BoxStroke::Light => 0b00100,
+            BoxStroke::Heavy => 0b01110,
+            BoxStroke::Double => 0b01010,
+        };
+        for row in &mut rows[start..=end] {
+            *row |= mask;
+        }
+    }
+
+    fn horizontal_arm(rows: &mut [u8; 7], stroke: BoxStroke, start: usize, end: usize) {
+        let mut mask = 0;
+        for column in start..=end {
+            mask |= 1 << (4 - column);
+        }
+        match stroke {
+            BoxStroke::None => {}
+            BoxStroke::Light => rows[3] |= mask,
+            BoxStroke::Heavy => {
+                for row in &mut rows[2..=4] {
+                    *row |= mask;
+                }
+            }
+            BoxStroke::Double => {
+                rows[2] |= mask;
+                rows[4] |= mask;
+            }
+        }
+    }
+
+    let mut rows = [0; 7];
+    vertical_arm(&mut rows, up, 0, 3);
+    horizontal_arm(&mut rows, right, 2, 4);
+    vertical_arm(&mut rows, down, 3, 6);
+    horizontal_arm(&mut rows, left, 0, 2);
+    rows
+}
+
+/// Bitmap coverage for the complete Unicode Box Drawing block
+/// (`U+2500..=U+257F`). Weight variants share a topology rasterizer; dashed,
+/// rounded, and diagonal forms have explicit bitmaps where arm weights are not
+/// enough to describe their appearance.
+#[rustfmt::skip]
+fn box_drawing_rows(character: char) -> Option<[u8; 7]> {
+    use BoxStroke::{Double as D, Heavy as H, Light as L, None as N};
+
+    let rows = match character {
+        '\u{2500}' => box_stroke_rows(N, L, N, L),
+        '\u{2501}' => box_stroke_rows(N, H, N, H),
+        '\u{2502}' => box_stroke_rows(L, N, L, N),
+        '\u{2503}' => box_stroke_rows(H, N, H, N),
+        '\u{2504}' => [0, 0, 0, 0b11011, 0, 0, 0],
+        '\u{2505}' => [0, 0, 0b11011, 0b11011, 0b11011, 0, 0],
+        '\u{2506}' => [4, 4, 0, 4, 4, 0, 4],
+        '\u{2507}' => [14, 14, 0, 14, 14, 0, 14],
+        '\u{2508}' => [0, 0, 0, 0b10101, 0, 0, 0],
+        '\u{2509}' => [0, 0, 0b10101, 0b10101, 0b10101, 0, 0],
+        '\u{250a}' => [4, 0, 4, 0, 4, 0, 4],
+        '\u{250b}' => [14, 0, 14, 0, 14, 0, 14],
+        '\u{250c}' => box_stroke_rows(N, L, L, N),
+        '\u{250d}' => box_stroke_rows(N, H, L, N),
+        '\u{250e}' => box_stroke_rows(N, L, H, N),
+        '\u{250f}' => box_stroke_rows(N, H, H, N),
+        '\u{2510}' => box_stroke_rows(N, N, L, L),
+        '\u{2511}' => box_stroke_rows(N, N, L, H),
+        '\u{2512}' => box_stroke_rows(N, N, H, L),
+        '\u{2513}' => box_stroke_rows(N, N, H, H),
+        '\u{2514}' => box_stroke_rows(L, L, N, N),
+        '\u{2515}' => box_stroke_rows(L, H, N, N),
+        '\u{2516}' => box_stroke_rows(H, L, N, N),
+        '\u{2517}' => box_stroke_rows(H, H, N, N),
+        '\u{2518}' => box_stroke_rows(L, N, N, L),
+        '\u{2519}' => box_stroke_rows(L, N, N, H),
+        '\u{251a}' => box_stroke_rows(H, N, N, L),
+        '\u{251b}' => box_stroke_rows(H, N, N, H),
+        '\u{251c}' => box_stroke_rows(L, L, L, N),
+        '\u{251d}' => box_stroke_rows(L, H, L, N),
+        '\u{251e}' => box_stroke_rows(H, L, L, N),
+        '\u{251f}' => box_stroke_rows(L, L, H, N),
+        '\u{2520}' => box_stroke_rows(H, L, H, N),
+        '\u{2521}' => box_stroke_rows(H, H, L, N),
+        '\u{2522}' => box_stroke_rows(L, H, H, N),
+        '\u{2523}' => box_stroke_rows(H, H, H, N),
+        '\u{2524}' => box_stroke_rows(L, N, L, L),
+        '\u{2525}' => box_stroke_rows(L, N, L, H),
+        '\u{2526}' => box_stroke_rows(H, N, L, L),
+        '\u{2527}' => box_stroke_rows(L, N, H, L),
+        '\u{2528}' => box_stroke_rows(H, N, H, L),
+        '\u{2529}' => box_stroke_rows(H, N, L, H),
+        '\u{252a}' => box_stroke_rows(L, N, H, H),
+        '\u{252b}' => box_stroke_rows(H, N, H, H),
+        '\u{252c}' => box_stroke_rows(N, L, L, L),
+        '\u{252d}' => box_stroke_rows(N, L, L, H),
+        '\u{252e}' => box_stroke_rows(N, H, L, L),
+        '\u{252f}' => box_stroke_rows(N, H, L, H),
+        '\u{2530}' => box_stroke_rows(N, L, H, L),
+        '\u{2531}' => box_stroke_rows(N, L, H, H),
+        '\u{2532}' => box_stroke_rows(N, H, H, L),
+        '\u{2533}' => box_stroke_rows(N, H, H, H),
+        '\u{2534}' => box_stroke_rows(L, L, N, L),
+        '\u{2535}' => box_stroke_rows(L, L, N, H),
+        '\u{2536}' => box_stroke_rows(L, H, N, L),
+        '\u{2537}' => box_stroke_rows(L, H, N, H),
+        '\u{2538}' => box_stroke_rows(H, L, N, L),
+        '\u{2539}' => box_stroke_rows(H, L, N, H),
+        '\u{253a}' => box_stroke_rows(H, H, N, L),
+        '\u{253b}' => box_stroke_rows(H, H, N, H),
+        '\u{253c}' => box_stroke_rows(L, L, L, L),
+        '\u{253d}' => box_stroke_rows(L, L, L, H),
+        '\u{253e}' => box_stroke_rows(L, H, L, L),
+        '\u{253f}' => box_stroke_rows(L, H, L, H),
+        '\u{2540}' => box_stroke_rows(H, L, L, L),
+        '\u{2541}' => box_stroke_rows(L, L, H, L),
+        '\u{2542}' => box_stroke_rows(H, L, H, L),
+        '\u{2543}' => box_stroke_rows(H, L, L, H),
+        '\u{2544}' => box_stroke_rows(H, H, L, L),
+        '\u{2545}' => box_stroke_rows(L, L, H, H),
+        '\u{2546}' => box_stroke_rows(L, H, H, L),
+        '\u{2547}' => box_stroke_rows(H, H, L, H),
+        '\u{2548}' => box_stroke_rows(L, H, H, H),
+        '\u{2549}' => box_stroke_rows(H, L, H, H),
+        '\u{254a}' => box_stroke_rows(H, H, H, L),
+        '\u{254b}' => box_stroke_rows(H, H, H, H),
+        '\u{254c}' => [0, 0, 0, 0b11101, 0, 0, 0],
+        '\u{254d}' => [0, 0, 0b11101, 0b11101, 0b11101, 0, 0],
+        '\u{254e}' => [4, 4, 4, 0, 4, 4, 4],
+        '\u{254f}' => [14, 14, 14, 0, 14, 14, 14],
+        '\u{2550}' => box_stroke_rows(N, D, N, D),
+        '\u{2551}' => box_stroke_rows(D, N, D, N),
+        '\u{2552}' => box_stroke_rows(N, D, L, N),
+        '\u{2553}' => box_stroke_rows(N, L, D, N),
+        '\u{2554}' => box_stroke_rows(N, D, D, N),
+        '\u{2555}' => box_stroke_rows(N, N, L, D),
+        '\u{2556}' => box_stroke_rows(N, N, D, L),
+        '\u{2557}' => box_stroke_rows(N, N, D, D),
+        '\u{2558}' => box_stroke_rows(L, D, N, N),
+        '\u{2559}' => box_stroke_rows(D, L, N, N),
+        '\u{255a}' => box_stroke_rows(D, D, N, N),
+        '\u{255b}' => box_stroke_rows(L, N, N, D),
+        '\u{255c}' => box_stroke_rows(D, N, N, L),
+        '\u{255d}' => box_stroke_rows(D, N, N, D),
+        '\u{255e}' => box_stroke_rows(L, D, L, N),
+        '\u{255f}' => box_stroke_rows(D, L, D, N),
+        '\u{2560}' => box_stroke_rows(D, D, D, N),
+        '\u{2561}' => box_stroke_rows(L, N, L, D),
+        '\u{2562}' => box_stroke_rows(D, N, D, L),
+        '\u{2563}' => box_stroke_rows(D, N, D, D),
+        '\u{2564}' => box_stroke_rows(N, D, L, D),
+        '\u{2565}' => box_stroke_rows(N, L, D, L),
+        '\u{2566}' => box_stroke_rows(N, D, D, D),
+        '\u{2567}' => box_stroke_rows(L, D, N, D),
+        '\u{2568}' => box_stroke_rows(D, L, N, L),
+        '\u{2569}' => box_stroke_rows(D, D, N, D),
+        '\u{256a}' => box_stroke_rows(L, D, L, D),
+        '\u{256b}' => box_stroke_rows(D, L, D, L),
+        '\u{256c}' => box_stroke_rows(D, D, D, D),
+        '\u{256d}' => [0, 0, 2, 7, 4, 4, 4],
+        '\u{256e}' => [0, 0, 8, 28, 4, 4, 4],
+        '\u{256f}' => [4, 4, 4, 28, 8, 0, 0],
+        '\u{2570}' => [4, 4, 4, 7, 2, 0, 0],
+        '\u{2571}' => [1, 2, 2, 4, 8, 8, 16],
+        '\u{2572}' => [16, 8, 8, 4, 2, 2, 1],
+        '\u{2573}' => [17, 10, 10, 4, 10, 10, 17],
+        '\u{2574}' => box_stroke_rows(N, N, N, L),
+        '\u{2575}' => box_stroke_rows(L, N, N, N),
+        '\u{2576}' => box_stroke_rows(N, L, N, N),
+        '\u{2577}' => box_stroke_rows(N, N, L, N),
+        '\u{2578}' => box_stroke_rows(N, N, N, H),
+        '\u{2579}' => box_stroke_rows(H, N, N, N),
+        '\u{257a}' => box_stroke_rows(N, H, N, N),
+        '\u{257b}' => box_stroke_rows(N, N, H, N),
+        '\u{257c}' => box_stroke_rows(N, H, N, L),
+        '\u{257d}' => box_stroke_rows(L, N, H, N),
+        '\u{257e}' => box_stroke_rows(N, L, N, H),
+        '\u{257f}' => box_stroke_rows(H, N, L, N),
+        _ => return None,
+    };
+    Some(rows)
 }
 
 #[rustfmt::skip]
@@ -919,7 +1146,7 @@ fn glyph_rows(character: char) -> [u8; 7] {
         '<' => [2, 4, 8, 16, 8, 4, 2],
         '>' => [8, 4, 2, 1, 2, 4, 8],
         '!' => [4, 4, 4, 4, 4, 0, 4],
-        '?' => [14, 17, 1, 2, 4, 0, 4],
+        '?' => QUESTION_MARK_GLYPH,
         '"' => [10, 10, 10, 0, 0, 0, 0],
         '\'' => [4, 4, 8, 0, 0, 0, 0],
         '`' => [8, 4, 2, 0, 0, 0, 0],
@@ -931,7 +1158,7 @@ fn glyph_rows(character: char) -> [u8; 7] {
         '^' => [4, 10, 17, 0, 0, 0, 0],
         '&' => [12, 18, 20, 8, 21, 18, 13],
         '*' => [0, 21, 14, 31, 14, 21, 0],
-        _ => [14, 17, 1, 2, 4, 0, 4],
+        _ => box_drawing_rows(character).unwrap_or(QUESTION_MARK_GLYPH),
     }
 }
 
@@ -1360,6 +1587,67 @@ mod tests {
         }
 
         assert_eq!(seen.len(), 95, "printable ASCII must contain 95 glyphs");
+    }
+
+    #[test]
+    fn complete_box_drawing_block_avoids_the_question_mark_fallback() {
+        for scalar in 0x2500..=0x257f {
+            let character = char::from_u32(scalar).expect("box-drawing scalar is valid");
+            let rows = box_drawing_rows(character)
+                .unwrap_or_else(|| panic!("missing box-drawing glyph U+{scalar:04X}"));
+            assert_eq!(
+                glyph_rows(character),
+                rows,
+                "U+{scalar:04X} is not reachable through the production lookup"
+            );
+            assert_ne!(
+                rows, QUESTION_MARK_GLYPH,
+                "U+{scalar:04X} aliases the unsupported-character fallback"
+            );
+        }
+        assert!(
+            box_drawing_rows('\u{2580}').is_none(),
+            "coverage must stop at the documented U+257F boundary"
+        );
+    }
+
+    #[test]
+    fn common_box_drawing_glyphs_preserve_topology_and_weight() {
+        assert_eq!(glyph_rows('─'), [0, 0, 0, 31, 0, 0, 0]);
+        assert_eq!(glyph_rows('│'), [4, 4, 4, 4, 4, 4, 4]);
+        assert_eq!(glyph_rows('┌'), [0, 0, 0, 7, 4, 4, 4]);
+        assert_eq!(glyph_rows('┼'), [4, 4, 4, 31, 4, 4, 4]);
+        assert_eq!(glyph_rows('═'), [0, 0, 31, 0, 31, 0, 0]);
+        assert_eq!(glyph_rows('║'), [10, 10, 10, 10, 10, 10, 10]);
+        assert_ne!(glyph_rows('─'), glyph_rows('━'));
+        assert_ne!(glyph_rows('│'), glyph_rows('┃'));
+        assert_ne!(glyph_rows('┌'), glyph_rows('╭'));
+        assert_ne!(glyph_rows('╱'), glyph_rows('╲'));
+    }
+
+    #[test]
+    fn box_drawing_strokes_reach_cell_edges_through_the_vertex_path() {
+        let metrics = poc_metrics();
+        let width = metrics.width();
+        let height = metrics.height();
+        let vertices_for = |text: &str| {
+            let terminal = snapshot(1, 1, text.as_bytes());
+            glyph_vertices(Some(&terminal), None, None, width, height, metrics)
+        };
+
+        let horizontal = vertices_for("─");
+        assert!(
+            horizontal.iter().any(|vertex| vertex.position[0] == -1.0)
+                && horizontal.iter().any(|vertex| vertex.position[0] == 1.0),
+            "horizontal frame stroke must span both cell edges"
+        );
+
+        let vertical = vertices_for("│");
+        assert!(
+            vertical.iter().any(|vertex| vertex.position[1] == 1.0)
+                && vertical.iter().any(|vertex| vertex.position[1] == -1.0),
+            "vertical frame stroke must span both cell edges"
+        );
     }
 
     /// The encoded vertex stride must match what the pipeline's vertex buffer

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -858,6 +858,142 @@ pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
 }
 
 const QUESTION_MARK_GLYPH: [u8; 7] = [14, 17, 1, 2, 4, 0, 4];
+const UNICODE_REPLACEMENT_GLYPH: [u8; 7] = [4, 10, 17, 21, 17, 10, 4];
+
+/// Add one visible diacritic row to an ASCII base glyph.
+///
+/// Uppercase glyphs already consume all seven rows, so their repeated lower
+/// body row is compressed out while the final baseline row is retained.
+/// Lowercase accented letters have room above their x-height; replacing row
+/// zero also replaces the dot on `i` with the requested accent.
+fn top_marked_ascii(base: char, mark: u8) -> [u8; 7] {
+    let rows = glyph_rows(base);
+    if base.is_ascii_uppercase() {
+        [mark, rows[0], rows[1], rows[2], rows[3], rows[4], rows[6]]
+    } else {
+        [mark, rows[1], rows[2], rows[3], rows[4], rows[5], rows[6]]
+    }
+}
+
+fn bottom_marked_ascii(base: char, mark: u8) -> [u8; 7] {
+    let rows = glyph_rows(base);
+    [rows[0], rows[1], rows[2], rows[3], rows[4], rows[6], mark]
+}
+
+/// Bitmap coverage for the complete Latin-1 Supplement block
+/// (`U+00A0..=U+00FF`). Precomposed letters retain their ASCII base shape and
+/// encode their accent in the spare top or bottom row; Latin-1 punctuation and
+/// symbols use compact 5×7 approximations.
+#[rustfmt::skip]
+fn latin1_rows(character: char) -> Option<[u8; 7]> {
+    const GRAVE: u8 = 0b01000;
+    const ACUTE: u8 = 0b00010;
+    const CIRCUMFLEX: u8 = 0b01010;
+    const TILDE: u8 = 0b01011;
+    const DIAERESIS: u8 = 0b10001;
+    const RING: u8 = 0b00100;
+
+    let rows = match character {
+        '\u{00a0}' => [0, 0, 0, 0, 0, 0, 0],
+        '\u{00a1}' => [4, 0, 4, 4, 4, 4, 4],
+        '\u{00a2}' => [4, 14, 20, 20, 21, 14, 4],
+        '\u{00a3}' => [6, 8, 8, 30, 8, 8, 31],
+        '\u{00a4}' => [0, 17, 14, 10, 14, 17, 0],
+        '\u{00a5}' => [17, 10, 4, 31, 4, 31, 4],
+        '\u{00a6}' => [4, 4, 4, 0, 4, 4, 4],
+        '\u{00a7}' => [14, 16, 12, 18, 6, 1, 14],
+        '\u{00a8}' => [17, 0, 0, 0, 0, 0, 0],
+        '\u{00a9}' => [14, 17, 23, 20, 23, 17, 14],
+        '\u{00aa}' => [4, 10, 14, 10, 0, 14, 0],
+        '\u{00ab}' => [0, 5, 10, 20, 10, 5, 0],
+        '\u{00ac}' => [0, 0, 31, 1, 1, 0, 0],
+        '\u{00ad}' => [0, 0, 0, 14, 0, 0, 0],
+        '\u{00ae}' => [14, 17, 30, 21, 18, 17, 14],
+        '\u{00af}' => [31, 0, 0, 0, 0, 0, 0],
+        '\u{00b0}' => [6, 9, 9, 6, 0, 0, 0],
+        '\u{00b1}' => [4, 4, 31, 4, 4, 0, 31],
+        '\u{00b2}' => [6, 9, 2, 4, 15, 0, 0],
+        '\u{00b3}' => [14, 1, 6, 1, 14, 0, 0],
+        '\u{00b4}' => [2, 4, 0, 0, 0, 0, 0],
+        '\u{00b5}' => [0, 0, 17, 17, 19, 29, 16],
+        '\u{00b6}' => [15, 29, 29, 13, 5, 5, 5],
+        '\u{00b7}' => [0, 0, 0, 4, 0, 0, 0],
+        '\u{00b8}' => [0, 0, 0, 0, 0, 4, 8],
+        '\u{00b9}' => [4, 12, 4, 4, 14, 0, 0],
+        '\u{00ba}' => [4, 10, 4, 10, 0, 14, 0],
+        '\u{00bb}' => [0, 20, 10, 5, 10, 20, 0],
+        '\u{00bc}' => [8, 24, 9, 2, 5, 7, 1],
+        '\u{00bd}' => [8, 24, 9, 2, 7, 1, 7],
+        '\u{00be}' => [24, 8, 25, 2, 5, 7, 1],
+        '\u{00bf}' => [4, 0, 4, 8, 16, 17, 14],
+        '\u{00c0}' => top_marked_ascii('A', GRAVE),
+        '\u{00c1}' => top_marked_ascii('A', ACUTE),
+        '\u{00c2}' => top_marked_ascii('A', CIRCUMFLEX),
+        '\u{00c3}' => top_marked_ascii('A', TILDE),
+        '\u{00c4}' => top_marked_ascii('A', DIAERESIS),
+        '\u{00c5}' => top_marked_ascii('A', RING),
+        '\u{00c6}' => [14, 21, 20, 30, 20, 21, 23],
+        '\u{00c7}' => bottom_marked_ascii('C', 4),
+        '\u{00c8}' => top_marked_ascii('E', GRAVE),
+        '\u{00c9}' => top_marked_ascii('E', ACUTE),
+        '\u{00ca}' => top_marked_ascii('E', CIRCUMFLEX),
+        '\u{00cb}' => top_marked_ascii('E', DIAERESIS),
+        '\u{00cc}' => top_marked_ascii('I', GRAVE),
+        '\u{00cd}' => top_marked_ascii('I', ACUTE),
+        '\u{00ce}' => top_marked_ascii('I', CIRCUMFLEX),
+        '\u{00cf}' => top_marked_ascii('I', DIAERESIS),
+        '\u{00d0}' => [30, 9, 9, 29, 9, 9, 30],
+        '\u{00d1}' => top_marked_ascii('N', TILDE),
+        '\u{00d2}' => top_marked_ascii('O', GRAVE),
+        '\u{00d3}' => top_marked_ascii('O', ACUTE),
+        '\u{00d4}' => top_marked_ascii('O', CIRCUMFLEX),
+        '\u{00d5}' => top_marked_ascii('O', TILDE),
+        '\u{00d6}' => top_marked_ascii('O', DIAERESIS),
+        '\u{00d7}' => [0, 17, 10, 4, 10, 17, 0],
+        '\u{00d8}' => [15, 19, 21, 21, 21, 25, 30],
+        '\u{00d9}' => top_marked_ascii('U', GRAVE),
+        '\u{00da}' => top_marked_ascii('U', ACUTE),
+        '\u{00db}' => top_marked_ascii('U', CIRCUMFLEX),
+        '\u{00dc}' => top_marked_ascii('U', DIAERESIS),
+        '\u{00dd}' => top_marked_ascii('Y', ACUTE),
+        '\u{00de}' => [16, 16, 30, 17, 30, 16, 16],
+        '\u{00df}' => [12, 18, 18, 28, 18, 18, 29],
+        '\u{00e0}' => top_marked_ascii('a', GRAVE),
+        '\u{00e1}' => top_marked_ascii('a', ACUTE),
+        '\u{00e2}' => top_marked_ascii('a', CIRCUMFLEX),
+        '\u{00e3}' => top_marked_ascii('a', TILDE),
+        '\u{00e4}' => top_marked_ascii('a', DIAERESIS),
+        '\u{00e5}' => top_marked_ascii('a', RING),
+        '\u{00e6}' => [0, 0, 14, 5, 15, 20, 15],
+        '\u{00e7}' => bottom_marked_ascii('c', 4),
+        '\u{00e8}' => top_marked_ascii('e', GRAVE),
+        '\u{00e9}' => top_marked_ascii('e', ACUTE),
+        '\u{00ea}' => top_marked_ascii('e', CIRCUMFLEX),
+        '\u{00eb}' => top_marked_ascii('e', DIAERESIS),
+        '\u{00ec}' => top_marked_ascii('i', GRAVE),
+        '\u{00ed}' => top_marked_ascii('i', ACUTE),
+        '\u{00ee}' => top_marked_ascii('i', CIRCUMFLEX),
+        '\u{00ef}' => top_marked_ascii('i', DIAERESIS),
+        '\u{00f0}' => [2, 4, 14, 3, 15, 17, 14],
+        '\u{00f1}' => top_marked_ascii('n', TILDE),
+        '\u{00f2}' => top_marked_ascii('o', GRAVE),
+        '\u{00f3}' => top_marked_ascii('o', ACUTE),
+        '\u{00f4}' => top_marked_ascii('o', CIRCUMFLEX),
+        '\u{00f5}' => top_marked_ascii('o', TILDE),
+        '\u{00f6}' => top_marked_ascii('o', DIAERESIS),
+        '\u{00f7}' => [0, 4, 0, 31, 0, 4, 0],
+        '\u{00f8}' => [0, 0, 15, 19, 21, 25, 30],
+        '\u{00f9}' => top_marked_ascii('u', GRAVE),
+        '\u{00fa}' => top_marked_ascii('u', ACUTE),
+        '\u{00fb}' => top_marked_ascii('u', CIRCUMFLEX),
+        '\u{00fc}' => top_marked_ascii('u', DIAERESIS),
+        '\u{00fd}' => top_marked_ascii('y', ACUTE),
+        '\u{00fe}' => [16, 16, 30, 17, 30, 16, 16],
+        '\u{00ff}' => top_marked_ascii('y', DIAERESIS),
+        _ => return None,
+    };
+    Some(rows)
+}
 
 fn is_box_drawing(character: char) -> bool {
     matches!(character, '\u{2500}'..='\u{257f}')
@@ -1158,7 +1294,9 @@ fn glyph_rows(character: char) -> [u8; 7] {
         '^' => [4, 10, 17, 0, 0, 0, 0],
         '&' => [12, 18, 20, 8, 21, 18, 13],
         '*' => [0, 21, 14, 31, 14, 21, 0],
-        _ => box_drawing_rows(character).unwrap_or(QUESTION_MARK_GLYPH),
+        _ => latin1_rows(character)
+            .or_else(|| box_drawing_rows(character))
+            .unwrap_or(UNICODE_REPLACEMENT_GLYPH),
     }
 }
 
@@ -1567,10 +1705,12 @@ mod tests {
     }
 
     #[test]
-    fn ascii_glyphs_are_distinct_and_unknown_is_question_mark() {
+    fn ascii_glyphs_are_distinct_and_unknown_unicode_uses_replacement() {
         assert_ne!(glyph_rows('A'), glyph_rows('B'));
         assert_ne!(glyph_rows('a'), glyph_rows('A'));
-        assert_eq!(glyph_rows('界'), glyph_rows('?'));
+        assert_eq!(glyph_rows('界'), UNICODE_REPLACEMENT_GLYPH);
+        assert_eq!(glyph_rows('日'), UNICODE_REPLACEMENT_GLYPH);
+        assert_ne!(glyph_rows('界'), glyph_rows('?'));
     }
 
     #[test]
@@ -1587,6 +1727,37 @@ mod tests {
         }
 
         assert_eq!(seen.len(), 95, "printable ASCII must contain 95 glyphs");
+    }
+
+    #[test]
+    fn complete_latin1_supplement_is_reachable_without_unicode_fallback() {
+        for scalar in 0x00a0..=0x00ff {
+            let character = char::from_u32(scalar).expect("Latin-1 scalar is valid");
+            let rows = latin1_rows(character)
+                .unwrap_or_else(|| panic!("missing Latin-1 glyph U+{scalar:04X}"));
+            assert_eq!(
+                glyph_rows(character),
+                rows,
+                "U+{scalar:04X} is not reachable through the production lookup"
+            );
+            assert_ne!(
+                rows, UNICODE_REPLACEMENT_GLYPH,
+                "U+{scalar:04X} aliases the unsupported-Unicode fallback"
+            );
+            assert!(
+                rows.iter().all(|row| *row <= 0b1_1111),
+                "U+{scalar:04X} escapes the five-bit bitmap width"
+            );
+        }
+
+        assert_eq!(glyph_rows('\u{00a0}'), glyph_rows(' '));
+        assert_ne!(glyph_rows('É'), glyph_rows('E'));
+        assert_ne!(glyph_rows('é'), glyph_rows('e'));
+        assert_ne!(glyph_rows('ø'), glyph_rows('o'));
+        assert!(
+            latin1_rows('\u{0100}').is_none(),
+            "coverage must stop at the documented U+00FF boundary"
+        );
     }
 
     #[test]
@@ -1718,7 +1889,11 @@ mod tests {
     #[test]
     fn wide_output_renders_like_the_equivalent_single_width_layout() {
         let wide = snapshot(1, 6, "a日b".as_bytes());
-        let aligned = snapshot(1, 6, b"a? b");
+        // U+FFFD is a narrow scalar that intentionally uses the same explicit
+        // replacement bitmap as unsupported wide U+65E5. The intervening
+        // space models the wide character's continuation column without
+        // reviving the old (and now invalid) assumption that fallback is '?'.
+        let aligned = snapshot(1, 6, "a\u{fffd} b".as_bytes());
         let m = poc_metrics();
         assert_eq!(
             glyph_vertices(Some(&wide), None, None, 900, 600, m),

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -835,7 +835,7 @@ pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
 
 #[rustfmt::skip]
 fn glyph_rows(character: char) -> [u8; 7] {
-    match character.to_ascii_uppercase() {
+    match character {
         ' ' => [0, 0, 0, 0, 0, 0, 0],
         'A' => [14, 17, 17, 31, 17, 17, 17],
         'B' => [30, 17, 17, 30, 17, 17, 30],
@@ -863,6 +863,32 @@ fn glyph_rows(character: char) -> [u8; 7] {
         'X' => [17, 17, 10, 4, 10, 17, 17],
         'Y' => [17, 17, 10, 4, 4, 4, 4],
         'Z' => [31, 1, 2, 4, 8, 16, 31],
+        'a' => [0, 0, 14, 1, 15, 17, 15],
+        'b' => [16, 16, 22, 25, 17, 17, 30],
+        'c' => [0, 0, 14, 17, 16, 17, 14],
+        'd' => [1, 1, 13, 19, 17, 17, 15],
+        'e' => [0, 0, 14, 17, 31, 16, 14],
+        'f' => [6, 9, 8, 28, 8, 8, 8],
+        'g' => [0, 0, 15, 17, 15, 1, 14],
+        'h' => [16, 16, 22, 25, 17, 17, 17],
+        'i' => [4, 0, 12, 4, 4, 4, 14],
+        'j' => [2, 0, 6, 2, 2, 18, 12],
+        'k' => [16, 16, 18, 20, 24, 20, 18],
+        'l' => [12, 4, 4, 4, 4, 4, 14],
+        'm' => [0, 0, 26, 21, 21, 17, 17],
+        'n' => [0, 0, 30, 17, 17, 17, 17],
+        'o' => [0, 0, 14, 17, 17, 17, 14],
+        'p' => [0, 0, 30, 17, 30, 16, 16],
+        'q' => [0, 0, 15, 17, 15, 1, 1],
+        'r' => [0, 0, 22, 25, 16, 16, 16],
+        's' => [0, 0, 15, 16, 14, 1, 30],
+        't' => [8, 8, 28, 8, 8, 9, 6],
+        'u' => [0, 0, 17, 17, 17, 19, 13],
+        'v' => [0, 0, 17, 17, 17, 10, 4],
+        'w' => [0, 0, 17, 17, 21, 21, 10],
+        'x' => [0, 0, 17, 10, 4, 10, 17],
+        'y' => [0, 0, 17, 17, 15, 1, 14],
+        'z' => [0, 0, 31, 2, 4, 8, 31],
         '0' => [14, 17, 19, 21, 25, 17, 14],
         '1' => [4, 12, 4, 4, 4, 4, 14],
         '2' => [14, 17, 1, 2, 4, 8, 31],
@@ -1316,8 +1342,24 @@ mod tests {
     #[test]
     fn ascii_glyphs_are_distinct_and_unknown_is_question_mark() {
         assert_ne!(glyph_rows('A'), glyph_rows('B'));
-        assert_eq!(glyph_rows('a'), glyph_rows('A'));
+        assert_ne!(glyph_rows('a'), glyph_rows('A'));
         assert_eq!(glyph_rows('界'), glyph_rows('?'));
+    }
+
+    #[test]
+    fn every_printable_ascii_glyph_is_pairwise_distinct() {
+        let mut seen = std::collections::HashMap::new();
+
+        for byte in b' '..=b'~' {
+            let character = char::from(byte);
+            let rows = glyph_rows(character);
+            assert!(
+                seen.insert(rows, character).is_none(),
+                "printable ASCII glyph {character:?} collides with an earlier glyph"
+            );
+        }
+
+        assert_eq!(seen.len(), 95, "printable ASCII must contain 95 glyphs");
     }
 
     /// The encoded vertex stride must match what the pipeline's vertex buffer

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -954,9 +954,17 @@ fn latin1_rows(character: char) -> Option<[u8; 7]> {
         '\u{00d9}' => top_marked_ascii('U', GRAVE),
         '\u{00da}' => top_marked_ascii('U', ACUTE),
         '\u{00db}' => top_marked_ascii('U', CIRCUMFLEX),
-        '\u{00dc}' => top_marked_ascii('U', DIAERESIS),
+        // `top_marked_ascii` cannot express an umlauted U: every U body row
+        // is 0b10001 — the same bits as DIAERESIS — so the compressed glyph
+        // would be pixel-identical to plain U and the diaeresis invisible.
+        // The U is therefore shortened by one row and a blank separator row
+        // keeps the two dots readable as a floating diaeresis.
+        '\u{00dc}' => [DIAERESIS, 0, 17, 17, 17, 17, 14],
         '\u{00dd}' => top_marked_ascii('Y', ACUTE),
-        '\u{00de}' => [16, 16, 30, 17, 30, 16, 16],
+        // Uppercase thorn keeps a full-height stem but drops its bowl one
+        // row below cap height, staying distinct from both `P` and the
+        // x-height-bowled lowercase `þ` below.
+        '\u{00de}' => [16, 30, 17, 17, 30, 16, 16],
         '\u{00df}' => [12, 18, 18, 28, 18, 18, 29],
         '\u{00e0}' => top_marked_ascii('a', GRAVE),
         '\u{00e1}' => top_marked_ascii('a', ACUTE),

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -1737,6 +1737,46 @@ mod tests {
         assert_eq!(seen.len(), 95, "printable ASCII must contain 95 glyphs");
     }
 
+    /// Distinct covered characters may share a bitmap only where a 5×7 grid
+    /// genuinely cannot tell them apart. Every acceptable pair is hardcoded
+    /// below, so a future glyph edit that reintroduces a case-blind or
+    /// diacritic-losing collision — or invents a new box-drawing alias —
+    /// fails here instead of passing silently.
+    #[test]
+    fn covered_range_glyph_collisions_match_the_hardcoded_allowlist() {
+        // A space and a non-breaking space are both blank cells.
+        // At 5×7 an ASCII hyphen, slash, equals sign, backslash, and bar are
+        // pixel-identical to their box-drawing equivalents, and a broken bar
+        // matches the dashed U+254E column.
+        let allowlist: [(char, char); 7] = [
+            (' ', '\u{00a0}'),
+            ('-', '\u{2500}'),
+            ('/', '\u{2571}'),
+            ('=', '\u{2550}'),
+            ('\\', '\u{2572}'),
+            ('|', '\u{2502}'),
+            ('\u{00a6}', '\u{254e}'),
+        ];
+
+        let mut covered: Vec<char> = (0x20u8..=0x7e).map(char::from).collect();
+        covered.extend((0x00a0..=0x00ff).filter_map(char::from_u32));
+        covered.extend((0x2500..=0x257f).filter_map(char::from_u32));
+
+        let mut collisions = Vec::new();
+        for (index, &first) in covered.iter().enumerate() {
+            for &second in &covered[index + 1..] {
+                if glyph_rows(first) == glyph_rows(second) {
+                    collisions.push((first, second));
+                }
+            }
+        }
+
+        assert_eq!(
+            collisions, allowlist,
+            "covered-range glyph collisions must equal the accepted list exactly"
+        );
+    }
+
     #[test]
     fn complete_latin1_supplement_is_reachable_without_unicode_fallback() {
         for scalar in 0x00a0..=0x00ff {

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -47,8 +47,9 @@
 //!
 //! - `lowercase_distinct_from_uppercase` guards the fixed case-folding defect:
 //!   `a` and `A` must render differently.
-//! - `non_ascii_glyph_is_not_the_question_mark`: every non-ASCII code point
-//!   falls to the `?` default arm, so `日` renders as `?`.
+//! - `non_ascii_glyph_is_not_the_question_mark` guards the fixed fallback
+//!   defect: unsupported Unicode such as `日` uses a visible replacement glyph,
+//!   while Latin-1 Supplement and Box Drawing have built-in coverage.
 
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
@@ -784,15 +785,10 @@ fn lowercase_distinct_from_uppercase() {
 }
 
 #[test]
-#[ignore = "known defect: every non-ASCII code point falls through to the '?' \
-            arm, so '日' and '?' draw identically. Ignored rather than deleted \
-            or weakened — this assertion is the executable specification of the \
-            fix. `cargo test -- --ignored` confirms it still fails; remove this \
-            attribute when a real font stack lands."]
 fn non_ascii_glyph_is_not_the_question_mark() {
-    // DEFECT (reported): every non-ASCII code point hits the `?` default arm in
-    // `glyph_rows`, so '日' renders as '?'. A correct UTF-8 terminal must at
-    // least draw a different glyph for a different character.
+    // Full CJK is intentionally outside this fixed bitmap font. Unsupported
+    // Unicode uses a visible replacement glyph, which must not impersonate a
+    // literal question mark typed by the terminal application.
     let renderer = OffscreenRenderer::new().expect("offscreen renderer");
     let kanji = snapshot(1, 4, "日".as_bytes());
     let question = snapshot(1, 4, b"?");

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -41,14 +41,12 @@
 //! same shader + glyph vertex generation, so a vertex/glyph/grid defect in the
 //! binary is caught here, not hidden behind a parallel implementation.
 //!
-//! ## Defects surfaced (reported, not fixed)
+//! ## Defects surfaced
 //!
-//! The assertions below are written the way a *correct* renderer requires. Two
-//! of them fail today and are reported as defects rather than weakened:
+//! The assertions below are written the way a *correct* renderer requires:
 //!
-//! - `lowercase_distinct_from_uppercase`: the bitmap font folds lower to upper
-//!   case (`renderer.rs` `glyph_rows` uses `to_ascii_uppercase`), so `a` and
-//!   `A` render identically.
+//! - `lowercase_distinct_from_uppercase` guards the fixed case-folding defect:
+//!   `a` and `A` must render differently.
 //! - `non_ascii_glyph_is_not_the_question_mark`: every non-ASCII code point
 //!   falls to the `?` default arm, so `日` renders as `?`.
 
@@ -761,20 +759,14 @@ fn colour_follows_the_cell_across_wide_characters_and_rows() {
 }
 
 // ===========================================================================
-// Defect tests: written the way a correct renderer requires. Both fail today;
-// see the module docs and the report. They are NOT weakened to pass.
+// Defect tests: written the way a correct renderer requires. They are not
+// weakened to pass; fixed behaviours are removed from the ignored set.
 // ===========================================================================
 
 #[test]
-#[ignore = "known defect: the bitmap font case-folds, so 'a' and 'A' draw the \
-            same glyph. Ignored rather than deleted or weakened — this assertion \
-            is the executable specification of the fix. `cargo test -- --ignored` \
-            confirms it still fails; remove this attribute when a real font \
-            stack lands."]
 fn lowercase_distinct_from_uppercase() {
-    // DEFECT (reported): the bitmap font folds case via `to_ascii_uppercase`
-    // (renderer.rs `glyph_rows`), so 'a' and 'A' produce identical pixels. A
-    // correct terminal font must distinguish them.
+    // Regression guard: the bitmap font used to fold case via
+    // `to_ascii_uppercase`, making 'a' and 'A' produce identical pixels.
     let renderer = OffscreenRenderer::new().expect("offscreen renderer");
     let lower = snapshot(1, 2, b"a");
     let upper = snapshot(1, 2, b"A");

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -133,21 +133,25 @@ Each item states what you would actually see if you ran the build.
   `config.rs` exposes no palette or theme setting. In practice, SGR foreground
   and explicit background colours appear, but users cannot select or customise
   a light, dark, high-contrast, or colour-vision-friendly theme.
-- **The font cannot distinguish case.** Glyphs are a hand-built 5x7 ASCII
-  bitmap indexed through `character.to_ascii_uppercase()` inside the
-  `glyph_rows` function (`crates/noren-app/src/renderer.rs`); the test
-  `ascii_glyphs_are_distinct_and_unknown_is_question_mark` asserts
-  `glyph_rows('a') == glyph_rows('A')`. `a` and `A`
-  are pixel-identical, so code, filenames, and password prompts lose case
-  visually.
-- **All non-ASCII renders as `?`.** Every character outside the bitmap table
-  falls through to the question-mark glyph — the final `_ =>` default arm of
-  `glyph_rows` (`crates/noren-app/src/renderer.rs`) — asserted by the same
-  `ascii_glyphs_are_distinct_and_unknown_is_question_mark` test. CJK text,
-  accented characters, box-drawing output, and
-  emoji all appear as `?` — even though the terminal state core measures their
-  display width correctly (Unicode/CJK display width, recorded in the
-  [roadmap](../ROADMAP.md)).
+- **The bitmap font is coverage-bounded, and seven glyph pairs are visually
+  identical.** Glyphs are a hand-built 5x7 bitmap in `glyph_rows`
+  (`crates/noren-app/src/renderer.rs`): printable ASCII keeps distinct
+  upper/lower case, the Latin-1 Supplement (`U+00A0..=U+00FF`) and Box
+  Drawing (`U+2500..=U+257F`) blocks have per-character bitmaps, and every
+  other code point draws a visible replacement glyph rather than `?` — so
+  CJK text and emoji still do not render, even though the terminal state
+  core measures their display width correctly (Unicode/CJK display width,
+  recorded in the [roadmap](../ROADMAP.md)). Coverage is deliberately **not**
+  claimed collision-free: seven pairs of distinct characters are visually
+  identical because at 5x7 their pixel grids genuinely coincide —
+  space/`U+00A0` (both blank), and hyphen/`─`, slash/`╱`, equals/`═`,
+  backslash/`╲`, bar/`│`, broken-bar/`╎` against their box-drawing
+  equivalents. The test
+  `covered_range_glyph_collisions_match_the_hardcoded_allowlist` in
+  `renderer.rs` enumerates every pair across the three covered ranges and
+  pins the collision set to exactly that hardcoded allowlist, so a future
+  glyph edit cannot reintroduce a case-blind or diacritic-losing collision
+  (or invent a new box-drawing alias) silently.
 - **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
   the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
   drops the event without forwarding it. Japanese, Chinese, and
@@ -289,13 +293,13 @@ colour-aware assertions also cover distinct SGR foregrounds, unchanged defaults,
 ANSI/256-colour and direct RGB resolution, explicit truecolor backgrounds,
 background-only spaces, and indexed/background equivalence. It does **not**
 assert an `A` looks like an A — only that the structure and resolved pixel
-colours are right. Its two `#[ignore]`d tests (`lowercase_distinct_from_uppercase`,
-`non_ascii_glyph_is_not_the_question_mark`) are the executable specifications of
-the two font defects listed above — case-blindness and non-ASCII falling
-through to `?` — left failing rather than weakened, and their `#[ignore]`
-attributes say so in the source. The oracle needs
-a headless Metal adapter and reports `offscreen=blocked` honestly when the host
-has none.
+colours are right. Its two former defect specifications
+(`lowercase_distinct_from_uppercase`, `non_ascii_glyph_is_not_the_question_mark`)
+are no longer `#[ignore]`d and no longer failing: the bitmap font now
+distinguishes case, Latin-1 Supplement and Box Drawing have built-in coverage,
+and unsupported Unicode draws a replacement glyph instead of `?`. The oracle
+needs a headless Metal adapter and reports `offscreen=blocked` honestly when
+the host has none.
 
 What this evidence does **not** cover: there is still **no key injection into
 the real window**, so live input is unverified end-to-end — the byte-level


### PR DESCRIPTION
Closes the two oldest unfixed blockers on the preview list. Both were recorded as `#[ignore]`d failing frame-oracle tests — executable specifications waiting for an implementation — and both now pass, so **the long-standing "exactly 2 `--ignored` failures" expectation is now 0. Reviewers and the merge gate need to know that number changed.**

## What was broken

- **Case-blindness.** `glyph_rows('a') == glyph_rows('A')`; lowercase and uppercase drew identically, and a test in `renderer.rs` *asserted* that equality, encoding the bug as expected behaviour.
- **Non-ASCII rendered as `?`.**

## What changed

Distinct bitmaps across printable ASCII, proven by construction over the whole range rather than a hand-picked pair. Added **U+00A0–U+00FF** (Latin-1 supplement) and **U+2500–U+257F** (box drawing).

Box drawing was prioritised because **Zellij draws its status bar and pane frames with those glyphs**. Rendering them as `?` is visible corruption in Noren's primary use case — running Zellij inside it — so this was the highest-value range, not merely the easiest.

The `renderer.rs` assertion is flipped to `assert_ne!`, and the two oracle defect tests are un-`#[ignore]`d rather than deleted.

## Verified by the coordinator, not taken on the lane's report

The lane reported `tests=FAIL`, which was its usual mid-work snapshot: on the pushed tree, `fmt`/`clippy -D warnings`/`cargo test --workspace` are all clean at **948 passing**, and `frame_oracle` is **48/48 with 0 ignored**.

Both fixes were mutation-tested through the real rendering pipeline:

| Mutation | Result |
| --- | --- |
| Restore `'a'`'s bitmap to `'A'`'s (reintroduce case-blindness) | `lowercase_distinct_from_uppercase` **FAILED** |
| Disable the `box_drawing_rows` fallback | `common_box_drawing_glyphs_preserve_topology_and_weight` and `complete_box_drawing_block_avoids_the_question_mark_fallback` **FAILED** (46 passed, 2 failed) |

So the coverage is asserted by tests that actually fail when it is removed.

## Follow-up worth noting

Coverage beyond these ranges still falls back to a replacement glyph. That is a deliberate scope line for a built-in bitmap font, not an oversight — CJK and combining marks need a real font stack, which is a separate decision. `docs/known-limitations.md` should keep saying so.