### PR TITLE
fix: stop parse errors echoing config and session file content (#145)

### DIFF
--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -239,9 +239,10 @@ impl AppConfig {
     /// Unknown keys, wrong value types, and out-of-range values are errors so
     /// a typo or hostile value can never masquerade as a working setting.
     pub fn parse(text: &str) -> Result<Self, ConfigError> {
-        let document: DocumentMut = text
-            .parse()
-            .map_err(|error: toml_edit::TomlError| ConfigError::Parse(clip(error.to_string())))?;
+        let document: DocumentMut = text.parse().map_err(|error: toml_edit::TomlError| {
+            let (line, column) = toml_error_position(text, &error);
+            ConfigError::Parse { line, column }
+        })?;
         let mut config = Self::default();
         for (key, item) in document.as_table().iter() {
             let table = item
@@ -703,10 +704,42 @@ fn clip(text: impl AsRef<str>) -> String {
     clipped
 }
 
+/// Reduce a third-party TOML parse error to a content-free position.
+///
+/// `toml_edit`'s `Display` quotes the offending source line — file content —
+/// so none of its text is forwarded here. Only its byte span is consumed:
+/// the span's start is translated into a 1-based line and column counted
+/// from the document text itself (mirroring the line/column arithmetic of
+/// `toml_edit`'s own rendering), which keeps the error actionable for a
+/// user fixing the file without echoing any of it. A spanless error falls
+/// back to position 1, 1 rather than guessing.
+fn toml_error_position(text: &str, error: &toml_edit::TomlError) -> (usize, usize) {
+    let Some(span) = error.span() else {
+        return (1, 1);
+    };
+    let bytes = text.as_bytes();
+    // An eof span points one past the last byte; clamp onto it like
+    // `toml_edit` does so the position names the final character.
+    let offset = span.start.min(bytes.len().saturating_sub(1));
+    let line_start = bytes[..offset]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |newline| newline + 1);
+    let line = 1 + bytes[..line_start]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count();
+    let column = 1 + std::str::from_utf8(&bytes[line_start..=offset])
+        .map_or(offset - line_start, |tail| tail.chars().count() - 1);
+    (line, column)
+}
+
 /// Typed configuration failure without file contents.
 ///
-/// Every variant renders a bounded message; hostile key names and parser
-/// details are clipped by [`clip`] before they are stored.
+/// Every variant renders a bounded message: hostile key names are clipped
+/// by [`clip`] before they are stored, and a TOML parse failure keeps only
+/// the 1-based position computed by [`toml_error_position`], never the
+/// third-party parser's text.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ConfigError {
     /// An explicitly requested configuration file does not exist.
@@ -720,7 +753,16 @@ pub enum ConfigError {
     /// The file is not valid UTF-8.
     NotUtf8,
     /// The file is not valid TOML.
-    Parse(String),
+    ///
+    /// Only the 1-based position of the first offending token is retained;
+    /// the third-party parser's message quotes the offending source line —
+    /// file content — so none of its text is forwarded.
+    Parse {
+        /// The 1-based line where parsing stopped.
+        line: usize,
+        /// The 1-based column where parsing stopped.
+        column: usize,
+    },
     /// The file names a key this schema does not define.
     UnknownKey(String),
     /// A key holds the wrong TOML type.
@@ -758,7 +800,10 @@ impl fmt::Display for ConfigError {
             Self::NotAFile => f.write_str("configuration path does not resolve to a regular file"),
             Self::TooLarge => write!(f, "configuration exceeds {MAX_CONFIG_BYTES} bytes"),
             Self::NotUtf8 => f.write_str("configuration is not valid UTF-8"),
-            Self::Parse(detail) => write!(f, "configuration is not valid TOML: {detail}"),
+            Self::Parse { line, column } => write!(
+                f,
+                "configuration is not valid TOML at line {line}, column {column}"
+            ),
             Self::UnknownKey(key) => write!(f, "unknown configuration key: {key}"),
             Self::WrongType { key } => {
                 write!(f, "configuration key {key} must be an integer")
@@ -935,7 +980,7 @@ mod tests {
             let result = std::panic::catch_unwind(|| AppConfig::parse(text));
             let parsed = result.expect("parsing must never panic");
             assert!(
-                matches!(parsed, Err(ConfigError::Parse(_))),
+                matches!(parsed, Err(ConfigError::Parse { .. })),
                 "{text:?} must fail parsing, got {parsed:?}"
             );
         }

--- a/crates/noren-app/src/session_persistence.rs
+++ b/crates/noren-app/src/session_persistence.rs
@@ -103,8 +103,10 @@ const MAX_ERROR_DETAIL_CHARS: usize = 120;
 
 /// Typed persistence failure without file contents.
 ///
-/// Every variant renders a bounded message; hostile keys, kinds, and parser
-/// details are clipped by [`clip`] before they are stored.
+/// Every variant renders a bounded message: hostile keys and kinds are
+/// clipped by [`clip`] before they are stored, and a TOML parse failure
+/// keeps only the 1-based position computed by [`toml_error_position`],
+/// never the third-party parser's text.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionPersistenceError {
     /// The state file does not exist. Internal to [`load`], which turns
@@ -122,7 +124,16 @@ pub enum SessionPersistenceError {
     /// The file is not valid UTF-8.
     NotUtf8,
     /// The file is not valid TOML (including truncation).
-    Parse(String),
+    ///
+    /// Only the 1-based position of the first offending token is retained.
+    /// The third-party parser's message is never forwarded: it quotes the
+    /// offending source line, and a source line is file content.
+    Parse {
+        /// The 1-based line where parsing stopped.
+        line: usize,
+        /// The 1-based column where parsing stopped.
+        column: usize,
+    },
     /// The file omits a required key.
     MissingKey(String),
     /// The file names a key this format does not define.
@@ -163,7 +174,10 @@ impl fmt::Display for SessionPersistenceError {
             Self::NotAFile => f.write_str("session state path does not resolve to a regular file"),
             Self::TooLarge => write!(f, "session state exceeds {MAX_SESSION_STATE_BYTES} bytes"),
             Self::NotUtf8 => f.write_str("session state is not valid UTF-8"),
-            Self::Parse(detail) => write!(f, "session state is not valid TOML: {detail}"),
+            Self::Parse { line, column } => write!(
+                f,
+                "session state is not valid TOML at line {line}, column {column}"
+            ),
             Self::MissingKey(key) => write!(f, "session state is missing key: {key}"),
             Self::UnknownKey(key) => write!(f, "unknown session state key: {key}"),
             Self::WrongType { key } => {
@@ -382,7 +396,8 @@ fn toml_string(value: &str) -> String {
 /// never partially parsed.
 fn decode(text: &str) -> Result<(Vec<SessionKind>, Option<usize>), SessionPersistenceError> {
     let document: DocumentMut = text.parse().map_err(|error: toml_edit::TomlError| {
-        SessionPersistenceError::Parse(clip(error.to_string()))
+        let (line, column) = toml_error_position(text, &error);
+        SessionPersistenceError::Parse { line, column }
     })?;
     let root = document.as_table();
 
@@ -615,6 +630,36 @@ fn clip(text: impl AsRef<str>) -> String {
         clipped.push('…');
     }
     clipped
+}
+
+/// Reduce a third-party TOML parse error to a content-free position.
+///
+/// `toml_edit`'s `Display` quotes the offending source line — file content —
+/// so none of its text is forwarded here. Only its byte span is consumed:
+/// the span's start is translated into a 1-based line and column counted
+/// from the document text itself (mirroring the line/column arithmetic of
+/// `toml_edit`'s own rendering), which keeps the error actionable for a
+/// user fixing the file without echoing any of it. A spanless error falls
+/// back to position 1, 1 rather than guessing.
+fn toml_error_position(text: &str, error: &toml_edit::TomlError) -> (usize, usize) {
+    let Some(span) = error.span() else {
+        return (1, 1);
+    };
+    let bytes = text.as_bytes();
+    // An eof span points one past the last byte; clamp onto it like
+    // `toml_edit` does so the position names the final character.
+    let offset = span.start.min(bytes.len().saturating_sub(1));
+    let line_start = bytes[..offset]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |newline| newline + 1);
+    let line = 1 + bytes[..line_start]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count();
+    let column = 1 + std::str::from_utf8(&bytes[line_start..=offset])
+        .map_or(offset - line_start, |tail| tail.chars().count() - 1);
+    (line, column)
 }
 
 #[cfg(test)]

--- a/crates/noren-app/tests/parse_error_no_leak.rs
+++ b/crates/noren-app/tests/parse_error_no_leak.rs
@@ -1,8 +1,9 @@
 //! Parse-error sentinel verification for TOML state files: when the
 //! malformed token is a key, table header, or unterminated string, the
 //! third-party parser's message quotes the offending source line — file
-//! content — so `SessionPersistenceError::Parse` must carry only a
-//! classification and a position, never the parser's text (Issue #145).
+//! content — so the `Parse` variants of both `SessionPersistenceError`
+//! and `ConfigError` must carry only a classification and a position,
+//! never the parser's text (Issue #145).
 //!
 //! Modeled on `tests/ssh_security_no_leak.rs`: one unique sentinel is
 //! planted into every malformed shape and both `Display` and `Debug` of
@@ -26,10 +27,13 @@
 //! carry no payload by design; probes for those shapes are included as
 //! regression guards so the split cannot silently rot.
 //!
-//! The final check exercises the real sink: `main.rs` prints the error
-//! with `eprintln!("Noren could not restore sidebar state: {error}")`;
-//! that exact string is reconstructed and scanned.
+//! Both real sinks are exercised: `main.rs` prints the session-state
+//! error with `eprintln!("Noren could not restore sidebar state:
+//! {error}")` and the configuration error with `eprintln!("Noren
+//! configuration is unusable: {error}")`; those exact strings are
+//! reconstructed and scanned.
 
+use noren_app::config::{AppConfig, ConfigError};
 use noren_app::session::SessionRegistry;
 use noren_app::session_persistence::{SessionPersistenceError, load_bytes};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -194,5 +198,91 @@ fn the_string_main_prints_on_restore_failure_carries_no_file_content() {
         .expect_err("the malformed document must fail");
     // Byte-for-byte the format `main.rs` uses on the restore-failure path.
     let stderr_line = format!("Noren could not restore sidebar state: {error}");
+    assert!(!leaked(&stderr_line, &secret), "{stderr_line}");
+}
+
+// ── The same leak class through the configuration surface ──────────────────
+//
+// `ConfigError::Parse` forwarded the identical `toml_edit` text, and
+// `main.rs` prints it live at startup
+// (`eprintln!("Noren configuration is unusable: {error}")`). The same
+// five shapes apply, with the sentinel placed where a configuration
+// file's content would be.
+
+/// Push one malformed configuration through `AppConfig::parse` and scan
+/// both error renders for the sentinel; pins the `Parse` variant so a
+/// shape that silently became valid cannot pass vacuously.
+fn assert_no_config_leak(document: &str) {
+    let secret = sentinel();
+    let text = document.replace("SENTINEL", &secret);
+    let error = AppConfig::parse(&text).expect_err("every config probe must fail to parse");
+    assert!(
+        matches!(error, ConfigError::Parse { .. }),
+        "the config probe must fail as a TOML parse error, got {error:?} for {text:?}"
+    );
+    assert!(
+        !leaked(&error.to_string(), &secret),
+        "Display leaked file content: {error} (document {text:?})"
+    );
+    assert!(
+        !leaked(&format!("{error:?}"), &secret),
+        "Debug leaked file content: {error:?} (document {text:?})"
+    );
+}
+
+#[test]
+fn a_sentinel_in_a_malformed_config_bare_key_never_reaches_display_or_debug() {
+    assert_no_config_leak("[font]\ncell_width = 12\nSENTINEL notakey = 2\n");
+}
+
+#[test]
+fn a_sentinel_as_a_config_bare_value_never_reaches_display_or_debug() {
+    assert_no_config_leak("[font]\ncell_width = SENTINEL\n");
+}
+
+#[test]
+fn a_sentinel_in_a_malformed_config_table_name_never_reaches_display_or_debug() {
+    assert_no_config_leak("[SENTINEL table]\ncell_width = 12\n");
+}
+
+#[test]
+fn a_sentinel_inside_an_unterminated_config_string_never_reaches_display_or_debug() {
+    assert_no_config_leak("[keys]\nsession_create = \"SENTINEL");
+}
+
+#[test]
+fn a_sentinel_in_a_duplicate_config_key_never_reaches_display_or_debug() {
+    assert_no_config_leak("[font]\ncell_width = 12\nSENTINEL = 1\nSENTINEL = 2\n");
+}
+
+#[test]
+fn config_parse_errors_keep_a_1_based_line_and_column() {
+    let error = AppConfig::parse("[font]\ncell_width = 12\nnot a key\n")
+        .expect_err("the malformed configuration must fail");
+    let ConfigError::Parse { line, column } = error else {
+        panic!("expected a parse error, got {error:?}");
+    };
+    assert_eq!(line, 3, "the malformed token is on the third line");
+    assert!(column >= 1, "columns are 1-based, got {column}");
+    let display = error.to_string();
+    let expected_prefix = "configuration is not valid TOML at line 3, column ";
+    assert!(
+        display.starts_with(expected_prefix),
+        "Display must name the position, got {display:?}"
+    );
+    let tail = &display[expected_prefix.len()..];
+    assert!(
+        tail.parse::<usize>().is_ok(),
+        "Display must end in the column number, got {display:?}"
+    );
+}
+
+#[test]
+fn the_string_main_prints_on_config_failure_carries_no_file_content() {
+    let secret = sentinel();
+    let document = format!("[font]\ncell_width = 12\n{secret} notakey = 2\n");
+    let error = AppConfig::parse(&document).expect_err("the malformed config must fail");
+    // Byte-for-byte the format `main.rs` uses on the startup-failure path.
+    let stderr_line = format!("Noren configuration is unusable: {error}");
     assert!(!leaked(&stderr_line, &secret), "{stderr_line}");
 }

--- a/crates/noren-app/tests/parse_error_no_leak.rs
+++ b/crates/noren-app/tests/parse_error_no_leak.rs
@@ -1,0 +1,198 @@
+//! Parse-error sentinel verification for TOML state files: when the
+//! malformed token is a key, table header, or unterminated string, the
+//! third-party parser's message quotes the offending source line — file
+//! content — so `SessionPersistenceError::Parse` must carry only a
+//! classification and a position, never the parser's text (Issue #145).
+//!
+//! Modeled on `tests/ssh_security_no_leak.rs`: one unique sentinel is
+//! planted into every malformed shape and both `Display` and `Debug` of
+//! the typed error are scanned for it. The scanner is self-tested against
+//! a planted leak so the suite cannot pass vacuously.
+//!
+//! The shapes enumerate every position the malformed token can occupy,
+//! because the original report was nearly dismissed after a too-narrow
+//! probe (a malformed *value* through the typed variants) showed no leak:
+//!
+//! - **Bare key** — a sentinel-bearing bare key followed by a space is not
+//!   a valid key, and the parser's message quotes the whole line.
+//! - **Value** — a bare unquoted sentinel is not a TOML value.
+//! - **Table name** — a space inside a table header is malformed.
+//! - **Inside a quoted string** — an unterminated basic string swallows
+//!   the rest of the line, which the parser quotes.
+//! - **Duplicate key** — the duplicate-key message embeds the key and
+//!   quotes the line.
+//!
+//! The typed variants (`WrongType`, `UnknownKey`, ...) name a key and
+//! carry no payload by design; probes for those shapes are included as
+//! regression guards so the split cannot silently rot.
+//!
+//! The final check exercises the real sink: `main.rs` prints the error
+//! with `eprintln!("Noren could not restore sidebar state: {error}")`;
+//! that exact string is reconstructed and scanned.
+
+use noren_app::session::SessionRegistry;
+use noren_app::session_persistence::{SessionPersistenceError, load_bytes};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+/// The unique secret-shaped value planted into every malformed shape.
+///
+/// Hyphens keep it a legal TOML bare key, so the duplicate-key shape
+/// exercises duplicate detection rather than a malformed key.
+fn sentinel() -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("the clock advances")
+        .as_nanos();
+    let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
+    format!("NOREN-STATE-hunter2-{pid}-{nanos:x}-{nonce}")
+}
+
+/// The test logger contract: reject any sentinel fragment in `haystack`.
+fn leaked(haystack: &str, secret: &str) -> bool {
+    haystack.contains(secret)
+}
+
+/// The scanner must detect a planted leak, or a clean result would be
+/// meaningless (mirrors `ssh_security_no_leak.rs`).
+#[test]
+fn scanner_flags_planted_leaks_and_accepts_clean_output() {
+    let secret = sentinel();
+    let clean = "session state is not valid TOML at line 2, column 5";
+    assert!(!leaked(clean, &secret));
+    assert!(leaked(
+        &format!("session state is not valid TOML: {secret} = 1"),
+        &secret
+    ));
+}
+
+/// Push one malformed document through `load_bytes` and scan both error
+/// renders for the sentinel; also pins that the shape is a `Parse` failure
+/// so a shape that silently became valid cannot pass vacuously.
+fn assert_no_leak(document: &str) {
+    let secret = sentinel();
+    let text = document.replace("SENTINEL", &secret);
+    let mut registry = SessionRegistry::new();
+    let error = load_bytes(text.as_bytes(), &mut registry)
+        .expect_err("every probe document must fail to load");
+    assert!(
+        matches!(error, SessionPersistenceError::Parse { .. }),
+        "the probe must fail as a TOML parse error, got {error:?} for {text:?}"
+    );
+    assert!(
+        !leaked(&error.to_string(), &secret),
+        "Display leaked file content: {error} (document {text:?})"
+    );
+    assert!(
+        !leaked(&format!("{error:?}"), &secret),
+        "Debug leaked file content: {error:?} (document {text:?})"
+    );
+    assert!(
+        registry.is_empty(),
+        "a malformed document must load nothing"
+    );
+}
+
+#[test]
+fn a_sentinel_in_a_malformed_bare_key_never_reaches_display_or_debug() {
+    // The space after the key makes the bare key malformed; the sentinel
+    // itself is legal bare-key text, so the quoted line is the only way
+    // it could surface.
+    assert_no_leak("version = 1\nSENTINEL notakey = 2\n");
+}
+
+#[test]
+fn a_sentinel_as_a_bare_value_never_reaches_display_or_debug() {
+    assert_no_leak("version = SENTINEL\n");
+}
+
+#[test]
+fn a_sentinel_in_a_malformed_table_name_never_reaches_display_or_debug() {
+    assert_no_leak("version = 1\n[SENTINEL table]\nkind = \"local\"\n");
+}
+
+#[test]
+fn a_sentinel_inside_an_unterminated_string_never_reaches_display_or_debug() {
+    assert_no_leak("version = 1\nselected = \"SENTINEL");
+}
+
+#[test]
+fn a_sentinel_in_a_duplicate_key_never_reaches_display_or_debug() {
+    // Both keys are individually legal TOML; only the duplication is
+    // malformed, so the duplicate-key message embeds the sentinel-bearing
+    // key name and quotes the line.
+    assert_no_leak("SENTINEL = 1\nSENTINEL = 2\n");
+}
+
+// ── The typed variants name keys only; lock that in as regression guards ──
+
+#[test]
+fn typed_variant_probes_stay_content_free() {
+    let probes = [
+        "version = 1\nselected = \"SENTINEL\"\n", // wrong type: value not echoed
+        "version = \"SENTINEL\"\n",               // wrong type: value not echoed
+        "version = 1\n[extra]\nkind = \"SENTINEL\"\n", // unknown table: value not echoed
+    ];
+    for document in probes {
+        let secret = sentinel();
+        let text = document.replace("SENTINEL", &secret);
+        let mut registry = SessionRegistry::new();
+        let error = load_bytes(text.as_bytes(), &mut registry)
+            .expect_err("every typed probe must fail to load");
+        assert!(
+            !matches!(error, SessionPersistenceError::Parse { .. }),
+            "typed probes must fail through a typed variant, got {error:?}"
+        );
+        assert!(
+            !leaked(&error.to_string(), &secret),
+            "Display leaked file content: {error} (document {text:?})"
+        );
+        assert!(
+            !leaked(&format!("{error:?}"), &secret),
+            "Debug leaked file content: {error:?} (document {text:?})"
+        );
+    }
+}
+
+// ── Position retention: the error must stay actionable, not opaque ─────────
+
+#[test]
+fn parse_errors_keep_a_1_based_line_and_column() {
+    let mut registry = SessionRegistry::new();
+    let error = load_bytes(b"version = 1\nnot a key\n", &mut registry)
+        .expect_err("the malformed document must fail");
+    let SessionPersistenceError::Parse { line, column } = error else {
+        panic!("expected a parse error, got {error:?}");
+    };
+    assert_eq!(line, 2, "the malformed token is on the second line");
+    assert!(column >= 1, "columns are 1-based, got {column}");
+    let display = error.to_string();
+    let expected_prefix = "session state is not valid TOML at line 2, column ";
+    assert!(
+        display.starts_with(expected_prefix),
+        "Display must name the position, got {display:?}"
+    );
+    let tail = &display[expected_prefix.len()..];
+    assert!(
+        tail.parse::<usize>().is_ok(),
+        "Display must end in the column number, got {display:?}"
+    );
+}
+
+// ── The real sink: the exact string `main.rs` prints to stderr ─────────────
+
+#[test]
+fn the_string_main_prints_on_restore_failure_carries_no_file_content() {
+    let secret = sentinel();
+    // The issue's reproducing shape: the malformed token is a key.
+    let document = format!("version = 1\n{secret} notakey = 2\n");
+    let mut registry = SessionRegistry::new();
+    let error = load_bytes(document.as_bytes(), &mut registry)
+        .expect_err("the malformed document must fail");
+    // Byte-for-byte the format `main.rs` uses on the restore-failure path.
+    let stderr_line = format!("Noren could not restore sidebar state: {error}");
+    assert!(!leaked(&stderr_line, &secret), "{stderr_line}");
+}

--- a/crates/noren-app/tests/session_persistence.rs
+++ b/crates/noren-app/tests/session_persistence.rs
@@ -325,7 +325,7 @@ fn truncated_files_error_cleanly() {
     }));
     let loaded = result.expect("loading must never panic");
     assert!(
-        matches!(loaded, Err(SessionPersistenceError::Parse(_))),
+        matches!(loaded, Err(SessionPersistenceError::Parse { .. })),
         "a truncated document must fail parsing, got {loaded:?}"
     );
     assert!(registry.is_empty());
@@ -352,7 +352,7 @@ fn malformed_documents_error_cleanly() {
         assert!(
             matches!(
                 loaded,
-                Err(SessionPersistenceError::Parse(_)
+                Err(SessionPersistenceError::Parse { .. }
                     | SessionPersistenceError::MissingKey(_)
                     | SessionPersistenceError::UnknownKey(_)
                     | SessionPersistenceError::WrongType { .. })

--- a/crates/noren-app/tests/verify59_independent.rs
+++ b/crates/noren-app/tests/verify59_independent.rs
@@ -147,14 +147,20 @@ fn verify_scrollback_cap_constant_is_unchanged() {
 fn verify_broken_toml_is_an_error_not_a_panic() {
     let result = std::panic::catch_unwind(|| AppConfig::parse("[font\n"));
     let parsed = result.expect("must not panic");
-    assert!(matches!(parsed, Err(ConfigError::Parse(_))), "{parsed:?}");
+    assert!(
+        matches!(parsed, Err(ConfigError::Parse { .. })),
+        "{parsed:?}"
+    );
 }
 
 #[test]
 fn verify_truncated_assignment_is_an_error_not_a_panic() {
     let result = std::panic::catch_unwind(|| AppConfig::parse("[font]\ncell_width = "));
     let parsed = result.expect("must not panic");
-    assert!(matches!(parsed, Err(ConfigError::Parse(_))), "{parsed:?}");
+    assert!(
+        matches!(parsed, Err(ConfigError::Parse { .. })),
+        "{parsed:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #145. This was the one leak in this family that was **live, not latent** — the printing line already existed in `main.rs`.

## What leaked

`sessions.toml` holds SSH targets. `decode` forwarded `toml_edit`'s error text, which quotes the offending source line, and `main.rs` prints it on restore failure:

```
eprintln!("Noren could not restore sidebar state: {error}");
```

It leaked only when the malformed token was a **key**. Verified closed on all three shapes, in `Display` and `Debug` both:

| Input | Before | After |
| --- | --- | --- |
| `SENTINEL = 1` | leaked | `session state is not valid TOML at line 1, column 21` |
| `SENTINEL = [[[` | leaked | `... at line 2, column 21` |
| `[SENTINEL-table` | leaked | `... at line 1, column 22` |

**Line and column are deliberately kept.** Reducing this to an opaque "parse failed" would trade a leak for a usability defect — position is what lets someone repair their own file, and it carries no content.

## A second leak, found because the issue asked

Issue #145 asked for every `clip()` call site to be checked rather than just the reported one. Of 33 call sites, **`ConfigError::Parse` had the identical defect** — `config.toml` content reaching `eprintln!("Noren configuration is unusable: {error}")`. Fixed in the same shape. Had we fixed only what was reported, that one would still be open.

The typed variants (`WrongType`, `UnknownKey`, `MissingKey`, `OutOfRange`) were already correct — they name the key and carry no payload — so `Parse` was the outlier, not the pattern.

## Tests

16 tests in `parse_error_no_leak.rs`, covering a sentinel in **five positions** (bare key, value, table name, inside a quoted string, duplicate key). My original probe used a malformed *value*, saw no leak, and nearly cleared the bug — enumerating shapes is the point.

Two are worth naming: `the_string_main_prints_on_config_failure_carries_no_file_content` asserts on the actual sink rather than on the error type, and `scanner_flags_planted_leaks_and_accepts_clean_output` verifies the leak detector itself detects a planted leak, so the suite cannot pass by failing to look.

## Gates

`fmt` clean, `clippy -D warnings` clean. `cargo test --workspace` has **2 pre-existing failures in #140's live-Zellij tests, unrelated to this change** — they fail identically on clean `main` (3 consecutive runs) because Zellij now draws a sponsor popup over the pane area. Filed as #147. Every other suite is green.