### PR TITLE
ci: run the live-Zellij pass-through suite in CI against the pinned release

### DIFF
--- a/.github/workflows/zellij-live.yml
+++ b/.github/workflows/zellij-live.yml
@@ -35,8 +35,14 @@ on:
 permissions:
   contents: read
 
+# `github.event_name` in the group keeps the nightly schedule and pushes to
+# main apart: both carry `github.ref` == refs/heads/main, so a ref-only group
+# let a nightly run cancel a push run mid-flight (or vice versa), discarding
+# one run's gathered evidence for no benefit. Same-event runs of the same ref
+# still cancel each other — a superseded push, or an over-long nightly by the
+# next one — which is the desired behaviour.
 concurrency:
-  group: zellij-live-${{ github.workflow }}-${{ github.ref }}
+  group: zellij-live-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -49,6 +55,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # The suite is one `cargo test` target, but it compiles the whole
+      # dependency tree from scratch on every PR, push, and nightly run
+      # (~5 CI minutes each; issue #153 review). rust-cache shares the
+      # compiled dependencies across runs — the same economics the artifact
+      # cache below applies to the Zellij download — and its key derives
+      # from the lockfile and toolchain, so a dependency bump misses by
+      # design and a stale cache can never satisfy a new lockfile. Pinned
+      # by SHA like every action here; dependabot bumps it weekly.
+      - name: Cache the Rust build
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       # The corpus fixture and the live binary must not be able to drift
       # apart silently, so the download is DERIVED from `ZELLIJ_FIXTURE_TAG`
       # in `crates/noren-app/src/passthrough.rs` rather than re-hard-coded

--- a/.github/workflows/zellij-live.yml
+++ b/.github/workflows/zellij-live.yml
@@ -156,6 +156,16 @@ jobs:
           fi
           grep -q 'test result: ok' /tmp/zellij_live.log \
             || { echo "::error::No 'test result: ok' line from the live suite; it did not run to completion."; exit 1; }
-          echo "Live pass-through evidence gathered against Zellij ${PINNED_VERSION}: $(grep -c '^test .* \.\.\. ok$' /tmp/zellij_live.log) tests ok."
+          # Zero-test runs also read as green (review path #15): a suite whose
+          # every test was deleted or gated out emits no skip notice and exits
+          # 0, so the guards above pass while the job verified nothing. Fail
+          # unless at least one test actually reported ok. grep -c exits 1 on
+          # a zero count, hence the || true under set -e.
+          ok_count="$(grep -c '^test .* \.\.\. ok$' /tmp/zellij_live.log || true)"
+          if [ "$ok_count" -eq 0 ]; then
+            echo "::error::The live suite passed ZERO tests; every test in zellij_live.rs is deleted or gated out, so pass-through evidence was NOT gathered."
+            exit 1
+          fi
+          echo "Live pass-through evidence gathered against Zellij ${PINNED_VERSION}: ${ok_count} tests ok."
         env:
           PINNED_VERSION: ${{ steps.pin.outputs.version }}

--- a/.github/workflows/zellij-live.yml
+++ b/.github/workflows/zellij-live.yml
@@ -16,13 +16,20 @@ name: Zellij live
 # version and the evidence guard fails the job on any skip notice.
 #
 # Triggers: every PR and push to main, so a Noren change that breaks
-# pass-through is caught before merge.
+# pass-through is caught before merge — plus a nightly schedule, because
+# pass-through drift is also driven by Zellij releases and runner-image
+# changes rather than Noren commits, which a per-PR gate alone notices
+# only belatedly. Both cost the same job; the artifact cache below keeps
+# the marginal runs cheap. `workflow_dispatch` allows running the job on a
+# branch without opening a PR first.
 
 on:
   pull_request:
   push:
     branches:
       - main
+  schedule:
+    - cron: "30 15 * * *"
   workflow_dispatch:
 
 permissions:
@@ -64,6 +71,17 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "Pinned Zellij fixture tag: ${tag}"
+      # The ~15 MB release tarball is fetched from github.com on every run
+      # without this, which is slow and rate-limitable (issue #153). The
+      # cache key IS the pinned tag, and cache keys are immutable, so a tag
+      # bump is guaranteed to miss and re-download the new artifact. The
+      # .sha256sum check in the install step still verifies a restored
+      # artifact, so a corrupted cache cannot read as good evidence.
+      - name: Cache the pinned Zellij release artifact
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/noren-zellij
+          key: zellij-aarch64-apple-darwin-${{ steps.pin.outputs.tag }}
       # A failed download must fail THIS job loudly (issue #153): falling
       # through to the suite's own "Zellij absent, skipping" path would look
       # green while gathering no evidence. curl --fail plus the explicit

--- a/.github/workflows/zellij-live.yml
+++ b/.github/workflows/zellij-live.yml
@@ -1,0 +1,137 @@
+name: Zellij live
+
+# Live pass-through evidence against the pinned upstream Zellij (issue #153).
+# This workflow is intentionally separate from `rust.yml`: `rust.yml` owns
+# build/lint/test and runs with no Zellij on PATH, so the live suite in
+# `crates/noren-app/tests/zellij_live.rs` skips there by design. This job
+# installs the exact Zellij release the default-binding corpus is pinned to
+# and runs that suite for real, so a failed install or a silent skip can
+# never read as gathered evidence.
+#
+# Advisory by choice (issue #153, "decisions to make, not assume"): this job
+# is NOT added to the branch-protection required-check list. The pinned
+# artifact lives upstream, so a Zellij release or hosting change could turn
+# every Noren PR red with no Noren change; drift still cannot hide, because
+# the install step hard-fails unless the binary reports exactly the pinned
+# version and the evidence guard fails the job on any skip notice.
+#
+# Triggers: every PR and push to main, so a Noren change that breaks
+# pass-through is caught before merge.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zellij-live-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live:
+    name: Live Zellij pass-through suite (macOS arm64)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The corpus fixture and the live binary must not be able to drift
+      # apart silently, so the download is DERIVED from `ZELLIJ_FIXTURE_TAG`
+      # in `crates/noren-app/src/passthrough.rs` rather than re-hard-coded
+      # here (the same read-it-from-the-source discipline as the MSRV
+      # resolution in audit.yml). Bumping the constant is the single move
+      # that updates the corpus, this download, and the version assertion
+      # below together.
+      - name: Resolve pinned Zellij fixture tag
+        id: pin
+        run: |
+          tag="$(sed -n 's/^pub const ZELLIJ_FIXTURE_TAG: &str = "\(.*\)";$/\1/p' crates/noren-app/src/passthrough.rs)"
+          if [ -z "$tag" ]; then
+            echo "::error::ZELLIJ_FIXTURE_TAG not found in crates/noren-app/src/passthrough.rs"
+            exit 1
+          fi
+          case "$tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::ZELLIJ_FIXTURE_TAG is not a release tag: ${tag}"; exit 1 ;;
+          esac
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Pinned Zellij fixture tag: ${tag}"
+      # A failed download must fail THIS job loudly (issue #153): falling
+      # through to the suite's own "Zellij absent, skipping" path would look
+      # green while gathering no evidence. curl --fail plus the explicit
+      # ::error annotation makes the failure unmissable in the job log. The
+      # upstream .sha256sum asset pins the artifact's integrity even when it
+      # came from the runner cache.
+      - name: Install the pinned Zellij release
+        run: |
+          set -euo pipefail
+          dir="$HOME/.cache/noren-zellij"
+          mkdir -p "$dir"
+          base="https://github.com/zellij-org/zellij/releases/download/${PINNED_TAG}"
+          cd "$dir"
+          if [ ! -f zellij-aarch64-apple-darwin.tar.gz ]; then
+            echo "No cached artifact for ${PINNED_TAG}; downloading the release."
+            curl --fail --location --retry 3 --retry-delay 5 \
+              -o zellij-aarch64-apple-darwin.tar.gz \
+              "${base}/zellij-aarch64-apple-darwin.tar.gz" \
+              || { echo "::error::Could not download the pinned Zellij ${PINNED_TAG} release artifact; live pass-through evidence was NOT gathered and this job must not pass."; exit 1; }
+            curl --fail --location --retry 3 --retry-delay 5 \
+              -o zellij-aarch64-apple-darwin.sha256sum \
+              "${base}/zellij-aarch64-apple-darwin.sha256sum" \
+              || { echo "::error::Could not download the checksum for Zellij ${PINNED_TAG}; live pass-through evidence was NOT gathered and this job must not pass."; exit 1; }
+          fi
+          # The upstream .sha256sum pins the BINARY inside the tarball (its
+          # stored path is the pre-archive `target/...` build path), so the
+          # extracted binary's hash is compared to the recorded token.
+          mkdir -p "$dir/bin"
+          tar -xzf zellij-aarch64-apple-darwin.tar.gz -C "$dir/bin"
+          expected="$(awk '{print $1}' zellij-aarch64-apple-darwin.sha256sum)"
+          actual="$(shasum -a 256 bin/zellij | awk '{print $1}')"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Checksum mismatch for the pinned Zellij ${PINNED_TAG} artifact (expected ${expected}, got ${actual}); live pass-through evidence was NOT gathered and this job must not pass."
+            exit 1
+          fi
+          echo "$dir/bin" >> "$GITHUB_PATH"
+        env:
+          PINNED_TAG: ${{ steps.pin.outputs.tag }}
+      # Drift gate: the suite's corpus assertions are only valid against the
+      # pinned version, and the suite itself only REPORTS a version mismatch.
+      # This step makes a mismatch fail the job instead.
+      - name: Assert the installed Zellij is exactly the pinned version
+        run: |
+          set -euo pipefail
+          installed="$(zellij --version | awk '{print $NF}')"
+          echo "zellij --version -> ${installed} (pinned: ${PINNED_VERSION})"
+          if [ "$installed" != "${PINNED_VERSION}" ]; then
+            echo "::error::Installed Zellij ${installed} differs from the pinned ZELLIJ_FIXTURE_TAG ${PINNED_VERSION}; the corpus fixture and the live binary have drifted."
+            exit 1
+          fi
+        env:
+          PINNED_VERSION: ${{ steps.pin.outputs.version }}
+      - name: Run the live-Zellij pass-through suite
+        run: |
+          set -euo pipefail
+          cargo test -p noren-app --test zellij_live 2>&1 | tee /tmp/zellij_live.log
+      # Evidence guard (issue #153): with Zellij installed the suite skips
+      # nothing, so a skip notice in the log means the environment lied
+      # (e.g. PATH broke between steps) and a green run would prove nothing.
+      - name: Guard against a silent skip reading as a pass
+        run: |
+          set -euo pipefail
+          if grep -q 'SKIP \[' /tmp/zellij_live.log; then
+            echo "::error::The live suite printed a skip notice: pass-through evidence was NOT gathered even though Zellij was installed."
+            exit 1
+          fi
+          grep -q 'test result: ok' /tmp/zellij_live.log \
+            || { echo "::error::No 'test result: ok' line from the live suite; it did not run to completion."; exit 1; }
+          echo "Live pass-through evidence gathered against Zellij ${PINNED_VERSION}: $(grep -c '^test .* \.\.\. ok$' /tmp/zellij_live.log) tests ok."
+        env:
+          PINNED_VERSION: ${{ steps.pin.outputs.version }}

--- a/.github/workflows/zellij-live.yml
+++ b/.github/workflows/zellij-live.yml
@@ -141,10 +141,16 @@ jobs:
       # Evidence guard (issue #153): with Zellij installed the suite skips
       # nothing, so a skip notice in the log means the environment lied
       # (e.g. PATH broke between steps) and a green run would prove nothing.
+      # The grep token is the suite's own `SKIP_NOTICE_PREFIX` constant,
+      # pinned to this line by `ci_skip_guard_greps_for_the_exact_notice_prefix`
+      # in zellij_live.rs: rewording the notice fails that test (locally and
+      # in every CI test job) instead of silently disarming this guard. `-F`
+      # matches the prefix as a fixed string, so no regex quoting can wedge
+      # itself between the two sides.
       - name: Guard against a silent skip reading as a pass
         run: |
           set -euo pipefail
-          if grep -q 'SKIP \[' /tmp/zellij_live.log; then
+          if grep -qF 'SKIP [' /tmp/zellij_live.log; then
             echo "::error::The live suite printed a skip notice: pass-through evidence was NOT gathered even though Zellij was installed."
             exit 1
           fi

--- a/crates/noren-app/tests/passthrough.rs
+++ b/crates/noren-app/tests/passthrough.rs
@@ -245,6 +245,28 @@ fn corpus_is_pinned_and_contains_the_documented_anchors() {
     );
 }
 
+/// The live-Zellij workflow resolves the pinned tag from this crate's source
+/// with `sed -n 's/^pub const ZELLIJ_FIXTURE_TAG: &str = "\(.*\)";$/\1/p'`
+/// (.github/workflows/zellij-live.yml): the download, the artifact cache key,
+/// and the version assertion are all DERIVED from that one line. The parse
+/// fails CLOSED today (an empty tag aborts the job), but a rustfmt-legal
+/// rewrap of the line would surface only in CI as a confusing "tag not
+/// found" error far from its cause. This test mirrors the parse — a
+/// line-anchored exact match on the declaration — so a reformat fails HERE
+/// first, naming the line the workflow reads.
+#[test]
+fn ci_sed_parse_of_the_fixture_tag_line_still_matches() {
+    let source = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/passthrough.rs"));
+    let expected = format!("pub const ZELLIJ_FIXTURE_TAG: &str = \"{ZELLIJ_FIXTURE_TAG}\";");
+    assert!(
+        source.lines().any(|line| line == expected),
+        "the line the zellij-live workflow's sed extracts is no longer exactly \
+         `{expected}` — the CI resolve step would fail closed with a confusing \
+         'tag not found' error; keep the declaration on one line, or update the \
+         workflow's sed pattern with it"
+    );
+}
+
 // ── Collision assertions against Zellij's documented defaults ──────────
 
 #[test]

--- a/crates/noren-app/tests/zellij_live.rs
+++ b/crates/noren-app/tests/zellij_live.rs
@@ -17,7 +17,7 @@
 //!   ordering: encode first, gate-decide, forward on `GateKind::Forwarded`.
 //!
 //! Skip policy: when `zellij` is not on `PATH`, each live test returns early
-//! after printing `SKIP: [...]` to the REAL stderr (bypassing the harness's
+//! after printing `SKIP [...]` to the REAL stderr (bypassing the harness's
 //! output capture) — CI without Zellij stays green while the output states
 //! explicitly that live evidence was NOT gathered. A skip is never reported
 //! as gathered evidence.
@@ -271,6 +271,29 @@ fn parse_version_line(line: &str) -> Option<&str> {
         .filter(|token| token.starts_with(|c: char| c.is_ascii_digit()))
 }
 
+/// The prefix every live skip notice starts with (`SKIP [<test>]: ...`).
+///
+/// CI coupling (issue #153): the live-Zellij workflow's evidence guard greps
+/// the suite log for exactly this prefix (`grep -qF 'SKIP ['` in
+/// `.github/workflows/zellij-live.yml`) and fails the job when it appears,
+/// because a green run that skipped is a green run that gathered nothing.
+/// YAML cannot import a Rust constant, so the coupling is pinned from this
+/// side: [`ci_skip_guard_greps_for_the_exact_notice_prefix`] fails unless the
+/// workflow file contains the grep token built from this constant AND the
+/// printed notice really starts with it. A reworded notice therefore fails a
+/// test instead of silently disarming the CI guard.
+const SKIP_NOTICE_PREFIX: &str = "SKIP [";
+
+/// Build the skip notice shared by every live test when Zellij is absent.
+/// The notice starts with [`SKIP_NOTICE_PREFIX`] by construction, which is
+/// what the CI evidence guard keys on.
+fn skip_notice(test: &str) -> String {
+    format!(
+        "{SKIP_NOTICE_PREFIX}{test}]: zellij is not installed (or `zellij --version` failed); \
+         live pass-through evidence was NOT gathered. This is a skip, not a pass."
+    )
+}
+
 /// Print the skip notice shared by every live test when Zellij is absent.
 ///
 /// The notice is written straight to the process's stderr file descriptor so
@@ -278,11 +301,7 @@ fn parse_version_line(line: &str) -> Option<&str> {
 /// otherwise reads as a silent pass under default `cargo test` output, and a
 /// skip must never be mistaken for gathered evidence.
 fn report_skip(test: &str) {
-    let notice = format!(
-        "SKIP [{test}]: zellij is not installed (or `zellij --version` failed); \
-         live pass-through evidence was NOT gathered. This is a skip, not a pass."
-    );
-    write_raw_stderr(&notice);
+    write_raw_stderr(&skip_notice(test));
 }
 
 /// Write a notice to the real stderr file descriptor, bypassing the test
@@ -1272,6 +1291,37 @@ fn version_line_parser_reads_zellij_output_shape() {
     assert_eq!(parse_version_line("zellij 0.41.2\r\n"), Some("0.41.2"));
     assert_eq!(parse_version_line("zellij\n"), None);
     assert_eq!(parse_version_line(""), None);
+}
+
+/// Issue #153 pin: the workflow's evidence guard greps the suite log for the
+/// exact skip-notice prefix, and nothing in YAML can import the constant —
+/// so a reworded notice used to disarm that guard SILENTLY (the job stayed
+/// green while skipping every test). This test reads the workflow file at
+/// compile time and fails unless the guard's grep token is built from
+/// [`SKIP_NOTICE_PREFIX`] and the printed notice really starts with it, so
+/// the two sides can no longer drift apart unnoticed. It runs in every
+/// `cargo test --workspace` CI job, so the drift is caught before the live
+/// job even starts.
+#[test]
+fn ci_skip_guard_greps_for_the_exact_notice_prefix() {
+    let workflow = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../.github/workflows/zellij-live.yml"
+    ));
+    let guard = format!("grep -qF '{SKIP_NOTICE_PREFIX}'");
+    assert!(
+        workflow.contains(&guard),
+        "the live-Zellij workflow no longer greps for `{guard}`; its skip guard \
+         has drifted from the notice this suite prints, so a skip would read as \
+         a pass again (issue #153). Restore the fixed-string grep of \
+         `{SKIP_NOTICE_PREFIX}` or move the notice prefix on BOTH sides"
+    );
+    assert!(
+        skip_notice("ci-pin").starts_with(SKIP_NOTICE_PREFIX),
+        "the printed skip notice must start with `{SKIP_NOTICE_PREFIX}` — the \
+         exact token the CI guard greps for; a reworded notice must change \
+         SKIP_NOTICE_PREFIX (and the workflow grep) with it, not bypass it"
+    );
 }
 
 /// A teardown subprocess that ignores its budget is killed, not waited on


### PR DESCRIPTION
Closes #153.

## What this delivers

A dedicated `Zellij live` workflow (.github/workflows/zellij-live.yml) on the existing `macos-14` (arm64) runner that installs the pinned Zellij and runs `cargo test -p noren-app --test zellij_live` — the suite that verifies ADR 0003's core claim (Zellij owns tabs/panes/layout through Noren's pass-through) against a live binary instead of a pinned corpus.

- **Pinned from the constant, not a second copy**: the download tag is sed-derived from `ZELLIJ_FIXTURE_TAG` in `crates/noren-app/src/passthrough.rs:37`; absent/malformed constant fails the job. Bumping the constant moves the corpus, the download, and the version assertion together.
- **A failed download cannot read as a pass**: `curl --fail` + explicit `::error` `evidence was NOT gathered` fails the install step before the suite's skip path is reachable; an evidence guard then fails the job if the log carries any `SKIP [` notice or lacks `test result: ok`. Both verified locally (404 simulation, skip-shaped log, truncated log → exit 1 each).
- **Advisory, not required**: an upstream Zellij release must not be able to block every Noren PR with no Noren change, so this is deliberately NOT added to required checks / merge_gate.py. Drift still cannot hide: the drift gate hard-fails unless `zellij --version` equals the pinned version, and the nightly schedule surfaces upstream/runner-image rot within a day.
- **Both triggers**: per-PR (Noren regressions) + nightly (Zellij-release-driven drift — the actual failure mode, cf. #147 where the environment changed under an unchanged suite) + `workflow_dispatch`.
- **Cache**: `actions/cache` (v6.1.0, SHA-pinned like every action here) keyed on the derived tag; immutable keys force a re-download on bump; the per-run `.sha256sum` check validates even restored artifacts (the checksum covers the extracted binary, so the tar is unpacked before checking).

## Local verification (macOS arm64, this machine)

Download + checksum + extract + PATH + `zellij --version` → `0.44.3`: all reproduced with the exact script from the workflow. Suite against the downloaded binary: **13/13 passed** (incl. all 4 live tests), guard step replayed on the real log. Failed-download and skip-notice paths: exit 1 with the explicit notice. `fmt`/`clippy -D warnings` clean at both commits.

## Unverified until this very PR's checks run

The Actions-side behavior itself (runner image, `GITHUB_PATH`, actions/cache v6.1.0 on macos-14, cron firing) — that is what the checks on this PR demonstrate.