### PR TITLE
fix(test): assert shutdown outcome and drain bound instead of wall-clock time (#159)

### DIFF
--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -1557,13 +1557,37 @@ mod tests {
         );
         thread::sleep(Duration::from_millis(100));
         session.request_close();
-        let started = Instant::now();
+        // Assert what the name claims — one bounded shutdown — on outcomes
+        // and counts rather than elapsed time (issue #159).  The session's
+        // own internal SHUTDOWN_DEADLINE is the hang-catcher: a supervisor
+        // that loops or never finishes surfaces as Err(SupervisorJoinTimeout)
+        // and a stuck reader as Err(ReaderJoinTimeout), so demanding the
+        // orderly outcome fails deterministically on either.  (The previous
+        // form accepted both errors and re-derived the same deadline from
+        // wall-clock time, which raced the internal one at the margin.)
         let result = session.shutdown();
-        assert!(started.elapsed() <= SHUTDOWN_DEADLINE);
-        assert!(matches!(
+        assert_eq!(
             result,
-            Ok(()) | Err(PtyError::ReaderJoinTimeout | PtyError::SupervisorJoinTimeout)
-        ));
+            Ok(()),
+            "shutdown must complete orderly within its own deadline"
+        );
+
+        // Bounded drain: shutdown() joins the supervisor before returning, so
+        // no producer remains and the event channel yields at most the
+        // OUTPUT_CHANNEL_CAPACITY chunks ever queued, then ends.
+        let mut drained = 0usize;
+        while let Some(_event) = session.try_recv().expect("drain PTY events") {
+            drained += 1;
+            assert!(
+                drained <= OUTPUT_CHANNEL_CAPACITY,
+                "drained {drained} events after shutdown; at most \
+                 {OUTPUT_CHANNEL_CAPACITY} can be queued"
+            );
+        }
+
+        // One shutdown suffices: the second call returns immediately via the
+        // finished flag instead of waiting a second deadline.
+        session.shutdown().expect("second shutdown is a no-op");
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Closes #159, the last of the machine-dependent tests found by the #154 audit.

## The problem

`output_pressure_close_has_one_bounded_shutdown` asserted a 2-second wall clock while measuring **0.86 s in debug and 0.87 s in release — 43% of its ceiling in both profiles**. It spawns a real PTY, feeds unbounded output, then closes. Slower hardware or a loaded CI runner crosses 2.3x margins, and unlike #154 this one is not profile-dependent, so it would have failed in both when it went.

## The fix: assert the claim, not the clock

The test's own name says "one bounded shutdown". It now asserts exactly that:

- **`shutdown()` returns `Ok(())`** — orderly completion.
- **Drained events ≤ `OUTPUT_CHANNEL_CAPACITY`** — `shutdown()` joins the supervisor first, so no producer remains and the channel can only yield what was already queued.
- **A second `shutdown()` is a no-op**, returning via the finished flag rather than waiting another deadline.

## A hang is still caught — the condition I insisted on

Replacing a timeout with a count is the obvious trap here: a counter that never increments while the process is stuck would pass forever. It does not, because the session's **own internal `SHUTDOWN_DEADLINE`** is the hang-catcher. A looping supervisor surfaces as `Err(SupervisorJoinTimeout)` and a stuck reader as `Err(ReaderJoinTimeout)`, and the test demands `Ok(())`, so either fails deterministically.

Verified by mutation — making `shutdown()` report a hang:

```
assertion `left == right` failed: shutdown must complete orderly within its own deadline
```

The commit notes something subtle worth repeating: the previous form accepted both errors *and* re-derived the same deadline from wall-clock time, which **raced the internal deadline at the margin**. Asserting the outcome removes that race rather than tuning around it.

## Wall-clock audit

Re-measured after the change: **11 wall-clock assertions, 0 now at risk.** #154 and #159 were the two.

## Gates

`fmt` clean, `clippy -D warnings` clean, passes in debug (0.84 s) and release (0.84 s), `cargo test --workspace` green.
