### PR TITLE
fix: make Debug redaction a property of the leaves, not the container (#146)

### DIFF
--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -245,13 +245,35 @@ fn ssh_status_source_label(label: &str) -> String {
     result
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 struct ConfiguredSshHost {
     /// Shared session vocabulary used for target identity; this is still only
     /// a configured fact and is never inserted into the live registry.
     kind: SessionKind,
     /// Bounded, root-relative provenance supplied by `SshConfig`.
     source_label: String,
+}
+
+/// Shape-only [`Debug`] (issue #146 triage): the launch-shape discriminant
+/// and a provenance length, never the target or the config path text.
+///
+/// This is the configured-target leaf held directly by `WorkspaceState`
+/// next to the fields its Debug used to redact; with this impl the vec can
+/// be handed to Debug without a container-side guard.
+impl fmt::Debug for ConfiguredSshHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match &self.kind {
+            SessionKind::Local => "local",
+            SessionKind::Project { .. } => "project",
+            SessionKind::Worktree { .. } => "worktree",
+            SessionKind::Ssh { .. } => "ssh",
+            SessionKind::Agent { .. } => "agent",
+        };
+        f.debug_struct("ConfiguredSshHost")
+            .field("kind", &kind)
+            .field("source_label_chars", &self.source_label.chars().count())
+            .finish_non_exhaustive()
+    }
 }
 
 /// The dispatchable intent behind each palette command.

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -343,29 +343,29 @@ struct WorkspaceState {
 
 impl fmt::Debug for WorkspaceState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // The selected and connected SSH targets may embed secret-shaped
-        // values, so every debug surface redacts them. The provenance label
-        // is bounded root-relative display text and stays visible.
+        // Every nested leaf this struct reaches (SidebarView,
+        // PersistenceState) is shape-only by construction, so no per-field
+        // redaction is needed for them. The remaining direct content fields
+        // — the selected and connected SSH targets, their provenance label,
+        // and the state-file path — print presence only; the connection
+        // phase is a fixed enum and safe to name.
         f.debug_struct("WorkspaceState")
             .field("registry", &self.registry.len())
             .field("registry_selection", &self.registry.selected())
             .field("sidebar", &self.sidebar)
             .field("ssh_hosts", &self.ssh_hosts.len())
             .field("ssh_hosts_omitted", &self.ssh_hosts_omitted)
+            .field("selected_ssh_target", &self.selected_ssh_target.is_some())
             .field(
-                "selected_ssh_target",
-                &self.selected_ssh_target.as_deref().map(|_| "<redacted>"),
+                "selected_ssh_source_label",
+                &self.selected_ssh_source_label.is_some(),
             )
-            .field("selected_ssh_source_label", &self.selected_ssh_source_label)
             .field(
                 "ssh_connection",
-                &self
-                    .ssh_connection
-                    .as_ref()
-                    .map(|(_, phase)| format!("<redacted target, phase={phase:?}>")),
+                &self.ssh_connection.as_ref().map(|(_, phase)| *phase),
             )
             .field("palette", &self.palette)
-            .field("state_path", &self.state_path)
+            .field("state_path", &self.state_path.is_some())
             .field("persistence", &self.persistence)
             .finish()
     }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3547,6 +3547,34 @@ fn workspace_debug_holds_no_nested_content_through_the_sidebar_and_persistence()
     );
 }
 
+#[test]
+fn configured_ssh_host_debug_reports_shape_without_target_or_source() {
+    // Issue #146 triage: ConfiguredSshHost holds the SSH target and its
+    // config-path provenance inside WorkspaceState itself — the same
+    // secret, one container field away from Debug. The leaf must be safe
+    // by construction, with the discriminant and lengths only.
+    let secret = ssh_secret_sentinel("CFGHOST");
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(format!("Host {secret}\n").as_bytes());
+    let mut workspace = WorkspaceState::new();
+    let config = SshConfig::read(fixture.path()).expect("bounded SSH fixture parses");
+    workspace.load_ssh_config(&config);
+
+    let rendered = format!("{:?}", workspace.ssh_hosts);
+    assert!(
+        !rendered.contains(&secret),
+        "configured host debug leaked the target or source: {rendered}"
+    );
+    assert!(
+        rendered.contains("ConfiguredSshHost { kind: \"ssh\""),
+        "the launch-shape discriminant stays visible: {rendered}"
+    );
+    assert!(
+        rendered.contains("source_label_chars"),
+        "the provenance length stays visible: {rendered}"
+    );
+}
+
 // ── Live multi-session bookkeeping (supervisor-backed switching, slice 1) ──
 //
 // The palette's `session_create` now spawns a real `/bin/zsh` PTY per row.

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3492,6 +3492,61 @@ fn ssh_connect_flow_never_persists_or_debug_prints_the_destination() {
     cleanup_state_file(&path);
 }
 
+#[test]
+fn workspace_debug_holds_no_nested_content_through_the_sidebar_and_persistence() {
+    // Issue #146: the guard must survive nesting. Sentinels are planted in
+    // the NESTED leaves — the configured-host sidebar rows, the persistence
+    // baseline bytes — and in the workspace's own content fields, then the
+    // OUTER WorkspaceState is formatted directly with `{:?}` (per PR #142,
+    // the guard never depends on a production formatter existing).
+    let secret = ssh_secret_sentinel("NESTED");
+    // Short enough to survive the sidebar's bounded-target truncation, so a
+    // leaked row label carries it in full.
+    let short_secret = format!("Ns{}", std::process::id() % 10_000);
+
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(format!("Host {short_secret}\n").as_bytes());
+    let mut workspace = WorkspaceState::with_state_path(Some(PathBuf::from(format!(
+        "/tmp/{secret}-sessions.toml"
+    ))));
+    let config = SshConfig::read(fixture.path()).expect("bounded SSH fixture parses");
+    workspace.load_ssh_config(&config);
+    assert!(
+        workspace.select_ssh_sidebar_row(0),
+        "row 0 is the configured host (the registry is empty)"
+    );
+    workspace.set_ssh_connection(&short_secret, SshConnectionPhase::Connecting);
+    // Direct plants for fields no public seam reaches from this scenario.
+    workspace.selected_ssh_source_label = Some(secret.clone());
+    let sentinel_bytes = secret.as_bytes().to_vec();
+    workspace
+        .persistence
+        .restore_succeeded(Some(sentinel_bytes.clone()));
+
+    let rendered = format!("{workspace:?}");
+    assert!(
+        !rendered.contains(&secret),
+        "workspace debug leaked the long sentinel: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&short_secret),
+        "workspace debug leaked the sidebar-visible sentinel: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&format!("{:?}", sentinel_bytes.as_slice())),
+        "workspace debug leaked the persisted bytes as a byte list: {rendered}"
+    );
+    // Not vacuous: the workspace still describes its shape.
+    assert!(rendered.contains("WorkspaceState"), "{rendered}");
+    assert!(rendered.contains("SidebarView"), "{rendered}");
+    assert!(rendered.contains("PersistenceState"), "{rendered}");
+    assert!(rendered.contains("selected_row: Some(0)"), "{rendered}");
+    assert!(
+        rendered.contains("ssh_connection: Some(Connecting)"),
+        "the fixed connection phase is safe shape: {rendered}"
+    );
+}
+
 // ── Live multi-session bookkeeping (supervisor-backed switching, slice 1) ──
 //
 // The palette's `session_create` now spawns a real `/bin/zsh` PTY per row.

--- a/crates/noren-app/src/persistence_state.rs
+++ b/crates/noren-app/src/persistence_state.rs
@@ -4,6 +4,8 @@
 //! records only what those boundaries proved about the latest save and any
 //! external replacement observed along the way.
 
+use std::fmt;
+
 /// One bounded state-file observation. Errors carry no untrusted details
 /// here; the I/O boundary reports the typed error before using `Unavailable`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -48,13 +50,42 @@ enum Baseline {
 
 /// Persistence diagnostics and the exact baseline that makes conflict
 /// comparisons meaningful.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub(super) struct PersistenceState {
     baseline: Baseline,
     /// Sticky once an external replacement is definitively observed.
     conflict: bool,
     /// Describes only the latest restore or persistence attempt.
     unverified: bool,
+}
+
+/// Shape-only [`Debug`] (issue #146): baseline validity and byte count,
+/// conflict and verification flags — never the persisted bytes.
+///
+/// The baseline and the save observations hold the exact `sessions.toml`
+/// document, which embeds user-derived workspace text; printing those bytes
+/// through `Debug` would leak what the persistence boundary keeps out of
+/// diagnostics. Any holder of a `PersistenceState` is safe by construction
+/// instead of by a redacting container.
+impl fmt::Debug for PersistenceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut shape = f.debug_struct("PersistenceState");
+        match &self.baseline {
+            Baseline::Invalid => {
+                shape.field("baseline", &format_args!("invalid"));
+            }
+            Baseline::Verified(None) => {
+                shape.field("baseline", &format_args!("absent"));
+            }
+            Baseline::Verified(Some(bytes)) => {
+                shape.field("baseline", &format_args!("{} bytes", bytes.len()));
+            }
+        }
+        shape
+            .field("conflict", &self.conflict)
+            .field("unverified", &self.unverified)
+            .finish()
+    }
 }
 
 impl PersistenceState {
@@ -328,5 +359,49 @@ mod tests {
         assert!(!state.conflict());
         assert!(!state.unverified());
         assert_eq!(state.baseline, Baseline::Verified(Some(restored.to_vec())));
+    }
+
+    // ── Debug is shape-only (issue #146) ──
+    //
+    // The baseline holds the exact persisted document (user-derived
+    // workspace text). The guard asserts directly on `format!("{:?}")` —
+    // per PR #142 it must not depend on a production formatter existing —
+    // so the sentinel bytes must not appear in any rendering, including
+    // the decimal byte-list a derived impl would print.
+
+    #[test]
+    fn debug_reports_baseline_shape_without_persisted_bytes() {
+        let sentinel = format!("NOREN-PERSIST-SENTINEL-{}", std::process::id());
+        let mut state = PersistenceState::default();
+        state.restore_succeeded(Some(sentinel.clone().into_bytes()));
+
+        let rendered = format!("{state:?}");
+        assert!(
+            !rendered.contains(&sentinel),
+            "debug leaked the document as text: {rendered}"
+        );
+        assert!(
+            !rendered.contains(&format!("{:?}", sentinel.as_bytes())),
+            "debug leaked the document as a byte list: {rendered}"
+        );
+        // Not vacuous: the baseline's validity and size stay visible.
+        assert!(rendered.contains("PersistenceState"), "{rendered}");
+        assert!(
+            rendered.contains(&format!("baseline: {} bytes", sentinel.len())),
+            "{rendered}"
+        );
+        assert!(rendered.contains("conflict: false"), "{rendered}");
+        assert!(rendered.contains("unverified: false"), "{rendered}");
+    }
+
+    #[test]
+    fn debug_reports_invalid_and_absent_baselines_by_name() {
+        let invalid = format!("{:?}", PersistenceState::default());
+        assert!(invalid.contains("baseline: invalid"), "{invalid}");
+
+        let mut absent = PersistenceState::default();
+        absent.restore_succeeded(None);
+        let rendered = format!("{absent:?}");
+        assert!(rendered.contains("baseline: absent"), "{rendered}");
     }
 }

--- a/crates/noren-app/src/sidebar.rs
+++ b/crates/noren-app/src/sidebar.rs
@@ -22,6 +22,7 @@
 //! launches an agent.
 
 use crate::session::{SessionDescriptor, SessionId, SessionKind, SessionStatus};
+use std::fmt;
 
 /// The entry classes the sidebar can list.
 ///
@@ -41,6 +42,24 @@ pub enum EntryKind {
     Agent,
     /// A live terminal session described by a `SessionDescriptor`.
     Session,
+}
+
+impl EntryKind {
+    /// The fixed, content-free name of this kind.
+    ///
+    /// For diagnostics that name row classes without ever touching the
+    /// user-derived text a row carries; [`Debug`](std::fmt::Debug) output of
+    /// this module's types uses it instead of formatting payloads.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Worktree => "worktree",
+            Self::SshConnection => "ssh",
+            Self::Agent => "agent",
+            Self::Session => "session",
+        }
+    }
 }
 
 /// One sidebar row: what to show, not how to draw it.
@@ -89,7 +108,7 @@ impl SidebarRow {
 /// plain text facts describing workspace items that are not live sessions.
 /// Construction is data-only: no variant opens a connection or launches a
 /// process.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum SidebarEntry {
     /// A project anchored at `root`.
     Project {
@@ -124,6 +143,34 @@ pub enum SidebarEntry {
     },
     /// A live terminal session, described by the shared contract descriptor.
     Session(SessionDescriptor),
+}
+
+/// Shape-only [`Debug`] (issue #146): variant names and selection state,
+/// never payload content.
+///
+/// Every payload here is user- or environment-derived text — project names
+/// and roots, branch names, and, for `SshConnection`, a `label` that embeds
+/// the (truncated) SSH target and a `host` detail — or a shared
+/// [`SessionDescriptor`]. The label is therefore user-controlled content,
+/// not a safe fixed string, and printing any payload through `Debug` would
+/// leak exactly what the workspace keeps out of diagnostics. With this
+/// impl, any holder of a `SidebarEntry` is safe by construction instead of
+/// by a redacting container.
+impl fmt::Debug for SidebarEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Project { .. } => f.debug_struct("Project").finish_non_exhaustive(),
+            Self::Worktree { .. } => f.debug_struct("Worktree").finish_non_exhaustive(),
+            Self::SshConnection { selected, .. } => f
+                .debug_struct("SshConnection")
+                .field("selected", selected)
+                .finish_non_exhaustive(),
+            Self::Agent { .. } => f.debug_struct("Agent").finish_non_exhaustive(),
+            // The registry-generated id (e.g. `session-1`) is safe shape; the
+            // descriptor's kind, status, and title stay unformatted.
+            Self::Session(descriptor) => f.debug_tuple("Session").field(&descriptor.id()).finish(),
+        }
+    }
 }
 
 /// The view shown when the sidebar has no entries.
@@ -199,11 +246,40 @@ impl SessionViewport {
 ///    this actual viewport. A restored entry has no live process to attach to,
 ///    so selecting it does not create a viewport.
 /// 4. A selection that matches no entry is dropped, never rendered dangling.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SidebarView {
     rows: Vec<SidebarRow>,
     empty_state: Option<EmptyState>,
     viewport: Option<SessionViewport>,
+}
+
+/// Shape-only [`Debug`] (issue #146): row count, row kinds, selection
+/// index, empty-state and viewport presence — never row or viewport
+/// content.
+///
+/// Row labels and details are user- or environment-derived text (project
+/// roots, branch names, and bounded SSH-target text), and the viewport
+/// carries a [`SessionDescriptor`]; the only values printed here are the
+/// fixed [`EntryKind`] names and the registry-generated viewport id. Any
+/// holder of a `SidebarView` is safe by construction instead of by a
+/// redacting container.
+impl fmt::Debug for SidebarView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let row_kinds: Vec<&'static str> = self.rows.iter().map(|row| row.kind().name()).collect();
+        f.debug_struct("SidebarView")
+            .field("row_count", &self.rows.len())
+            .field("row_kinds", &row_kinds)
+            .field(
+                "selected_row",
+                &self.rows.iter().position(|row| row.is_selected()),
+            )
+            .field("empty_state", &self.empty_state.is_some())
+            .field(
+                "viewport",
+                &self.viewport.as_ref().map(SessionViewport::session_id),
+            )
+            .finish()
+    }
 }
 
 impl SidebarView {

--- a/crates/noren-app/tests/sidebar_view.rs
+++ b/crates/noren-app/tests/sidebar_view.rs
@@ -7,7 +7,9 @@
 
 use std::collections::BTreeSet;
 
-use noren_app::session::{SessionDescriptor, SessionId, SessionRegistry, SessionStatus};
+use noren_app::session::{
+    SessionDescriptor, SessionId, SessionKind, SessionRegistry, SessionStatus,
+};
 use noren_app::sidebar::{
     EMPTY_SIDEBAR_MESSAGE, EmptyState, EntryKind, SessionViewport, SidebarEntry, SidebarRow,
     SidebarView, fixtures,
@@ -260,4 +262,118 @@ fn non_session_entries_render_without_any_sessions() {
     assert_eq!(view.viewport(), None);
     assert_eq!(view.empty_state(), None);
     assert!(!view.is_empty());
+}
+
+// ── Debug is shape-only (issue #146) ──
+//
+// The sidebar's payloads are user- or environment-derived text (project
+// names and roots, branch names, SSH labels that embed the target, host
+// details) plus shared session descriptors. These guards assert directly on
+// `format!("{:?}")` — per PR #142, the guard must not depend on a
+// production formatter existing — so the sentinel must not appear even
+// while no production code path formats these types yet.
+
+/// Unique content stand-in: any debug surface that prints it is a leak.
+fn leak_sentinel() -> String {
+    format!("NOREN-SIDEBAR-SENTINEL-{}", std::process::id())
+}
+
+/// One entry of every kind, each carrying the sentinel in every payload
+/// field the type has, plus the id of the session entry.
+fn sentinel_entries(sentinel: &str) -> (Vec<SidebarEntry>, SessionId) {
+    let mut registry = SessionRegistry::new();
+    let id = registry.create(SessionKind::Project {
+        root: sentinel.parse().expect("sentinel parses as a path"),
+    });
+    registry
+        .observe(
+            id,
+            SessionStatus::Failed {
+                reason: sentinel.to_string(),
+            },
+        )
+        .expect("a fresh session may be observed failed");
+    let descriptor: SessionDescriptor = registry.get(id).expect("created id is live").clone();
+    (
+        vec![
+            SidebarEntry::Project {
+                name: sentinel.to_string(),
+                root: sentinel.to_string(),
+            },
+            SidebarEntry::Worktree {
+                name: sentinel.to_string(),
+                branch: sentinel.to_string(),
+            },
+            SidebarEntry::SshConnection {
+                label: sentinel.to_string(),
+                host: sentinel.to_string(),
+                selected: true,
+            },
+            SidebarEntry::Agent {
+                label: sentinel.to_string(),
+            },
+            SidebarEntry::Session(descriptor),
+        ],
+        id,
+    )
+}
+
+#[test]
+fn entry_debug_reports_shape_without_content() {
+    let sentinel = leak_sentinel();
+    for entry in sentinel_entries(&sentinel).0 {
+        let rendered = format!("{entry:?}");
+        assert!(
+            !rendered.contains(&sentinel),
+            "entry debug leaked content: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn entry_debug_keeps_useful_shape() {
+    let sentinel = leak_sentinel();
+    let entries = sentinel_entries(&sentinel).0;
+    let ssh = format!("{:?}", &entries[2]);
+    assert!(ssh.contains("SshConnection"), "variant name: {ssh}");
+    assert!(ssh.contains("selected: true"), "selection state: {ssh}");
+
+    let mut registry = SessionRegistry::new();
+    let id = registry.create(SessionKind::Local);
+    let session = format!(
+        "{:?}",
+        SidebarEntry::Session(registry.get(id).expect("id live").clone())
+    );
+    assert!(session.contains("Session"), "variant name: {session}");
+    assert!(
+        session.contains(&format!("{id:?}")),
+        "the registry-generated id is safe shape: {session}"
+    );
+    assert!(
+        !session.contains("Local"),
+        "the launch shape may carry paths or targets: {session}"
+    );
+}
+
+#[test]
+fn view_debug_reports_shape_without_content() {
+    let sentinel = leak_sentinel();
+    let (entries, session_id) = sentinel_entries(&sentinel);
+    let view = SidebarView::build(&entries, Some(session_id));
+
+    let rendered = format!("{view:?}");
+    assert!(
+        !rendered.contains(&sentinel),
+        "view debug leaked content: {rendered}"
+    );
+    // Not vacuous: the shape a renderer bug report needs stays visible.
+    assert!(rendered.contains("row_count: 5"), "{rendered}");
+    assert!(rendered.contains("row_kinds: ["), "{rendered}");
+    assert!(rendered.contains("\"ssh\""), "kind names: {rendered}");
+    assert!(rendered.contains("selected_row: Some(2)"), "{rendered}");
+    assert!(rendered.contains("empty_state: false"), "{rendered}");
+    assert!(
+        rendered.contains(&format!("viewport: Some({session_id:?})")),
+        "the viewport id is safe shape: {rendered}"
+    );
 }


### PR DESCRIPTION
Closes #146.

## The defect

`WorkspaceState::Debug` redacted `selected_ssh_target` to `<redacted>` and then handed `&self.sidebar` to derived Debug, so the same target printed in full through the sidebar row. `state_path` and `PersistenceState` went the same way.

A **manual, deliberately-redacting** impl is the worst place for this, because its existence is what stops anyone checking further.

## The fix is structural

Shape-only `Debug` on the leaves — `SidebarEntry`, `SidebarView`, `PersistenceState`, and `ConfiguredSshHost` — so every holder is safe by construction rather than by audit. `WorkspaceState::Debug` is then simplified: with safe leaves its per-field redaction was dead weight, and a redaction that no longer does anything is future confusion.

`label` was judged **user-controlled content** and is redacted accordingly, not treated as a fixed string.

Verified at the leaf:

```
SidebarEntry::SshConnection { label: "NOREN-SENTINEL-label", host: "NOREN-SENTINEL-admin@prod-db.internal", selected: true }
→ SshConnection { selected: true, .. }
```

## The guard, and a correction to my own first reading

The nested test plants sentinels in nested leaves and formats the **outer** `WorkspaceState` directly with `{:?}`, keeping #142's rule that the guard must not depend on a production formatter existing. It is also explicitly non-vacuous: it asserts the shape is still described (`WorkspaceState`, `SidebarView`, `PersistenceState`, `selected_row: Some(0)`).

I first concluded the guard did not work, because re-deriving Debug on `SidebarEntry` left every suite green. That was my mutation being on the wrong type: the sidebar renders through `SidebarRow`/`SidebarView`, so `SidebarEntry` is not on the path the test exercises. Mutating the leaf that *is* on the path fails immediately and exposes the label:

```
SidebarView → #[derive(Debug)]
→ workspace_debug_holds_no_nested_content_through_the_sidebar_and_persistence FAILED
→ "leaked the sidebar-visible sentinel: ... SidebarRow { kind: SshConnection, label: \"SSH-ON  Ns2905\", ... }"
```

The same output confirms `PersistenceState` prints `baseline: 34 bytes` — a count, not content.

## Triage, deliberately narrow

Of the ~20 further content-bearing types the #142 review listed, **one** (`ConfiguredSshHost`) was fixed here, because it holds an SSH target one container field away from Debug — the same short leak path as the sidebar. The rest stay latent and unfixed rather than being blanket-rewritten; a 20-type sweep would be unreviewable and most of those types are nowhere near a print site.

## Gates

`fmt` clean, `clippy -D warnings` clean, lib 214 passing, bin 186 passing, `security_no_leak` 5/5, `session_persistence` 33/33. The 2 `zellij_live` failures are pre-existing and unrelated (Issue #147 — Zellij's sponsor popup); they fail identically on clean `main`.