### PR TITLE
fix(test): assert resolution work count instead of wall-clock time (#154)

### DIFF
--- a/crates/noren-app/src/ssh_config.rs
+++ b/crates/noren-app/src/ssh_config.rs
@@ -690,8 +690,13 @@ impl ResolutionWork {
 }
 
 fn ensure_resolution_work(work: ResolutionWork, limit: u128) -> Result<(), SshConfigError> {
-    if work.total() > limit {
-        return Err(error(0, SshConfigErrorKind::ResolutionComplexityExceeded));
+    let total = work.total();
+    if total > limit {
+        return Err(SshConfigError {
+            line: 0,
+            kind: SshConfigErrorKind::ResolutionComplexityExceeded,
+            resolution_work: Some(total),
+        });
     }
     Ok(())
 }
@@ -722,6 +727,11 @@ fn apply_settings(host: &mut SshHost, block: &Block) {
 pub struct SshConfigError {
     line: usize,
     kind: SshConfigErrorKind,
+    /// The aggregate resolution-work total when the error is
+    /// [`ResolutionComplexityExceeded`]; `None` for all other kinds.
+    /// Tests assert on this build-independent operation count instead of
+    /// wall-clock time (issue #154).
+    resolution_work: Option<u128>,
 }
 
 impl SshConfigError {
@@ -736,6 +746,15 @@ impl SshConfigError {
     #[must_use]
     pub const fn kind(&self) -> &SshConfigErrorKind {
         &self.kind
+    }
+
+    /// The aggregate resolution-work total that caused
+    /// [`ResolutionComplexityExceeded`].  `None` for every other kind.
+    /// The budget wall enforces this count, not elapsed time; exposing it
+    /// lets tests assert on the build-independent operation count.
+    #[must_use]
+    pub const fn resolution_work(&self) -> Option<u128> {
+        self.resolution_work
     }
 }
 
@@ -1340,7 +1359,11 @@ fn charge_token_item(used: &mut usize, limit: usize, line: usize) -> Result<(), 
 }
 
 fn error(line: usize, kind: SshConfigErrorKind) -> SshConfigError {
-    SshConfigError { line, kind }
+    SshConfigError {
+        line,
+        kind,
+        resolution_work: None,
+    }
 }
 
 fn parse_port(value: &str, line: usize) -> Result<u16, SshConfigError> {

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -2422,25 +2422,26 @@ fn baseline_mixed_quadratic_measurement() {
 fn mixed_quadratic_config_is_rejected_promptly_at_default_limits() {
     // The 1 MiB mixed literal+wildcard file from the DoS report. The
     // resolution-work budget must reject it as complexity, not spend
-    // minutes resolving it: measured 18-22 ms, ceiling has two orders of
-    // headroom.
+    // minutes resolving it.  The guard asserts on the build-independent
+    // operation count (resolution_work.total()) rather than wall-clock
+    // time so the test is green in both debug and release (issue #154).
     let text = baseline_mixed_text(14_189);
-    let started = std::time::Instant::now();
     let result = SshConfig::parse(&text);
-    let elapsed = started.elapsed();
-    assert!(
-        matches!(
-            result,
-            Err(SshConfigError {
-                kind: SshConfigErrorKind::ResolutionComplexityExceeded,
-                ..
-            })
-        ),
-        "expected ResolutionComplexityExceeded, got {result:?}"
+    let error = match result {
+        Ok(_) => panic!("expected ResolutionComplexityExceeded, got Ok"),
+        Err(e) => e,
+    };
+    assert_eq!(
+        error.kind(),
+        &SshConfigErrorKind::ResolutionComplexityExceeded,
+        "expected ResolutionComplexityExceeded, got {error:?}"
     );
+    let work = error
+        .resolution_work()
+        .expect("ResolutionComplexityExceeded must carry the work total");
     assert!(
-        elapsed < std::time::Duration::from_secs(2),
-        "rejection took {elapsed:?}; the budget wall must fail fast"
+        work > MAX_RESOLUTION_WORK,
+        "resolution work {work} should exceed the default budget {MAX_RESOLUTION_WORK}"
     );
 }
 


### PR DESCRIPTION
Closes #154. **`cargo test --workspace` is green in debug again** — it was red on `main` for anyone running the default command.

## The problem

`mixed_quadratic_config_is_rejected_promptly_at_default_limits` asserted a 2-second wall clock, calibrated against a **release** measurement (its own comment said "measured 18-22 ms, two orders of headroom"). An unoptimized build of this parser is far slower, so debug took ~4.3-4.7 s and failed 3/3, while release passed in 0.13 s.

CI is green, so CI runs release or skips it. The people it actually failed were contributors running `cargo test`.

## The fix: assert the work count, not the clock

The budget wall already counts resolution work internally — the timing was only ever a proxy for it. That count is now exposed on the error (`resolution_work`) and asserted directly, so the test is **build-independent**:

| Profile | Result | Time |
| --- | --- | --- |
| debug | pass | 0.17 s |
| release | pass | 0.02 s |

This was option 1 of the three the issue listed, and it is the only one that removes the machine-dependence rather than accommodating it. Scaling a ceiling by `cfg!(debug_assertions)` would have kept two numbers that both drift.

## The guard still guards, in both profiles

The assertion exists because #137 closed a real denial of service — a valid 1 MiB config that took 41.5 s. Verified by disabling the budget wall (`if total > limit` → `if false`):

```
debug:   test result: FAILED. 0 passed; 1 failed
release: test result: FAILED. 0 passed; 1 failed
```

Previously the timing assertion could only ever fire in release. Now it fires in both, so a regression cannot slip through whichever profile a contributor happens to run.

## Wall-clock audit

11 other tests assert a wall-clock duration; **0 are currently at risk** — they were checked and none has a ceiling calibrated the way this one was. They are reported rather than changed, since rewriting passing tests is not this PR's job.

The `1 ignored` alongside this test is `baseline_mixed_quadratic_measurement`, a pre-existing `#[ignore]`d baseline probe — not something disabled here.

## Gates

`fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` **985 passing, 0 failed, in debug**.
