### PR TITLE
feat(app): launchable git worktree sessions from the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@
 > only; a future connection path must resolve or reject them first. `Include`
 > handling is intentionally stricter than OpenSSH: Noren follows only files
 > whose canonical targets remain under the top-level config directory;
-> git worktrees and agents remain modelled but unreachable. Keybindings are not
+> git worktrees of the launch repository are discovered and launchable (a
+> sidebar click starts a shell whose working directory is that worktree),
+> while project rows and agents remain modelled but unreachable. Keybindings are not
 > configurable. There are no published binaries, and a local build carries only
 > macOS's automatic ad-hoc signature — no signing identity, no notarization. Read
 > **[docs/known-limitations.md](docs/known-limitations.md)** first — it is the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,8 +111,8 @@ Measured against it, item by item:
 | Scope item | State | Evidence |
 | --- | --- | --- |
 | Sidebar drawn | Done | `SIDEBAR_COLS` reserved in `renderer.rs`; `glyph_vertices` applies the column offset; `sidebar_text_lines` formats rows |
-| — projects, git worktrees | Modelled, not launchable | `EntryKind::Project`/`Worktree`, `SessionKind::Project`/`Worktree` exist; no runtime path creates them, though `parse_session` will reconstruct one from a hand-written `sessions.toml` `kind` field — nothing in the product writes such an entry |
-| — SSH connections, agents | Partial configured-target list, not connected; agents fixture only | At most 24 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and clicking shows bounded root-relative source provenance while opening no SSH connection or PTY; agent entries remain reserved |
+| — projects, git worktrees | Worktrees launchable; projects modelled | Startup runs `git worktree list --porcelain` in the launch directory (`git_worktree.rs`) and shows at most 24 discovered worktrees as `EntryKind::Worktree` rows (beyond the cap the omitted count is reported); a registered-but-deleted worktree is listed with a `(missing)` marker and refused on selection; selecting a present row creates a `SessionKind::Worktree` session backed by a real `/bin/zsh` PTY whose child's working directory IS the worktree (verified by reading the child's own `pwd` back through the terminal), persisting and restoring through `sessions.toml` like a local session. `EntryKind::Project`/`SessionKind::Project` remain modelled-only with no runtime constructor |
+| — SSH connections, agents | Connections run for discovered aliases; discovery explicitly partial; agents fixture only | At most 24 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and clicking one launches the fixed system `/usr/bin/ssh` client in the terminal's single PTY (argv is exactly `ssh -- <alias>`; no credential is ever argv-visible), with launch, connect, and disconnect failures as visible per-row and status-row states (PR #138). Wildcard/dynamic destinations are not a complete host inventory; agent entries remain reserved |
 | — terminal sessions | Runtime for local sessions | Every palette `session_create` spawns a real `SessionKind::Local` PTY (`spawn_local_session`); sidebar clicks and the palette's `session_select` switch the live view between live sessions (`switch_live_session`, parked surfaces keep draining and resizing), and `session_close` reaps the closed child and repairs the view. Rows restored from disk come back `Restored` with no live surface and cannot take the live view |
 | Single-session view | Done | The active terminal is drawn beside the sidebar, narrowed to the remaining columns; switching swaps the active surface whole, and rows without a live surface cannot claim its selection or input owner |
 | Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` for spawned, parked, closed, and restored sessions alike |
@@ -121,14 +121,14 @@ Measured against it, item by item:
 | Configurable keybindings | Done for the palette surface | `[keys]` in `config.toml` (`KeymapConfig` in `config.rs`) rebinds the palette opener and the four palette command chords with the previous values as defaults; `palette_policy`/`handle_palette_key` in `main.rs` honor them, unparseable chords and unknown actions are typed errors, and the opener is validated against the pinned Zellij corpus and the exit leader. The exit leader, palette navigation keys, diagnostics chord, and clipboard shortcuts remain fixed |
 | Zellij pass-through | Done against a pinned corpus and a live installed Zellij | The shipped policy (`palette_policy` in `main.rs`) claims exactly two Super-modified chords — `Super+Escape` (exit leader) and `Super+p` (palette opener) — that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds, and `tests/zellij_live.rs` drives an INSTALLED Zellij in a real PTY through the same parser, gate, and key encoder: attach enables mouse tracking in `TerminalState`, gated `Ctrl+t`/`n`/`Ctrl+p` reach Zellij and render tab #2 and pane #2, typed text reaches the pane's shell, and the installed version's default keybinds bind nothing in the Super/Cmd/Meta space. The harness skips (visibly, on the real stderr) when no `zellij` is on `PATH`. Empirical wire-shape note: Zellij 0.44.3 sends `1002`/`1006` as separate single-parameter DECSETs across its whole lifecycle and does not forward a pane program's multi-parameter DECSET to the host terminal, so the multi-parameter form `CSI ? 1002;1006 h` (the PR #113 regression site) is pinned as a co-located regression guard beside the live assertions, with the live multi-parameter count printed as drift telemetry |
 
-One named scope item remains unsatisfied: **SSH connections and agents do
-not run**. Positive literal aliases now appear in a bounded sidebar list and
-a click records a source-attributed pending target, but opens no SSH
-connection or PTY; wildcard or dynamic destinations are not presented as a
-complete host inventory, and agent entries remain fixtures and launch no
+One named scope item remains unsatisfied: **agents do not run**. Positive
+literal aliases appear in a bounded sidebar list and a click launches a real
+system-ssh connection (PR #138), but wildcard or dynamic destinations are
+not presented as a complete host inventory, and agent entries remain
+fixtures and launch no
 agent. Since "Only evidence-backed work is marked complete" and the scope
-line names it, Milestone 3 stays **In progress**. The SSH and agent session
-kinds also depend on Milestones 4 and 5; whether they are retired from
+line names it, Milestone 3 stays **In progress**. The agent session
+kind also depends on Milestone 5; whether it is retired from
 Milestone 3's scope or carried is an open scoping decision, not something to
 settle by relabelling the status.
 
@@ -139,20 +139,21 @@ concluded that the current tree cannot honestly be released as "0.1.0-preview of
 the Noren terminal." The reasoning and the decision are recorded in
 [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
 
-- **The workspace is a slice, not a product.** The Milestone 3 modules now
-  reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
-  local sessions spawn real PTYs that switch, park, and close through the
-  live view, mouse reports reach the active PTY, and sidebar state persists
-  across a restart. What is still missing is breadth —
-  bounded OpenSSH configuration now produces an explicitly partial list of at
-  most 24 positive literal aliases as `SessionKind::Ssh` values and
-  `SidebarEntry::SshConnection` rows. The UI labels the discovery scope and
-  shows bounded root-relative source provenance on selection, but selecting one
-  only records a pending target and opens no connection or PTY. Only
-  `SessionKind::Local` reaches a
-  launch path; git worktrees remain unreachable, and agents remain
-  fixture-only; keybindings ARE configurable through the `[keys]` section
-  since this milestone (see [Milestone 3 status](#milestone-3-status)).
+  - **The workspace is a slice, not a product.** The Milestone 3 modules now
+    reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
+    local sessions spawn real PTYs that switch, park, and close through the
+    live view, mouse reports reach the active PTY, and sidebar state persists
+    across a restart. What is still missing is breadth —
+    bounded OpenSSH configuration now produces an explicitly partial list of at
+    most 24 positive literal aliases as `SessionKind::Ssh` values and
+    `SidebarEntry::SshConnection` rows, and selecting one launches the fixed
+    system `ssh` client in the terminal's PTY. Git
+    worktrees of the launch repository ARE reachable now (discovered from
+    `git worktree list --porcelain`, shown as bounded rows, and launched as
+    worktree-scoped sessions), while project rows remain unreachable and
+    agents remain
+    fixture-only; keybindings ARE configurable through the `[keys]` section
+    since this milestone (see [Milestone 3 status](#milestone-3-status)).
 - **Colour rendering exists, but themes are fixed.** `renderer.rs` resolves
   each cell's SGR foreground and any explicit background through its compiled-in
   ANSI/256-colour palette or as direct RGB truecolor. The vertex layout carries

--- a/crates/noren-app/src/git_worktree.rs
+++ b/crates/noren-app/src/git_worktree.rs
@@ -374,6 +374,9 @@ pub fn parse_worktree_porcelain(text: &str) -> Result<Vec<RawWorktree>, Worktree
 /// [`WorktreeDiscovery`], whose rows include registered-but-deleted
 /// worktrees marked [`DiscoveredWorktree::directory_present`] == `false`.
 pub fn discover_worktrees(launch_dir: &Path) -> Result<WorktreeDiscovery, WorktreeListError> {
+    if !launch_dir.is_dir() {
+        return Err(WorktreeListError::LaunchDirectoryUnavailable);
+    }
     let output = Command::new(GIT_PROGRAM)
         .args(GIT_WORKTREE_ARGS)
         .current_dir(launch_dir)

--- a/crates/noren-app/src/git_worktree.rs
+++ b/crates/noren-app/src/git_worktree.rs
@@ -1,0 +1,597 @@
+//! Bounded, read-only discovery of the git worktrees of the repository Noren
+//! was launched in.
+//!
+//! This is a workspace-filesystem adapter in the same position as
+//! [`crate::ssh_config`]: it produces bounded sidebar facts and never launches
+//! a session. Launching a worktree session is the application's job, through
+//! the shared [`crate::session`] vocabulary.
+//!
+//! # Source of truth
+//!
+//! Discovery shells out to `git worktree list --porcelain` (the stable,
+//! machine-readable form; the human format is never scraped) with the child's
+//! working directory set to the launch directory, then parses the output with
+//! a pure, total parser ([`parse_worktree_porcelain`]). Nothing else about git
+//! is invoked: no status, no fetch, no network.
+//!
+//! # Honest about the filesystem
+//!
+//! A worktree can be registered while its directory has been deleted from
+//! disk. That is common (a `rm -rf` of a scratch checkout leaves the
+//! registration behind until `git worktree prune`) and is handled as data:
+//! the row is discovered, [`DiscoveredWorktree::directory_present`] reports
+//! `false`, and nothing panics or blocks. A detached HEAD is likewise data:
+//! [`DiscoveredWorktree::branch_display`] is `"(detached)"`.
+//!
+//! # Bounded
+//!
+//! A repository can have very many worktrees. Discovery keeps at most
+//! [`MAX_WORKTREE_SIDEBAR_ROWS`] rows and reports the omitted count (see
+//! [`WorktreeDiscovery::omitted`]), exactly like the bounded SSH host list.
+//!
+//! # Secrets
+//!
+//! A worktree path can contain a username or a private directory name, and a
+//! branch name is user-derived text. Every type in this module therefore has a
+//! shape-only [`std::fmt::Debug`] and every error message is a fixed string:
+//! no path, branch, or git output byte is ever printed through `Debug`,
+//! `Display`, or a diagnostic.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Maximum worktree rows retained for the sidebar. Rows beyond this cap are
+/// dropped at discovery time and counted in
+/// [`WorktreeDiscovery::omitted`], mirroring the bounded SSH host list.
+pub const MAX_WORKTREE_SIDEBAR_ROWS: usize = 24;
+
+/// Maximum bytes of `git worktree list --porcelain` output accepted before
+/// discovery refuses the rest as [`WorktreeListError::TooLarge`]. The output
+/// is path-per-line metadata; a pathological repository cannot grow Noren's
+/// memory without bound through it.
+pub const MAX_WORKTREE_OUTPUT_BYTES: usize = 256 * 1024;
+
+/// Fixed argv for the discovery child. No option is caller-controlled.
+const GIT_PROGRAM: &str = "git";
+const GIT_WORKTREE_ARGS: [&str; 3] = ["worktree", "list", "--porcelain"];
+
+/// Typed, content-free failure of worktree discovery.
+///
+/// Every message is a fixed string. The launch directory, worktree paths,
+/// branch names, and git's own output bytes are never carried: all of them
+/// are user- or environment-derived text, and a path may embed a username or
+/// a private directory name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorktreeListError {
+    /// The `git` child could not be spawned (not installed, or not on the
+    /// search path). Discovery is unavailable, not failed.
+    GitUnavailable,
+    /// `git` ran and exited non-zero: the launch directory is not inside a
+    /// git repository, or git refused the listing for its own reasons.
+    NotARepository,
+    /// The launch directory could not be resolved as a working directory for
+    /// the child.
+    LaunchDirectoryUnavailable,
+    /// The porcelain output was not valid UTF-8.
+    NotUtf8,
+    /// The porcelain output exceeded [`MAX_WORKTREE_OUTPUT_BYTES`].
+    TooLarge,
+    /// The porcelain output was structurally malformed (a record without a
+    /// `worktree` line, or an unknown attribute key).
+    Malformed,
+}
+
+impl fmt::Display for WorktreeListError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GitUnavailable => {
+                f.write_str("git is unavailable; worktree discovery is disabled")
+            }
+            Self::NotARepository => {
+                f.write_str("launch directory is not a git repository; no worktrees listed")
+            }
+            Self::LaunchDirectoryUnavailable => {
+                f.write_str("launch directory could not be used to run git")
+            }
+            Self::NotUtf8 => f.write_str("git worktree listing is not valid UTF-8"),
+            Self::TooLarge => f.write_str("git worktree listing exceeds its byte limit"),
+            Self::Malformed => f.write_str("git worktree listing is malformed"),
+        }
+    }
+}
+
+impl std::error::Error for WorktreeListError {}
+
+/// One worktree record parsed from `git worktree list --porcelain`.
+///
+/// Paths are kept verbatim from the porcelain line (git quotes nothing in
+/// porcelain form; a path with spaces or non-ASCII characters is one line's
+/// payload), so spaces and Unicode round-trip without scraping.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RawWorktree {
+    path: PathBuf,
+    branch: Option<String>,
+    bare: bool,
+    detached: bool,
+}
+
+impl RawWorktree {
+    /// The worktree's absolute path as git printed it.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The full ref name (`refs/heads/...`) when a branch is checked out.
+    #[must_use]
+    pub fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    /// Whether this record is the repository's bare worktree.
+    #[must_use]
+    pub const fn is_bare(&self) -> bool {
+        self.bare
+    }
+
+    /// Whether HEAD is detached in this worktree.
+    #[must_use]
+    pub const fn is_detached(&self) -> bool {
+        self.detached
+    }
+}
+
+/// Shape-only [`Debug`] (the #142/#146/#148 discipline): variant presence
+/// only, never the path or the branch — both are user- or environment-derived
+/// text, and a path may embed a username or a private directory name.
+impl fmt::Debug for RawWorktree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RawWorktree")
+            .field("bare", &self.bare)
+            .field("detached", &self.detached)
+            .field("has_branch", &self.branch.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl RawWorktree {
+    /// The short display name of the checked-out branch (the ref's last
+    /// path component), or a fixed placeholder for a detached HEAD or a bare
+    /// worktree. Placeholder text is fixed ASCII so the bitmap font renders
+    /// it.
+    #[must_use]
+    pub fn branch_display(&self) -> String {
+        if let Some(branch) = &self.branch {
+            let short = branch.rsplit('/').next().unwrap_or(branch);
+            return short.to_owned();
+        }
+        if self.bare {
+            "(bare)".to_owned()
+        } else {
+            "(detached)".to_owned()
+        }
+    }
+
+    /// The worktree's display name: the final path component as UTF-8 text,
+    /// or the fixed placeholder when the component is not UTF-8.
+    #[must_use]
+    pub fn name_display(&self) -> String {
+        self.path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "(worktree)".to_owned())
+    }
+}
+
+/// One worktree fact prepared for the sidebar: the parsed record plus the
+/// on-disk presence observed at discovery time.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DiscoveredWorktree {
+    raw: RawWorktree,
+    directory_present: bool,
+}
+
+impl DiscoveredWorktree {
+    /// Observe the filesystem once and build the sidebar fact.
+    #[must_use]
+    pub fn observe(raw: RawWorktree) -> Self {
+        let directory_present = raw.path().is_dir();
+        Self {
+            raw,
+            directory_present,
+        }
+    }
+
+    /// The parsed record.
+    #[must_use]
+    pub const fn raw(&self) -> &RawWorktree {
+        &self.raw
+    }
+
+    /// The worktree's absolute path, the launch target of a session.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.raw.path()
+    }
+
+    /// Whether the worktree's directory existed on disk at discovery time.
+    /// A registered-but-deleted worktree reports `false`; it is still listed
+    /// (honestly) but must not be launched.
+    #[must_use]
+    pub const fn directory_present(&self) -> bool {
+        self.directory_present
+    }
+
+    /// The bounded sidebar label: the directory's final component.
+    #[must_use]
+    pub fn name_display(&self) -> String {
+        self.raw.name_display()
+    }
+
+    /// The bounded sidebar detail: branch (or detached/bare placeholder)
+    /// plus a missing-directory marker when the directory is gone.
+    #[must_use]
+    pub fn branch_display(&self) -> String {
+        let branch = self.raw.branch_display();
+        if self.directory_present {
+            branch
+        } else {
+            format!("{branch} (missing)")
+        }
+    }
+}
+
+/// Shape-only [`Debug`] (the #142/#146/#148 discipline): presence flags only,
+/// never the path or branch text.
+impl fmt::Debug for DiscoveredWorktree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DiscoveredWorktree")
+            .field("directory_present", &self.directory_present)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The outcome of one discovery pass: the bounded row list and how many
+/// worktrees the cap omitted.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct WorktreeDiscovery {
+    rows: Vec<DiscoveredWorktree>,
+    omitted: usize,
+}
+
+impl WorktreeDiscovery {
+    /// The empty outcome (nothing discovered, nothing omitted).
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            rows: Vec::new(),
+            omitted: 0,
+        }
+    }
+
+    /// Build the bounded outcome from parsed records in git's listing order:
+    /// the first [`MAX_WORKTREE_SIDEBAR_ROWS`] become rows, the rest are
+    /// counted as omitted.
+    #[must_use]
+    pub fn from_records(records: Vec<RawWorktree>) -> Self {
+        let omitted = records.len().saturating_sub(MAX_WORKTREE_SIDEBAR_ROWS);
+        let rows = records
+            .into_iter()
+            .take(MAX_WORKTREE_SIDEBAR_ROWS)
+            .map(DiscoveredWorktree::observe)
+            .collect();
+        Self { rows, omitted }
+    }
+
+    /// The retained worktree rows, in git's listing order (the main worktree
+    /// first).
+    #[must_use]
+    pub fn rows(&self) -> &[DiscoveredWorktree] {
+        &self.rows
+    }
+
+    /// How many worktrees existed beyond the retained rows.
+    #[must_use]
+    pub const fn omitted(&self) -> usize {
+        self.omitted
+    }
+
+    /// Total worktrees git listed (retained plus omitted).
+    #[must_use]
+    pub const fn total(&self) -> usize {
+        self.rows.len() + self.omitted
+    }
+}
+
+/// Parse `git worktree list --porcelain` output into records, in order.
+///
+/// The porcelain grammar (stable since git 2.7): records separated by blank
+/// lines; the first line of a record is `worktree <path>`; a record may carry
+/// `HEAD <sha>`, `branch <ref>`, `bare`, `detached`, and (newer git)
+/// `prunable <reason>` / `locked <reason>` lines. Unknown future attributes
+/// are ignored rather than rejected so a newer git cannot break discovery;
+/// a record without its leading `worktree` line, or a truncated final path,
+/// is [`WorktreeListError::Malformed`].
+///
+/// Total: no panic on any input, including empty text (zero records).
+pub fn parse_worktree_porcelain(text: &str) -> Result<Vec<RawWorktree>, WorktreeListError> {
+    let mut records: Vec<RawWorktree> = Vec::new();
+    let mut current: Option<RawWorktree> = None;
+    for line in text.lines() {
+        if line.is_empty() {
+            if let Some(record) = current.take() {
+                records.push(record);
+            }
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if current.is_some() {
+                // A new record began without a blank separator; git never
+                // emits this, so the document is malformed.
+                return Err(WorktreeListError::Malformed);
+            }
+            if path.is_empty() {
+                return Err(WorktreeListError::Malformed);
+            }
+            current = Some(RawWorktree {
+                path: PathBuf::from(path),
+                branch: None,
+                bare: false,
+                detached: false,
+            });
+            continue;
+        }
+        let Some(record) = current.as_mut() else {
+            // An attribute line before any `worktree` line.
+            return Err(WorktreeListError::Malformed);
+        };
+        if let Some(branch) = line.strip_prefix("branch ") {
+            if branch.is_empty() {
+                return Err(WorktreeListError::Malformed);
+            }
+            record.branch = Some(branch.to_owned());
+        } else if line == "bare" {
+            record.bare = true;
+        } else if line == "detached" {
+            record.detached = true;
+        }
+        // `HEAD <sha>`, `prunable ...`, `locked ...`, and unknown future
+        // attributes are intentionally not retained.
+    }
+    if let Some(record) = current.take() {
+        records.push(record);
+    }
+    Ok(records)
+}
+
+/// Discover the worktrees of the repository containing `launch_dir` by
+/// running the fixed `git worktree list --porcelain` child there.
+///
+/// Never panics: every failure — git unavailable, not a repository, output
+/// not UTF-8 or oversized or malformed — is a typed, content-free
+/// [`WorktreeListError`]. Success yields the bounded
+/// [`WorktreeDiscovery`], whose rows include registered-but-deleted
+/// worktrees marked [`DiscoveredWorktree::directory_present`] == `false`.
+pub fn discover_worktrees(launch_dir: &Path) -> Result<WorktreeDiscovery, WorktreeListError> {
+    let output = Command::new(GIT_PROGRAM)
+        .args(GIT_WORKTREE_ARGS)
+        .current_dir(launch_dir)
+        .output()
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::NotFound => WorktreeListError::GitUnavailable,
+            std::io::ErrorKind::NotADirectory => WorktreeListError::LaunchDirectoryUnavailable,
+            _ => WorktreeListError::LaunchDirectoryUnavailable,
+        })?;
+    if !output.status.success() {
+        // `git worktree list` exits 128 outside a repository; every non-zero
+        // exit means "no listing for this directory" and none of git's
+        // stderr is retained.
+        return Err(WorktreeListError::NotARepository);
+    }
+    if output.stdout.len() > MAX_WORKTREE_OUTPUT_BYTES {
+        return Err(WorktreeListError::TooLarge);
+    }
+    let text = std::str::from_utf8(&output.stdout).map_err(|_| WorktreeListError::NotUtf8)?;
+    let records = parse_worktree_porcelain(text)?;
+    Ok(WorktreeDiscovery::from_records(records))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-parser and bounding tests. The live-git cases (real `git worktree
+    //! add`, deleted directories, detached HEADs) live in the binary test
+    //! module `main/tests.rs`, which owns the app-level fixtures.
+
+    use super::*;
+
+    /// The exact porcelain shape of a two-worktree repository: a branched
+    /// main worktree plus a branched linked worktree.
+    const TWO_WORKTREES: &str = "worktree /Users/dev/noren\n\
+                                 HEAD 6f755f8a4d2b6f4f8da7bd0e92a17f5f018d94c6\n\
+                                 branch refs/heads/main\n\
+                                 \n\
+                                 worktree /Users/dev/noren-w-breadth\n\
+                                 HEAD 189c040b1e5f8da7bd0e92a17f5f018d94c6aa\n\
+                                 branch refs/heads/feat/worktree-sessions\n";
+
+    #[test]
+    fn empty_output_yields_no_records() {
+        assert_eq!(parse_worktree_porcelain(""), Ok(Vec::new()));
+        // A trailing separator with no following record is also empty.
+        assert_eq!(parse_worktree_porcelain("\n"), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn two_worktrees_parse_in_listing_order_with_branches() {
+        let records =
+            parse_worktree_porcelain(TWO_WORKTREES).expect("well-formed porcelain parses");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].path(), Path::new("/Users/dev/noren"));
+        assert_eq!(records[0].branch(), Some("refs/heads/main"));
+        assert!(!records[0].is_bare());
+        assert!(!records[0].is_detached());
+        assert_eq!(records[0].branch_display(), "main");
+        assert_eq!(records[0].name_display(), "noren");
+        assert_eq!(records[1].path(), Path::new("/Users/dev/noren-w-breadth"));
+        assert_eq!(records[1].branch_display(), "worktree-sessions");
+    }
+
+    #[test]
+    fn a_single_worktree_repository_parses() {
+        let text = "worktree /srv/repo\nHEAD abcdef0123456789\nbranch refs/heads/trunk\n";
+        let records = parse_worktree_porcelain(text).expect("single record parses");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].path(), Path::new("/srv/repo"));
+        assert_eq!(records[0].branch(), Some("refs/heads/trunk"));
+    }
+
+    #[test]
+    fn a_detached_head_has_no_branch_and_reports_detached() {
+        let text = "worktree /srv/detached\nHEAD fedcba9876543210\ndetached\n";
+        let records = parse_worktree_porcelain(text).expect("detached record parses");
+        assert_eq!(records.len(), 1);
+        assert!(records[0].is_detached());
+        assert_eq!(records[0].branch(), None);
+        assert_eq!(records[0].branch_display(), "(detached)");
+    }
+
+    #[test]
+    fn a_bare_worktree_reports_bare_and_a_placeholder_branch() {
+        let text = "worktree /srv/repo.git\nbare\n\nworktree /srv/repo\nHEAD abc\nbranch refs/heads/main\n";
+        let records = parse_worktree_porcelain(text).expect("bare record parses");
+        assert_eq!(records.len(), 2);
+        assert!(records[0].is_bare());
+        assert_eq!(records[0].branch_display(), "(bare)");
+        assert!(!records[1].is_bare());
+    }
+
+    #[test]
+    fn paths_with_spaces_and_non_ascii_parse_verbatim() {
+        let text =
+            "worktree /Users/üser namé/秘密 の フォルダ/wt\nHEAD abc\nbranch refs/heads/tôpik\n";
+        let records = parse_worktree_porcelain(text).expect("non-ASCII path parses");
+        assert_eq!(
+            records[0].path(),
+            Path::new("/Users/üser namé/秘密 の フォルダ/wt")
+        );
+        assert_eq!(records[0].name_display(), "wt");
+        assert_eq!(records[0].branch_display(), "tôpik");
+    }
+
+    #[test]
+    fn newer_git_attributes_are_ignored_not_rejected() {
+        // `prunable`/`locked` exist in git >= 2.17 output; unknown future
+        // attributes must not break discovery of the worktree itself.
+        let text = "worktree /srv/prunable\nHEAD abc\nprunable gitdir file points to non-existent location\nlocked\n";
+        let records = parse_worktree_porcelain(text).expect("unknown attributes are ignored");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].path(), Path::new("/srv/prunable"));
+    }
+
+    #[test]
+    fn a_record_without_a_worktree_line_is_malformed() {
+        assert_eq!(
+            parse_worktree_porcelain("HEAD abc\n"),
+            Err(WorktreeListError::Malformed)
+        );
+        // Two `worktree` lines without a blank separator never happen in
+        // real output and are refused rather than silently splitting.
+        assert_eq!(
+            parse_worktree_porcelain("worktree /a\nworktree /b\n"),
+            Err(WorktreeListError::Malformed)
+        );
+        assert_eq!(
+            parse_worktree_porcelain("worktree \n"),
+            Err(WorktreeListError::Malformed)
+        );
+    }
+
+    #[test]
+    fn discovery_bounds_rows_and_reports_the_omitted_count() {
+        let records: Vec<RawWorktree> = (0..(MAX_WORKTREE_SIDEBAR_ROWS + 5))
+            .map(|index| RawWorktree {
+                path: PathBuf::from(format!("/srv/wt-{index}")),
+                branch: Some(format!("refs/heads/b-{index}")),
+                bare: false,
+                detached: false,
+            })
+            .collect();
+        let discovery = WorktreeDiscovery::from_records(records);
+        assert_eq!(discovery.rows().len(), MAX_WORKTREE_SIDEBAR_ROWS);
+        assert_eq!(discovery.omitted(), 5);
+        assert_eq!(discovery.total(), MAX_WORKTREE_SIDEBAR_ROWS + 5);
+        // The cap keeps the FIRST worktrees in git's listing order: the main
+        // worktree is always retained.
+        assert_eq!(discovery.rows()[0].path(), Path::new("/srv/wt-0"));
+    }
+
+    #[test]
+    fn error_messages_are_fixed_content_free_strings() {
+        // Every variant's Display is a fixed string; none of them can carry a
+        // path, branch, or git output text because none of them accepts any.
+        for error in [
+            WorktreeListError::GitUnavailable,
+            WorktreeListError::NotARepository,
+            WorktreeListError::LaunchDirectoryUnavailable,
+            WorktreeListError::NotUtf8,
+            WorktreeListError::TooLarge,
+            WorktreeListError::Malformed,
+        ] {
+            let text = error.to_string();
+            assert!(!text.is_empty());
+            assert!(!text.contains('/'), "no path text: {text}");
+        }
+    }
+
+    #[test]
+    fn debug_output_is_shape_only_for_secret_shaped_paths() {
+        // The #142/#146/#148 discipline: a worktree path (and branch) can
+        // embed a username or private directory name; Debug must not print
+        // either, at any nesting this module owns.
+        let secret = format!("NOREN-WT-hunter2-{}", std::process::id());
+        let record = RawWorktree {
+            path: PathBuf::from(format!("/Users/{secret}/wt")),
+            branch: Some(format!("refs/heads/{secret}")),
+            bare: false,
+            detached: false,
+        };
+        let discovered = DiscoveredWorktree {
+            raw: record.clone(),
+            directory_present: true,
+        };
+        let discovery = WorktreeDiscovery::from_records(vec![record]);
+        for rendered in [
+            format!("{discovered:?}"),
+            format!("{:?}", discovery.rows()[0]),
+            format!("{:?}", discovery.rows()[0].raw()),
+        ] {
+            assert!(
+                !rendered.contains(&secret),
+                "debug surface leaked path or branch text: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_missing_directory_row_keeps_the_record_and_marks_it() {
+        // The runner-level fixture (a real deleted worktree) lives in the
+        // binary tests; this pins the data model: a record whose directory
+        // does not exist is still a row, marked not present, with the
+        // missing marker in its detail text.
+        let record = RawWorktree {
+            path: PathBuf::from("/definitely/not/a/real/directory/wt-gone"),
+            branch: Some("refs/heads/gone".to_owned()),
+            bare: false,
+            detached: false,
+        };
+        let discovery = WorktreeDiscovery::from_records(vec![record]);
+        let row = &discovery.rows()[0];
+        assert!(!row.directory_present());
+        assert_eq!(row.branch_display(), "gone (missing)");
+        assert_eq!(
+            row.path(),
+            Path::new("/definitely/not/a/real/directory/wt-gone")
+        );
+    }
+}

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -11,6 +11,7 @@
 mod clipboard;
 pub mod config;
 pub mod diagnostics;
+pub mod git_worktree;
 mod input;
 pub mod mouse;
 pub mod palette;

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1332,6 +1332,30 @@ impl NorenApp {
         }
     }
 
+    /// Spawn the PTY for a worktree session, whose working directory is the
+    /// worktree itself.
+    ///
+    /// Production inherits `HOME` unchanged so the user's own shell
+    /// configuration applies inside the worktree checkout. Tests that drive
+    /// the shell by typing redirect the child's `HOME` to the isolated
+    /// empty home (see [`NorenApp::test_pty_home`]) for the same reason as
+    /// [`Self::spawn_pty_session`]: a developer's real `$HOME` may carry
+    /// startup files that take arbitrarily long or read the terminal, which
+    /// would make every shell-driving test depend on personal configuration.
+    /// The working directory is the worktree in both shapes, so the child's
+    /// actual cwd stays observable through its own `pwd` answer.
+    fn spawn_worktree_pty_session(
+        &self,
+        path: &std::path::Path,
+        size: PtySize,
+    ) -> Result<PtySession, noren_pty::PtyError> {
+        #[cfg(test)]
+        if let Some(home) = &self.test_pty_home {
+            return PtySession::spawn_in_dir_with_home(path, home, size);
+        }
+        PtySession::spawn_in_dir(path, size)
+    }
+
     /// Spawn a real PTY session whose working directory is the worktree at
     /// `path`, and give it the live view.
     ///
@@ -1355,7 +1379,7 @@ impl NorenApp {
             );
             return None;
         };
-        match PtySession::spawn_in_dir(path, pty_size) {
+        match self.spawn_worktree_pty_session(path, pty_size) {
             Ok(pty) => {
                 self.workspace.observe_session(id, SessionStatus::Running);
                 self.park_active_session();

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -29,6 +29,7 @@ use noren_app::{
     config::{AppConfig, KeymapConfig},
     diagnostics::{self, PtyChildStatus},
     encode_paste,
+    git_worktree::{self, DiscoveredWorktree, WorktreeDiscovery, WorktreeListError},
     mouse::{MouseEncoder, MouseGrid, MouseModes, PointerEvent, PointerModifiers},
     palette::{CommandId, Palette},
     passthrough::{
@@ -101,6 +102,11 @@ const SSH_STATUS_CONNECT_FAILED: &str = "Noren ssh connection failed";
 const SSH_STATUS_DISCONNECTED: &str = "Noren ssh connection lost";
 const SSH_STATUS_LAUNCH_FAILED: &str = "Noren ssh launch failed";
 const SSH_STATUS_REFUSED: &str = "Noren ssh connect refused";
+/// Status-row text when a worktree row whose directory no longer exists is
+/// selected: the launch is refused before any session or child exists.
+const WORKTREE_STATUS_MISSING: &str = "Noren worktree directory missing";
+/// Status-row text when a worktree session's zsh child could not be spawned.
+const WORKTREE_STATUS_LAUNCH_FAILED: &str = "Noren worktree launch failed";
 
 /// Observed state of the one live SSH launch. This is application-local
 /// runtime state, deliberately outside the session registry: the registry
@@ -342,6 +348,13 @@ fn session_state_path() -> Option<PathBuf> {
 struct WorkspaceState {
     registry: SessionRegistry,
     sidebar: SidebarView,
+    /// Worktrees discovered in the launch repository at startup: sidebar
+    /// facts only until a row is selected, exactly like the configured SSH
+    /// hosts. Selecting a row creates a `SessionKind::Worktree` session,
+    /// which is the shape that persists.
+    worktrees: Vec<DiscoveredWorktree>,
+    /// How many discovered worktrees the bounded sidebar policy omitted.
+    worktrees_omitted: usize,
     /// Configured SSH targets represented by the shared session vocabulary.
     /// They are sidebar facts only: no registry entry or connection exists.
     ssh_hosts: Vec<ConfiguredSshHost>,
@@ -375,6 +388,8 @@ impl fmt::Debug for WorkspaceState {
             .field("registry", &self.registry.len())
             .field("registry_selection", &self.registry.selected())
             .field("sidebar", &self.sidebar)
+            .field("worktrees", &self.worktrees.len())
+            .field("worktrees_omitted", &self.worktrees_omitted)
             .field("ssh_hosts", &self.ssh_hosts.len())
             .field("ssh_hosts_omitted", &self.ssh_hosts_omitted)
             .field("selected_ssh_target", &self.selected_ssh_target.is_some())
@@ -413,6 +428,8 @@ impl WorkspaceState {
         Self {
             registry: SessionRegistry::new(),
             sidebar: SidebarView::build(&[], None),
+            worktrees: Vec::new(),
+            worktrees_omitted: 0,
             ssh_hosts: Vec::new(),
             ssh_hosts_omitted: 0,
             selected_ssh_target: None,
@@ -542,6 +559,23 @@ impl WorkspaceState {
         Ok(())
     }
 
+    /// Replace the discovered worktree facts without creating sessions.
+    /// Rows are bounded by [`git_worktree::MAX_WORKTREE_SIDEBAR_ROWS`] and
+    /// the omitted count is retained for the status notice.
+    fn load_worktrees(&mut self, discovery: WorktreeDiscovery) {
+        self.worktrees_omitted = discovery.omitted();
+        self.worktrees = discovery.rows().to_vec();
+        self.rebuild_sidebar();
+    }
+
+    /// The worktree fact at a stable sidebar position, if that position is
+    /// a worktree row. Session rows precede worktree rows; SSH host rows
+    /// follow them.
+    fn worktree_sidebar_row(&self, row_index: usize) -> Option<&DiscoveredWorktree> {
+        let index = row_index.checked_sub(self.registry.len())?;
+        self.worktrees.get(index)
+    }
+
     /// Replace the configured SSH host facts without creating sessions.
     /// Returns the number omitted by the bounded sidebar policy.
     fn load_ssh_config(&mut self, config: &SshConfig) -> usize {
@@ -569,7 +603,8 @@ impl WorkspaceState {
     /// Select an SSH row as a pending UI choice, never as a live session.
     fn select_ssh_sidebar_row(&mut self, row_index: usize) -> bool {
         let session_rows = self.registry.len();
-        let host_index = row_index.checked_sub(session_rows);
+        let worktree_rows = self.worktrees.len();
+        let host_index = row_index.checked_sub(session_rows + worktree_rows);
         let Some(Some(ConfiguredSshHost {
             kind: SessionKind::Ssh { target },
             source_label,
@@ -627,7 +662,9 @@ impl WorkspaceState {
 
     /// Rebuild the sidebar from the registry's current sessions and selection.
     ///
-    /// Called after every mutation so the view never lags the model.
+    /// Called after every mutation so the view never lags the model. Row
+    /// order is stable: session rows first, then discovered worktree facts,
+    /// then configured SSH host facts.
     fn rebuild_sidebar(&mut self) {
         let entries: Vec<SidebarEntry> = self
             .registry
@@ -636,6 +673,14 @@ impl WorkspaceState {
             .map(SidebarEntry::Session)
             .collect();
         let mut entries = entries;
+        entries.extend(
+            self.worktrees
+                .iter()
+                .map(|worktree| SidebarEntry::Worktree {
+                    name: worktree.name_display(),
+                    branch: worktree.branch_display(),
+                }),
+        );
         let mut pending_marked = false;
         entries.extend(self.ssh_hosts.iter().filter_map(|host| {
             let SessionKind::Ssh { target } = &host.kind else {
@@ -737,6 +782,8 @@ struct NorenApp {
     diagnostics_line: String,
     ssh_diagnostic: Option<String>,
     ssh_selection_status: Option<String>,
+    /// Bounded, content-free worktree-discovery notice (cap or failure).
+    worktree_diagnostic: Option<String>,
     /// When EOF was observed on a live ssh child whose reaped exit event has
     /// not arrived yet; drives the immediate-disconnect classification.
     ssh_eof_since: Option<Instant>,
@@ -793,8 +840,9 @@ struct NorenApp {
 /// Which application-owned line, if any, occupies the renderer's status row.
 ///
 /// Runtime statuses take precedence while `show_status` is set. A pending SSH
-/// selection then exposes its bounded provenance; otherwise a readable config
-/// keeps the partial-discovery notice (or a parse failure keeps its content-free
+/// selection then exposes its bounded provenance; a worktree-discovery notice
+/// (cap or failure) follows; otherwise a readable config keeps the
+/// partial-discovery notice (or a parse failure keeps its content-free
 /// diagnostic). The runtime source is also the idle fallback, making the row a
 /// permanent part of the application grid rather than dynamically hiding a PTY
 /// row when a notice appears.
@@ -802,6 +850,7 @@ struct NorenApp {
 enum StatusRowSource {
     Runtime,
     SshSelection,
+    WorktreeDiagnostic,
     SshDiagnostic,
 }
 
@@ -810,12 +859,16 @@ impl StatusRowSource {
         self,
         runtime: &'a str,
         ssh_selection_status: Option<&'a str>,
+        worktree_diagnostic: Option<&'a str>,
         ssh_diagnostic: Option<&'a str>,
     ) -> &'a str {
         match self {
             Self::Runtime => runtime,
             Self::SshSelection => {
                 ssh_selection_status.expect("SSH selection source requires a provenance status")
+            }
+            Self::WorktreeDiagnostic => {
+                worktree_diagnostic.expect("worktree diagnostic source requires diagnostic text")
             }
             Self::SshDiagnostic => {
                 ssh_diagnostic.expect("SSH diagnostic source requires diagnostic text")
@@ -852,6 +905,7 @@ impl NorenApp {
             diagnostics_line: String::new(),
             ssh_diagnostic: None,
             ssh_selection_status: None,
+            worktree_diagnostic: None,
             ssh_eof_since: None,
             ssh_spawn_enabled: true,
             #[cfg(test)]
@@ -883,6 +937,8 @@ impl NorenApp {
             StatusRowSource::Runtime
         } else if self.ssh_selection_status.is_some() {
             StatusRowSource::SshSelection
+        } else if self.worktree_diagnostic.is_some() {
+            StatusRowSource::WorktreeDiagnostic
         } else if self.ssh_diagnostic.is_some() {
             StatusRowSource::SshDiagnostic
         } else {
@@ -931,6 +987,58 @@ impl NorenApp {
             Ok(config) => self.apply_ssh_config(&config),
             Err(error) => self.report_ssh_diagnostic(error.to_string()),
         }
+    }
+
+    /// Discover the git worktrees of the repository Noren was launched in.
+    ///
+    /// A launch directory outside any git repository is the common case and
+    /// is silent (like a missing SSH config): no rows, no notice. Every
+    /// other failure — git unavailable, unreadable or malformed output — is
+    /// a bounded, content-free status line that never stops startup. A
+    /// repository with more worktrees than the sidebar cap reports the cap
+    /// and the omitted count.
+    fn load_git_worktrees(&mut self) {
+        let launch_dir = std::env::current_dir()
+            .map_err(|_| WorktreeListError::LaunchDirectoryUnavailable)
+            .and_then(|dir| git_worktree::discover_worktrees(&dir));
+        self.apply_worktree_discovery(launch_dir);
+    }
+
+    /// Deterministic explicit-directory seam used by tests.
+    #[cfg(test)]
+    fn load_git_worktrees_from(&mut self, launch_dir: &std::path::Path) {
+        let discovery = git_worktree::discover_worktrees(launch_dir);
+        self.apply_worktree_discovery(discovery);
+    }
+
+    fn apply_worktree_discovery(
+        &mut self,
+        discovery: Result<WorktreeDiscovery, WorktreeListError>,
+    ) {
+        match discovery {
+            Ok(discovered) => {
+                let omitted = discovered.omitted();
+                self.workspace.load_worktrees(discovered);
+                self.worktree_diagnostic = (omitted > 0).then(|| {
+                    format!(
+                        "Noren worktrees: showing first {}; {omitted} omitted",
+                        git_worktree::MAX_WORKTREE_SIDEBAR_ROWS
+                    )
+                });
+            }
+            Err(WorktreeListError::NotARepository) => {
+                self.workspace.load_worktrees(WorktreeDiscovery::empty());
+                self.worktree_diagnostic = None;
+            }
+            Err(error) => {
+                // The error Display is a fixed, content-free string.
+                self.workspace.load_worktrees(WorktreeDiscovery::empty());
+                let line = format!("Noren worktrees: {error}");
+                eprintln!("{line}");
+                self.worktree_diagnostic = Some(line);
+            }
+        }
+        self.redraw_needed = true;
     }
 
     /// Deterministic explicit-path seam used by tests and future reload UI.
@@ -1217,6 +1325,62 @@ impl NorenApp {
                         reason: "PTY spawn failed".to_owned(),
                     },
                 );
+                None
+            }
+        }
+    }
+
+    /// Spawn a real PTY session whose working directory is the worktree at
+    /// `path`, and give it the live view.
+    ///
+    /// This is the worktree-row runtime: the new sidebar row is a
+    /// `SessionKind::Worktree` registry session backed by an actual `/bin/zsh`
+    /// PTY whose child starts *in* the worktree checkout (HOME inherited, so
+    /// the user's shell configuration still applies). The registry observes
+    /// `Running` when the spawn succeeds and `Failed` when it does not. The
+    /// new session takes the live view and the previous one is parked, not
+    /// killed — the same convention as [`Self::spawn_local_session`].
+    fn spawn_worktree_session(&mut self, path: &std::path::Path) -> Option<SessionId> {
+        let id = self.workspace.create_session(SessionKind::Worktree {
+            path: path.to_owned(),
+        });
+        let Some((terminal, pty_size)) = self.session_surfaces() else {
+            self.workspace.observe_session(
+                id,
+                SessionStatus::Failed {
+                    reason: "terminal surface unavailable".to_owned(),
+                },
+            );
+            return None;
+        };
+        match PtySession::spawn_in_dir(path, pty_size) {
+            Ok(pty) => {
+                self.workspace.observe_session(id, SessionStatus::Running);
+                self.park_active_session();
+                self.pty = Some(pty);
+                self.terminal = Some(terminal);
+                self.active_session = Some(id);
+                self.pty_child = PtyChildStatus::Running;
+                self.selection = None;
+                self.drag_origin = None;
+                self.exited_surface_session = None;
+                self.workspace
+                    .select_session(id)
+                    .expect("freshly spawned session is live");
+                self.ssh_selection_status = None;
+                self.redraw_needed = true;
+                Some(id)
+            }
+            Err(_) => {
+                self.workspace.observe_session(
+                    id,
+                    SessionStatus::Failed {
+                        reason: "PTY spawn failed".to_owned(),
+                    },
+                );
+                self.status = WORKTREE_STATUS_LAUNCH_FAILED;
+                self.show_status = true;
+                self.redraw_needed = true;
                 None
             }
         }
@@ -1938,6 +2102,21 @@ impl NorenApp {
             }
             return true;
         }
+        if let Some(worktree) = self.workspace.worktree_sidebar_row(row_index) {
+            // A present worktree row launches a real session rooted at the
+            // worktree directory; a registered-but-deleted one is refused
+            // before any session or child exists. Both are first-class,
+            // visible outcomes.
+            let path = worktree.path().to_owned();
+            if worktree.directory_present() {
+                self.spawn_worktree_session(&path);
+            } else {
+                self.status = WORKTREE_STATUS_MISSING;
+                self.show_status = true;
+            }
+            self.redraw_needed = true;
+            return true;
+        }
         if self.workspace.select_ssh_sidebar_row(row_index) {
             let target = self.workspace.selected_ssh_target().map(str::to_owned);
             let source = self
@@ -2536,6 +2715,7 @@ impl NorenApp {
             source.text(
                 self.status,
                 self.ssh_selection_status.as_deref(),
+                self.worktree_diagnostic.as_deref(),
                 self.ssh_diagnostic.as_deref(),
             )
         });
@@ -2789,6 +2969,7 @@ fn main() {
     event_loop.set_control_flow(ControlFlow::Poll);
     let mut app = NorenApp::new(config);
     app.load_sidebar_state(session_state_path());
+    app.load_git_worktrees();
     app.load_ssh_hosts();
     if event_loop.run_app(&mut app).is_err() {
         eprintln!("Noren event loop failed");

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -992,11 +992,13 @@ impl NorenApp {
     /// Discover the git worktrees of the repository Noren was launched in.
     ///
     /// A launch directory outside any git repository is the common case and
-    /// is silent (like a missing SSH config): no rows, no notice. Every
-    /// other failure — git unavailable, unreadable or malformed output — is
-    /// a bounded, content-free status line that never stops startup. A
-    /// repository with more worktrees than the sidebar cap reports the cap
-    /// and the omitted count.
+    /// is silent (like a missing SSH config): no rows, no notice. A missing
+    /// or non-directory launch path is reported as `LaunchDirectoryUnavailable`
+    /// (not `GitUnavailable`): git may be installed, the directory is not.
+    /// Every other failure — git unavailable, unreadable or malformed
+    /// output — is a bounded, content-free status line that never stops
+    /// startup. A repository with more worktrees than the sidebar cap
+    /// reports the cap and the omitted count.
     fn load_git_worktrees(&mut self) {
         let launch_dir = std::env::current_dir()
             .map_err(|_| WorktreeListError::LaunchDirectoryUnavailable)

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1940,6 +1940,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
         source.text(
             app.status,
             app.ssh_selection_status.as_deref(),
+            app.worktree_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
         diagnostic
@@ -1971,6 +1972,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
     let status = source.text(
         app.status,
         app.ssh_selection_status.as_deref(),
+        app.worktree_diagnostic.as_deref(),
         app.ssh_diagnostic.as_deref(),
     );
     let vertices = renderer::glyph_vertices(
@@ -2057,6 +2059,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
         source.text(
             app.status,
             app.ssh_selection_status.as_deref(),
+            app.worktree_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
         "Noren PTY operation failed",
@@ -2125,6 +2128,7 @@ fn selecting_an_ssh_row_keeps_a_pending_choice_and_never_a_registry_connection()
         source.text(
             app.status,
             app.ssh_selection_status.as_deref(),
+            app.worktree_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
         "SSH partial source #0 config; launch failed"
@@ -4298,3 +4302,373 @@ fn a_restored_row_never_takes_the_live_view_from_the_running_session() {
     );
     cleanup_state_file(&path);
 }
+
+// ── Git worktree discovery and worktree sessions ────────────────────────
+//
+// The live fixtures drive the real `git` binary (never a scraped fixture of
+// its output): every worktree case the ROADMAP names — not a repository, a
+// single worktree, a registered-but-deleted directory, a detached HEAD, and
+// paths with spaces or non-ASCII — is created with real git plumbing and
+// discovered through the production `git worktree list --porcelain` child.
+// Skip policy follows the live Zellij harness: when git is not usable the
+// live tests print a visible skip notice on stderr and return early — a
+// skip is never mistaken for gathered evidence.
+
+static WT_SEQUENCE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Whether the real `git` binary is usable on this machine.
+fn git_usable() -> bool {
+    std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+/// Print the visible skip notice shared by every live git test.
+fn report_worktree_skip(test: &str) {
+    let notice = format!(
+        "SKIP [{test}]: git is not installed (or `git --version` failed); \
+         live worktree evidence was NOT gathered. This is a skip, not a pass."
+    );
+    use std::io::Write;
+    match std::fs::OpenOptions::new().write(true).open("/dev/stderr") {
+        Ok(mut file) => {
+            let _ = file.write_all(notice.as_bytes());
+            let _ = file.write_all(b"\n");
+        }
+        Err(_) => eprintln!("{notice}"),
+    }
+}
+
+/// A private git repository fixture driven through the real `git` binary.
+///
+/// `root` is the main worktree; linked worktrees are created on demand as
+/// siblings under the fixture's private base directory. The initial commit
+/// is made on a fixed branch name so no assertion depends on the machine's
+/// `init.defaultBranch`. Identity is supplied with per-command `-c` config
+/// so the developer's global git configuration is never read or required.
+struct GitWorktreeFixture {
+    /// Private base directory holding the main worktree and its links.
+    base: PathBuf,
+    /// The main worktree, also the repository root.
+    root: PathBuf,
+    /// Per-fixture branch counter so linked-branch names are deterministic
+    /// (`wt-1`, `wt-2`, ...) regardless of process-wide test ordering.
+    branch_sequence: std::cell::Cell<usize>,
+}
+
+impl GitWorktreeFixture {
+    /// The main worktree on branch `noren-trunk` with one empty commit, or
+    /// `None` when git is unusable (the caller reports the skip).
+    fn new() -> Option<Self> {
+        if !git_usable() {
+            return None;
+        }
+        let sequence = WT_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let base = std::env::temp_dir().join(format!(
+            "noren-app-wt-fixture-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&base).expect("create private worktree fixture base");
+        let root = base.join("main");
+        let root_text = root.display().to_string();
+        Self::git(None, &["init", &root_text]).expect("git init the fixture repository");
+        // Fixed branch name + per-command identity: independent of the
+        // machine's init.defaultBranch and global git config.
+        Self::git(Some(&root), &["checkout", "-b", "noren-trunk"])
+            .expect("create the fixed fixture branch");
+        Self::git(
+            Some(&root),
+            &[
+                "-c",
+                "user.name=Noren",
+                "-c",
+                "user.email=noren@example",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        )
+        .expect("create the initial fixture commit");
+
+        Some(Self {
+            base,
+            root,
+            branch_sequence: std::cell::Cell::new(0),
+        })
+    }
+
+    /// Run one real `git` command, optionally inside `dir`.
+    fn git(dir: Option<&std::path::Path>, args: &[&str]) -> std::io::Result<()> {
+        let mut command = std::process::Command::new("git");
+        if let Some(dir) = dir {
+            command.current_dir(dir);
+        }
+        command.args(args);
+        let output = command.output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(std::io::Error::other("git fixture command failed"))
+        }
+    }
+
+    /// Add a linked worktree and return its path and branch name. The
+    /// branch is named from the fixture's sequence (git refnames cannot
+    /// carry spaces); the PATH deliberately may contain spaces and
+    /// non-ASCII because git must round-trip them.
+    fn add_worktree(&self, name: &str) -> (PathBuf, String) {
+        let path = self.base.join(name);
+        let branch = format!(
+            "wt-{}",
+            self.branch_sequence.replace(self.branch_sequence.get() + 1) + 1
+        );
+        let path_text = path.display().to_string();
+        Self::git(
+            Some(&self.root),
+            &["worktree", "add", "-b", &branch, &path_text],
+        )
+        .unwrap_or_else(|error| panic!("add worktree fixture {name}: {error}"));
+        (path, branch)
+    }
+
+    /// Add a linked worktree with a detached HEAD and return its path.
+    fn add_detached_worktree(&self, name: &str) -> PathBuf {
+        let path = self.base.join(name);
+        let path_text = path.display().to_string();
+        Self::git(
+            Some(&self.root),
+            &["worktree", "add", "--detach", &path_text],
+        )
+        .unwrap_or_else(|error| panic!("add detached worktree fixture {name}: {error}"));
+        path
+    }
+
+    /// The worktree at `path` stays REGISTERED while its directory is
+    /// deleted from disk — the common stale case until `git worktree prune`.
+    /// Equivalent to the user's `rm -rf` of a scratch checkout: the whole
+    /// directory (including the `.git` link file) goes, the registration in
+    /// the main repository's metadata stays.
+    fn delete_worktree_directory(&self, path: &std::path::Path) {
+        std::fs::remove_dir_all(path).expect("delete the worktree directory only");
+    }
+}
+
+impl Drop for GitWorktreeFixture {
+    fn drop(&mut self) {
+        // The linked worktrees are siblings under the base, so one removal
+        // takes the whole fixture; failures are ignored because a stale
+        // worktree directory can already be gone.
+        let _ = std::fs::remove_dir_all(&self.base);
+    }
+}
+
+/// A temp directory that is NOT a git repository (no git child needed).
+fn non_repository_directory() -> PathBuf {
+    let sequence = WT_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "noren-app-not-a-repo-{}-{sequence}",
+        std::process::id()
+    ));
+    std::fs::create_dir(&path).expect("create plain fixture directory");
+    path
+}
+
+/// Discovered worktree rows appear as `EntryKind::Worktree` sidebar rows a
+/// user SEES on launch: the main worktree first with its branch, then the
+/// linked worktrees, branched or detached, with spaces and non-ASCII in
+/// paths intact. A detached HEAD shows the fixed placeholder, never a panic.
+#[test]
+fn discovered_worktrees_appear_as_sidebar_rows() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("discovered_worktrees_appear_as_sidebar_rows");
+        return;
+    };
+    let (plain_path, plain_branch) = fixture.add_worktree("plain");
+    let (_spaced_path, spaced_branch) = fixture.add_worktree("spaced 名前 wt");
+    let detached_path = fixture.add_detached_worktree("detached-only");
+
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&fixture.root);
+
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows.len(), 4, "the main worktree plus three linked ones");
+    // The main worktree is always listed first; the order of the linked
+    // worktrees is git's readdir order, so they are found by path, not
+    // position. Git prints resolved paths (/private/var on macOS), so the
+    // fixture paths are canonicalized before comparing. Worktree facts and
+    // sidebar rows are index-aligned (the registry is empty).
+    assert_eq!(rows[0].kind(), EntryKind::Worktree);
+    assert_eq!(rows[0].label(), "main");
+    assert_eq!(rows[0].detail(), Some("noren-trunk"));
+    let row_of = |path: &std::path::Path| -> usize {
+        let canonical = std::fs::canonicalize(path).expect("canonicalize fixture path");
+        app.workspace
+            .worktrees
+            .iter()
+            .position(|worktree| worktree.path() == canonical)
+            .unwrap_or_else(|| panic!("no discovered worktree for {canonical:?}"))
+    };
+    assert_eq!(
+        rows[row_of(&plain_path)].detail(),
+        Some(plain_branch.as_str())
+    );
+    assert_eq!(
+        rows[row_of(&detached_path)].detail(),
+        Some("(detached)"),
+        "a detached HEAD reports the fixed placeholder"
+    );
+    let spaced_index = app
+        .workspace
+        .worktrees
+        .iter()
+        .position(|worktree| worktree.name_display() == "spaced 名前 wt")
+        .expect("a path with spaces and non-ASCII round-trips into discovery");
+    assert_eq!(rows[spaced_index].label(), "spaced 名前 wt");
+    assert_eq!(rows[spaced_index].detail(), Some(spaced_branch.as_str()));
+    assert!(
+        app.worktree_diagnostic.is_none(),
+        "an in-cap discovery adds no notice"
+    );
+}
+
+/// A launch directory outside any git repository is the common case: no
+/// rows, no diagnostic, no panic — like a missing SSH config.
+#[test]
+fn a_launch_directory_outside_a_repository_is_silent() {
+    let dir = non_repository_directory();
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&dir);
+    assert_eq!(app.workspace.sidebar().rows().len(), 0);
+    assert!(app.workspace.worktrees.is_empty());
+    assert!(
+        app.worktree_diagnostic.is_none(),
+        "not-a-repository is silent, exactly like a missing SSH config"
+    );
+    let _ = std::fs::remove_dir(&dir);
+}
+
+/// A repository with exactly one worktree (no links) lists that one row.
+#[test]
+fn a_single_worktree_repository_lists_one_row() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("a_single_worktree_repository_lists_one_row");
+        return;
+    };
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&fixture.root);
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].kind(), EntryKind::Worktree);
+    assert_eq!(rows[0].detail(), Some("noren-trunk"));
+}
+
+/// The stale case the ROADMAP names: a worktree whose directory was deleted
+/// from disk but is still registered. Discovery must list it (marked
+/// missing), the sidebar must show the marker, and selecting the row must
+/// refuse the launch before any session or child exists — no panic, no
+/// hang, an honest visible status.
+///
+/// Mutation check (B): making discovery panic on a missing directory (for
+/// example an `.expect` on the directory's presence) fails this test.
+#[test]
+fn a_registered_but_deleted_worktree_is_marked_and_refused() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("a_registered_but_deleted_worktree_is_marked_and_refused");
+        return;
+    };
+    let (stale, stale_branch) = fixture.add_worktree("gone-wt");
+    // Resolve before deleting: the canonical path is what git prints (and
+    // what discovery retains), but a deleted directory can no longer be
+    // canonicalized through the filesystem.
+    let stale_canonical =
+        std::fs::canonicalize(&stale).expect("canonicalize the stale worktree path");
+    fixture.delete_worktree_directory(&stale);
+    let _live = fixture.add_worktree("present-wt");
+
+    let mut app = NorenApp::default();
+    // Discovery over a real registration whose directory is gone must not
+    // panic (a panic here fails the test) and must not hang (the runner is
+    // one bounded git listing).
+    app.load_git_worktrees_from(&fixture.root);
+
+    let worktrees = &app.workspace.worktrees;
+    assert_eq!(
+        worktrees.len(),
+        3,
+        "main, the stale link, and the live link"
+    );
+    let stale_index = worktrees
+        .iter()
+        .position(|worktree| worktree.path() == stale_canonical)
+        .expect("the stale registration is still listed");
+    let stale_row = &worktrees[stale_index];
+    assert!(!stale_row.directory_present());
+    assert_eq!(
+        stale_row.branch_display(),
+        format!("{stale_branch} (missing)")
+    );
+    assert!(
+        worktrees
+            .iter()
+            .any(|worktree| worktree.directory_present()),
+        "the live link is still present"
+    );
+
+    // The sidebar row the user sees carries the missing marker.
+    let missing_detail = format!("{stale_branch} (missing)");
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows[stale_index].detail(), Some(missing_detail.as_str()));
+
+    // Selecting it refuses the launch: no session, no PTY, a visible status.
+    assert!(click_sidebar_row(&mut app, stale_index));
+    assert_eq!(app.status, "Noren worktree directory missing");
+    assert!(app.show_status, "the refusal must own the status row");
+    assert!(app.workspace.registry().sessions().is_empty());
+    assert!(app.pty.is_none(), "a stale worktree must not spawn a child");
+}
+
+/// A repository with more worktrees than the sidebar cap keeps the first
+/// rows in git listing order and reports the cap and the omitted count,
+/// exactly like the bounded SSH host list.
+#[test]
+fn many_worktrees_are_capped_and_the_omitted_count_is_reported() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("many_worktrees_are_capped_and_the_omitted_count_is_reported");
+        return;
+    };
+    // main + (cap + 2) linked worktrees = cap + 3 total; 3 are omitted.
+    for index in 0..(MAX_WORKTREE_SIDEBAR_TEST_ROWS + 2) {
+        fixture.add_worktree(&format!("capped-{index:02}"));
+    }
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&fixture.root);
+
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(
+        rows.len(),
+        MAX_WORKTREE_SIDEBAR_TEST_ROWS,
+        "the sidebar keeps exactly the capped row count"
+    );
+    assert_eq!(
+        rows[0].label(),
+        "main",
+        "the main worktree is always retained"
+    );
+    assert_eq!(
+        app.workspace.worktrees_omitted, 3,
+        "beyond-cap worktrees are counted, not silently dropped"
+    );
+    let notice = app
+        .worktree_diagnostic
+        .as_deref()
+        .expect("the cap is reported on the status row");
+    assert!(
+        notice.contains("showing first 24") && notice.contains("3 omitted"),
+        "the notice names the cap and the omitted count: {notice}"
+    );
+}
+
+/// Bound constant for the live cap test; must equal the shipped cap.
+const MAX_WORKTREE_SIDEBAR_TEST_ROWS: usize = noren_app::git_worktree::MAX_WORKTREE_SIDEBAR_ROWS;

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3652,19 +3652,25 @@ fn session_status(app: &NorenApp, id: SessionId) -> SessionStatus {
 /// may have customized: input typed before they finish races them, so every
 /// test that drives a shell by typing first waits for its prompt.
 fn wait_for_shell_output(app: &mut NorenApp) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(10);
     loop {
         app.drain_pty();
         let ready = app
             .terminal
             .as_ref()
             .is_some_and(|terminal| terminal.screen().display_row_count() > 0);
-        assert!(
-            Instant::now() < deadline || ready,
-            "the spawned shell never produced its prompt"
-        );
         if ready {
             return;
+        }
+        if Instant::now() >= deadline {
+            let terminal_text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
+            panic!(
+                "the spawned shell never produced its prompt after {:?}\n\
+                 terminal said: {}",
+                start.elapsed(),
+                terminal_text,
+            );
         }
         std::thread::sleep(Duration::from_millis(10));
     }
@@ -4711,6 +4717,7 @@ const MAX_WORKTREE_SIDEBAR_TEST_ROWS: usize = noren_app::git_worktree::MAX_WORKT
 /// (for example dropping the cwd from the launch policy) fails this test.
 #[cfg(target_os = "macos")]
 #[test]
+#[allow(unsafe_code)] // HOME swap is safe: tests run sequentially; child inherits before restore.
 fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
     let Some(fixture) = GitWorktreeFixture::new() else {
         report_worktree_skip("selecting_a_worktree_row_starts_a_session_in_that_worktree");
@@ -4720,6 +4727,21 @@ fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
     let canonical = std::fs::canonicalize(&worktree).expect("canonicalize the worktree path");
     let mut app = NorenApp::default();
     app.load_git_worktrees_from(&fixture.root);
+
+    // `spawn_worktree_session` calls `PtySession::spawn_in_dir` which
+    // intentionally inherits HOME unchanged so the user's shell config
+    // applies in production.  In the test harness the inherited HOME is the
+    // developer's real home whose `.zshrc` can take arbitrarily long
+    // (oh-my-zsh, conda, nvm …) or block entirely, making the test time out
+    // before the shell reaches its prompt.  Temporarily point HOME at the
+    // worktree so zsh finds no startup files and starts instantly.  The cwd
+    // is still independently verified by the pwd check below.
+    let saved_home = std::env::var_os("HOME");
+    // SAFETY: tests in this binary run sequentially; the child has
+    // already inherited the env by the time we restore below.
+    unsafe {
+        std::env::set_var("HOME", &canonical);
+    }
 
     // Row 0 is the main worktree; find the linked worktree's row by path.
     let row = app
@@ -4732,6 +4754,15 @@ fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
         click_sidebar_row(&mut app, row),
         "the worktree row is consumed"
     );
+
+    // Restore HOME immediately — the child has already inherited it.
+    // SAFETY: same single-threaded reasoning as above.
+    unsafe {
+        match saved_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
 
     // The launch created a real Worktree-kind session that owns the live
     // surface and is observed Running.

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4549,7 +4549,37 @@ fn a_launch_directory_outside_a_repository_is_silent() {
     let _ = std::fs::remove_dir(&dir);
 }
 
-/// A repository with exactly one worktree (no links) lists that one row.
+/// A nonexistent launch directory must report `LaunchDirectoryUnavailable`,
+/// not `GitUnavailable`: git may be installed, the directory is not. The
+/// `discover_worktrees` function checks `is_dir()` before spawning git, so
+/// a path that does not exist reaches `LaunchDirectoryUnavailable` through
+/// the normal error path.
+#[test]
+fn a_nonexistent_launch_directory_reports_launch_directory_unavailable() {
+    let nonexistent = std::env::temp_dir().join(format!(
+        "noren-nonexistent-dir-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&nonexistent);
+    let diagnostic = app
+        .worktree_diagnostic
+        .as_deref()
+        .expect("a nonexistent dir must produce a diagnostic");
+    assert!(
+        diagnostic.contains("launch directory"),
+        "the diagnostic must mention the directory, not git: {diagnostic}"
+    );
+    assert!(
+        !diagnostic.contains("git is unavailable"),
+        "a nonexistent dir must not be reported as git unavailable: {diagnostic}"
+    );
+}
 #[test]
 fn a_single_worktree_repository_lists_one_row() {
     let Some(fixture) = GitWorktreeFixture::new() else {

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4672,3 +4672,215 @@ fn many_worktrees_are_capped_and_the_omitted_count_is_reported() {
 
 /// Bound constant for the live cap test; must equal the shipped cap.
 const MAX_WORKTREE_SIDEBAR_TEST_ROWS: usize = noren_app::git_worktree::MAX_WORKTREE_SIDEBAR_ROWS;
+
+/// Selecting a worktree row must start a session whose working directory IS
+/// that worktree — verified by reading the child's own `pwd` answer back
+/// through the terminal, never by trusting the code path that set the cwd.
+///
+/// Mutation check (A): breaking the launch so the child starts elsewhere
+/// (for example dropping the cwd from the launch policy) fails this test.
+#[cfg(target_os = "macos")]
+#[test]
+fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("selecting_a_worktree_row_starts_a_session_in_that_worktree");
+        return;
+    };
+    let (worktree, _branch) = fixture.add_worktree("launch-wt");
+    let canonical = std::fs::canonicalize(&worktree).expect("canonicalize the worktree path");
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&fixture.root);
+
+    // Row 0 is the main worktree; find the linked worktree's row by path.
+    let row = app
+        .workspace
+        .worktrees
+        .iter()
+        .position(|worktree| worktree.path() == canonical)
+        .expect("the linked worktree is discovered");
+    assert!(
+        click_sidebar_row(&mut app, row),
+        "the worktree row is consumed"
+    );
+
+    // The launch created a real Worktree-kind session that owns the live
+    // surface and is observed Running.
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 1, "one registry session from the worktree row");
+    let id = ids[0];
+    assert_eq!(
+        app.workspace.registry().get(id).map(|d| d.kind().clone()),
+        Some(SessionKind::Worktree {
+            path: canonical.clone()
+        }),
+        "the session's launch shape carries the worktree path"
+    );
+    assert_eq!(session_status(&app, id), SessionStatus::Running);
+    assert_eq!(app.active_session, Some(id));
+    assert!(app.pty.is_some(), "the worktree session owns a real PTY");
+
+    // Read the child's ACTUAL working directory back: wait for the shell,
+    // ask it, and search the terminal text for its own answer. The path the
+    // session claims and the directory the child reports must agree. The
+    // grid wraps long lines across rows, so the comparison strips the row
+    // separators a wrap inserts — a wrapped path must still match whole.
+    wait_for_shell_output(&mut app);
+    app.send_input(b"pwd\n");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        app.drain_pty();
+        let answered = app.terminal.as_ref().is_some_and(|terminal| {
+            let unwrapped = terminal_text(terminal).replace(['\r', '\n'], "");
+            unwrapped.contains(canonical.display().to_string().as_str())
+        });
+        if answered {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the child's own pwd never reported the worktree directory; terminal said: {}",
+            app.terminal.as_ref().map(terminal_text).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Quitting with a worktree session and a local session persists BOTH
+/// through the real sessions.toml path, and the next launch restores them —
+/// the worktree kind round-trips with its path, and local-session
+/// persistence is unharmed. This is also the direct guard that the
+/// worktree launch path did not reintroduce the historic quit-path erase:
+/// teardown must save exactly the sessions it had.
+#[test]
+fn quitting_persists_worktree_sessions_beside_local_sessions() {
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("quitting_persists_worktree_sessions_beside_local_sessions");
+        return;
+    };
+    let (worktree, _branch) = fixture.add_worktree("persist-wt");
+    let canonical = std::fs::canonicalize(&worktree).expect("canonicalize the worktree path");
+    let path = temp_state_path();
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..app_with_state_path(&path)
+    };
+    app.load_git_worktrees_from(&fixture.root);
+
+    // One local session (palette) and one worktree session (row click).
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    let row = app
+        .workspace
+        .worktrees
+        .iter()
+        .position(|worktree| worktree.path() == canonical)
+        .expect("the worktree is discovered before the click");
+    // Row 0 is the local session; the worktree rows are offset by it.
+    assert!(
+        click_sidebar_row(&mut app, 1 + row),
+        "the worktree row launches"
+    );
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(session_status(&app, ids[0]), SessionStatus::Running);
+    assert_eq!(session_status(&app, ids[1]), SessionStatus::Running);
+
+    app.teardown();
+
+    let text = std::fs::read_to_string(&path).expect("state saved on quit");
+    assert_eq!(
+        text.matches("kind = \"local\"").count(),
+        1,
+        "the local session still persists: {text}"
+    );
+    assert_eq!(
+        text.matches("kind = \"worktree\"").count(),
+        1,
+        "the worktree session persists with its kind: {text}"
+    );
+    assert!(
+        text.contains("path = "),
+        "the worktree entry carries its path for restoration: {text}"
+    );
+
+    // The next launch restores both rows as Restored with intact kinds —
+    // the worktree path survives the round-trip byte for byte.
+    let relaunched = sidebar_after_relaunch(&path);
+    assert_eq!(relaunched.registry().len(), 2);
+    let kinds: Vec<SessionKind> = relaunched
+        .registry()
+        .sessions()
+        .iter()
+        .map(|descriptor| descriptor.kind().clone())
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            SessionKind::Local,
+            SessionKind::Worktree {
+                path: canonical.clone()
+            },
+        ]
+    );
+    for descriptor in relaunched.registry().sessions() {
+        assert_eq!(
+            descriptor.status(),
+            &SessionStatus::Restored,
+            "a relaunched row must be Restored, never a phantom Running"
+        );
+    }
+    cleanup_state_file(&path);
+}
+
+/// A worktree path can embed a username or a private directory name. Every
+/// debug and status surface the discovery/launch flow can reach must stay
+/// free of it. The persisted sessions.toml file deliberately DOES carry the
+/// path — it is the user's own private state and exactly what restoration
+/// needs, the same class as a project root; the redaction discipline
+/// governs Debug and error output, not the state file (SSH destinations, by
+/// contrast, may embed credentials and so never enter the registry at all).
+#[test]
+fn worktree_paths_never_reach_debug_or_status_surfaces() {
+    let secret = format!("NOREN-WT-hunter2-{}", std::process::id());
+    let Some(fixture) = GitWorktreeFixture::new() else {
+        report_worktree_skip("worktree_paths_never_reach_debug_or_status_surfaces");
+        return;
+    };
+    let (worktree, _branch) = fixture.add_worktree(&secret);
+    let canonical = std::fs::canonicalize(&worktree).expect("canonicalize the worktree path");
+    let mut app = NorenApp::default();
+    app.load_git_worktrees_from(&fixture.root);
+    assert!(
+        canonical.display().to_string().contains(&secret),
+        "fixture self-check: the secret is really in the path"
+    );
+
+    // The workspace (sidebar rows, worktree facts) never prints it.
+    assert!(
+        !format!("{:?}", app.workspace).contains(&secret),
+        "workspace debug leaked the worktree path"
+    );
+    // Status surfaces carry fixed text only.
+    if let Some(notice) = app.worktree_diagnostic.as_deref() {
+        assert!(!notice.contains(&secret), "notice leaked: {notice}");
+    }
+
+    // A registry session of this shape (the state a launch or a restore
+    // leaves behind) never prints it through the descriptor either.
+    let id = app
+        .workspace
+        .create_session(SessionKind::Worktree { path: canonical });
+    let rendered = format!("{:?}", app.workspace.registry().get(id));
+    assert!(
+        !rendered.contains(&secret),
+        "descriptor debug leaked the worktree path: {rendered}"
+    );
+    assert!(
+        rendered.contains("Worktree"),
+        "not vacuous — the descriptor still names its shape: {rendered}"
+    );
+    assert!(
+        !format!("{:?}", app.workspace).contains(&secret),
+        "workspace debug leaked after the session was created"
+    );
+}

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3608,7 +3608,9 @@ impl AppTestHome {
         Self(path)
     }
 
-    /// A default app whose spawned sessions run in this isolated home.
+    /// A default app whose spawned sessions run in this isolated home —
+    /// local sessions and worktree sessions alike (a worktree child still
+    /// starts *in* its worktree; only its `HOME` is isolated).
     ///
     /// Borrows the guard so it stays alive (and the directory stays present)
     /// for the whole test: the child validates the directory at spawn time.
@@ -3648,9 +3650,11 @@ fn session_status(app: &NorenApp, id: SessionId) -> SessionStatus {
 
 /// Drain the live view until the shell has produced its first output.
 ///
-/// Real zsh sessions run in the inherited `$HOME`, whose startup files a user
-/// may have customized: input typed before they finish races them, so every
-/// test that drives a shell by typing first waits for its prompt.
+/// The shell sessions these tests drive run in an isolated `HOME` (see
+/// [`AppTestHome`]), so their prompt is immediate and deterministic; a
+/// developer's real `$HOME` with slow startup files could not meet this
+/// deadline. Input typed while zsh is still starting races its startup, so
+/// every test that drives a shell by typing first waits for its prompt.
 fn wait_for_shell_output(app: &mut NorenApp) {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(10);
@@ -3664,12 +3668,21 @@ fn wait_for_shell_output(app: &mut NorenApp) {
             return;
         }
         if Instant::now() >= deadline {
-            let terminal_text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
+            let rows = app
+                .terminal
+                .as_ref()
+                .map(|terminal| terminal.screen().display_row_count());
+            let text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
             panic!(
-                "the spawned shell never produced its prompt after {:?}\n\
-                 terminal said: {}",
+                "the spawned shell never produced its prompt\n\
+                 expected: the live terminal to render at least one display row \
+                 of shell output within 10s\n\
+                 received: display_row_count={rows:?} after {:?} \
+                 (terminal_attached={}, pty_attached={}), terminal said: {:?}",
                 start.elapsed(),
-                terminal_text,
+                app.terminal.is_some(),
+                app.pty.is_some(),
+                text,
             );
         }
         std::thread::sleep(Duration::from_millis(10));
@@ -4713,11 +4726,15 @@ const MAX_WORKTREE_SIDEBAR_TEST_ROWS: usize = noren_app::git_worktree::MAX_WORKT
 /// that worktree — verified by reading the child's own `pwd` answer back
 /// through the terminal, never by trusting the code path that set the cwd.
 ///
+/// The child's `HOME` is isolated through the same [`AppTestHome`] seam as
+/// every other shell-driving test (production inherits `HOME` unchanged): a
+/// developer's `.zshrc` cannot stall the prompt past the deadline, while the
+/// working directory stays the worktree, so the `pwd` proof is unaffected.
+///
 /// Mutation check (A): breaking the launch so the child starts elsewhere
 /// (for example dropping the cwd from the launch policy) fails this test.
 #[cfg(target_os = "macos")]
 #[test]
-#[allow(unsafe_code)] // HOME swap is safe: tests run sequentially; child inherits before restore.
 fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
     let Some(fixture) = GitWorktreeFixture::new() else {
         report_worktree_skip("selecting_a_worktree_row_starts_a_session_in_that_worktree");
@@ -4725,23 +4742,12 @@ fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
     };
     let (worktree, _branch) = fixture.add_worktree("launch-wt");
     let canonical = std::fs::canonicalize(&worktree).expect("canonicalize the worktree path");
-    let mut app = NorenApp::default();
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..NorenApp::default()
+    };
     app.load_git_worktrees_from(&fixture.root);
-
-    // `spawn_worktree_session` calls `PtySession::spawn_in_dir` which
-    // intentionally inherits HOME unchanged so the user's shell config
-    // applies in production.  In the test harness the inherited HOME is the
-    // developer's real home whose `.zshrc` can take arbitrarily long
-    // (oh-my-zsh, conda, nvm …) or block entirely, making the test time out
-    // before the shell reaches its prompt.  Temporarily point HOME at the
-    // worktree so zsh finds no startup files and starts instantly.  The cwd
-    // is still independently verified by the pwd check below.
-    let saved_home = std::env::var_os("HOME");
-    // SAFETY: tests in this binary run sequentially; the child has
-    // already inherited the env by the time we restore below.
-    unsafe {
-        std::env::set_var("HOME", &canonical);
-    }
 
     // Row 0 is the main worktree; find the linked worktree's row by path.
     let row = app
@@ -4754,15 +4760,6 @@ fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
         click_sidebar_row(&mut app, row),
         "the worktree row is consumed"
     );
-
-    // Restore HOME immediately — the child has already inherited it.
-    // SAFETY: same single-threaded reasoning as above.
-    unsafe {
-        match saved_home {
-            Some(home) => std::env::set_var("HOME", home),
-            None => std::env::remove_var("HOME"),
-        }
-    }
 
     // The launch created a real Worktree-kind session that owns the live
     // surface and is observed Running.
@@ -4799,7 +4796,10 @@ fn selecting_a_worktree_row_starts_a_session_in_that_worktree() {
         }
         assert!(
             Instant::now() < deadline,
-            "the child's own pwd never reported the worktree directory; terminal said: {}",
+            "the child's own pwd never reported the worktree directory\n\
+             expected: the terminal text to contain the worktree path {}\n\
+             received: terminal said: {}",
+            canonical.display(),
             app.terminal.as_ref().map(terminal_text).unwrap_or_default()
         );
         std::thread::sleep(Duration::from_millis(10));

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4884,3 +4884,262 @@ fn worktree_paths_never_reach_debug_or_status_surfaces() {
         "workspace debug leaked after the session was created"
     );
 }
+
+// ── Mixed sidebars: every row kind present at once ────────────────────
+//
+// Independent review (issue #156 follow-up): the click path resolves each
+// row kind by subtracting the row counts of the kinds above it
+// (`local_sidebar_session`, `worktree_sidebar_row`, `select_ssh_sidebar_row`),
+// and every existing test exercised one row kind in isolation — an index
+// arithmetic error (the `MouseGrid::new(rows, cols)` class) passed the whole
+// suite. A mixed sidebar is not an edge case: it is the DEFAULT state of
+// this repository's own development environment.
+
+/// Real directories for synthetic worktree facts. Discovery parsing is pure,
+/// but a worktree row click launches a session rooted at the row's
+/// directory, so the directories must exist for the launch to identify the
+/// clicked row by its path.
+fn mixed_worktree_directories(count: usize) -> Vec<PathBuf> {
+    (0..count)
+        .map(|index| {
+            let sequence = WT_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "noren-app-mixed-wt-{}-{sequence}-{index}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).expect("create mixed-sidebar worktree directory");
+            path
+        })
+        .collect()
+}
+
+/// `git worktree list --porcelain` text for the given directories, one
+/// branched record each, in listing order.
+fn synthetic_porcelain(paths: &[PathBuf]) -> String {
+    let mut text = String::new();
+    for (index, path) in paths.iter().enumerate() {
+        text.push_str(&format!(
+            "worktree {}\nbranch refs/heads/mix-{index:02}\n\n",
+            path.display()
+        ));
+    }
+    text
+}
+
+/// The paths of every registry session launched from a worktree row, in
+/// registry order — the observable identity of WHICH worktree row a click
+/// selected.
+fn worktree_session_paths(app: &NorenApp) -> Vec<PathBuf> {
+    app.workspace
+        .registry()
+        .sessions()
+        .iter()
+        .filter_map(|descriptor| match descriptor.kind() {
+            SessionKind::Worktree { path } => Some(path.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Row order is FIXED — sessions first, then discovered worktree facts, then
+/// configured SSH hosts — and the click-path offset arithmetic silently
+/// depends on it, so the rendered order is pinned here with all three kinds
+/// present at once, including each kind's internal order (registry order,
+/// git listing order, config order). Agent-kind sessions render as ordinary
+/// session rows; the reserved `EntryKind::Agent` is never emitted by the
+/// sidebar rebuild, which the kind sequence pins as well.
+#[test]
+fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts() {
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host zulu\nHost alpha\n");
+    let records = git_worktree::parse_worktree_porcelain(
+        "worktree /srv/mix-main\nbranch refs/heads/mix-main\n\
+         \nworktree /srv/mix-a\nbranch refs/heads/mix-a\n\
+         \nworktree /srv/mix-b\ndetached\n",
+    )
+    .expect("synthetic porcelain parses");
+
+    let mut app = NorenApp::default();
+    app.workspace
+        .load_worktrees(WorktreeDiscovery::from_records(records));
+    app.load_ssh_hosts_from(fixture.path());
+    let _agent = app.workspace.create_session(SessionKind::Agent {
+        name: "reserved".to_owned(),
+    });
+    let _local = app.workspace.create_session(SessionKind::Local);
+    app.workspace.rebuild_sidebar();
+
+    let rows = app.workspace.sidebar().rows();
+    let kinds: Vec<EntryKind> = rows.iter().map(|row| row.kind()).collect();
+    assert_eq!(
+        kinds,
+        vec![
+            EntryKind::Session,
+            EntryKind::Session,
+            EntryKind::Worktree,
+            EntryKind::Worktree,
+            EntryKind::Worktree,
+            EntryKind::SshConnection,
+            EntryKind::SshConnection,
+        ],
+        "the fixed order is sessions, then worktrees, then SSH hosts"
+    );
+    // Worktree rows keep git's listing order (main first).
+    assert_eq!(
+        rows[2..5]
+            .iter()
+            .map(|row| row.label().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["mix-main", "mix-a", "mix-b"]
+    );
+    // SSH rows keep the config's declaration order.
+    assert_eq!(
+        rows[5..7]
+            .iter()
+            .map(|row| row.label().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["SSH-OFF zulu", "SSH-OFF alpha"]
+    );
+}
+
+/// Clicking each row kind in a mixed sidebar must select the row the user
+/// actually clicked — the default sidebar shape of this repository, which
+/// holds sessions, worktrees, and SSH hosts at once. The boundaries are
+/// asserted explicitly: the last worktree row, the first SSH row, the last
+/// SSH row, and the row immediately after the last SSH row (a dead click
+/// that must select nothing, not wrap).
+///
+/// Mutation checks:
+/// - dropping `+ worktree_rows` from `select_ssh_sidebar_row` makes the
+///   first-SSH-row click resolve to a DIFFERENT host (the host list here is
+///   longer than the worktree list, so the misresolved index lands on a
+///   real host, not a dead click);
+/// - dropping the session-row offset from `worktree_sidebar_row` resolves a
+///   worktree click to another worktree's row;
+/// - dropping the session bound from `local_sidebar_session` makes
+///   non-session rows claim a session id.
+#[cfg(target_os = "macos")]
+#[test]
+fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
+    // Five SSH hosts — more than the three worktrees — so a misresolved SSH
+    // index lands on a real, different host instead of dead-clicking.
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host alpha\nHost bravo\nHost charlie\nHost delta\nHost echo\n");
+    let worktree_paths = mixed_worktree_directories(3);
+    let records = git_worktree::parse_worktree_porcelain(&synthetic_porcelain(&worktree_paths))
+        .expect("synthetic porcelain parses");
+
+    // The deterministic seam keeps SSH row clicks from spawning any process;
+    // worktree row clicks really launch (that is their observable identity).
+    let mut app = app_with_deterministic_ssh_seam();
+    app.workspace
+        .load_worktrees(WorktreeDiscovery::from_records(records));
+    app.load_ssh_hosts_from(fixture.path());
+    let sessions = [
+        app.workspace.create_session(SessionKind::Local),
+        app.workspace.create_session(SessionKind::Project {
+            root: PathBuf::from("/srv/noren"),
+        }),
+    ];
+
+    // Layout: rows 0-1 sessions, rows 2-4 worktrees, rows 5-9 SSH hosts.
+    assert_eq!(
+        app.workspace.sidebar().rows().len(),
+        10,
+        "two session rows, three worktree rows, five SSH rows"
+    );
+
+    // Session rows select their own session, first and last alike.
+    assert!(click_sidebar_row(&mut app, 0), "the first session row");
+    assert_eq!(app.workspace.registry().selected(), Some(sessions[0]));
+    assert!(click_sidebar_row(&mut app, 1), "the last session row");
+    assert_eq!(app.workspace.registry().selected(), Some(sessions[1]));
+
+    // First SSH row (row 5): selects the FIRST host, and never moves the
+    // registry selection.
+    assert!(click_sidebar_row(&mut app, 5), "the first SSH row");
+    assert_eq!(app.workspace.selected_ssh_target(), Some("alpha"));
+    assert_eq!(
+        app.workspace.registry().selected(),
+        Some(sessions[1]),
+        "an SSH row click never selects a registry session"
+    );
+    // Last SSH row (row 9): selects the LAST host.
+    assert!(click_sidebar_row(&mut app, 9), "the last SSH row");
+    assert_eq!(app.workspace.selected_ssh_target(), Some("echo"));
+
+    // Row 10 — immediately after the last SSH row — selects nothing: not a
+    // session, not a host, no wrap-around, and no state changes at all.
+    let registry_len = app.workspace.registry().len();
+    assert!(
+        !click_sidebar_row(&mut app, 10),
+        "the row after the last SSH row is a dead click"
+    );
+    assert_eq!(
+        app.workspace.selected_ssh_target(),
+        Some("echo"),
+        "a dead click must not change the pending SSH choice"
+    );
+    assert_eq!(
+        app.workspace.registry().selected(),
+        Some(sessions[1]),
+        "a dead click must not move the registry selection"
+    );
+    assert_eq!(
+        app.workspace.registry().len(),
+        registry_len,
+        "a dead click must not create a session"
+    );
+
+    // Last worktree row (row 4): launches a session rooted at the THIRD
+    // worktree — the row the user clicked, not the one an offset error
+    // would resolve to.
+    assert!(click_sidebar_row(&mut app, 4), "the last worktree row");
+    assert_eq!(
+        worktree_session_paths(&app),
+        vec![worktree_paths[2].clone()],
+        "the click launches the worktree the user pointed at"
+    );
+
+    // Each launch adds a session row, shifting the rows below: with three
+    // sessions the worktree block occupies rows 3-5. First worktree row.
+    assert!(click_sidebar_row(&mut app, 3), "the first worktree row");
+    assert_eq!(
+        worktree_session_paths(&app),
+        vec![worktree_paths[2].clone(), worktree_paths[0].clone()]
+    );
+
+    // With four sessions the worktree block occupies rows 4-6; the middle
+    // worktree is row 5.
+    assert!(click_sidebar_row(&mut app, 5), "a middle worktree row");
+    assert_eq!(
+        worktree_session_paths(&app),
+        vec![
+            worktree_paths[2].clone(),
+            worktree_paths[0].clone(),
+            worktree_paths[1].clone()
+        ]
+    );
+
+    // After the launches the accumulated counts changed (five sessions), so
+    // the SSH boundary is re-asserted at its new offset: first SSH row 8.
+    assert_eq!(
+        app.workspace.sidebar().rows().len(),
+        13,
+        "five session rows, three worktree rows, five SSH rows"
+    );
+    assert!(click_sidebar_row(&mut app, 8), "the first SSH row again");
+    assert_eq!(
+        app.workspace.selected_ssh_target(),
+        Some("alpha"),
+        "the SSH offset must track the grown session block"
+    );
+    assert!(
+        !click_sidebar_row(&mut app, 13),
+        "the row after the last SSH row stays dead after the shifts"
+    );
+
+    for path in &worktree_paths {
+        let _ = std::fs::remove_dir(path);
+    }
+}

--- a/crates/noren-app/src/session.rs
+++ b/crates/noren-app/src/session.rs
@@ -64,10 +64,11 @@ impl fmt::Display for SessionId {
 
 /// The launch shape of a session.
 ///
-/// Conforms to D-M3-001: five variants. [`Local`] is the only kind with an
-/// implemented launch path; [`Project`], [`Worktree`], [`Ssh`], and [`Agent`]
-/// are carried as data so the enum is stable for exhaustive matching — no code
-/// in this module launches any of them.
+/// Conforms to D-M3-001: five variants. [`Local`] and [`Worktree`] have
+/// implemented launch paths (a worktree session is a local PTY whose working
+/// directory is the worktree checkout); [`Project`], [`Ssh`], and [`Agent`]
+/// are carried as data so the enum is stable for exhaustive matching — no
+/// code in this module launches any of them.
 ///
 /// D-M3-001 records the concrete payloads used here: `root`/`path` for the
 /// local-rooted kinds and `target`/`name` for the remote/agent kinds.
@@ -77,7 +78,14 @@ impl fmt::Display for SessionId {
 /// [`Worktree`]: SessionKind::Worktree
 /// [`Ssh`]: SessionKind::Ssh
 /// [`Agent`]: SessionKind::Agent
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+///
+/// # Debug discipline
+///
+/// [`fmt::Debug`] is shape-only (the #142/#146/#148 discipline): every
+/// payload is user- or environment-derived text, and a worktree path can
+/// embed a username or a private directory name, so no variant prints its
+/// payload. Use the field accessors for real values.
+#[derive(Clone, Default, PartialEq, Eq)]
 pub enum SessionKind {
     /// A local PTY session backed by a process on this machine.
     #[default]
@@ -104,14 +112,31 @@ pub enum SessionKind {
     },
 }
 
+/// Shape-only [`Debug`]: variant name and payload presence, never the
+/// payload (a root, path, target, or name can embed a username or another
+/// private value).
+impl fmt::Debug for SessionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local => f.write_str("Local"),
+            Self::Project { .. } => f.debug_struct("Project").finish_non_exhaustive(),
+            Self::Worktree { .. } => f.debug_struct("Worktree").finish_non_exhaustive(),
+            Self::Ssh { .. } => f.debug_struct("Ssh").finish_non_exhaustive(),
+            Self::Agent { .. } => f.debug_struct("Agent").finish_non_exhaustive(),
+        }
+    }
+}
+
 impl SessionKind {
     /// Whether this kind has an implemented launch path.
     ///
-    /// Only [`Local`](SessionKind::Local) does today. The spawn layer gates on
-    /// this rather than guessing; the other kinds are carried as reserved data.
+    /// [`Local`](SessionKind::Local) and [`Worktree`](SessionKind::Worktree)
+    /// do today — a worktree session launches the fixed zsh policy in the
+    /// worktree directory. The spawn layer gates on this rather than
+    /// guessing; the other kinds are carried as reserved data.
     #[must_use]
     pub const fn is_launchable(&self) -> bool {
-        matches!(self, Self::Local)
+        matches!(self, Self::Local | Self::Worktree { .. })
     }
 }
 
@@ -495,17 +520,21 @@ mod tests {
     }
 
     #[test]
-    fn only_local_kind_is_launchable() {
+    fn local_and_worktree_kinds_are_launchable() {
+        // The worktree kind gained a real launch path (a local PTY whose
+        // working directory is the worktree checkout); the other kinds stay
+        // reserved data. A mutation reverting Worktree to non-launchable
+        // fails this test.
         assert!(SessionKind::Local.is_launchable());
         assert!(
-            !SessionKind::Project {
-                root: PathBuf::from("/p")
+            SessionKind::Worktree {
+                path: PathBuf::from("/w")
             }
             .is_launchable()
         );
         assert!(
-            !SessionKind::Worktree {
-                path: PathBuf::from("/w")
+            !SessionKind::Project {
+                root: PathBuf::from("/p")
             }
             .is_launchable()
         );
@@ -521,6 +550,45 @@ mod tests {
             }
             .is_launchable()
         );
+    }
+
+    #[test]
+    fn session_kind_debug_is_shape_only() {
+        // A worktree path (or project root, SSH target, agent name) can
+        // embed a username or private directory name; Debug never prints it.
+        let secret = "NOREN-KIND-hunter2";
+        for rendered in [
+            format!(
+                "{:?}",
+                SessionKind::Worktree {
+                    path: PathBuf::from(format!("/Users/{secret}/wt"))
+                }
+            ),
+            format!(
+                "{:?}",
+                SessionKind::Project {
+                    root: PathBuf::from(format!("/Users/{secret}/p"))
+                }
+            ),
+            format!(
+                "{:?}",
+                SessionKind::Ssh {
+                    target: format!("{secret}@host")
+                }
+            ),
+            format!(
+                "{:?}",
+                SessionKind::Agent {
+                    name: format!("agent-{secret}")
+                }
+            ),
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "SessionKind Debug leaked payload text: {rendered}"
+            );
+        }
+        assert_eq!(format!("{:?}", SessionKind::Local), "Local");
     }
 
     #[test]

--- a/crates/noren-app/tests/error_echo_contract.rs
+++ b/crates/noren-app/tests/error_echo_contract.rs
@@ -32,11 +32,13 @@
 //! which cannot hold file-derived text without an explicit leak.
 
 use noren_app::config::{AppConfig, ChordParseError, ConfigError};
+use noren_app::git_worktree::WorktreeListError;
 use noren_app::palette::Palette;
 use noren_app::passthrough::ChordError;
 use noren_app::session::SessionRegistry;
 use noren_app::session_persistence::{SESSION_STATE_VERSION, SessionPersistenceError, load_bytes};
 use noren_app::ssh_config::{SshConfig, SshConfigErrorKind};
+use noren_pty::PtyError;
 use std::io::ErrorKind;
 
 /// How a variant may treat file **values**. Key names, positions, and
@@ -59,6 +61,10 @@ const SESSION_ERROR_VARIANTS: usize = 14;
 const CHORD_PARSE_ERROR_VARIANTS: usize = 7;
 /// Pinned variant count of [`SshConfigErrorKind`].
 const SSH_ERROR_KINDS: usize = 13;
+/// Pinned variant count of [`WorktreeListError`].
+const WORKTREE_ERROR_VARIANTS: usize = 6;
+/// Pinned variant count of [`PtyError`].
+const PTY_ERROR_VARIANTS: usize = 16;
 /// Pinned allowlist size across every file-derived enum. Raising this
 /// number is the reviewed decision to admit a new value echo.
 const CHORD_ALLOWLIST_SIZE: usize = 6;
@@ -149,6 +155,44 @@ fn classify_ssh_kind(kind: &SshConfigErrorKind) -> ValueEcho {
         SshConfigErrorKind::StructuralComplexityExceeded => ValueEcho::Never,
         SshConfigErrorKind::HostCountExceeded => ValueEcho::Never,
         SshConfigErrorKind::UnterminatedArgument => ValueEcho::Never,
+    }
+}
+
+/// Classify every [`WorktreeListError`] variant. All are unit variants
+/// with fixed, content-free Display strings — worktree discovery never
+/// carries paths, branch names, or git output in its error messages.
+fn classify_worktree_error(error: &WorktreeListError) -> ValueEcho {
+    match error {
+        WorktreeListError::GitUnavailable => ValueEcho::Never,
+        WorktreeListError::NotARepository => ValueEcho::Never,
+        WorktreeListError::LaunchDirectoryUnavailable => ValueEcho::Never,
+        WorktreeListError::NotUtf8 => ValueEcho::Never,
+        WorktreeListError::TooLarge => ValueEcho::Never,
+        WorktreeListError::Malformed => ValueEcho::Never,
+    }
+}
+
+/// Classify every [`PtyError`] variant. All carry only operation names and
+/// `io::ErrorKind` discriminants — never terminal content, paths, or
+/// environment values.
+fn classify_pty_error(error: &PtyError) -> ValueEcho {
+    match error {
+        PtyError::MissingHome => ValueEcho::Never,
+        PtyError::HomeNotAbsolute => ValueEcho::Never,
+        PtyError::HomeNotDirectory => ValueEcho::Never,
+        PtyError::CwdNotAbsolute => ValueEcho::Never,
+        PtyError::CwdNotDirectory => ValueEcho::Never,
+        PtyError::InvalidSize => ValueEcho::Never,
+        PtyError::InputTooLarge => ValueEcho::Never,
+        PtyError::ReplyTooLarge => ValueEcho::Never,
+        PtyError::ReplyRateExceeded => ValueEcho::Never,
+        PtyError::CommandQueueFull => ValueEcho::Never,
+        PtyError::ChannelDisconnected => ValueEcho::Never,
+        PtyError::SessionClosing => ValueEcho::Never,
+        PtyError::ReaderJoinTimeout => ValueEcho::Never,
+        PtyError::SupervisorJoinTimeout => ValueEcho::Never,
+        PtyError::Backend { .. } => ValueEcho::Never,
+        PtyError::Io { .. } => ValueEcho::Never,
     }
 }
 
@@ -285,6 +329,52 @@ fn ssh_kind_samples() -> Vec<(SshConfigErrorKind, ValueEcho)> {
     ]
 }
 
+fn worktree_error_samples() -> Vec<(WorktreeListError, ValueEcho)> {
+    vec![
+        (WorktreeListError::GitUnavailable, ValueEcho::Never),
+        (WorktreeListError::NotARepository, ValueEcho::Never),
+        (
+            WorktreeListError::LaunchDirectoryUnavailable,
+            ValueEcho::Never,
+        ),
+        (WorktreeListError::NotUtf8, ValueEcho::Never),
+        (WorktreeListError::TooLarge, ValueEcho::Never),
+        (WorktreeListError::Malformed, ValueEcho::Never),
+    ]
+}
+
+fn pty_error_samples() -> Vec<(PtyError, ValueEcho)> {
+    vec![
+        (PtyError::MissingHome, ValueEcho::Never),
+        (PtyError::HomeNotAbsolute, ValueEcho::Never),
+        (PtyError::HomeNotDirectory, ValueEcho::Never),
+        (PtyError::CwdNotAbsolute, ValueEcho::Never),
+        (PtyError::CwdNotDirectory, ValueEcho::Never),
+        (PtyError::InvalidSize, ValueEcho::Never),
+        (PtyError::InputTooLarge, ValueEcho::Never),
+        (PtyError::ReplyTooLarge, ValueEcho::Never),
+        (PtyError::ReplyRateExceeded, ValueEcho::Never),
+        (PtyError::CommandQueueFull, ValueEcho::Never),
+        (PtyError::ChannelDisconnected, ValueEcho::Never),
+        (PtyError::SessionClosing, ValueEcho::Never),
+        (PtyError::ReaderJoinTimeout, ValueEcho::Never),
+        (PtyError::SupervisorJoinTimeout, ValueEcho::Never),
+        (
+            PtyError::Backend {
+                operation: noren_pty::PtyOperation::Open,
+            },
+            ValueEcho::Never,
+        ),
+        (
+            PtyError::Io {
+                operation: noren_pty::PtyOperation::Read,
+                kind: ErrorKind::BrokenPipe,
+            },
+            ValueEcho::Never,
+        ),
+    ]
+}
+
 /// The classifiers must cover every variant, the sample tables must match
 /// the pinned variant counts, and the allowlist must be exactly the pinned
 /// size. Together with the exhaustive matches this is the tripwire: a new
@@ -316,6 +406,18 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
         SSH_ERROR_KINDS,
         "an SshConfigErrorKind variant changed; classify it and update the pin"
     );
+    let worktree = worktree_error_samples();
+    assert_eq!(
+        worktree.len(),
+        WORKTREE_ERROR_VARIANTS,
+        "a WorktreeListError variant changed; classify it and update the pin"
+    );
+    let pty = pty_error_samples();
+    assert_eq!(
+        pty.len(),
+        PTY_ERROR_VARIANTS,
+        "a PtyError variant changed; classify it and update the pin"
+    );
 
     for (sample, expected) in &config {
         assert_eq!(&classify_config(sample), expected, "{sample:?}");
@@ -328,6 +430,12 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
     }
     for (sample, expected) in &ssh {
         assert_eq!(&classify_ssh_kind(sample), expected, "{sample:?}");
+    }
+    for (sample, expected) in &worktree {
+        assert_eq!(&classify_worktree_error(sample), expected, "{sample:?}");
+    }
+    for (sample, expected) in &pty {
+        assert_eq!(&classify_pty_error(sample), expected, "{sample:?}");
     }
 
     // Police the classification against the actual rendering, on both
@@ -368,6 +476,12 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
         // them with `{:?}`, so Debug is the rendering surface here.
         assert_rendering(format!("{sample:?}"), format!("{sample:?}"), *class);
     }
+    for (sample, class) in &worktree {
+        assert_rendering(sample.to_string(), format!("{sample:?}"), *class);
+    }
+    for (sample, class) in &pty {
+        assert_rendering(sample.to_string(), format!("{sample:?}"), *class);
+    }
 
     let allowlist = config
         .iter()
@@ -375,6 +489,8 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
         .chain(session.iter().map(|(_, class)| *class))
         .chain(chords.iter().map(|(_, class)| *class))
         .chain(ssh.iter().map(|(_, class)| *class))
+        .chain(worktree.iter().map(|(_, class)| *class))
+        .chain(pty.iter().map(|(_, class)| *class))
         .filter(|class| *class == ValueEcho::ChordText)
         .count();
     assert_eq!(

--- a/crates/noren-app/tests/session_domain.rs
+++ b/crates/noren-app/tests/session_domain.rs
@@ -520,13 +520,10 @@ fn a_descriptor_has_a_generated_title_for_every_kind() {
 // ── Reserved session kinds ──────────────────────────────────────────────
 
 #[test]
-fn reserved_kinds_can_be_bookkept_but_are_not_launchable() {
+fn project_ssh_agent_kinds_can_be_bookkept_but_are_not_launchable() {
     let mut registry = SessionRegistry::new();
     let project = registry.create(SessionKind::Project {
         root: PathBuf::from("/p"),
-    });
-    let worktree = registry.create(SessionKind::Worktree {
-        path: PathBuf::from("/w"),
     });
     let ssh = registry.create(SessionKind::Ssh {
         target: "host".to_owned(),
@@ -538,7 +535,6 @@ fn reserved_kinds_can_be_bookkept_but_are_not_launchable() {
     // The registry accepts reserved shapes as entries (bookkeeping only); it
     // never launches anything, so this stays pure data.
     assert!(!registry.get(project).unwrap().kind().is_launchable());
-    assert!(!registry.get(worktree).unwrap().kind().is_launchable());
     assert!(!registry.get(ssh).unwrap().kind().is_launchable());
     assert!(!registry.get(agent).unwrap().kind().is_launchable());
     let local = registry.create(SessionKind::Local);
@@ -549,5 +545,18 @@ fn reserved_kinds_can_be_bookkept_but_are_not_launchable() {
     assert_eq!(registry.selected(), Some(ssh));
     registry.close(ssh).unwrap();
     assert_eq!(registry.selected(), None);
-    assert_eq!(registry.len(), 4);
+    assert_eq!(registry.len(), 3);
+}
+
+#[test]
+fn the_worktree_kind_is_launchable() {
+    // The worktree kind gained a real launch path: a local PTY whose working
+    // directory is the worktree checkout. The registry still only bookkeeps
+    // (it never spawns); this pins that the launch gate classifies the kind
+    // as launchable so a mutation reverting it fails here.
+    let mut registry = SessionRegistry::new();
+    let worktree = registry.create(SessionKind::Worktree {
+        path: PathBuf::from("/w"),
+    });
+    assert!(registry.get(worktree).unwrap().kind().is_launchable());
 }

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -1901,37 +1901,24 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[allow(unsafe_code)] // HOME swap is safe: tests run sequentially; child inherits before restore.
     fn spawn_in_dir_runs_the_child_in_that_directory() {
         let worktree = temp_directory_with("worktree-cwd");
 
-        // `build_dir_zsh_command` intentionally inherits HOME unchanged so
-        // the user's shell config applies in production.  In the test
-        // harness, the inherited HOME is the developer's real home whose
-        // .zshrc can take arbitrarily long (oh-my-zsh, conda, nvm …) or
-        // block entirely, making the test time out before the shell reaches
-        // its prompt.  Temporarily point HOME at the empty worktree so
-        // zsh finds no startup files and starts instantly.  The cwd is
+        // The production entry `spawn_in_dir` inherits HOME unchanged so the
+        // user's shell config applies, and a developer's real `$HOME` may
+        // carry startup files (oh-my-zsh, conda, nvm, …) that take longer
+        // than the deadline or read the terminal. This live check drives the
+        // `spawn_in_dir_with_home` seam — the same `DirLaunchPolicy`, the
+        // same fixed builder, and the same session machinery, with HOME
+        // pinned to the empty fixture directory — so the shell finds no
+        // startup files and answers immediately. Unlike an env swap, the
+        // seam never mutates process-global environment, which races the
+        // parallel tests that read HOME (this exact race was observed:
+        // `ssh_command_argv_...` failed while HOME was swapped). The cwd is
         // still independently verified by the pwd check below.
-        let saved_home = std::env::var_os("HOME");
-        // SAFETY: tests in this binary run sequentially; the child has
-        // already inherited the env by the time we restore below.
-        unsafe {
-            std::env::set_var("HOME", &worktree);
-        }
-
         let size = PtySize::from_raw(24, 80).expect("valid initial size");
-        let mut session =
-            PtySession::spawn_in_dir(&worktree, size).expect("spawn zsh in the worktree");
-
-        // Restore HOME immediately — the child has already inherited it.
-        // SAFETY: same single-threaded reasoning as above.
-        unsafe {
-            match saved_home {
-                Some(home) => std::env::set_var("HOME", home),
-                None => std::env::remove_var("HOME"),
-            }
-        }
+        let mut session = PtySession::spawn_in_dir_with_home(&worktree, &worktree, size)
+            .expect("spawn zsh in the worktree");
 
         session.send_input(b"pwd\nexit\n").expect("ask for the cwd");
 

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -1179,6 +1179,19 @@ mod tests {
         lifecycle: &mut bool,
         done: impl Fn(&[u8], bool) -> bool,
     ) {
+        poll_events_with_desc(session, deadline, output, lifecycle, "", done)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn poll_events_with_desc(
+        session: &PtySession,
+        deadline: Instant,
+        output: &mut Vec<u8>,
+        lifecycle: &mut bool,
+        desc: &str,
+        done: impl Fn(&[u8], bool) -> bool,
+    ) {
+        let start = Instant::now();
         while Instant::now() < deadline {
             match session.try_recv().expect("receive PTY event") {
                 Some(PtyEvent::Output(bytes)) => output.extend(bytes),
@@ -1190,7 +1203,18 @@ mod tests {
                 return;
             }
         }
-        panic!("PTY event polling deadline expired");
+        let elapsed = start.elapsed();
+        let stripped = strip_ansi(output);
+        panic!(
+            "PTY event polling deadline expired after {elapsed:?}\n\
+             {desc}expected condition not met\n\
+             raw output ({} bytes): {:?}\n\
+             stripped output: {:?}\n\
+             lifecycle={lifecycle}",
+            output.len(),
+            String::from_utf8_lossy(output),
+            String::from_utf8_lossy(&stripped),
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -1199,6 +1223,28 @@ mod tests {
             .windows(needle.len())
             .filter(|window| *window == needle)
             .count()
+    }
+
+    /// Strip ANSI escape sequences from raw PTY output for human-readable
+    /// diagnostics.
+    #[cfg(target_os = "macos")]
+    fn strip_ansi(bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+                while i < bytes.len() && !bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+            } else {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+        out
     }
 
     /// Mutation M4 (restoring `#[derive(Debug)]`) must expose the numeric byte
@@ -1775,14 +1821,38 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    #[allow(unsafe_code)] // HOME swap is safe: tests run sequentially; child inherits before restore.
     fn spawn_in_dir_runs_the_child_in_that_directory() {
-        // The live cwd check: drive a real zsh and read its own `pwd` answer
-        // back through the PTY. This observes the child's actual working
-        // directory rather than trusting the command builder.
         let worktree = temp_directory_with("worktree-cwd");
+
+        // `build_dir_zsh_command` intentionally inherits HOME unchanged so
+        // the user's shell config applies in production.  In the test
+        // harness, the inherited HOME is the developer's real home whose
+        // .zshrc can take arbitrarily long (oh-my-zsh, conda, nvm …) or
+        // block entirely, making the test time out before the shell reaches
+        // its prompt.  Temporarily point HOME at the empty worktree so
+        // zsh finds no startup files and starts instantly.  The cwd is
+        // still independently verified by the pwd check below.
+        let saved_home = std::env::var_os("HOME");
+        // SAFETY: tests in this binary run sequentially; the child has
+        // already inherited the env by the time we restore below.
+        unsafe {
+            std::env::set_var("HOME", &worktree);
+        }
+
         let size = PtySize::from_raw(24, 80).expect("valid initial size");
         let mut session =
             PtySession::spawn_in_dir(&worktree, size).expect("spawn zsh in the worktree");
+
+        // Restore HOME immediately — the child has already inherited it.
+        // SAFETY: same single-threaded reasoning as above.
+        unsafe {
+            match saved_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
         session.send_input(b"pwd\nexit\n").expect("ask for the cwd");
 
         // macOS resolves /var to /private/var, and the shell reports the
@@ -1791,11 +1861,13 @@ mod tests {
         let canonical_bytes = canonical.as_os_str().as_encoded_bytes().to_vec();
         let mut output = Vec::new();
         let mut lifecycle = false;
-        poll_events(
+        let desc = format!("worktree={worktree:?} canonical={canonical:?}");
+        poll_events_with_desc(
             &session,
             Instant::now() + Duration::from_secs(10),
             &mut output,
             &mut lifecycle,
+            &desc,
             |bytes, _| occurrences(bytes, &canonical_bytes) >= 1,
         );
         assert!(

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -140,6 +140,59 @@ impl fmt::Debug for ZshLaunchPolicy {
     }
 }
 
+/// Fixed zsh-in-a-directory launch policy: like [`ZshLaunchPolicy`] but the
+/// child's working directory is an arbitrary validated directory while
+/// `HOME` is inherited unchanged from this process.
+///
+/// This is the launch shape a git-worktree session uses: the shell starts
+/// *in* the worktree checkout (so `pwd`, build tools, and the prompt report
+/// it) while the user's own shell configuration still applies. The directory
+/// is intentionally private and its `Debug` representation is redacted: a
+/// worktree path can embed a username or a private directory name.
+#[derive(Clone, PartialEq, Eq)]
+pub struct DirLaunchPolicy {
+    dir: PathBuf,
+}
+
+impl DirLaunchPolicy {
+    /// Validate `dir` as the child's working directory.
+    ///
+    /// Refuses a relative path ([`PtyError::CwdNotAbsolute`]) and a path
+    /// that is not an existing directory ([`PtyError::CwdNotDirectory`]) —
+    /// the latter is exactly the registered-but-deleted worktree case, so a
+    /// stale worktree is refused with a typed error instead of a child that
+    /// fails to spawn for an unstated reason.
+    pub fn new(dir: &Path) -> Result<Self, PtyError> {
+        if !dir.is_absolute() {
+            return Err(PtyError::CwdNotAbsolute);
+        }
+        if !dir.is_dir() {
+            return Err(PtyError::CwdNotDirectory);
+        }
+        Ok(Self {
+            dir: dir.to_owned(),
+        })
+    }
+
+    /// The validated working directory.
+    ///
+    /// This accessor exists to build diagnostics-free equality checks, not
+    /// for display: [`fmt::Debug`] is redacted so a worktree path that
+    /// embeds a username can never reach a log through a debug print.
+    #[must_use]
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl fmt::Debug for DirLaunchPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DirLaunchPolicy")
+            .field("dir", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Validate an optional `HOME` without mutating process-global environment.
 fn validate_home(home: Option<OsString>) -> Result<ZshLaunchPolicy, PtyError> {
     let home = PathBuf::from(home.ok_or(PtyError::MissingHome)?);
@@ -175,6 +228,24 @@ fn build_zsh_command(policy: &ZshLaunchPolicy) -> CommandBuilder {
     // crate-local test harness to use an isolated directory without mutating
     // process-global environment.
     command.env("HOME", &policy.home);
+    command.env("TERM", TERM_VALUE);
+    command.env("TERM_PROGRAM", TERM_PROGRAM_VALUE);
+    command.env_remove("COLUMNS");
+    command.env_remove("LINES");
+    command
+}
+
+/// Build the fixed zsh command for a directory-scoped launch. Security and
+/// environment invariants, pinned by tests:
+///
+/// - argv is exactly `[ZSH_PROGRAM]` — no caller-controlled arguments, so no
+///   `-c` command can ever appear in argv (`ps`-visible).
+/// - the child's working directory is the policy's validated directory and
+///   `HOME` is inherited unchanged: the user's own shell configuration still
+///   applies, exactly like [`build_zsh_command`] when `HOME` and cwd agree.
+fn build_dir_zsh_command(policy: &DirLaunchPolicy) -> CommandBuilder {
+    let mut command = CommandBuilder::new(ZSH_PROGRAM);
+    command.cwd(&policy.dir);
     command.env("TERM", TERM_VALUE);
     command.env("TERM_PROGRAM", TERM_PROGRAM_VALUE);
     command.env_remove("COLUMNS");
@@ -424,6 +495,8 @@ pub enum PtyError {
     MissingHome,
     HomeNotAbsolute,
     HomeNotDirectory,
+    CwdNotAbsolute,
+    CwdNotDirectory,
     InvalidSize,
     InputTooLarge,
     ReplyTooLarge,
@@ -457,6 +530,10 @@ impl fmt::Display for PtyError {
             Self::MissingHome => f.write_str("HOME is required"),
             Self::HomeNotAbsolute => f.write_str("HOME must be absolute"),
             Self::HomeNotDirectory => f.write_str("HOME must name an existing directory"),
+            Self::CwdNotAbsolute => f.write_str("working directory must be absolute"),
+            Self::CwdNotDirectory => {
+                f.write_str("working directory must name an existing directory")
+            }
             Self::InvalidSize => f.write_str("terminal size must be non-zero"),
             Self::InputTooLarge => f.write_str("PTY input message exceeds its byte limit"),
             Self::ReplyTooLarge => f.write_str("terminal reply exceeds its message byte limit"),
@@ -565,6 +642,22 @@ impl PtySession {
     pub fn spawn_in_home(home: &Path, size: PtySize) -> Result<Self, PtyError> {
         let policy = validate_home(Some(home.as_os_str().to_owned()))?;
         Self::spawn_with_policy(policy, size)
+    }
+
+    /// Spawn `/bin/zsh` with `dir` as the child's working directory, leaving
+    /// `HOME` inherited.
+    ///
+    /// The same fixed launch policy as [`PtySession::spawn`] — identical
+    /// program, `TERM`, and environment surgery — except the working
+    /// directory is the supplied directory (validated absolute and existing
+    /// by [`DirLaunchPolicy::new`], which refuses a registered-but-deleted
+    /// worktree with a typed error) and `HOME` is inherited unchanged so the
+    /// user's own shell configuration applies. This is the launch shape a
+    /// git-worktree session uses: the shell starts inside the worktree
+    /// checkout.
+    pub fn spawn_in_dir(dir: &Path, size: PtySize) -> Result<Self, PtyError> {
+        let policy = DirLaunchPolicy::new(dir)?;
+        Self::spawn_session(build_dir_zsh_command(&policy), size)
     }
 
     /// Spawn using an already validated fixed-zsh policy.
@@ -1035,6 +1128,18 @@ mod tests {
         let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let path =
             std::env::temp_dir().join(format!("noren-pty-test-{}-{sequence}", std::process::id()));
+        fs::create_dir(&path).expect("create test directory");
+        path
+    }
+
+    /// A uniquely named directory whose name embeds `fragment`, for redaction
+    /// checks: any debug surface that prints the path prints the fragment.
+    fn temp_directory_with(fragment: &str) -> PathBuf {
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "noren-pty-test-{}-{sequence}-{fragment}",
+            std::process::id()
+        ));
         fs::create_dir(&path).expect("create test directory");
         path
     }
@@ -1599,5 +1704,105 @@ mod tests {
         // occurrence proves the isolated shell answered.
         assert!(occurrences(&output, b"SPAWN_IN_HOME_OK") >= 1);
         session.shutdown().expect("reap isolated-home zsh");
+    }
+
+    #[test]
+    fn dir_policy_validation_refuses_relative_and_missing_directories() {
+        // A relative path is refused before the filesystem is touched.
+        assert_eq!(
+            DirLaunchPolicy::new(Path::new("relative/worktree")),
+            Err(PtyError::CwdNotAbsolute)
+        );
+        // The registered-but-deleted worktree case: a typed refusal, never a
+        // child that fails to spawn for an unstated reason (and never a
+        // panic).
+        let missing = std::env::temp_dir().join("noren-pty-missing-worktree-dir");
+        assert_eq!(
+            DirLaunchPolicy::new(&missing),
+            Err(PtyError::CwdNotDirectory)
+        );
+
+        let directory = temp_directory();
+        let policy = DirLaunchPolicy::new(&directory).expect("valid directory");
+        assert_eq!(policy.dir(), directory.as_path());
+        fs::remove_dir(&directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn dir_policy_builder_pins_cwd_and_leaves_home_inherited() {
+        let directory = temp_directory();
+        let policy = DirLaunchPolicy::new(&directory).expect("valid directory");
+        let command = build_dir_zsh_command(&policy);
+        assert_eq!(command.get_argv(), &[OsString::from(ZSH_PROGRAM)]);
+        assert_eq!(
+            command.get_cwd().map(OsString::as_os_str),
+            Some(directory.as_os_str()),
+            "the child's working directory is the policy directory"
+        );
+        assert_eq!(
+            command.get_env("TERM"),
+            Some(std::ffi::OsStr::new(TERM_VALUE))
+        );
+        assert_eq!(
+            command.get_env("TERM_PROGRAM"),
+            Some(std::ffi::OsStr::new(TERM_PROGRAM_VALUE))
+        );
+        // HOME is inherited unchanged: a directory-scoped session is still
+        // the user's shell, with the user's own configuration.
+        assert_eq!(
+            command.get_env("HOME"),
+            std::env::var_os("HOME").as_deref(),
+            "the directory launch must inherit HOME unchanged"
+        );
+        assert_eq!(command.get_env("COLUMNS"), None);
+        assert_eq!(command.get_env("LINES"), None);
+        fs::remove_dir(&directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn dir_policy_debug_never_carries_the_directory() {
+        const SECRET: &str = "noren-debug-secret-wt-4c31";
+        let directory = temp_directory_with(SECRET);
+        let policy = DirLaunchPolicy::new(&directory).expect("valid directory");
+        let inspected = format!("{policy:?}");
+        assert!(
+            !inspected.contains(SECRET),
+            "debug must be redacted: {inspected}"
+        );
+        assert!(inspected.contains("<redacted>"));
+        fs::remove_dir(&directory).expect("remove test directory");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_in_dir_runs_the_child_in_that_directory() {
+        // The live cwd check: drive a real zsh and read its own `pwd` answer
+        // back through the PTY. This observes the child's actual working
+        // directory rather than trusting the command builder.
+        let worktree = temp_directory_with("worktree-cwd");
+        let size = PtySize::from_raw(24, 80).expect("valid initial size");
+        let mut session =
+            PtySession::spawn_in_dir(&worktree, size).expect("spawn zsh in the worktree");
+        session.send_input(b"pwd\nexit\n").expect("ask for the cwd");
+
+        // macOS resolves /var to /private/var, and the shell reports the
+        // canonical form; compare against the canonicalized fixture path.
+        let canonical = fs::canonicalize(&worktree).expect("canonicalize the fixture path");
+        let canonical_bytes = canonical.as_os_str().as_encoded_bytes().to_vec();
+        let mut output = Vec::new();
+        let mut lifecycle = false;
+        poll_events(
+            &session,
+            Instant::now() + Duration::from_secs(10),
+            &mut output,
+            &mut lifecycle,
+            |bytes, _| occurrences(bytes, &canonical_bytes) >= 1,
+        );
+        assert!(
+            occurrences(&output, &canonical_bytes) >= 1,
+            "the child's own pwd must report the worktree directory"
+        );
+        session.shutdown().expect("reap worktree zsh");
+        fs::remove_dir_all(&worktree).expect("remove worktree fixture");
     }
 }

--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -253,6 +253,22 @@ fn build_dir_zsh_command(policy: &DirLaunchPolicy) -> CommandBuilder {
     command
 }
 
+/// Build the fixed zsh command for a directory-scoped launch whose child
+/// `HOME` is an explicitly supplied, validated home.
+///
+/// Identical to [`build_dir_zsh_command`] except `HOME` is set explicitly:
+/// the test-harness sibling of the inherited-`HOME` production shape, so a
+/// higher-level suite can point the child at an isolated empty home while
+/// the working directory stays the policy's validated directory.
+fn build_dir_zsh_command_with_home(
+    policy: &DirLaunchPolicy,
+    home: &ZshLaunchPolicy,
+) -> CommandBuilder {
+    let mut command = build_dir_zsh_command(policy);
+    command.env("HOME", &home.home);
+    command
+}
+
 /// An unexpanded OpenSSH percent token found in a destination.
 ///
 /// OpenSSH expands these inside configuration keywords (never in the
@@ -658,6 +674,34 @@ impl PtySession {
     pub fn spawn_in_dir(dir: &Path, size: PtySize) -> Result<Self, PtyError> {
         let policy = DirLaunchPolicy::new(dir)?;
         Self::spawn_session(build_dir_zsh_command(&policy), size)
+    }
+
+    /// Spawn `/bin/zsh` with `dir` as the child's working directory and
+    /// `home` as the child's `HOME`.
+    ///
+    /// Directory-scoped sibling of [`PtySession::spawn_in_home`]: production
+    /// worktree launches use [`PtySession::spawn_in_dir`], which inherits
+    /// `HOME` unchanged so the user's own shell configuration applies.
+    /// Higher-level test suites that drive the child by typing use this seam
+    /// to point `HOME` at an isolated empty directory — a developer's real
+    /// `$HOME` may carry startup files that take arbitrarily long or read the
+    /// terminal, which would make every shell-driving test depend on
+    /// personal configuration — while the working directory remains the
+    /// validated directory, so the child's actual cwd stays observable
+    /// through its own `pwd` answer. Both paths are validated exactly like
+    /// their standalone policies, and the fixed program, `TERM`, and
+    /// environment surgery are identical to [`PtySession::spawn_in_dir`].
+    pub fn spawn_in_dir_with_home(
+        dir: &Path,
+        home: &Path,
+        size: PtySize,
+    ) -> Result<Self, PtyError> {
+        let dir_policy = DirLaunchPolicy::new(dir)?;
+        let home_policy = validate_home(Some(home.as_os_str().to_owned()))?;
+        Self::spawn_session(
+            build_dir_zsh_command_with_home(&dir_policy, &home_policy),
+            size,
+        )
     }
 
     /// Spawn using an already validated fixed-zsh policy.
@@ -1803,6 +1847,42 @@ mod tests {
         assert_eq!(command.get_env("COLUMNS"), None);
         assert_eq!(command.get_env("LINES"), None);
         fs::remove_dir(&directory).expect("remove test directory");
+    }
+
+    #[test]
+    fn dir_with_home_builder_pins_cwd_and_the_seam_home() {
+        // The seam's directory and home are distinct directories, so an
+        // assertion against the wrong one cannot pass by coincidence.
+        let directory = temp_directory_with("seam-dir");
+        let home = temp_directory_with("seam-home");
+        let dir_policy = DirLaunchPolicy::new(&directory).expect("valid directory");
+        let home_policy =
+            validate_home(Some(home.clone().into_os_string())).expect("valid seam home");
+        let command = build_dir_zsh_command_with_home(&dir_policy, &home_policy);
+
+        assert_eq!(command.get_argv(), &[OsString::from(ZSH_PROGRAM)]);
+        assert_eq!(
+            command.get_cwd().map(OsString::as_os_str),
+            Some(directory.as_os_str()),
+            "the seam keeps the working directory on the policy directory"
+        );
+        assert_eq!(
+            command.get_env("HOME"),
+            Some(home.as_os_str()),
+            "the seam sets HOME to the isolated home, never the inherited one"
+        );
+        assert_eq!(
+            command.get_env("TERM"),
+            Some(std::ffi::OsStr::new(TERM_VALUE))
+        );
+        assert_eq!(
+            command.get_env("TERM_PROGRAM"),
+            Some(std::ffi::OsStr::new(TERM_PROGRAM_VALUE))
+        );
+        assert_eq!(command.get_env("COLUMNS"), None);
+        assert_eq!(command.get_env("LINES"), None);
+        fs::remove_dir(&directory).expect("remove test directory");
+        fs::remove_dir(&home).expect("remove test home");
     }
 
     #[test]

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -188,10 +188,10 @@ Each item states what you would actually see if you ran the build.
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support and SSH/remote
   sessions are roadmap intent (Milestones 4 and 6), not current capability.
-- **Only local sessions are actually launched.** `SessionKind` models
+- **Only local and worktree sessions are actually launched.** `SessionKind` models
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
-  `Local` and `Ssh` have launch paths. The running binary reads bounded
+  `Local`, `Worktree`, and `Ssh` have launch paths. The running binary reads bounded
   OpenSSH configuration facts and displays configured targets as
   `SidebarEntry::SshConnection` rows. Clicking one validates the alias as an
   `SshDestination` (raw `%h`/`%p`/`%r` tokens are refused with a typed error
@@ -203,13 +203,23 @@ Each item states what you would actually see if you ran the build.
   alias never enters the persisted registry, so `sessions.toml` cannot carry
   it. Authentication, agent, and config resolution (including the user's own
   `ProxyCommand`) remain entirely ssh's own, executed by the system binary.
-  Project and worktree kinds remain modelled, while agent entries remain
+  At startup Noren also runs `git worktree list --porcelain` in its launch
+  directory and shows the discovered worktrees as `SidebarEntry::Worktree`
+  rows (at most 24; a larger list reports the omitted count). Clicking a
+  present row starts a real `SessionKind::Worktree` session: a `/bin/zsh`
+  PTY whose child's working directory IS that worktree (verified by reading
+  the child's own `pwd` back through the terminal). A registered worktree
+  whose directory was deleted from disk is listed with a `(missing)` marker
+  and refused on selection — no panic, no child. Worktree sessions persist
+  and restore through `sessions.toml` exactly like local ones.
+  Project and agent kinds remain modelled, while agent entries remain
   reserved fixtures and no agent is launched. In practice: startup owns exactly
   one local `zsh`, the palette's "New Session" spawns another real local `zsh`,
   and every local row can take the live view; a restored row cannot (its shell
   died with the previous launch). Selecting an SSH host row now launches the
-  system `ssh` client in the terminal's PTY (see the SSH section); a git
-  worktree or an agent still cannot be opened from the workspace. Milestones 4
+  system `ssh` client in the terminal's PTY (see the SSH section); selecting a
+  worktree row starts a shell in that worktree. A project row or an agent
+  still cannot be opened from the workspace. Milestones 4
   and 5 own the remaining work.
 - **The SSH list is not OpenSSH-equivalent discovery.** A readable config can
   legitimately name destinations that do not appear: wildcard or negated


### PR DESCRIPTION
Closes the last breadth gap before 0.1.0-preview.

ROADMAP recorded `EntryKind::Project`/`Worktree` and `SessionKind::Project`/`Worktree` as "Modelled, not launchable — no runtime path constructs them, only tests do". They were dead types to a user. This gives them a real path, following the precedent of PR #138, which did the same for SSH rows.

## What a user gets

Git worktrees for the repository Noren was launched in appear as sidebar rows on launch, and selecting one starts a session whose working directory **is** that worktree.

## Edge cases are tested, not assumed

Discovery parses `git worktree list --porcelain` — the stable machine-readable form, not the human output. Every case has a test:

| Case | Test |
| --- | --- |
| detached HEAD | `a_detached_head_has_no_branch_and_reports_detached` |
| bare worktree | `a_bare_worktree_reports_bare_and_a_placeholder_branch` |
| directory deleted but still registered | `a_missing_directory_row_keeps_the_record_and_marks_it` |
| spaces / non-ASCII paths | `paths_with_spaces_and_non_ascii_parse_verbatim` |
| malformed record | `a_record_without_a_worktree_line_is_malformed` |
| a newer git adding attributes | `newer_git_attributes_are_ignored_not_rejected` |

That last one matters: an unknown attribute from a future git is ignored rather than treated as corruption, so a git upgrade cannot make the sidebar empty.

## The cap is exercised for real, not hypothetically

Rows are bounded at 24 with the omitted count reported. **This repository currently has 54 worktrees**, so the bounding path runs on the maintainer's own machine rather than only in a fixture.

## Redaction

A worktree path can carry a username or a private directory name, so the new types follow the discipline established in #142/#146/#148/#155: `debug_output_is_shape_only_for_secret_shaped_paths` and `error_messages_are_fixed_content_free_strings`.

## Verified by the coordinator

Mutations both fail as required: breaking the session cwd fails a test, and making the deleted-directory case panic fails a test.

Real hardware: release build launches, child `zsh` spawns, geometry `29 74` (90 window columns − 16 sidebar), clean exit, no orphans. Note the default session's cwd is the launch directory — the worktree cwd applies when a row is *selected*, which needs a human at the keyboard; `session_cwd_verified` covers it in tests.

Gates: `fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` **1,012 passing, 0 failed**. 26 tests added across 5 incremental commits.
