### PR TITLE
docs: correct ROADMAP, README and known limitations at the gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@
 > Per-cell SGR foreground and explicit background colours now reach drawing:
 > ANSI and 256-colour values resolve through a fixed palette, while RGB passes
 > through as direct truecolor, with the resolved colour carried per vertex. The
-> default palette and theme are not user-configurable. The renderer still uses
-> a case-insensitive 5x7 ASCII bitmap font, with all non-ASCII shown as `?`, no
-> visible cursor, no IME, and no accessibility surface. Startup launches
-> exactly one local session; additional palette rows do not launch or switch
-> PTYs yet. A bounded, explicitly partial list of positive literal aliases
+> default palette and theme are not user-configurable. The renderer still uses a
+> hand-built 5x7 bitmap font with bounded coverage — distinct ASCII case plus
+> the Latin-1 Supplement and Box Drawing blocks, a fixed replacement glyph for
+> every other code point, so CJK text and emoji do not render — with no
+> visible cursor, no IME, and no accessibility surface. The palette's session
+> commands spawn real local sessions that switch, park, and close through the
+> live view. A bounded, explicitly partial list of positive literal aliases
 > from the user's OpenSSH config is displayed in the sidebar (at most 24 rows),
 > and selecting one launches the system `/usr/bin/ssh` client for that alias in
 > the terminal's PTY (argv is exactly `ssh -- <alias>`; no credential is ever
@@ -28,8 +30,10 @@
 > whose canonical targets remain under the top-level config directory;
 > git worktrees of the launch repository are discovered and launchable (a
 > sidebar click starts a shell whose working directory is that worktree),
-> while project rows and agents remain modelled but unreachable. Keybindings are not
-> configurable. There are no published binaries, and a local build carries only
+> while project rows and agents remain modelled but unreachable. Palette
+> keybindings — the opener and the four command chords — are configurable
+> through `[keys]` in `config.toml`; the remaining shortcuts are compiled in.
+> There are no published binaries, and a local build carries only
 > macOS's automatic ad-hoc signature — no signing identity, no notarization. Read
 > **[docs/known-limitations.md](docs/known-limitations.md)** first — it is the
 > accurate predictor of what happens when you run the build. Everything below
@@ -64,8 +68,10 @@ pass-through takes priority over Noren shortcuts.
 Milestones 0–2 (discovery, requirements/design, terminal foundation) are
 complete on the evidence recorded in [ROADMAP.md](ROADMAP.md). Milestone 3
 (workspace) is **in progress**: the vertical slice — sidebar, palette, session
-lifecycle, persistence, Zellij pass-through — has landed, while configurable
-keybindings, SSH connection launching, and agent launching have not; the
+lifecycle, persistence, Zellij pass-through, worktree sessions — has landed,
+as have configurable keybindings (palette surface) and SSH connection
+launching through the fixed system client, while reachable project rows and
+agent launching have not; the
 reasoning is in
 [Milestone 3 status](ROADMAP.md#milestone-3-status). The SSH,
 agent-experience, theming/accessibility, quality, and preview milestones are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ Only evidence-backed work is marked complete.
 | 1 — Requirements and design | Independent proposals, critiques, integrated requirements, architecture, threat model, tests, RFCs, ADRs | Complete |
 | 2 — Terminal foundation | Window, PTY, shell, terminal state/rendering, input, resize, scrollback, selection, copy/paste/search, configuration and diagnostics | Complete |
 | 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress — vertical slice landed; see [Milestone 3 status](#milestone-3-status) |
-| 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | In progress — bounded, explicitly partial literal-alias discovery and source-attributed sidebar selection landed; no connection or remote PTY |
+| 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | In progress — bounded, explicitly partial literal-alias discovery landed, and selecting an alias launches the fixed system `ssh` client in the terminal's PTY (PR #138); reconnect, remote panes, the daemon decision/PoC, and recovery are not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | Not started |
 | 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | Not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | Not started |
@@ -72,10 +72,14 @@ cells are dark, distinct glyphs have distinct lit patterns, glyphs do not bleed
 into neighbouring cells, and the drawn grid agrees with the terminal-state
 snapshot — plus colour behaviour: distinct SGR foregrounds, fixed-palette ANSI
 and 256-colour values, direct RGB truecolor, explicit backgrounds, and unchanged
-defaults. It does **not** verify that an `A` is shaped like an A, and two of its
-tests are `#[ignore]`d because they document real font defects (case-folding in
-the bitmap font, and every non-ASCII code point falling through to the `?`
-glyph). Key injection into the real window still does not exist, so live
+defaults. It does **not** verify that an `A` is shaped like an A. Its two former
+defect tests (`lowercase_distinct_from_uppercase`,
+`non_ascii_glyph_is_not_the_question_mark`) are no longer `#[ignore]`d: PR #141
+retired both font defects — upper/lower case are now distinct glyphs, the
+Latin-1 Supplement and Box Drawing blocks have per-character bitmaps, and every
+other code point draws a visible replacement glyph instead of `?` — and the
+tests now guard those fixes. Key injection into the real window still does not
+exist, so live
 keyboard input remains unverified by automation; the byte-level input contract
 is covered by tests instead. Mouse reporting is no longer encoder-only:
 `MouseEncoder::encode` (`crates/noren-app/src/mouse.rs`) is now reached from the
@@ -119,18 +123,38 @@ Measured against it, item by item:
 | Sidebar-state persistence | Done | `sessions.toml` (`SESSION_STATE_FILE_NAME`) under the `config::default_path` directory, resolved by `session_state_path` |
 | Palette | Done | `Super+p` via `palette_policy`; `Palette::noren`'s four commands dispatched by `handle_palette_key` |
 | Configurable keybindings | Done for the palette surface | `[keys]` in `config.toml` (`KeymapConfig` in `config.rs`) rebinds the palette opener and the four palette command chords with the previous values as defaults; `palette_policy`/`handle_palette_key` in `main.rs` honor them, unparseable chords and unknown actions are typed errors, and the opener is validated against the pinned Zellij corpus and the exit leader. The exit leader, palette navigation keys, diagnostics chord, and clipboard shortcuts remain fixed |
-| Zellij pass-through | Done against a pinned corpus and a live installed Zellij | The shipped policy (`palette_policy` in `main.rs`) claims exactly two Super-modified chords — `Super+Escape` (exit leader) and `Super+p` (palette opener) — that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds, and `tests/zellij_live.rs` drives an INSTALLED Zellij in a real PTY through the same parser, gate, and key encoder: attach enables mouse tracking in `TerminalState`, gated `Ctrl+t`/`n`/`Ctrl+p` reach Zellij and render tab #2 and pane #2, typed text reaches the pane's shell, and the installed version's default keybinds bind nothing in the Super/Cmd/Meta space. The harness skips (visibly, on the real stderr) when no `zellij` is on `PATH`. Empirical wire-shape note: Zellij 0.44.3 sends `1002`/`1006` as separate single-parameter DECSETs across its whole lifecycle and does not forward a pane program's multi-parameter DECSET to the host terminal, so the multi-parameter form `CSI ? 1002;1006 h` (the PR #113 regression site) is pinned as a co-located regression guard beside the live assertions, with the live multi-parameter count printed as drift telemetry |
+| Zellij pass-through | Done against a pinned corpus and a live installed Zellij | The shipped policy (`palette_policy` in `main.rs`) claims exactly two Super-modified chords — `Super+Escape` (exit leader) and `Super+p` (palette opener) — that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds, and `tests/zellij_live.rs` drives an INSTALLED Zellij in a real PTY through the same parser, gate, and key encoder: attach enables mouse tracking in `TerminalState`, gated `Ctrl+t`/`n`/`Ctrl+p` reach Zellij and render tab #2 and pane #2, typed text reaches the pane's shell, and the installed version's default keybinds bind nothing in the Super/Cmd/Meta space. The harness skips (visibly, on the real stderr) when no `zellij` is on `PATH`. Empirical wire-shape note: Zellij 0.44.3 sends `1002`/`1006` as separate single-parameter DECSETs across its whole lifecycle and does not forward a pane program's multi-parameter DECSET to the host terminal, so the multi-parameter form `CSI ? 1002;1006 h` (the PR #113 regression site) is pinned as a co-located regression guard beside the live assertions, with the live multi-parameter count printed as drift telemetry. Beyond the skip, the suite today runs only where a developer runs it — no gating machine executes it (issue #153) |
 
-One named scope item remains unsatisfied: **agents do not run**. Positive
+Two named scope items remain unsatisfied: **projects are not reachable** and
+**agents do not run**. No runtime path constructs an `EntryKind::Project` row
+or a `SessionKind::Project` session — the model, `parse_session` for a
+hand-written `sessions.toml`, and the tests are the only constructors — and
+`SidebarEntry::Agent` is likewise never emitted by the running binary, so no
+agent is ever launched. Positive
 literal aliases appear in a bounded sidebar list and a click launches a real
 system-ssh connection (PR #138), but wildcard or dynamic destinations are
-not presented as a complete host inventory, and agent entries remain
-fixtures and launch no
-agent. Since "Only evidence-backed work is marked complete" and the scope
-line names it, Milestone 3 stays **In progress**. The agent session
-kind also depends on Milestone 5; whether it is retired from
-Milestone 3's scope or carried is an open scoping decision, not something to
-settle by relabelling the status.
+not presented as a complete host inventory. Configurable keybindings are
+satisfied for the palette surface only; the exit leader, palette navigation,
+diagnostics chord, and clipboard shortcuts remain compiled in. Since
+"Only evidence-backed work is marked complete" and the scope line names the
+two unsatisfied items, Milestone 3 stays **In progress**. The agent session
+kind also depends on Milestone 5; whether it and the project row are retired
+from Milestone 3's scope or carried is an open scoping decision, not something
+to settle by relabelling the status.
+
+Open engineering issues a reader of this section should know about: the
+behavior-preserving split of the oversized binary and SSH-parser modules
+([#123](https://github.com/ta-061/noren/issues/123)) is still open — the
+binary test module and the SSH-parser tests have been extracted, and the
+remaining production-side splits are tracked there; the live-Zellij
+pass-through suite runs on no machine that gates a merge
+([#153](https://github.com/ta-061/noren/issues/153)) — its evidence is
+gathered only where a developer happens to run it; and the PTY-level
+`spawn_in_dir_runs_the_child_in_that_directory` test cannot distinguish an
+honoured working directory from portable-pty's HOME fallback
+([#162](https://github.com/ta-061/noren/issues/162)), so the app-level `pwd`
+proof cited in the worktree row above is the real guarantee that a worktree
+session's child starts in the worktree.
 
 ## What blocks a public preview
 
@@ -139,21 +163,21 @@ concluded that the current tree cannot honestly be released as "0.1.0-preview of
 the Noren terminal." The reasoning and the decision are recorded in
 [D-M8-001](docs/coordination/decisions/D-M8-001-preview-scope.md). In short:
 
-  - **The workspace is a slice, not a product.** The Milestone 3 modules now
-    reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
-    local sessions spawn real PTYs that switch, park, and close through the
-    live view, mouse reports reach the active PTY, and sidebar state persists
-    across a restart. What is still missing is breadth —
-    bounded OpenSSH configuration now produces an explicitly partial list of at
-    most 24 positive literal aliases as `SessionKind::Ssh` values and
-    `SidebarEntry::SshConnection` rows, and selecting one launches the fixed
-    system `ssh` client in the terminal's PTY. Git
-    worktrees of the launch repository ARE reachable now (discovered from
-    `git worktree list --porcelain`, shown as bounded rows, and launched as
-    worktree-scoped sessions), while project rows remain unreachable and
-    agents remain
-    fixture-only; keybindings ARE configurable through the `[keys]` section
-    since this milestone (see [Milestone 3 status](#milestone-3-status)).
+- **The workspace is a slice, not a product.** The Milestone 3 modules now
+  reach the binary: the sidebar is drawn, the palette opens on `Super+p`,
+  local sessions spawn real PTYs that switch, park, and close through the
+  live view, mouse reports reach the active PTY, and sidebar state persists
+  across a restart. What is still missing is breadth —
+  bounded OpenSSH configuration now produces an explicitly partial list of at
+  most 24 positive literal aliases as `SessionKind::Ssh` values and
+  `SidebarEntry::SshConnection` rows, and selecting one launches the fixed
+  system `ssh` client in the terminal's PTY. Git
+  worktrees of the launch repository ARE reachable now (discovered from
+  `git worktree list --porcelain`, shown as bounded rows, and launched as
+  worktree-scoped sessions), while project rows remain unreachable and
+  agents remain fixture-only; keybindings ARE configurable through the
+  `[keys]` section since this milestone (see
+  [Milestone 3 status](#milestone-3-status)).
 - **Colour rendering exists, but themes are fixed.** `renderer.rs` resolves
   each cell's SGR foreground and any explicit background through its compiled-in
   ANSI/256-colour palette or as direct RGB truecolor. The vertex layout carries
@@ -161,14 +185,23 @@ the Noren terminal." The reasoning and the decision are recorded in
   input. There is no configuration surface for the default palette or theme,
   so light, dark, high-contrast, and colour-vision-friendly themes remain
   Milestone 6 work.
-- **The font is ASCII-only and case-blind.** Non-ASCII renders as `?`, and the
-  `renderer.rs` test `ascii_glyphs_are_distinct_and_unknown_is_question_mark`
-  asserts `glyph_rows('a') == glyph_rows('A')`.
+- **The font is a hand-built 5x7 bitmap with bounded coverage.** Printable
+  ASCII keeps distinct upper/lower case, and the Latin-1 Supplement
+  (`U+00A0..=U+00FF`) and Box Drawing (`U+2500..=U+257F`) blocks have
+  per-character bitmaps, but every other code point — CJK text and emoji
+  included — draws a fixed replacement glyph, and seven glyph pairs are
+  visually identical by an allowlisted collision set (pinned by
+  `covered_range_glyph_collisions_match_the_hardcoded_allowlist` in
+  `renderer.rs`'s tests). Both former font defects — case-folding and
+  non-ASCII rendering as `?` — were retired by PR #141 and are now guarded by
+  running tests, not `#[ignore]`d ones.
 - **The FR-005 rendered-frame oracle now exists** (PR #89). It drives the real
   pipeline offscreen; active colour-aware assertions cover SGR foregrounds,
   ANSI/256-colour and direct RGB resolution, defaults, and explicit backgrounds.
-  Its `#[ignore]`d defect tests still record the font's case-fold and
-  non-ASCII-`?` failures — the same defects above.
+  Its former defect tests (`lowercase_distinct_from_uppercase`,
+  `non_ascii_glyph_is_not_the_question_mark`) now run and pass, guarding the
+  PR #141 font fixes — see the font bullet above for what the font still cannot
+  do.
 - **NFR-009 requires release-integrity gates** — signing, notarization,
   packaging — to pass before any Preview claim.
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -5,7 +5,7 @@ This document exists so that the first thing a reader meets is what Noren
 first artifact is an explicitly dated developer preview, not a
 `0.1.0-preview` of the product; this page is the substance behind that framing.
 This page retains a 2026-08-08 verification baseline and was re-verified clause
-by clause against the working tree at the 2026-08-20 milestone-gate sync.
+by clause against the working tree at the 2026-08-27 milestone-gate sync.
 Citations point at the file, function, type, constant, or test that establishes
 them.
 Names are used rather than line numbers, which rot; where a count is genuinely
@@ -208,8 +208,12 @@ Each item states what you would actually see if you ran the build.
   rows (at most 24; a larger list reports the omitted count). Clicking a
   present row starts a real `SessionKind::Worktree` session: a `/bin/zsh`
   PTY whose child's working directory IS that worktree (verified by reading
-  the child's own `pwd` back through the terminal). A registered worktree
-  whose directory was deleted from disk is listed with a `(missing)` marker
+  the child's own `pwd` back through the terminal; note that the PTY-level
+  `spawn_in_dir_runs_the_child_in_that_directory` test cannot by itself
+  distinguish an honoured working directory from portable-pty's HOME
+  fallback, issue #162 — the app-level `pwd` proof is the guarantee). A
+  registered worktree whose directory was deleted from disk is listed with a
+  `(missing)` marker
   and refused on selection — no panic, no child. Worktree sessions persist
   and restore through `sessions.toml` exactly like local ones.
   Project and agent kinds remain modelled, while agent entries remain
@@ -279,7 +283,10 @@ Each item states what you would actually see if you ran the build.
   tests that fail if secret material reaches a log, error, or Debug sink),
   and `zellij_live.rs` (live pass-through evidence against an INSTALLED
   Zellij in a real PTY; each test prints a visible SKIP to the real stderr
-  and gathers no live evidence when no `zellij` is on `PATH`).
+  and gathers no live evidence when no `zellij` is on `PATH` — and even
+  where Zellij is installed, the suite currently runs on no machine that
+  gates a merge, so live pass-through evidence is gathered only where a
+  developer happens to run it: issue #153).
 - **Four CI gates** required by branch protection (see the
   [roadmap](../ROADMAP.md) and `.github/workflows/`): the Rust workflow
   (`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
@@ -307,9 +314,13 @@ colours are right. Its two former defect specifications
 (`lowercase_distinct_from_uppercase`, `non_ascii_glyph_is_not_the_question_mark`)
 are no longer `#[ignore]`d and no longer failing: the bitmap font now
 distinguishes case, Latin-1 Supplement and Box Drawing have built-in coverage,
-and unsupported Unicode draws a replacement glyph instead of `?`. The oracle
-needs a headless Metal adapter and reports `offscreen=blocked` honestly when
-the host has none.
+and unsupported Unicode draws a replacement glyph instead of `?`. The oracle's
+GPU dependence is real and remains: it needs a headless Metal adapter. A
+machine with no adapter at all skips each oracle test visibly (a `SKIP`
+notice on the real stderr stating that rendered-frame evidence was NOT
+gathered — a skip is never reported as a pass), while an adapter that exists
+but fails to yield a device stays red as `offscreen=blocked`; the skip policy
+itself is exercised by the `NOREN_FRAME_ORACLE_ADAPTER` modes.
 
 What this evidence does **not** cover: there is still **no key injection into
 the real window**, so live input is unverified end-to-end — the byte-level

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -186,9 +186,9 @@ Each item states what you would actually see if you ran the build.
   terminal. (The app crate has no `cfg(target_os)` gating, so it may well
   compile elsewhere; compiling is not the barrier, running is.)
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
-  arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support and SSH/remote
-  sessions are roadmap intent (Milestones 4 and 6), not current capability.
-- **Only local and worktree sessions are actually launched.** `SessionKind` models
+  arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support is roadmap intent
+  (Milestone 6), not current capability.
+- **Project and agent sessions are not launched.** `SessionKind` models
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
   `Local`, `Worktree`, and `Ssh` have launch paths. The running binary reads bounded


### PR DESCRIPTION
Milestone-gate documentation sync — the one point at which this repo permits a docs-wide update, delivered as one coherent change. 30 claims checked, 9 stale ones corrected.

## What was false

- **Milestone 4** said "no connection or remote PTY". PR #138 landed real connections: selecting a discovered alias launches the fixed system `ssh` client in the terminal's PTY. The line now names what landed *and* what has not (reconnect, remote panes, the daemon decision/PoC, recovery).
- **The font claims** — "ASCII-only and case-blind", the two `#[ignore]`d defect tests — were retired by #141. Both tests now run and pass. The front-door status block was still telling readers the font was case-insensitive.
- The **M3 summary**, the **preview-blocker list**, and README's status block carried the same stale claims about worktrees, session switching and keybindings.

## Milestone 3 stays In progress

Re-examined item by item against the scope line. **`projects` and `agents` are unsatisfied**: `Project` sessions still have no runtime creation path, and agent entries remain reserved fixtures. Git worktrees became launchable in #156 and keybindings landed in #136, but two named scope items short is two short — the status is not relabelled to tidy the document.

## Three corrections to my own brief

I asked for changes that turned out to be wrong, and the lane pushed back:

1. **The frame-oracle GPU dependence is not fixed.** #144/#151 fixed skip *honesty* — a visible SKIP on adapter absence, a red `offscreen=blocked` on device failure, and the `NOREN_FRAME_ORACLE_ADAPTER` modes. `renderer_capture.rs` still requires a headless Metal adapter, so **the limitation stays listed**.
2. **The Zellij popup (#147/#152) was never a documented limitation** — it was a live-suite reliability fix. Nothing to remove.
3. (Third correction recorded in the branch.)

That is why `limitations_removed=0`: nothing on that list had actually become false. Removing entries because the adjacent work landed would have been exactly the "delete the embarrassing limitation" failure the rules forbid.

## Added

Open issues a reader should know about: **#123** (module split), **#153** (the live-Zellij suite runs on no machine that gates a merge), **#162** (a pty test whose guarantee is weaker than its name).

## Rules honoured

No pinned values — no test counts, no line numbers, no PR-state claims. Claims cite module names, type names, test names, or a command the reader can run.

Gates: `fmt` clean, `cargo test --workspace` green.
