### PR TITLE
test(pty): give spawn_in_dir a home distinct from the requested cwd (#162)

### DIFF
--- a/crates/noren-pty/src/lib.rs
+++ b/crates/noren-pty/src/lib.rs
@@ -1927,21 +1927,32 @@ mod tests {
     #[test]
     fn spawn_in_dir_runs_the_child_in_that_directory() {
         let worktree = temp_directory_with("worktree-cwd");
+        // The home must DIFFER from the requested cwd (issue #162).
+        // `portable-pty` falls back to the child's `HOME` when a launch
+        // carries no cwd, so a home that equalled the worktree let a
+        // dropped `command.cwd` pass unnoticed: the fallback landed in
+        // the very directory the test demanded. A distinct home keeps the
+        // discrimination the test's name claims while preserving #156's
+        // isolation — a controlled empty HOME, never the developer's
+        // real one, whose startup files (oh-my-zsh, conda, nvm, …) could
+        // outlast the deadline or read the terminal.
+        let home = temp_directory_with("worktree-home");
 
         // The production entry `spawn_in_dir` inherits HOME unchanged so the
-        // user's shell config applies, and a developer's real `$HOME` may
-        // carry startup files (oh-my-zsh, conda, nvm, …) that take longer
-        // than the deadline or read the terminal. This live check drives the
+        // user's shell config applies; this live check drives the
         // `spawn_in_dir_with_home` seam — the same `DirLaunchPolicy`, the
         // same fixed builder, and the same session machinery, with HOME
         // pinned to the empty fixture directory — so the shell finds no
         // startup files and answers immediately. Unlike an env swap, the
         // seam never mutates process-global environment, which races the
         // parallel tests that read HOME (this exact race was observed:
-        // `ssh_command_argv_...` failed while HOME was swapped). The cwd is
-        // still independently verified by the pwd check below.
+        // `ssh_command_argv_...` failed while HOME was swapped).
+        //
+        // Mutation check: dropping `command.cwd` from the builder makes the
+        // child land in the home fixture instead, and the pwd assertion
+        // below fails — the fallback can no longer mask a missing cwd.
         let size = PtySize::from_raw(24, 80).expect("valid initial size");
-        let mut session = PtySession::spawn_in_dir_with_home(&worktree, &worktree, size)
+        let mut session = PtySession::spawn_in_dir_with_home(&worktree, &home, size)
             .expect("spawn zsh in the worktree");
 
         session.send_input(b"pwd\nexit\n").expect("ask for the cwd");
@@ -1967,5 +1978,6 @@ mod tests {
         );
         session.shutdown().expect("reap worktree zsh");
         fs::remove_dir_all(&worktree).expect("remove worktree fixture");
+        fs::remove_dir_all(&home).expect("remove home fixture");
     }
 }


### PR DESCRIPTION
Closes #162.

## The gap

`spawn_in_dir_runs_the_child_in_that_directory` was meant to prove a session's child starts in the requested directory. It could not catch the most obvious way that breaks.

`portable-pty` 0.9 falls back to `home` when cwd is unset, and the HOME-isolation seam added in #156 set `HOME == dir` for the test. So with `command.cwd` removed the child still landed in the same directory, and the assertion could not tell the difference. The test proved "the child ends up here", not "cwd was honoured".

## The fix

The test's HOME is now **distinct** from the requested cwd, so the fallback cannot mask a missing cwd. The isolation #156 needed is kept — a controlled HOME, never the developer's real one. That coupling is what made these tests environment-dependent in the first place (#147), and undoing it would have traded one defect for a worse one.

## Verified by mutation

Removing `command.cwd(&policy.dir)` from `build_dir_zsh_command`:

| Test | Before this PR | After |
| --- | --- | --- |
| `spawn_in_dir_runs_the_child_in_that_directory` (pty) | **passed** — the bug | **FAILED** |
| `selecting_a_worktree_row_starts_a_session_in_that_worktree` (app) | FAILED | FAILED |

Both levels now catch it. The app-level test that already worked was not weakened.

## Seam audit

All **22 callers** of the HOME seam were enumerated; **1** could not distinguish cwd from HOME, and that one is fixed. The rest were checked and reported rather than assumed.

## A note for the next reviewer

This is a good reminder of why one passing mutation is not proof of coverage. I originally mutated `DirLaunchPolicy::new` and **both** tests failed, which looked like solid coverage — the weaker mutation (`command.cwd` dropped) is the one that separated them. Which mutation you pick decides what you can see.

Gates: `fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` green.
