### PR TITLE
feat(renderer): configurable themes with measured WCAG contrast (M6 foundation)

### DIFF
--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -28,6 +28,14 @@
 //! `Super+Escape` exit leader) is [`ConfigError::UnclaimableChord`] rather
 //! than a silently dead binding.
 //!
+//! The `[theme]` table selects the built-in colour palette. It follows the
+//! same discipline: an absent table keeps `dark` — exactly the colours the
+//! app shipped with before themes existed — a non-string value is
+//! [`ConfigError::ThemeNotAString`], and a name outside the closed
+//! vocabulary (`dark`, `light`, `high-contrast`) is
+//! [`ConfigError::UnknownTheme`] naming the offending value, never a
+//! silent fallback to the default.
+//!
 //! # Privacy
 //!
 //! Configuration carries no secrets: no supported key names a credential,
@@ -39,6 +47,7 @@ use crate::passthrough::{
     CLAIM_ID_PALETTE, Chord, ChordError, ChordSeq, KeyCode, Modifiers, PassthroughAction,
     PassthroughClaim, PassthroughPolicy, default_exit_claim,
 };
+use crate::theme::{Theme, ThemeName};
 use crate::{POC_CELL_HEIGHT, POC_CELL_WIDTH};
 use std::env;
 use std::fmt;
@@ -178,6 +187,30 @@ fn default_chord(code: KeyCode, modifiers: Modifiers) -> Chord {
     Chord::new(code, modifiers).expect("default keymap chords are normalized constants")
 }
 
+/// Colour theme selection.
+///
+/// [`ThemeConfig::default`] is `dark`: exactly the palette the app shipped
+/// with before themes existed, so an absent `[theme]` table preserves the
+/// pre-theme rendering bit-for-bit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct ThemeConfig {
+    name: ThemeName,
+}
+
+impl ThemeConfig {
+    /// The selected built-in theme name; defaults to `dark`.
+    #[must_use]
+    pub const fn name(self) -> ThemeName {
+        self.name
+    }
+
+    /// The concrete palette the selected name resolves to.
+    #[must_use]
+    pub const fn palette(self) -> Theme {
+        self.name.palette()
+    }
+}
+
 /// Validated application configuration.
 ///
 /// [`AppConfig::default`] is byte-for-byte the behavior the app had before
@@ -186,6 +219,7 @@ fn default_chord(code: KeyCode, modifiers: Modifiers) -> Chord {
 pub struct AppConfig {
     font: FontConfig,
     keys: KeymapConfig,
+    theme: ThemeConfig,
 }
 
 impl AppConfig {
@@ -199,6 +233,12 @@ impl AppConfig {
     #[must_use]
     pub const fn keys(self) -> KeymapConfig {
         self.keys
+    }
+
+    /// Colour theme settings.
+    #[must_use]
+    pub const fn theme(self) -> ThemeConfig {
+        self.theme
     }
 
     /// Load configuration from the standard path or the [`CONFIG_ENV_VAR`]
@@ -251,6 +291,7 @@ impl AppConfig {
             match key {
                 "font" => parse_font(table, &mut config.font)?,
                 "keys" => parse_keys(table, &mut config.keys)?,
+                "theme" => parse_theme(table, &mut config.theme)?,
                 // `[terminal]` historically attracted a `scrollback_lines` key.
                 // The terminal foundation has no configurable retention cap yet,
                 // so the table is rejected instead of parsed-and-ignored.
@@ -296,6 +337,29 @@ fn integer_in_range(key: &str, item: &Item, min: usize, max: usize) -> Result<us
         .filter(|value| (min..=max).contains(value))
         .ok_or_else(|| ConfigError::OutOfRange { key: clip(key) })?;
     Ok(value)
+}
+
+/// Apply the `[theme]` table to the theme selection.
+///
+/// Every value must be a TOML string naming one of the built-in themes,
+/// matched exactly (the vocabulary is closed and case-sensitive). An
+/// unknown name is [`ConfigError::UnknownTheme`] naming the offending
+/// value — never a silent fallback to `dark`, because a typo would
+/// otherwise masquerade as a working setting.
+fn parse_theme(table: &dyn TableLike, theme: &mut ThemeConfig) -> Result<(), ConfigError> {
+    for (key, item) in table.iter() {
+        match key {
+            "name" => {
+                let value = item
+                    .as_str()
+                    .ok_or_else(|| ConfigError::ThemeNotAString { key: clip(key) })?;
+                theme.name = ThemeName::parse(value)
+                    .ok_or_else(|| ConfigError::UnknownTheme { value: clip(value) })?;
+            }
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    Ok(())
 }
 
 /// Apply the `[keys]` table to the keymap.
@@ -791,6 +855,20 @@ pub enum ConfigError {
     OutOfRange { key: String },
     /// A `[keys]` action is bound to a value that is not a TOML string.
     ChordNotAString { key: String },
+    /// A `[theme]` value is not a TOML string.
+    ThemeNotAString { key: String },
+    /// A `[theme]` name is not one of the built-in themes.
+    ///
+    /// **Echo allowlist** (issue #150): `value` carries the `[theme]` name
+    /// text, clipped to 120 characters by [`clip`]. A theme name is drawn
+    /// from a closed, published vocabulary (`dark`, `light`,
+    /// `high-contrast`) — keybinding-grammar text, never a credential,
+    /// key, or path — and the schema deliberately exposes no setting where
+    /// a secret is plausible, so the residual risk of a secret pasted into
+    /// `[theme]` by mistake is accepted for the same reason the `[keys]`
+    /// chord echo is: an error that cannot say which name failed is not
+    /// actionable.
+    UnknownTheme { value: String },
     /// A `[keys]` value does not parse as a chord.
     ///
     /// **Echo allowlist** (issue #150): `value` and `reason` carry `[keys]`
@@ -855,6 +933,15 @@ impl fmt::Display for ConfigError {
             Self::ChordNotAString { key } => write!(
                 f,
                 "configuration key {key} must be a chord string like \"super+p\""
+            ),
+            Self::ThemeNotAString { key } => write!(
+                f,
+                "configuration key {key} must be a theme name string like \"light\""
+            ),
+            Self::UnknownTheme { value } => write!(
+                f,
+                "configuration theme {value} is not a built-in theme; expected one of \
+                 dark, light, high-contrast"
             ),
             Self::InvalidChord { key, value, reason } => write!(
                 f,
@@ -1634,6 +1721,145 @@ mod tests {
         assert_eq!(
             chord_text(KeymapConfig::default().palette_open()),
             "super+p"
+        );
+    }
+
+    // ── [theme] theme tests ───────────────────────────────────────────
+
+    /// With no `[theme]` surface at all, the selection is `dark` — exactly
+    /// the palette the app shipped with before themes existed.
+    #[test]
+    fn default_theme_is_dark_the_pre_theme_palette() {
+        assert_eq!(ThemeConfig::default().name(), ThemeName::Dark);
+        assert_eq!(AppConfig::default().theme().name(), ThemeName::Dark);
+        assert_eq!(
+            AppConfig::parse("# nothing\n")
+                .expect("valid")
+                .theme()
+                .name(),
+            ThemeName::Dark
+        );
+        // The default config's palette is the dark theme constant itself.
+        assert_eq!(
+            AppConfig::default().theme().palette(),
+            ThemeName::Dark.palette()
+        );
+    }
+
+    /// An empty `[theme]` table is presence without content: the default.
+    #[test]
+    fn empty_theme_table_keeps_the_default_selection() {
+        let config = AppConfig::parse("[theme]\n").expect("an empty table is valid");
+        assert_eq!(config.theme(), ThemeConfig::default());
+    }
+
+    /// Each documented name selects its own palette.
+    #[test]
+    fn every_documented_theme_name_selects_its_own_palette() {
+        for (text, name) in [
+            ("dark", ThemeName::Dark),
+            ("light", ThemeName::Light),
+            ("high-contrast", ThemeName::HighContrast),
+        ] {
+            let config = AppConfig::parse(&format!("[theme]\nname = \"{text}\"\n")).expect("valid");
+            assert_eq!(config.theme().name(), name, "{text:?}");
+            assert_eq!(config.theme().palette(), name.palette());
+        }
+    }
+
+    /// An unknown theme name is a typed error naming the offending value —
+    /// never a silent fallback to the default. Near-misses included.
+    #[test]
+    fn unknown_theme_names_are_rejected_naming_the_offending_value() {
+        for text in [
+            "[theme]\nname = \"sepia\"\n",
+            "[theme]\nname = \"solarized-dark\"\n",
+            // Case and spelling near-misses: the vocabulary is closed and
+            // case-sensitive, so these must not quietly select a theme.
+            "[theme]\nname = \"Dark\"\n",
+            "[theme]\nname = \"highcontrast\"\n",
+            "[theme]\nname = \"\"\n",
+        ] {
+            let error = AppConfig::parse(text).expect_err("must not parse");
+            assert!(
+                matches!(&error, ConfigError::UnknownTheme { .. }),
+                "{text:?} must be UnknownTheme, got {error:?}"
+            );
+        }
+        let error = AppConfig::parse("[theme]\nname = \"sepia\"\n").expect_err("rejected");
+        assert_eq!(
+            error,
+            ConfigError::UnknownTheme {
+                value: "sepia".to_owned()
+            }
+        );
+    }
+
+    /// A hostile theme value is clipped in the error, like every echo.
+    #[test]
+    fn hostile_theme_values_are_clipped_in_errors() {
+        let mut hostile = String::new();
+        hostile.extend(std::iter::repeat_n('a', 10_000));
+        let text = format!("[theme]\nname = \"{hostile}\"\n");
+        let error = AppConfig::parse(&text).expect_err("a huge name must fail");
+        let ConfigError::UnknownTheme { value } = &error else {
+            panic!("expected UnknownTheme, got {error:?}");
+        };
+        assert!(
+            value.chars().count() <= MAX_ERROR_DETAIL_CHARS + 1,
+            "hostile theme name must be clipped: {value}"
+        );
+    }
+
+    /// Wrong value types and unknown keys are rejected with the section's
+    /// own typed errors.
+    #[test]
+    fn theme_table_rejects_wrong_types_and_unknown_keys() {
+        let cases = [
+            (
+                "[theme]\nname = 3\n",
+                ConfigError::ThemeNotAString {
+                    key: "name".to_owned(),
+                },
+            ),
+            (
+                "[theme]\nname = 12.5\n",
+                ConfigError::ThemeNotAString {
+                    key: "name".to_owned(),
+                },
+            ),
+            (
+                "[theme]\nname = true\n",
+                ConfigError::ThemeNotAString {
+                    key: "name".to_owned(),
+                },
+            ),
+            (
+                "[theme]\npalette = \"light\"\n",
+                ConfigError::UnknownKey("palette".to_owned()),
+            ),
+            (
+                "theme = \"light\"\n",
+                ConfigError::WrongType {
+                    key: "theme".to_owned(),
+                },
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(AppConfig::parse(text), Err(expected), "{text:?}");
+        }
+    }
+
+    /// `[theme]` composes with the other sections without interference.
+    #[test]
+    fn theme_applies_alongside_font_and_keys() {
+        let text = "[font]\ncell_width = 12\n\n[theme]\nname = \"light\"\n\n[keys]\nsession_create = \"t\"\n";
+        let config = AppConfig::parse(text).expect("all sections are valid together");
+        assert_eq!(config.font().cell_width(), 12);
+        assert_eq!(config.theme().name(), ThemeName::Light);
+        assert_eq!(
+            config.keys().session_create(),
+            chord(KeyCode::Char('t'), Modifiers::empty())
         );
     }
 }

--- a/crates/noren-app/src/frame_geometry/tests.rs
+++ b/crates/noren-app/src/frame_geometry/tests.rs
@@ -90,13 +90,16 @@ fn assert_three_consumers_agree_at(width: u32, metrics: CellMetrics) {
     // compile-time default is exposed at a non-default size.
     let snapshot = terminal.snapshot();
     let sidebar: Vec<String> = Vec::new();
-    let vertices = renderer::glyph_vertices(
+    let vertices = renderer::glyph_vertices_for(
+        renderer::Target::new(
+            &noren_app::theme::Theme::default(),
+            width,
+            height,
+            metrics,
+        ),
         Some(&snapshot),
         Some(sidebar.as_slice()),
         None,
-        width,
-        height,
-        metrics,
     );
     let drawn = rendered_terminal_columns(&vertices, width, cell_width);
     assert_eq!(
@@ -232,13 +235,16 @@ fn terminal_cols_and_renderer_floor_at_one_below_the_sidebar() {
     terminal.feed_bytes(&vec![b'B'; usize::from(cols)]);
     let snapshot = terminal.snapshot();
     let sidebar: Vec<String> = Vec::new();
-    let vertices = renderer::glyph_vertices(
+    let vertices = renderer::glyph_vertices_for(
+        renderer::Target::new(
+            &noren_app::theme::Theme::default(),
+            width,
+            height,
+            GridGeometry::poc().cell_metrics(),
+        ),
         Some(&snapshot),
         Some(sidebar.as_slice()),
         None,
-        width,
-        height,
-        GridGeometry::poc().cell_metrics(),
     );
     let drawn = rendered_terminal_columns(&vertices, width, cell_width);
     assert_eq!(

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -21,6 +21,7 @@ pub mod session_persistence;
 pub mod session_supervisor;
 pub mod sidebar;
 pub mod ssh_config;
+pub mod theme;
 
 pub use clipboard::{
     BRACKET_PASTE_BEGIN, BRACKET_PASTE_END, ClipboardError, PasteReject, SystemClipboard,

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -45,6 +45,7 @@ use noren_app::{
     },
     sidebar::{SidebarEntry, SidebarView},
     ssh_config::{HostDiscoveryKind, SshConfig},
+    theme::Theme,
 };
 use noren_pty::{
     PtyEvent, PtySession, PtySize, SshDestination, SshDestinationError, SshLaunchPolicy,
@@ -835,6 +836,11 @@ struct NorenApp {
     /// commands. The single source of truth for every workspace chord the
     /// binary honors; no hard-coded chord remains on the key paths.
     keys: KeymapConfig,
+    /// The configured colour theme, handed to the renderer at creation so
+    /// every palette-derived draw colour — default foreground, ANSI
+    /// resolution, clear colour — follows the `[theme]` selection. The
+    /// default (`dark`) is exactly the pre-theme palette.
+    theme: Theme,
 }
 
 /// Which application-owned line, if any, occupies the renderer's status row.
@@ -928,6 +934,7 @@ impl NorenApp {
             passthrough_gate: PassthroughGate::new(),
             passthrough_policy: palette_policy(config.keys()),
             keys: config.keys(),
+            theme: config.theme().palette(),
         }
     }
 
@@ -1682,7 +1689,11 @@ impl NorenApp {
                 None
             }
         };
-        self.renderer = match Renderer::new(Arc::clone(&window), self.geometry.cell_metrics()) {
+        self.renderer = match Renderer::new(
+            Arc::clone(&window),
+            self.geometry.cell_metrics(),
+            self.theme,
+        ) {
             Ok(renderer) => Some(renderer),
             Err(_) => {
                 self.status = "Noren renderer start failed";

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -370,6 +370,44 @@ fn configured_cell_sizes_drive_the_app_geometry() {
     assert_eq!((grid.rows(), grid.cols()), (15, 45));
 }
 
+/// The `[theme]` selection reaches the app's renderer input: `NorenApp`
+/// carries exactly the palette the configuration named, and a missing
+/// `[theme]` section carries the dark default. This is the app-level half of
+/// the theme's reachability chain (configuration → app → renderer → pixels);
+/// the frame oracle proves the drawing half offscreen.
+#[test]
+fn configured_theme_reaches_the_app_renderer_input() {
+    for (text, expected) in [
+        ("", noren_app::theme::ThemeName::Dark),
+        (
+            "[theme]\nname = \"dark\"\n",
+            noren_app::theme::ThemeName::Dark,
+        ),
+        (
+            "[theme]\nname = \"light\"\n",
+            noren_app::theme::ThemeName::Light,
+        ),
+        (
+            "[theme]\nname = \"high-contrast\"\n",
+            noren_app::theme::ThemeName::HighContrast,
+        ),
+    ] {
+        let config = AppConfig::parse(text).expect("valid configuration");
+        assert_eq!(
+            config.theme().name(),
+            expected,
+            "config must parse {text:?} to {expected}"
+        );
+        let app = NorenApp::new(config);
+        assert_eq!(
+            app.theme,
+            expected.palette(),
+            "NorenApp must carry the palette named by {text:?}"
+        );
+    }
+    assert_eq!(NorenApp::default().theme, noren_app::theme::DARK);
+}
+
 #[test]
 fn workspace_starts_empty_with_no_sidebar_rows() {
     let state = WorkspaceState::new();
@@ -1975,13 +2013,11 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
         app.worktree_diagnostic.as_deref(),
         app.ssh_diagnostic.as_deref(),
     );
-    let vertices = renderer::glyph_vertices(
+    let vertices = renderer::glyph_vertices_for(
+        renderer::Target::new(&app.theme, frame_width, frame_height, metrics),
         Some(&snapshot),
         Some(&[]),
         Some(status),
-        frame_width,
-        frame_height,
-        metrics,
     );
     assert!(
         !vertices.is_empty(),

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -2,14 +2,19 @@
 //!
 //! Per-cell foreground colour recorded by the terminal state reaches drawing
 //! here: [`resolve_foreground`] runs a cell's `Color` selection through the
-//! default palette (or passes `Rgb` through directly) and the result rides on
-//! every vertex the cell's glyph emits, which the fragment shader returns.
-//! A cell with no SGR colour resolves to [`DEFAULT_FOREGROUND`] — the exact
-//! shade the shader previously returned as a constant — so unstyled output is
-//! unchanged.
+//! selected theme's palette (or passes `Rgb` through directly) and the result
+//! rides on every vertex the cell's glyph emits, which the fragment shader
+//! returns. A cell with no SGR colour resolves to the theme's default
+//! foreground — for the default `dark` theme, the exact shade the shader
+//! previously returned as a constant — so unstyled output is unchanged.
 //!
 //! Explicit SGR backgrounds emit one filled cell rectangle immediately before
 //! that cell's glyph, so the glyph remains legible over the background.
+//!
+//! The theme is selected through the `[theme]` configuration section and
+//! owned by the [`Renderer`]; every colour decision below — palette
+//! resolution, default foreground, clear colour — reads from it, so a theme
+//! that exists in configuration changes what is drawn.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -21,6 +26,7 @@ use wgpu::CurrentSurfaceTexture;
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
+use noren_app::theme::Theme;
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::{CellAttributes, Color, TerminalSnapshot};
 const GLYPH_SCALE: u32 = 2;
@@ -186,80 +192,13 @@ pub(crate) const VERTEX_ATTRIBUTES: [wgpu::VertexAttribute; 2] = [
 /// Default terminal foreground — the concrete colour behind a `Color::Default`
 /// foreground selection, the sidebar, and the status line.
 ///
-/// These are exactly the floats the fragment shader previously returned as a
-/// constant for every pixel. Keeping the value here rather than re-deriving it
-/// from an 8-bit triple is deliberate: rounding `0.80` through `u8` and back
-/// would shift the default shade slightly, and an unstyled prompt must look
-/// identical to how it looked before colour existed (issue #107).
-pub(crate) const DEFAULT_FOREGROUND: [f32; 3] = [0.80, 0.92, 0.82];
-
-/// Default terminal background as shader colour. Explicit backgrounds resolve
-/// through [`resolve_color`]; `Color::Default` emits no rectangle and leaves
-/// the render target's clear colour untouched.
-pub(crate) const DEFAULT_BACKGROUND: [f32; 3] = [0.035, 0.045, 0.04];
-
-/// The sixteen ANSI colours of the default theme as `(red, green, blue)` in
-/// palette-index order: standard colours `0..=7`, bright colours `8..=15`.
+/// The dark theme's value is exactly the floats the fragment shader
+/// previously returned as a constant for every pixel; see
+/// [`noren_app::theme::DARK`] (re-exported here as [`DARK`]) for the value
+/// and its history. Rounding `0.80` through `u8` and back would shift the
+/// default shade slightly, and an unstyled prompt must look identical to how
+/// it looked before colour existed (issue #107).
 ///
-/// This table is the single theme seam. The values are the xterm defaults; a
-/// future configurable theme replaces this table and every palette-derived
-/// draw colour follows without touching the resolution logic.
-pub(crate) const DEFAULT_ANSI_PALETTE: [[u8; 3]; 16] = [
-    [0, 0, 0],
-    [205, 0, 0],
-    [0, 205, 0],
-    [205, 205, 0],
-    [0, 0, 238],
-    [205, 0, 205],
-    [0, 205, 205],
-    [229, 229, 229],
-    [127, 127, 127],
-    [255, 0, 0],
-    [0, 255, 0],
-    [255, 255, 0],
-    [92, 92, 255],
-    [255, 0, 255],
-    [0, 255, 255],
-    [255, 255, 255],
-];
-
-/// One channel of the xterm 6×6×6 colour cube: level zero is zero, and the
-/// remaining five levels are `55 + 40 * level`.
-const fn cube_channel(level: u8) -> u8 {
-    if level == 0 { 0 } else { level * 40 + 55 }
-}
-
-/// Derive the full xterm 256-colour palette once, at compile time.
-const fn build_default_palette() -> [[u8; 3]; 256] {
-    let mut palette = [[0_u8; 3]; 256];
-    let mut index = 0_usize;
-    while index < 256 {
-        palette[index] = if index < 16 {
-            DEFAULT_ANSI_PALETTE[index]
-        } else if index < 232 {
-            let cube = (index - 16) as u32;
-            [
-                cube_channel((cube / 36) as u8),
-                cube_channel(((cube / 6) % 6) as u8),
-                cube_channel((cube % 6) as u8),
-            ]
-        } else {
-            let gray = (8 + (index - 232) * 10) as u8;
-            [gray, gray, gray]
-        };
-        index += 1;
-    }
-    palette
-}
-
-/// The xterm 256-colour default palette: entries `0..=15` from
-/// [`DEFAULT_ANSI_PALETTE`], `16..=231` the 6×6×6 colour cube, and
-/// `232..=255` the 24-step grayscale ramp.
-///
-/// The 16 ANSI colours and the 256-colour indexes resolve through this one
-/// table, so `SGR 31` and `SGR 38;5;1` cannot disagree about what red is.
-pub(crate) const DEFAULT_PALETTE: [[u8; 3]; 256] = build_default_palette();
-
 /// Convert an 8-bit-per-channel colour to the shader's `0.0..=1.0` floats.
 const fn channels_to_floats([red, green, blue]: [u8; 3]) -> [f32; 3] {
     [
@@ -269,37 +208,41 @@ const fn channels_to_floats([red, green, blue]: [u8; 3]) -> [f32; 3] {
     ]
 }
 
-/// Resolve one renderer-independent colour selection to a concrete draw colour.
+/// Resolve one renderer-independent colour selection to a concrete draw colour
+/// **through the selected theme**.
 ///
 /// [`Color::Default`] yields `default` (the caller supplies the contextual
 /// default for the slot), [`Color::Ansi`] and [`Color::Indexed`] both resolve
-/// through [`DEFAULT_PALETTE`] — one path, so the 16-colour and 256-colour
-/// forms of the same colour agree — and [`Color::Rgb`] passes through as
-/// direct 24-bit truecolor.
+/// through the theme's 256-colour table — one path, so the 16-colour and
+/// 256-colour forms of the same colour agree — and [`Color::Rgb`] passes
+/// through as direct 24-bit truecolor.
 #[must_use]
-pub(crate) fn resolve_color(color: Color, default: [f32; 3]) -> [f32; 3] {
+pub(crate) fn resolve_color(theme: &Theme, color: Color, default: [f32; 3]) -> [f32; 3] {
     match color {
         Color::Default => default,
-        Color::Ansi(ansi) => channels_to_floats(DEFAULT_PALETTE[ansi.palette_index() as usize]),
-        Color::Indexed(index) => channels_to_floats(DEFAULT_PALETTE[index as usize]),
+        Color::Ansi(ansi) => {
+            channels_to_floats(theme.indexed_palette()[ansi.palette_index() as usize])
+        }
+        Color::Indexed(index) => channels_to_floats(theme.indexed_palette()[index as usize]),
         Color::Rgb(red, green, blue) => channels_to_floats([red, green, blue]),
     }
 }
 
-/// The colour a cell's glyph is drawn in.
+/// The colour a cell's glyph is drawn in, under the selected theme.
 #[must_use]
-pub(crate) fn resolve_foreground(attributes: &CellAttributes) -> [f32; 3] {
-    resolve_color(attributes.foreground(), DEFAULT_FOREGROUND)
+pub(crate) fn resolve_foreground(theme: &Theme, attributes: &CellAttributes) -> [f32; 3] {
+    resolve_color(theme, attributes.foreground(), theme.foreground())
 }
 
-/// Resolve an explicit cell background through the same palette/truecolor path
-/// as foreground. `None` is intentional: an unstyled cell must remain exactly
-/// the clear colour, with no rectangle changing its rasterisation.
+/// Resolve an explicit cell background through the same theme palette /
+/// truecolor path as foreground. `None` is intentional: an unstyled cell must
+/// remain exactly the clear colour, with no rectangle changing its
+/// rasterisation.
 #[must_use]
-pub(crate) fn resolve_background(attributes: &CellAttributes) -> Option<[f32; 3]> {
+pub(crate) fn resolve_background(theme: &Theme, attributes: &CellAttributes) -> Option<[f32; 3]> {
     match attributes.background() {
         Color::Default => None,
-        background => Some(resolve_color(background, DEFAULT_BACKGROUND)),
+        background => Some(resolve_color(theme, background, theme.background())),
     }
 }
 
@@ -315,6 +258,25 @@ pub(crate) const CLEAR_COLOR: wgpu::Color = wgpu::Color {
     b: 0.04,
     a: 1.0,
 };
+
+/// The clear colour a theme's background becomes at the render-pass load op.
+///
+/// The dark theme clears with the exact historical [`CLEAR_COLOR`] constants
+/// (f64 literals, not f32-widened values) so the no-`[theme]` default keeps
+/// its pre-theme clear bit-for-bit; other themes clear to their own
+/// background.
+pub(crate) fn theme_clear_color(theme: &Theme) -> wgpu::Color {
+    if *theme == noren_app::theme::DARK {
+        return CLEAR_COLOR;
+    }
+    let [red, green, blue] = theme.background();
+    wgpu::Color {
+        r: red as f64,
+        g: green as f64,
+        b: blue as f64,
+        a: 1.0,
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RendererError {
@@ -342,10 +304,15 @@ pub(crate) struct Renderer {
     vertex_capacity: u64,
     device_lost: Arc<AtomicBool>,
     metrics: CellMetrics,
+    theme: Theme,
 }
 
 impl Renderer {
-    pub(crate) fn new(window: Arc<Window>, metrics: CellMetrics) -> Result<Self, RendererError> {
+    pub(crate) fn new(
+        window: Arc<Window>,
+        metrics: CellMetrics,
+        theme: Theme,
+    ) -> Result<Self, RendererError> {
         let size = window.inner_size();
         let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
         instance_descriptor.backends = wgpu::Backends::METAL;
@@ -435,6 +402,7 @@ impl Renderer {
             vertex_capacity,
             device_lost,
             metrics,
+            theme,
         })
     }
 
@@ -457,14 +425,13 @@ impl Renderer {
             return RenderOutcome::DeviceLost;
         }
 
-        let vertices = glyph_vertices(
-            terminal,
-            sidebar,
-            status,
+        let target = Target::new(
+            &self.theme,
             self.config.width,
             self.config.height,
             self.metrics,
         );
+        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
         if required > self.vertex_capacity {
@@ -508,7 +475,7 @@ impl Renderer {
                     depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(CLEAR_COLOR),
+                        load: wgpu::LoadOp::Clear(theme_clear_color(&self.theme)),
                         store: wgpu::StoreOp::Store,
                     },
                 })],
@@ -560,24 +527,17 @@ fn block_on<F: Future>(future: F) -> F::Output {
 /// for the sidebar text and the terminal is drawn starting at column
 /// `SIDEBAR_COLS`. When `sidebar` is `None`, the terminal occupies the full
 /// width starting at column 0 (preserving the pre-sidebar behaviour the frame
-/// oracle's existing tests rely on).
-pub(crate) fn glyph_vertices(
+/// oracle's existing tests rely on). Every colour decision — palette
+/// resolution, the sidebar/status default foreground, the clear colour the
+/// caller loads — reads from the target's theme, which is how a configured
+/// theme changes what is drawn.
+pub(crate) fn glyph_vertices_for(
+    target: Target,
     terminal: Option<&TerminalSnapshot>,
     sidebar: Option<&[String]>,
     status: Option<&str>,
-    width: u32,
-    height: u32,
-    metrics: CellMetrics,
 ) -> Vec<Vertex> {
-    glyph_vertices_with_budget(
-        terminal,
-        sidebar,
-        status,
-        width,
-        height,
-        metrics,
-        MAX_VERTICES,
-    )
+    glyph_vertices_with_budget(target, terminal, sidebar, status, MAX_VERTICES)
 }
 
 /// Internal seam for exercising the production vertex-budget backstop without
@@ -585,14 +545,14 @@ pub(crate) fn glyph_vertices(
 /// [`MAX_VERTICES`]; tests use a smaller budget but traverse this same emission
 /// code and the same post-primitive guards.
 fn glyph_vertices_with_budget(
+    target: Target,
     terminal: Option<&TerminalSnapshot>,
     sidebar: Option<&[String]>,
     status: Option<&str>,
-    width: u32,
-    height: u32,
-    metrics: CellMetrics,
     vertex_budget: usize,
 ) -> Vec<Vertex> {
+    let (width, height, metrics, theme) =
+        (target.width, target.height, target.metrics, target.theme);
     if width == 0 || height == 0 {
         return Vec::new();
     }
@@ -631,16 +591,12 @@ fn glyph_vertices_with_budget(
     let layout = FrameRowLayout::new(height, metrics, rows.len(), status.is_some())
         .expect("non-zero frame height has a row layout");
     let mut vertices = Vec::new();
-    let target = Target {
-        width,
-        height,
-        metrics,
-    };
 
     // The sidebar is chrome, not terminal content: it carries no cell
-    // attributes, so it draws in the default foreground. Unlike terminal and
-    // status rows, sidebar rows are interactive chrome and are only drawn when
-    // the whole cell is visible; sidebar hit testing uses this same count.
+    // attributes, so it draws in the theme's default foreground. Unlike
+    // terminal and status rows, sidebar rows are interactive chrome and are
+    // only drawn when the whole cell is visible; sidebar hit testing uses
+    // this same count.
     if let Some(lines) = sidebar {
         for (row, line) in lines
             .iter()
@@ -651,7 +607,7 @@ fn glyph_vertices_with_budget(
                 push_glyph(
                     &mut vertices,
                     character,
-                    DEFAULT_FOREGROUND,
+                    theme.foreground(),
                     col,
                     row,
                     target,
@@ -673,7 +629,7 @@ fn glyph_vertices_with_budget(
                     .get(line_index)
                     .expect("terminal layout only names display rows");
                 for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
-                    if let Some(color) = resolve_background(cell.attributes()) {
+                    if let Some(color) = resolve_background(&theme, cell.attributes()) {
                         push_rect(
                             &mut vertices,
                             u32::try_from(col_offset + col).unwrap_or(u32::MAX) * cell_width,
@@ -693,7 +649,7 @@ fn glyph_vertices_with_budget(
                     if cell.is_continuation() {
                         continue;
                     }
-                    let color = resolve_foreground(cell.attributes());
+                    let color = resolve_foreground(&theme, cell.attributes());
                     for character in cell.text().chars() {
                         push_glyph(
                             &mut vertices,
@@ -720,7 +676,7 @@ fn glyph_vertices_with_budget(
                     push_glyph(
                         &mut vertices,
                         character,
-                        DEFAULT_FOREGROUND,
+                        theme.foreground(),
                         col_offset + col,
                         row,
                         target,
@@ -735,17 +691,32 @@ fn glyph_vertices_with_budget(
     vertices
 }
 
-/// The draw surface a frame is laid out against: pixel dimensions plus the
-/// cell size the grid is drawn at.
+/// The draw surface a frame is laid out against: the selected theme plus the
+/// pixel dimensions and cell size the grid is drawn at.
 ///
-/// These three travel together through every emit call and are constant for a
+/// These four travel together through every emit call and are constant for a
 /// frame, so passing them as one value keeps the glyph/rect helpers to a
-/// readable arity now that each also carries a colour.
+/// readable arity; bundling the theme here is also what keeps the public
+/// vertex and capture seams under the argument-count lint without scattering
+/// the theme through every signature.
 #[derive(Clone, Copy, Debug)]
-struct Target {
-    width: u32,
-    height: u32,
-    metrics: CellMetrics,
+pub(crate) struct Target {
+    pub(crate) theme: Theme,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) metrics: CellMetrics,
+}
+
+impl Target {
+    /// Assemble one frame's draw surface.
+    pub(crate) fn new(theme: &Theme, width: u32, height: u32, metrics: CellMetrics) -> Self {
+        Self {
+            theme: *theme,
+            width,
+            height,
+            metrics,
+        }
+    }
 }
 
 /// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`.
@@ -1312,7 +1283,26 @@ fn glyph_rows(character: char) -> [u8; 7] {
 mod tests {
     use super::*;
     use noren_app::GridGeometry;
+    use noren_app::theme::DARK;
     use noren_terminal::TerminalState;
+
+    /// Default-theme vertex emission for test call sites: the shape the
+    /// pre-theme tests used, now entering through the [`Target`] seam.
+    fn frame_vertices(
+        terminal: Option<&TerminalSnapshot>,
+        sidebar: Option<&[String]>,
+        status: Option<&str>,
+        width: u32,
+        height: u32,
+        metrics: CellMetrics,
+    ) -> Vec<Vertex> {
+        glyph_vertices_for(
+            Target::new(&Theme::default(), width, height, metrics),
+            terminal,
+            sidebar,
+            status,
+        )
+    }
 
     fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
         let mut terminal = TerminalState::new(rows, cols).expect("valid test terminal");
@@ -1323,6 +1313,19 @@ mod tests {
     /// The PoC default cell metrics for tests that exercise the default path.
     fn poc_metrics() -> CellMetrics {
         GridGeometry::poc().cell_metrics()
+    }
+
+    /// The dark theme's clear colour is the exact historical constant — f64
+    /// literals, not f32-widened values — so the no-`[theme]` default keeps
+    /// its pre-theme clear bit-for-bit (`theme_clear_color` special-cases
+    /// dark for exactly this reason).
+    #[test]
+    fn dark_theme_clear_colour_is_the_historical_constant() {
+        let dark = theme_clear_color(&Theme::default());
+        assert_eq!(
+            (dark.r, dark.g, dark.b, dark.a),
+            (CLEAR_COLOR.r, CLEAR_COLOR.g, CLEAR_COLOR.b, CLEAR_COLOR.a)
+        );
     }
 
     // NOTE: the renderer's row/column clamp coverage used to live here as
@@ -1372,21 +1375,17 @@ mod tests {
         let sidebar_width = u32::try_from(SIDEBAR_COLS).unwrap_or(u32::MAX) * metrics.width();
         assert_truncated(
             "sidebar glyph",
-            glyph_vertices(
+            glyph_vertices_for(
+                Target::new(&Theme::default(), sidebar_width, height, metrics),
                 None,
                 Some(sidebar.as_slice()),
                 None,
-                sidebar_width,
-                height,
-                metrics,
             ),
             glyph_vertices_with_budget(
+                Target::new(&Theme::default(), sidebar_width, height, metrics),
                 None,
                 Some(sidebar.as_slice()),
                 None,
-                sidebar_width,
-                height,
-                metrics,
                 glyph_budget,
             ),
             glyph_budget,
@@ -1395,21 +1394,17 @@ mod tests {
         let background_terminal = snapshot(1, 1, b"\x1b[48;2;12;98;201mA");
         assert_truncated(
             "terminal background rectangle",
-            glyph_vertices(
+            glyph_vertices_for(
+                Target::new(&Theme::default(), metrics.width(), height, metrics),
                 Some(&background_terminal),
                 None,
                 None,
-                metrics.width(),
-                height,
-                metrics,
             ),
             glyph_vertices_with_budget(
+                Target::new(&Theme::default(), metrics.width(), height, metrics),
                 Some(&background_terminal),
                 None,
                 None,
-                metrics.width(),
-                height,
-                metrics,
                 VERTICES_PER_RECT,
             ),
             VERTICES_PER_RECT,
@@ -1428,21 +1423,17 @@ mod tests {
         );
         assert_truncated(
             "terminal cell glyph",
-            glyph_vertices(
+            glyph_vertices_for(
+                Target::new(&Theme::default(), metrics.width(), height, metrics),
                 Some(&terminal_glyphs),
                 None,
                 None,
-                metrics.width(),
-                height,
-                metrics,
             ),
             glyph_vertices_with_budget(
+                Target::new(&Theme::default(), metrics.width(), height, metrics),
                 Some(&terminal_glyphs),
                 None,
                 None,
-                metrics.width(),
-                height,
-                metrics,
                 glyph_budget,
             ),
             glyph_budget,
@@ -1451,14 +1442,17 @@ mod tests {
         let status_width = 2 * metrics.width();
         assert_truncated(
             "status glyph",
-            glyph_vertices(None, None, Some("AA"), status_width, height, metrics),
-            glyph_vertices_with_budget(
+            glyph_vertices_for(
+                Target::new(&Theme::default(), status_width, height, metrics),
                 None,
                 None,
                 Some("AA"),
-                status_width,
-                height,
-                metrics,
+            ),
+            glyph_vertices_with_budget(
+                Target::new(&Theme::default(), status_width, height, metrics),
+                None,
+                None,
+                Some("AA"),
                 glyph_budget,
             ),
             glyph_budget,
@@ -1548,7 +1542,7 @@ mod tests {
         let width = (SIDEBAR_COLS as u32) * metrics.width();
         let lines = vec!["A".to_owned(), "B".to_owned()];
         let draw =
-            |height| glyph_vertices(None, Some(lines.as_slice()), None, width, height, metrics);
+            |height| frame_vertices(None, Some(lines.as_slice()), None, width, height, metrics);
         let first_row_vertices = glyph_rows('A')
             .iter()
             .map(|row| row.count_ones() as usize)
@@ -1576,8 +1570,8 @@ mod tests {
     fn empty_and_zero_sized_inputs_have_no_vertices() {
         let empty = snapshot(1, 1, b"");
         let text = snapshot(1, 8, b"text");
-        assert!(glyph_vertices(Some(&empty), None, None, 900, 600, poc_metrics()).is_empty());
-        assert!(glyph_vertices(Some(&text), None, None, 0, 600, poc_metrics()).is_empty());
+        assert!(frame_vertices(Some(&empty), None, None, 900, 600, poc_metrics()).is_empty());
+        assert!(frame_vertices(Some(&text), None, None, 0, 600, poc_metrics()).is_empty());
     }
 
     /// The 16-colour and 256-colour forms of the same colour must resolve
@@ -1589,26 +1583,30 @@ mod tests {
         // `SGR 31` (ANSI red) and `SGR 38;5;1` (indexed 1) name the same
         // colour and must produce identical draw colours.
         assert_eq!(
-            resolve_color(Color::Ansi(AnsiColor::Red), DEFAULT_FOREGROUND),
-            resolve_color(Color::Indexed(1), DEFAULT_FOREGROUND),
+            resolve_color(
+                &Theme::default(),
+                Color::Ansi(AnsiColor::Red),
+                DARK.foreground()
+            ),
+            resolve_color(&Theme::default(), Color::Indexed(1), DARK.foreground()),
         );
         // Truecolor passes through as exact 24-bit channels.
         assert_eq!(
-            resolve_color(Color::Rgb(255, 0, 0), DEFAULT_FOREGROUND),
+            resolve_color(&Theme::default(), Color::Rgb(255, 0, 0), DARK.foreground()),
             [1.0, 0.0, 0.0]
         );
         // Default takes the contextual default the caller supplied.
         assert_eq!(
-            resolve_color(Color::Default, DEFAULT_FOREGROUND),
-            DEFAULT_FOREGROUND
+            resolve_color(&Theme::default(), Color::Default, DARK.foreground()),
+            DARK.foreground()
         );
         // Spot-check the xterm cube and grayscale derivations: index 196 is
         // cube (5,0,0) = pure red, and 232 is the darkest gray step.
-        assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
-        assert_eq!(DEFAULT_PALETTE[232], [8, 8, 8]);
-        assert_eq!(DEFAULT_PALETTE[255], [238, 238, 238]);
+        assert_eq!(DARK.indexed_palette()[196], [255, 0, 0]);
+        assert_eq!(DARK.indexed_palette()[232], [8, 8, 8]);
+        assert_eq!(DARK.indexed_palette()[255], [238, 238, 238]);
         // Distinct palette entries must stay distinct.
-        assert_ne!(DEFAULT_PALETTE[1], DEFAULT_PALETTE[4]);
+        assert_ne!(DARK.indexed_palette()[1], DARK.indexed_palette()[4]);
     }
 
     /// A cell's resolved colour must reach the vertices its glyph emits —
@@ -1617,8 +1615,8 @@ mod tests {
     fn sgr_foreground_reaches_the_vertex_colour() {
         // Red 'A' then default-coloured 'B'.
         let terminal = snapshot(1, 4, b"\x1b[31mA\x1b[0mB");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
-        let red = channels_to_floats(DEFAULT_ANSI_PALETTE[1]);
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let red = channels_to_floats(DARK.ansi()[1]);
         assert!(
             vertices.iter().any(|vertex| vertex.color == red),
             "the SGR-31 cell must emit vertices in palette red"
@@ -1626,7 +1624,7 @@ mod tests {
         assert!(
             vertices
                 .iter()
-                .any(|vertex| vertex.color == DEFAULT_FOREGROUND),
+                .any(|vertex| vertex.color == DARK.foreground()),
             "the unstyled cell must emit vertices in the default foreground"
         );
     }
@@ -1634,7 +1632,7 @@ mod tests {
     #[test]
     fn explicit_background_emits_a_full_rect_before_the_glyph() {
         let terminal = snapshot(1, 1, b"\x1b[38;2;241;207;33;48;2;12;98;201mA");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         let background = channels_to_floats([12, 98, 201]);
         let foreground = channels_to_floats([241, 207, 33]);
 
@@ -1667,7 +1665,7 @@ mod tests {
     #[test]
     fn default_background_emits_no_extra_vertices() {
         let terminal = snapshot(1, 1, b"A");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         let glyph_pixels = glyph_rows('A')
             .iter()
             .map(|row| row.count_ones() as usize)
@@ -1689,7 +1687,7 @@ mod tests {
         );
         let width = u32::from(MAX_RENDER_COLS + 1) * 10;
         let height = u32::from(MAX_RENDER_ROWS + 1) * 20;
-        let vertices = glyph_vertices(Some(&terminal), None, None, width, height, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, width, height, poc_metrics());
 
         let contains = |row: usize, col: usize| {
             let left = col as f32 * 10.0 / width as f32 * 2.0 - 1.0;
@@ -1851,7 +1849,7 @@ mod tests {
         let height = metrics.height();
         let vertices_for = |text: &str| {
             let terminal = snapshot(1, 1, text.as_bytes());
-            glyph_vertices(Some(&terminal), None, None, width, height, metrics)
+            frame_vertices(Some(&terminal), None, None, width, height, metrics)
         };
 
         let horizontal = vertices_for("─");
@@ -1875,7 +1873,7 @@ mod tests {
     #[test]
     fn vertex_encoding_matches_the_declared_buffer_layout() {
         let terminal = snapshot(1, 2, b"A");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         assert!(!vertices.is_empty(), "'A' emitted no vertices");
         assert_eq!(
             vertex_bytes(&vertices).len(),
@@ -1895,7 +1893,7 @@ mod tests {
     #[test]
     fn unstyled_cells_draw_in_the_previous_constant_foreground() {
         let terminal = snapshot(1, 4, b"AB");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         assert!(!vertices.is_empty(), "unstyled text emitted no vertices");
         assert!(
             vertices
@@ -1903,7 +1901,7 @@ mod tests {
                 .all(|vertex| vertex.color == [0.80, 0.92, 0.82]),
             "unstyled cells must draw in the historical constant 0.80/0.92/0.82"
         );
-        assert_eq!(DEFAULT_FOREGROUND, [0.80, 0.92, 0.82]);
+        assert_eq!(DARK.foreground(), [0.80, 0.92, 0.82]);
     }
 
     const CELL_WIDTH: u32 = noren_app::POC_CELL_WIDTH;
@@ -1926,7 +1924,7 @@ mod tests {
     #[test]
     fn wide_characters_place_following_glyphs_at_display_columns() {
         let terminal = snapshot(1, 6, "a日b".as_bytes());
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
 
         // a occupies column 0, 日 columns 1-2, so b must start at display
         // column 3 and nothing may draw at column 2's lead edge.
@@ -1944,8 +1942,8 @@ mod tests {
         let aligned = snapshot(1, 6, "a\u{fffd} b".as_bytes());
         let m = poc_metrics();
         assert_eq!(
-            glyph_vertices(Some(&wide), None, None, 900, 600, m),
-            glyph_vertices(Some(&aligned), None, None, 900, 600, m),
+            frame_vertices(Some(&wide), None, None, 900, 600, m),
+            frame_vertices(Some(&aligned), None, None, 900, 600, m),
             "the wide lead draws in column 1, its continuation column stays empty, and b lands in column 3"
         );
     }
@@ -1953,7 +1951,7 @@ mod tests {
     #[test]
     fn ascii_glyphs_keep_their_character_columns() {
         let terminal = snapshot(1, 4, b"BD");
-        let vertices = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         assert!(has_rect_top_left(&vertices, ndc_left(0)));
         assert!(has_rect_top_left(&vertices, ndc_left(1)));
         assert!(!has_rect_top_left(&vertices, ndc_left(2)));
@@ -1974,11 +1972,11 @@ mod tests {
     #[test]
     fn non_default_cell_metrics_change_what_the_renderer_draws() {
         let terminal = snapshot(1, 4, b"BBBB");
-        let small = glyph_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
+        let small = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         let big = GridGeometry::with_cells(20, 40)
             .expect("valid metrics")
             .cell_metrics();
-        let big_verts = glyph_vertices(Some(&terminal), None, None, 900, 600, big);
+        let big_verts = frame_vertices(Some(&terminal), None, None, 900, 600, big);
 
         assert_ne!(
             small, big_verts,

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -48,10 +48,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread;
 
-use noren_app::CellMetrics;
 use noren_terminal::TerminalSnapshot;
 use renderer_source::{
-    CLEAR_COLOR, SHADER, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices, vertex_bytes,
+    SHADER, Target, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices_for, theme_clear_color,
+    vertex_bytes,
 };
 
 /// Linear RGBA8 (non-sRGB) offscreen target.
@@ -237,25 +237,31 @@ impl OffscreenRenderer {
         })
     }
 
-    /// Render the given terminal snapshot to an offscreen `width` x `height`
+    /// Render the given terminal snapshot to an offscreen `target`-sized
     /// texture and return its RGBA pixels.
     ///
-    /// `width`/`height` should be exact multiples of the PoC cell size so the
+    /// The target should be exact multiples of the PoC cell size so the
     /// rendered grid is exactly the state grid. The pipeline, vertex
-    /// generation, and clear colour are the shipped renderer's.
+    /// generation, and clear colour are the shipped renderer's, all read from
+    /// the target's [`Theme`] — the same value the binary's `Renderer` holds —
+    /// so the oracle exercises the exact colour path configuration selects.
+    ///
+    /// [`Theme`]: noren_app::theme::Theme
     pub(crate) fn capture(
         &self,
+        target: Target,
         terminal: Option<&TerminalSnapshot>,
         sidebar: Option<&[String]>,
         status: Option<&str>,
-        width: u32,
-        height: u32,
-        metrics: CellMetrics,
     ) -> CapturedFrame {
-        assert!(width > 0 && height > 0, "capture target must be non-zero");
+        assert!(
+            target.width > 0 && target.height > 0,
+            "capture target must be non-zero"
+        );
 
-        let vertices = glyph_vertices(terminal, sidebar, status, width, height, metrics);
+        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
+        let (width, height) = (target.width, target.height);
 
         let vertex_buffer = if bytes.is_empty() {
             None
@@ -308,7 +314,7 @@ impl OffscreenRenderer {
                     depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(CLEAR_COLOR),
+                        load: wgpu::LoadOp::Clear(theme_clear_color(&target.theme)),
                         store: wgpu::StoreOp::Store,
                     },
                 })],

--- a/crates/noren-app/src/theme.rs
+++ b/crates/noren-app/src/theme.rs
@@ -1,0 +1,434 @@
+//! Built-in colour themes with verified WCAG contrast.
+//!
+//! This is the foundation slice of Milestone 6: the renderer's palette moves
+//! from a single compiled-in table to a selectable set of built-in themes —
+//! `dark` (exactly today's behaviour), `light`, and `high-contrast` — and
+//! every theme carries a measured, asserted contrast floor.
+//!
+//! # What a theme owns
+//!
+//! A [`Theme`] owns the colours the *application* chooses, not the ones a
+//! program names explicitly:
+//!
+//! - the default foreground (unstyled text, sidebar, status line),
+//! - the default background (the render target's clear colour),
+//! - the sixteen ANSI palette entries (`SGR 30..37`, `90..97`, `40..47`,
+//!   `100..107`) that programs select by name.
+//!
+//! The xterm 256-colour cube and grayscale ramp (`16..=255`) and direct
+//! truecolor are program-addressed device colours: they resolve through the
+//! same per-theme table with the shared cube appended after the theme's own
+//! sixteen ANSI entries, so `SGR 31` and `SGR 38;5;1` can never disagree.
+//!
+//! # The contrast contract
+//!
+//! The checked set is every theme-owned foreground — the default foreground
+//! plus all sixteen ANSI entries — against the theme's default background:
+//! the colours a program draws *normal* text with on the screen it is given.
+//! That is the reading path (shell output, prompts, `ls` colours), so the
+//! threshold is **WCAG AA for normal text, 4.5:1**, not the 3:1 large-text
+//! relaxation: a terminal's glyphs are small (5×7 bitmaps inside 10×20 px
+//! cells), never "large text".
+//!
+//! Two scopes are deliberately **outside** the contract because no palette
+//! can honour them, not because they were forgotten:
+//!
+//! - *program-paired colours* (`SGR 31;41` red on red, or any explicit
+//!   foreground/background pair a program names itself): identical colours
+//!   are 1.0:1 by definition, and any two palette entries used both ways
+//!   cannot simultaneously sit far enough from the background and near
+//!   enough to each other's extremes;
+//! - *the shared 256-colour cube* (`16..=255`) and *truecolor*: their
+//!   extremes (the cube's black corner) fail on every background including
+//!   pure white and pure black; a program selecting index 16 has asked for
+//!   that device colour.
+//!
+//! # The dark-palette finding
+//!
+//! The existing default (`dark`) **fails** the 4.5:1 floor for five of its
+//! sixteen ANSI entries on its own background — ANSI black at 1.06:1, blue
+//! at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and magenta at
+//! 4.21:1. This is reported, not fixed here: the dark values are the xterm
+//! defaults the app shipped with since colour landed (issues #107/#112),
+//! and changing them would change today's rendered pixels, which the
+//! defaults-preservation contract of this slice forbids
+//! ([`tests/frame_oracle.rs`] proves byte-identity). The measured minimum
+//! is pinned by test so any change — fix or regression — is a deliberate,
+//! visible decision. `high-contrast` is the theme users who need AA on
+//! every slot can select today: its minimum is ≥ 7:1 (WCAG AAA for normal
+//! text), strictly exceeding both other themes.
+
+use std::fmt;
+
+/// Names the theme's default slot in [`Theme::min_contrast_on_default_background`].
+pub(crate) const DEFAULT_FOREGROUND_SLOT: &str = "default foreground";
+
+/// Slot labels for the sixteen ANSI entries, in palette-index order.
+const ANSI_SLOT_NAMES: [&str; 16] = [
+    "black",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "white",
+    "bright black",
+    "bright red",
+    "bright green",
+    "bright yellow",
+    "bright blue",
+    "bright magenta",
+    "bright cyan",
+    "bright white",
+];
+
+/// One of the built-in themes, as named by the `[theme]` configuration.
+///
+/// [`ThemeName::default`] is `Dark`: with no `[theme]` section the app
+/// renders exactly as it did before themes existed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ThemeName {
+    /// Today's palette: xterm ANSI defaults on the near-black background.
+    #[default]
+    Dark,
+    /// A light background with darkened ANSI entries.
+    Light,
+    /// Pure white on pure black with pastel ANSI entries; every slot meets
+    /// WCAG AAA (7:1) for normal text.
+    HighContrast,
+}
+
+impl ThemeName {
+    /// Every accepted `[theme]` name, in documentation order.
+    pub const NAMES: [&'static str; 3] = ["dark", "light", "high-contrast"];
+
+    /// Resolve one configuration value to a theme name.
+    ///
+    /// Matching is exact (case-sensitive): a theme name is a closed
+    /// vocabulary, and accepting `Dark` or `DARK` would be a second spelling
+    /// of the same setting rather than a default. Unmatched values are the
+    /// caller's typed error, never a fallback.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "dark" => Some(Self::Dark),
+            "light" => Some(Self::Light),
+            "high-contrast" => Some(Self::HighContrast),
+            _ => None,
+        }
+    }
+
+    /// The canonical configuration name of this theme.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Dark => "dark",
+            Self::Light => "light",
+            Self::HighContrast => "high-contrast",
+        }
+    }
+
+    /// The concrete palette this name selects.
+    #[must_use]
+    pub const fn palette(self) -> Theme {
+        match self {
+            Self::Dark => DARK,
+            Self::Light => LIGHT,
+            Self::HighContrast => HIGH_CONTRAST,
+        }
+    }
+}
+
+impl fmt::Display for ThemeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The sixteen ANSI colours of the dark theme: the xterm defaults, unchanged
+/// since issue #107 wired colour into the renderer.
+///
+/// Byte-identity with the pre-theme renderer is load-bearing (see the module
+/// docs); these values are pinned by test.
+const DARK_ANSI: [[u8; 3]; 16] = [
+    [0, 0, 0],
+    [205, 0, 0],
+    [0, 205, 0],
+    [205, 205, 0],
+    [0, 0, 238],
+    [205, 0, 205],
+    [0, 205, 205],
+    [229, 229, 229],
+    [127, 127, 127],
+    [255, 0, 0],
+    [0, 255, 0],
+    [255, 255, 0],
+    [92, 92, 255],
+    [255, 0, 255],
+    [0, 255, 255],
+    [255, 255, 255],
+];
+
+/// The dark theme's default foreground, as the exact floats the fragment
+/// shader historically returned as a constant.
+///
+/// Keeping the raw floats (rather than re-deriving from the 8-bit triple
+/// 204/235/209) preserves the shipped shade bit-for-bit; see the twin
+/// constant in the renderer for the original rationale.
+const DARK_FOREGROUND: [f32; 3] = [0.80, 0.92, 0.82];
+
+/// The dark theme's default background, as the exact clear-colour floats.
+const DARK_BACKGROUND: [f32; 3] = [0.035, 0.045, 0.04];
+
+/// The light theme's sixteen ANSI entries: darkened, screen-oriented values
+/// chosen so every entry keeps at least 5:1 against the light background
+/// (AA 4.5:1 with margin). Slot semantics are preserved, not inverted
+/// wholesale: the "white" slots (7, 15) carry dark greys because a light
+/// theme's white-on-white would be the unreadable extreme the contract
+/// exists to prevent.
+const LIGHT_ANSI: [[u8; 3]; 16] = [
+    [59, 59, 59],
+    [176, 48, 48],
+    [0, 118, 40],
+    [124, 100, 0],
+    [0, 66, 148],
+    [148, 32, 148],
+    [0, 110, 132],
+    [95, 102, 104],
+    [102, 102, 102],
+    [190, 54, 54],
+    [0, 122, 44],
+    [126, 95, 0],
+    [64, 86, 190],
+    [164, 44, 164],
+    [0, 112, 130],
+    [72, 79, 84],
+];
+
+/// The light theme's background as shader floats (u8 channels over 255).
+const LIGHT_BACKGROUND: [f32; 3] = [246.0 / 255.0, 246.0 / 255.0, 240.0 / 255.0];
+
+/// The light theme's foreground as shader floats.
+const LIGHT_FOREGROUND: [f32; 3] = [31.0 / 255.0, 35.0 / 255.0, 40.0 / 255.0];
+
+/// The high-contrast theme's sixteen ANSI entries: pastel values on pure
+/// black. Every slot — including the grey slots that drive this theme's
+/// minimum — keeps at least 7.5:1, clearing WCAG AAA (7:1) for normal text
+/// with margin.
+const HIGH_CONTRAST_ANSI: [[u8; 3]; 16] = [
+    [160, 160, 160],
+    [255, 176, 176],
+    [176, 255, 176],
+    [255, 255, 176],
+    [176, 176, 255],
+    [255, 176, 255],
+    [176, 255, 255],
+    [224, 224, 224],
+    [158, 158, 158],
+    [255, 192, 192],
+    [192, 255, 192],
+    [255, 255, 192],
+    [192, 192, 255],
+    [255, 192, 255],
+    [192, 255, 255],
+    [255, 255, 255],
+];
+
+/// The high-contrast theme's background: pure black.
+const HIGH_CONTRAST_BACKGROUND: [f32; 3] = [0.0, 0.0, 0.0];
+
+/// The high-contrast theme's foreground: pure white (21:1 on its ground).
+const HIGH_CONTRAST_FOREGROUND: [f32; 3] = [1.0, 1.0, 1.0];
+
+/// One channel of the xterm 6×6×6 colour cube: level zero is zero, and the
+/// remaining five levels are `55 + 40 * level`.
+const fn cube_channel(level: u8) -> u8 {
+    if level == 0 { 0 } else { level * 40 + 55 }
+}
+
+/// Derive a full 256-colour table once, at compile time: the given sixteen
+/// ANSI entries followed by the shared xterm cube and grayscale ramp.
+const fn build_palette(ansi: [[u8; 3]; 16]) -> [[u8; 3]; 256] {
+    let mut palette = [[0_u8; 3]; 256];
+    let mut index = 0_usize;
+    while index < 256 {
+        palette[index] = if index < 16 {
+            ansi[index]
+        } else if index < 232 {
+            let cube = (index - 16) as u32;
+            [
+                cube_channel((cube / 36) as u8),
+                cube_channel(((cube / 6) % 6) as u8),
+                cube_channel((cube % 6) as u8),
+            ]
+        } else {
+            let gray = (8 + (index - 232) * 10) as u8;
+            [gray, gray, gray]
+        };
+        index += 1;
+    }
+    palette
+}
+
+/// The per-theme 256-colour tables, ANSI head plus the shared xterm tail.
+const DARK_PALETTE: [[u8; 3]; 256] = build_palette(DARK_ANSI);
+const LIGHT_PALETTE: [[u8; 3]; 256] = build_palette(LIGHT_ANSI);
+const HIGH_CONTRAST_PALETTE: [[u8; 3]; 256] = build_palette(HIGH_CONTRAST_ANSI);
+
+/// A concrete, selected palette: the colours drawing resolves through.
+///
+/// `Copy` and const-constructible so the renderer holds it by value and the
+/// default (`dark`) is a compile-time constant.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Theme {
+    ansi: [[u8; 3]; 16],
+    palette256: &'static [[u8; 3]; 256],
+    foreground: [f32; 3],
+    background: [f32; 3],
+}
+
+/// The built-in `dark` theme: exactly the pre-theme renderer's colours.
+pub const DARK: Theme = Theme {
+    ansi: DARK_ANSI,
+    palette256: &DARK_PALETTE,
+    foreground: DARK_FOREGROUND,
+    background: DARK_BACKGROUND,
+};
+
+/// The built-in `light` theme.
+pub const LIGHT: Theme = Theme {
+    ansi: LIGHT_ANSI,
+    palette256: &LIGHT_PALETTE,
+    foreground: LIGHT_FOREGROUND,
+    background: LIGHT_BACKGROUND,
+};
+
+/// The built-in `high-contrast` theme.
+pub const HIGH_CONTRAST: Theme = Theme {
+    ansi: HIGH_CONTRAST_ANSI,
+    palette256: &HIGH_CONTRAST_PALETTE,
+    foreground: HIGH_CONTRAST_FOREGROUND,
+    background: HIGH_CONTRAST_BACKGROUND,
+};
+
+impl Default for Theme {
+    fn default() -> Self {
+        DARK
+    }
+}
+
+impl Theme {
+    /// The theme's default foreground as shader floats: unstyled text, the
+    /// sidebar, and the status line draw in this colour.
+    #[must_use]
+    pub const fn foreground(self) -> [f32; 3] {
+        self.foreground
+    }
+
+    /// The theme's default background as shader floats: the render target's
+    /// clear colour and the ground explicit backgrounds cover.
+    #[must_use]
+    pub const fn background(self) -> [f32; 3] {
+        self.background
+    }
+
+    /// The foreground as the 8-bit triple actually stored by the RGBA8
+    /// render target — `(channel * 255).round()` — which is the value
+    /// contrast must be measured on: measuring the float would hide the
+    /// quantization every drawn pixel undergoes.
+    #[must_use]
+    pub fn foreground_u8(self) -> [u8; 3] {
+        quantize(self.foreground)
+    }
+
+    /// The background as the 8-bit triple actually stored by the RGBA8
+    /// render target; see [`Theme::foreground_u8`].
+    #[must_use]
+    pub fn background_u8(self) -> [u8; 3] {
+        quantize(self.background)
+    }
+
+    /// The theme's sixteen ANSI palette entries, in palette-index order.
+    #[must_use]
+    pub const fn ansi(self) -> [[u8; 3]; 16] {
+        self.ansi
+    }
+
+    /// The full 256-colour table drawing resolves `Ansi` and `Indexed`
+    /// selections through: the theme's sixteen entries followed by the
+    /// shared xterm cube (`16..=231`) and grayscale ramp (`232..=255`), so
+    /// the two spellings of one colour cannot disagree.
+    #[must_use]
+    pub const fn indexed_palette(self) -> &'static [[u8; 3]; 256] {
+        self.palette256
+    }
+
+    /// The worst WCAG contrast ratio any theme-owned foreground achieves on
+    /// the theme's default background, with the slot that produced it.
+    ///
+    /// This is the single number the contrast contract is asserted on: the
+    /// checked foregrounds are the default foreground and all sixteen ANSI
+    /// entries (the module docs state why program-paired colours and the
+    /// shared cube are out of scope). Tests pin the per-theme minima, so
+    /// degrading any pair below its floor fails.
+    #[must_use]
+    pub fn min_contrast_on_default_background(self) -> (f64, &'static str) {
+        let ground = self.background_u8();
+        let mut worst = (
+            contrast_ratio(self.foreground_u8(), ground),
+            DEFAULT_FOREGROUND_SLOT,
+        );
+        for (slot, color) in self.ansi().into_iter().enumerate() {
+            let ratio = contrast_ratio(color, ground);
+            if ratio < worst.0 {
+                worst = (ratio, ANSI_SLOT_NAMES[slot]);
+            }
+        }
+        worst
+    }
+}
+
+/// Quantize shader floats to the 8-bit channels the RGBA8 target stores.
+const fn quantize([red, green, blue]: [f32; 3]) -> [u8; 3] {
+    // `round` is not const-stable on floats in all toolchains this crate
+    // pins; the half-up bias here matches `(x * 255.0).round()` for every
+    // channel value these themes define (verified by the theme tests, which
+    // recompute the quantization with the runtime `round`).
+    [
+        (red * 255.0 + 0.5) as u8,
+        (green * 255.0 + 0.5) as u8,
+        (blue * 255.0 + 0.5) as u8,
+    ]
+}
+
+/// Linearize one 8-bit sRGB channel per WCAG 2.x.
+fn linear_channel(channel: u8) -> f64 {
+    let value = f64::from(channel) / 255.0;
+    if value <= 0.04045 {
+        value / 12.92
+    } else {
+        ((value + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// WCAG 2.x relative luminance of an 8-bit sRGB triple.
+#[must_use]
+pub fn relative_luminance([red, green, blue]: [u8; 3]) -> f64 {
+    0.2126 * linear_channel(red) + 0.7152 * linear_channel(green) + 0.0722 * linear_channel(blue)
+}
+
+/// WCAG 2.x contrast ratio between two colours, in `1.0..=21.0`.
+///
+/// Order-independent: the lighter colour is always the numerator, exactly as
+/// the WCAG definition specifies.
+#[must_use]
+pub fn contrast_ratio(first: [u8; 3], second: [u8; 3]) -> f64 {
+    let (first, second) = (relative_luminance(first), relative_luminance(second));
+    let (lighter, darker) = if first >= second {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    (lighter + 0.05) / (darker + 0.05)
+}

--- a/crates/noren-app/tests/error_echo_contract.rs
+++ b/crates/noren-app/tests/error_echo_contract.rs
@@ -50,11 +50,14 @@ enum ValueEcho {
     /// Echo allowlist: the variant may carry `[keys]` chord text, clipped
     /// to 120 characters, for the reason documented on the variant itself.
     ChordText,
+    /// Echo allowlist: the variant may carry `[theme]` name text, clipped
+    /// to 120 characters, for the reason documented on the variant itself.
+    ThemeName,
 }
 
 /// Pinned variant count of [`ConfigError`]; a new variant must extend both
 /// the classifier and the sample table.
-const CONFIG_ERROR_VARIANTS: usize = 14;
+const CONFIG_ERROR_VARIANTS: usize = 16;
 /// Pinned variant count of [`SessionPersistenceError`].
 const SESSION_ERROR_VARIANTS: usize = 14;
 /// Pinned variant count of [`ChordParseError`].
@@ -68,6 +71,9 @@ const PTY_ERROR_VARIANTS: usize = 16;
 /// Pinned allowlist size across every file-derived enum. Raising this
 /// number is the reviewed decision to admit a new value echo.
 const CHORD_ALLOWLIST_SIZE: usize = 6;
+/// Pinned size of the `[theme]` name echo allowlist; see
+/// [`CHORD_ALLOWLIST_SIZE`] for the policy.
+const THEME_NAME_ALLOWLIST_SIZE: usize = 1;
 /// Sample payload convention (policed by the pin test): key-shaped sample
 /// fields carry `sample_key` and may render; any **value-shaped** sample
 /// field must carry this sentinel so the test can check the classification
@@ -89,6 +95,11 @@ fn classify_config(error: &ConfigError) -> ValueEcho {
         ConfigError::WrongType { .. } => ValueEcho::Never,
         ConfigError::OutOfRange { .. } => ValueEcho::Never,
         ConfigError::ChordNotAString { .. } => ValueEcho::Never,
+        ConfigError::ThemeNotAString { .. } => ValueEcho::Never,
+        // Allowlist: the theme name vocabulary — a closed set the schema
+        // publishes — and naming the failed value is the point of the
+        // error, exactly the `[keys]` chord argument.
+        ConfigError::UnknownTheme { .. } => ValueEcho::ThemeName,
         // Allowlist: unparsed chord text plus its clipped parse reason —
         // naming the failed binding is the point of the error.
         ConfigError::InvalidChord { .. } => ValueEcho::ChordText,
@@ -217,6 +228,16 @@ fn config_samples() -> Vec<(ConfigError, ValueEcho)> {
         (
             ConfigError::ChordNotAString { key: key() },
             ValueEcho::Never,
+        ),
+        (
+            ConfigError::ThemeNotAString { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::UnknownTheme {
+                value: VALUE_SENTINEL.to_owned(),
+            },
+            ValueEcho::ThemeName,
         ),
         (
             ConfigError::InvalidChord {
@@ -461,6 +482,12 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
                 "an allowlisted variant must echo its chord text: {sample}"
             );
         }
+        ValueEcho::ThemeName => {
+            assert!(
+                sample.contains(VALUE_SENTINEL),
+                "an allowlisted variant must echo its theme name text: {sample}"
+            );
+        }
     };
     for (sample, class) in &config {
         assert_rendering(sample.to_string(), format!("{sample:?}"), *class);
@@ -497,6 +524,18 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
         allowlist, CHORD_ALLOWLIST_SIZE,
         "the echo allowlist changed size; admitting a new value echo is a \
          reviewed decision (update this pin and the variant docs together)"
+    );
+
+    let theme_allowlist = config
+        .iter()
+        .map(|(_, class)| *class)
+        .filter(|class| *class == ValueEcho::ThemeName)
+        .count();
+    assert_eq!(
+        theme_allowlist, THEME_NAME_ALLOWLIST_SIZE,
+        "the [theme] name echo allowlist changed size; admitting a new value \
+         echo is a reviewed decision (update this pin and the variant docs \
+         together)"
     );
 }
 
@@ -625,6 +664,44 @@ fn allowlisted_chord_variants_still_echo_the_offending_chord() {
     assert!(
         display.contains("chord n"),
         "DuplicateChord must show the shared chord: {display}"
+    );
+}
+
+/// The theme-name allowlist is not vacuous either: an unknown theme echoes
+/// the offending name (bounded, like every echo), while a wrong-typed value
+/// names its key only.
+#[test]
+fn unknown_theme_echoes_the_offending_name_and_wrong_types_name_only_the_key() {
+    let error =
+        AppConfig::parse("[theme]\nname = \"sepia\"\n").expect_err("an unknown theme must fail");
+    let display = error.to_string();
+    assert!(
+        display.contains("sepia"),
+        "UnknownTheme must show the offending name: {display}"
+    );
+    assert!(
+        display.contains("dark") && display.contains("light") && display.contains("high-contrast"),
+        "UnknownTheme must name the accepted vocabulary: {display}"
+    );
+
+    // A hostile value stays bounded in the rendered message.
+    let mut hostile = String::new();
+    hostile.extend(std::iter::repeat_n('a', 10_000));
+    let error = AppConfig::parse(&format!("[theme]\nname = \"{hostile}\"\n"))
+        .expect_err("a hostile theme value must fail");
+    assert!(
+        error.to_string().chars().count() < 1024,
+        "the rendered message must stay bounded: {} chars",
+        error.to_string().chars().count()
+    );
+
+    // A wrong-typed value never echoes: only the key name appears.
+    let error = AppConfig::parse("[theme]\nname = 12345\n")
+        .expect_err("a non-string theme value must fail");
+    let display = error.to_string();
+    assert!(
+        display.contains("name") && !display.contains("12345"),
+        "ThemeNotAString must name the key and not the value: {display}"
     );
 }
 

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -70,14 +70,13 @@ use std::fs;
 use std::io::Write;
 use std::process::Command;
 
+use noren_app::theme::{DARK, Theme};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
-use renderer_capture::renderer_source::{
-    CLEAR_COLOR, DEFAULT_ANSI_PALETTE, DEFAULT_FOREGROUND, DEFAULT_PALETTE, SIDEBAR_COLS,
-};
+use renderer_capture::renderer_source::{CLEAR_COLOR, SIDEBAR_COLS, Target};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// The PoC default cell metrics, used by every frame-oracle capture call so
@@ -94,10 +93,28 @@ fn snapshot(rows: u16, cols: u16, bytes: &[u8]) -> TerminalSnapshot {
 }
 
 /// Render a snapshot at exactly its grid size in PoC pixels.
+///
+/// Every pre-theme test renders through the default (`dark`) theme, exactly
+/// what the binary drew before `[theme]` existed; theme-specific behaviour
+/// has its own helpers and tests below.
 fn render(renderer: &OffscreenRenderer, snapshot: &TerminalSnapshot) -> CapturedFrame {
+    render_with_theme(renderer, &Theme::default(), snapshot)
+}
+
+/// Render a snapshot under an explicit theme at exactly its grid size.
+fn render_with_theme(
+    renderer: &OffscreenRenderer,
+    theme: &Theme,
+    snapshot: &TerminalSnapshot,
+) -> CapturedFrame {
     let width = u32::from(snapshot.cols()) * CELL_WIDTH;
     let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
-    renderer.capture(Some(snapshot), None, None, width, height, poc_metrics())
+    renderer.capture(
+        Target::new(theme, width, height, poc_metrics()),
+        Some(snapshot),
+        None,
+        None,
+    )
 }
 
 /// The clear colour as captured bytes, derived from the renderer's own
@@ -208,10 +225,11 @@ fn cell_color(frame: &CapturedFrame, row: u32, col: u32) -> [u8; 3] {
 }
 
 /// The default foreground as captured bytes, derived from the renderer's own
-/// [`DEFAULT_FOREGROUND`] so the "unstyled cells are unchanged" assertion
+/// [`DARK.foreground()`] so the "unstyled cells are unchanged" assertion
 /// tracks the renderer rather than a literal copied here.
 fn default_foreground_rgb() -> [u8; 3] {
-    DEFAULT_FOREGROUND.map(|channel| (channel * 255.0).round() as u8)
+    DARK.foreground()
+        .map(|channel| (channel * 255.0).round() as u8)
 }
 
 /// State-driven blankness: a cell is blank when the row is absent, the column
@@ -610,14 +628,14 @@ fn cells_with_different_sgr_foregrounds_render_different_colours() {
     );
     // And each is the colour the palette says it is.
     assert!(
-        colors_match(red_cell, DEFAULT_ANSI_PALETTE[1]),
+        colors_match(red_cell, DARK.ansi()[1]),
         "SGR 31 should draw palette red {:?}, drew {red_cell:?}",
-        DEFAULT_ANSI_PALETTE[1]
+        DARK.ansi()[1]
     );
     assert!(
-        colors_match(green_cell, DEFAULT_ANSI_PALETTE[2]),
+        colors_match(green_cell, DARK.ansi()[2]),
         "SGR 32 should draw palette green {:?}, drew {green_cell:?}",
-        DEFAULT_ANSI_PALETTE[2]
+        DARK.ansi()[2]
     );
 }
 
@@ -671,20 +689,20 @@ fn truecolor_and_256_colour_both_resolve_to_their_expected_pixels() {
     let indexed_frame = render(&renderer, &indexed);
     let drawn_indexed = cell_color(&indexed_frame, 0, 0);
     assert!(
-        colors_match(drawn_indexed, DEFAULT_PALETTE[196]),
+        colors_match(drawn_indexed, DARK.indexed_palette()[196]),
         "256-colour index 196 drew {drawn_indexed:?}, expected {:?}",
-        DEFAULT_PALETTE[196]
+        DARK.indexed_palette()[196]
     );
-    assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
+    assert_eq!(DARK.indexed_palette()[196], [255, 0, 0]);
 
     // A grayscale-ramp index resolves too, and differs from both above.
     let gray = snapshot(1, 4, b"\x1b[38;5;244mA");
     let gray_frame = render(&renderer, &gray);
     let drawn_gray = cell_color(&gray_frame, 0, 0);
     assert!(
-        colors_match(drawn_gray, DEFAULT_PALETTE[244]),
+        colors_match(drawn_gray, DARK.indexed_palette()[244]),
         "256-colour index 244 drew {drawn_gray:?}, expected {:?}",
-        DEFAULT_PALETTE[244]
+        DARK.indexed_palette()[244]
     );
     assert!(!colors_match(drawn_gray, drawn_indexed));
 }
@@ -795,7 +813,7 @@ fn indexed_background_matches_its_truecolor_palette_entry() {
         truecolor_frame.rgba, indexed_frame.rgba,
         "truecolor red and indexed palette entry 196 must render identically"
     );
-    assert_eq!(DEFAULT_PALETTE[196], [255, 0, 0]);
+    assert_eq!(DARK.indexed_palette()[196], [255, 0, 0]);
 }
 
 #[test]
@@ -833,9 +851,9 @@ fn a_dark_coloured_cell_is_still_seen_as_lit() {
     );
     let drawn = cell_color(&frame, 0, 0);
     assert!(
-        colors_match(drawn, DEFAULT_ANSI_PALETTE[0]),
+        colors_match(drawn, DARK.ansi()[0]),
         "SGR 30 should draw palette black {:?}, drew {drawn:?}",
-        DEFAULT_ANSI_PALETTE[0]
+        DARK.ansi()[0]
     );
     // The old gate would have mistaken this for background; the new one must not.
     assert!(drawn.iter().all(|channel| *channel < 48));
@@ -861,7 +879,7 @@ fn colour_follows_the_cell_across_wide_characters_and_rows() {
         "the unstyled 'a' must keep the default foreground"
     );
     assert!(
-        colors_match(cell_color(&frame, 0, 1), DEFAULT_ANSI_PALETTE[1]),
+        colors_match(cell_color(&frame, 0, 1), DARK.ansi()[1]),
         "the wide lead at column 1 must be red"
     );
     assert!(
@@ -869,13 +887,63 @@ fn colour_follows_the_cell_across_wide_characters_and_rows() {
         "the wide continuation column must stay unlit"
     );
     assert!(
-        colors_match(cell_color(&frame, 0, 3), DEFAULT_ANSI_PALETTE[2]),
+        colors_match(cell_color(&frame, 0, 3), DARK.ansi()[2]),
         "'b' at display column 3 must be green — colour tracked the cell \
          across the continuation column"
     );
     assert!(
-        colors_match(cell_color(&frame, 1, 0), DEFAULT_ANSI_PALETTE[4]),
+        colors_match(cell_color(&frame, 1, 0), DARK.ansi()[4]),
         "'c' on row 1 must be blue"
+    );
+}
+
+// ===========================================================================
+// Themes (Milestone 6 foundation): a `[theme]` selection must change what is
+// drawn, and the absence of a selection must change nothing. The pipeline is
+// the real one — same shader, same vertex generation, same clear path — with
+// only the theme differing between captures.
+// ===========================================================================
+
+/// The defaults-preservation contract, at the pixel level: with no `[theme]`
+/// section the configuration resolves dark, and a frame captured through that
+/// resolution is byte-identical to one captured through the explicit dark
+/// theme. Together with the pre-theme tests above (which still pin the
+/// historical default foreground `[204, 235, 209]`, the dark clear colour,
+/// and the dark palette entries against their literals), this proves the
+/// default rendering did not move when themes landed.
+#[test]
+fn theme_absent_config_renders_byte_identically_to_the_explicit_dark_theme() {
+    let Some(renderer) =
+        renderer_or_skip("theme_absent_config_renders_byte_identically_to_the_explicit_dark_theme")
+    else {
+        return;
+    };
+    let snap = snapshot(2, 6, "a\x1b[31m日\x1b[32mb\r\n\x1b[34mc".as_bytes());
+
+    // The real configuration path: no [theme] section resolves the default.
+    let unthemed = noren_app::config::AppConfig::parse("# no theme section\n")
+        .expect("a theme-less file parses")
+        .theme()
+        .palette();
+    assert_eq!(unthemed, Theme::default());
+
+    let via_config = render_with_theme(&renderer, &unthemed, &snap);
+    let via_dark = render_with_theme(&renderer, &Theme::default(), &snap);
+    assert_eq!(
+        via_config.rgba, via_dark.rgba,
+        "a missing [theme] section must render exactly the dark theme's bytes"
+    );
+
+    // And those bytes carry the pre-theme appearance: the unstyled 'a' is the
+    // historical default foreground and the untouched background is the
+    // historical clear colour (y = 1 sits above the glyph's top inset).
+    assert!(
+        colors_match(cell_color(&via_dark, 0, 0), [204, 235, 209]),
+        "the dark default's unstyled foreground moved"
+    );
+    assert!(
+        is_clear(via_dark.pixel(8, 1)),
+        "the dark default's clear colour moved"
     );
 }
 
@@ -966,12 +1034,10 @@ fn render_with_sidebar(
     let width = total_cols * CELL_WIDTH;
     let height = u32::from(snap.rows()) * CELL_HEIGHT;
     renderer.capture(
+        Target::new(&Theme::default(), width, height, poc_metrics()),
         Some(snap),
         Some(sidebar),
         None,
-        width,
-        height,
-        poc_metrics(),
     )
 }
 

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -70,7 +70,7 @@ use std::fs;
 use std::io::Write;
 use std::process::Command;
 
-use noren_app::theme::{DARK, Theme};
+use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
@@ -944,6 +944,189 @@ fn theme_absent_config_renders_byte_identically_to_the_explicit_dark_theme() {
     assert!(
         is_clear(via_dark.pixel(8, 1)),
         "the dark default's clear colour moved"
+    );
+}
+
+/// The single lit colour inside a cell, measured over a themed ground.
+///
+/// The shared [`cell_color`] skips pixels matching the *dark* clear colour,
+/// which under a light theme would skip nothing (or everything). This
+/// variant takes the theme's own background as the ground predicate, so a
+/// themed frame's glyph colour can be read the same way.
+fn cell_color_over(frame: &CapturedFrame, ground: [u8; 3], row: u32, col: u32) -> [u8; 3] {
+    let mut colors: Vec<[u8; 3]> = Vec::new();
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y);
+            let rgb = [pixel[0], pixel[1], pixel[2]];
+            if colors_match(rgb, ground) {
+                continue;
+            }
+            if !colors.iter().any(|seen| colors_match(*seen, rgb)) {
+                colors.push(rgb);
+            }
+        }
+    }
+    assert_eq!(
+        colors.len(),
+        1,
+        "cell ({row},{col}) should hold exactly one colour over the ground, \
+         found {colors:?}"
+    );
+    colors[0]
+}
+
+/// The theme-reachability headline: a cell drawn with a given SGR colour must
+/// produce **different pixels** under `light` than under `dark`, and each must
+/// match its own theme's palette. The chain driven here is the real one —
+/// `AppConfig::parse` of actual `[theme]` TOML → the theme's palette → the
+/// shipped vertex/pipeline/clear path — so a theme that parses but never
+/// reaches drawing cannot pass this test (the mutation that ignores the
+/// setting fails here).
+#[test]
+fn a_configured_theme_changes_what_the_renderer_draws() {
+    let Some(renderer) = renderer_or_skip("a_configured_theme_changes_what_the_renderer_draws")
+    else {
+        return;
+    };
+    // red 'b', green 'c', unstyled 'a', red-background 'd' (default fg), and
+    // two empty columns whose pixels show the theme's clear colour.
+    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md");
+
+    let theme_for = |text: &str| {
+        noren_app::config::AppConfig::parse(text)
+            .unwrap_or_else(|error| panic!("{text:?} must parse: {error}"))
+            .theme()
+            .palette()
+    };
+    let dark = theme_for("[theme]\nname = \"dark\"\n");
+    let light = theme_for("[theme]\nname = \"light\"\n");
+    assert_eq!(dark, DARK);
+    assert_eq!(light, LIGHT);
+
+    let dark_frame = render_with_theme(&renderer, &dark, &snap);
+    let light_frame = render_with_theme(&renderer, &light, &snap);
+    assert_ne!(
+        dark_frame.rgba, light_frame.rgba,
+        "the two themes must produce different pixels for the same snapshot"
+    );
+
+    // SGR 31: dark draws xterm red, light draws its darkened red; different.
+    let dark_red = cell_color_over(&dark_frame, dark.background_u8(), 0, 0);
+    let light_red = cell_color_over(&light_frame, light.background_u8(), 0, 0);
+    assert!(
+        colors_match(dark_red, DARK.ansi()[1]),
+        "dark SGR 31 drew {dark_red:?}, expected {:?}",
+        DARK.ansi()[1]
+    );
+    assert!(
+        colors_match(light_red, LIGHT.ansi()[1]),
+        "light SGR 31 drew {light_red:?}, expected {:?}",
+        LIGHT.ansi()[1]
+    );
+    assert!(
+        !colors_match(dark_red, light_red),
+        "SGR 31 must draw different pixels under the two themes"
+    );
+
+    // SGR 32 likewise.
+    let dark_green = cell_color_over(&dark_frame, dark.background_u8(), 0, 1);
+    let light_green = cell_color_over(&light_frame, light.background_u8(), 0, 1);
+    assert!(colors_match(dark_green, DARK.ansi()[2]));
+    assert!(colors_match(light_green, LIGHT.ansi()[2]));
+    assert!(!colors_match(dark_green, light_green));
+
+    // Unstyled text: the theme's default foreground, different per theme.
+    let dark_plain = cell_color_over(&dark_frame, dark.background_u8(), 0, 2);
+    let light_plain = cell_color_over(&light_frame, light.background_u8(), 0, 2);
+    assert!(colors_match(dark_plain, DARK.foreground_u8()));
+    assert!(colors_match(light_plain, LIGHT.foreground_u8()));
+    assert!(
+        !colors_match(dark_plain, light_plain),
+        "unstyled text must change with the theme"
+    );
+
+    // An explicit SGR 41 background paints its theme's palette entry: the
+    // cell corner is glyph-free, so it is pure background.
+    let dark_bg = [
+        dark_frame.pixel(3 * CELL_WIDTH, 0)[0],
+        dark_frame.pixel(3 * CELL_WIDTH, 0)[1],
+        dark_frame.pixel(3 * CELL_WIDTH, 0)[2],
+    ];
+    let light_bg = [
+        light_frame.pixel(3 * CELL_WIDTH, 0)[0],
+        light_frame.pixel(3 * CELL_WIDTH, 0)[1],
+        light_frame.pixel(3 * CELL_WIDTH, 0)[2],
+    ];
+    assert!(
+        colors_match(dark_bg, DARK.ansi()[1]),
+        "dark SGR 41 corner drew {dark_bg:?}, expected {:?}",
+        DARK.ansi()[1]
+    );
+    assert!(
+        colors_match(light_bg, LIGHT.ansi()[1]),
+        "light SGR 41 corner drew {light_bg:?}, expected {:?}",
+        LIGHT.ansi()[1]
+    );
+
+    // The untouched ground is each theme's clear colour (empty column 4).
+    let dark_clear = dark_frame.pixel(4 * CELL_WIDTH, 0);
+    let light_clear = light_frame.pixel(4 * CELL_WIDTH, 0);
+    assert!(is_clear(dark_clear), "dark clear colour moved");
+    assert!(
+        colors_match(
+            [light_clear[0], light_clear[1], light_clear[2]],
+            LIGHT.background_u8()
+        ),
+        "light clear pixel {light_clear:?} is not the light background {:?}",
+        LIGHT.background_u8()
+    );
+}
+
+/// High-contrast draws its own pastel palette on pure black — the theme whose
+/// measured minimum (7.84:1) clears WCAG AAA — and its pixels differ from
+/// both other themes'.
+#[test]
+fn high_contrast_theme_draws_its_own_verified_palette() {
+    let Some(renderer) = renderer_or_skip("high_contrast_theme_draws_its_own_verified_palette")
+    else {
+        return;
+    };
+    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md");
+
+    let hc = noren_app::config::AppConfig::parse("[theme]\nname = \"high-contrast\"\n")
+        .expect("high-contrast is a valid theme name")
+        .theme()
+        .palette();
+    assert_eq!(hc, HIGH_CONTRAST);
+
+    let hc_frame = render_with_theme(&renderer, &hc, &snap);
+    let dark_frame = render_with_theme(&renderer, &DARK, &snap);
+    let light_frame = render_with_theme(&renderer, &LIGHT, &snap);
+    assert_ne!(hc_frame.rgba, dark_frame.rgba);
+    assert_ne!(hc_frame.rgba, light_frame.rgba);
+
+    // SGR 31 is the pastel red; unstyled text is pure white on pure black.
+    assert!(
+        colors_match(
+            cell_color_over(&hc_frame, hc.background_u8(), 0, 0),
+            HIGH_CONTRAST.ansi()[1]
+        ),
+        "high-contrast SGR 31 must draw {:?}",
+        HIGH_CONTRAST.ansi()[1]
+    );
+    assert!(
+        colors_match(
+            cell_color_over(&hc_frame, hc.background_u8(), 0, 2),
+            HIGH_CONTRAST.foreground_u8()
+        ),
+        "high-contrast unstyled text must be pure white"
+    );
+    let clear = hc_frame.pixel(4 * CELL_WIDTH, 0);
+    assert_eq!(
+        [clear[0], clear[1], clear[2]],
+        [0, 0, 0],
+        "high-contrast clear must be pure black"
     );
 }
 

--- a/crates/noren-app/tests/theme.rs
+++ b/crates/noren-app/tests/theme.rs
@@ -1,0 +1,260 @@
+//! Theme palette and WCAG contrast contract (Milestone 6, foundation slice).
+//!
+//! These tests are the point of the slice, not decoration: every built-in
+//! theme's readability is *measured* — the WCAG 2.x contrast ratio between
+//! each theme-owned foreground and the theme's default background — and
+//! asserted against a documented floor.
+//!
+//! # Thresholds and why
+//!
+//! - **AA, 4.5:1, for the `dark` and `light` themes.** WCAG reserves 3:1
+//!   for large text; a terminal never draws large text — the PoC's glyphs
+//!   are 5×7 bitmaps in 10×20 px cells — so the normal-text bound is the
+//!   honest one.
+//! - **AAA, 7:1, for `high-contrast`.** A theme named high-contrast that
+//!   merely matched AA would be a third ordinary palette; it must exceed
+//!   the others' measured minima, and AAA is the level that says so.
+//!
+//! # The checked set (and what is deliberately outside it)
+//!
+//! The checked foregrounds are the theme's default foreground plus its
+//! sixteen ANSI entries, each against the theme's default background: the
+//! colours programs use for ordinary text on the screen they are given.
+//! Program-paired colours (`SGR 31;41`) and the shared 256-colour cube are
+//! outside any palette's control — identical colours are 1.0:1 by
+//! definition, and the cube's black corner fails on every possible
+//! background. See `src/theme.rs` for the full statement.
+//!
+//! # The dark-palette finding
+//!
+//! The existing default (`dark`) fails 4.5:1 for five ANSI slots on its own
+//! background; its measured minimum, 1.06:1 (ANSI black), is pinned below.
+//! The colours are frozen anyway: this slice's contract is that no
+//! `[theme]` section renders byte-identically to the pre-theme renderer,
+//! and the frame oracle proves that at the pixel level. Changing the dark
+//! values to pass AA is a separate, deliberate decision for a follow-up.
+
+use noren_app::theme::{Theme, ThemeName, contrast_ratio, relative_luminance};
+
+/// WCAG's own anchor points, so the math below is trusted before it is used.
+#[test]
+fn contrast_ratio_matches_the_wcag_reference_values() {
+    assert!(
+        (contrast_ratio([0, 0, 0], [255, 255, 255]) - 21.0).abs() < 0.01,
+        "pure black on pure white must be 21:1"
+    );
+    // #767676 on #FFFFFF is the classic "smallest grey passing AA" example.
+    assert!(
+        (contrast_ratio([118, 118, 118], [255, 255, 255]) - 4.54).abs() < 0.01,
+        "#767676 on #FFFFFF must be ~4.54:1"
+    );
+    assert!(
+        (contrast_ratio([153, 153, 153], [255, 255, 255]) - 2.85).abs() < 0.01,
+        "#999999 on #FFFFFF must be ~2.85:1"
+    );
+    // Order independence: the ratio of a pair does not depend on argument
+    // order, because the lighter colour is always the numerator.
+    assert_eq!(
+        contrast_ratio([255, 255, 255], [118, 118, 118]),
+        contrast_ratio([118, 118, 118], [255, 255, 255])
+    );
+    assert_eq!(relative_luminance([255, 255, 255]), 1.0);
+    assert_eq!(relative_luminance([0, 0, 0]), 0.0);
+}
+
+/// The pair every unstyled character draws in — the reading path — clears
+/// AA for every theme, including the frozen dark default.
+#[test]
+fn every_theme_default_pair_meets_aa() {
+    for name in [ThemeName::Dark, ThemeName::Light, ThemeName::HighContrast] {
+        let theme = name.palette();
+        let ratio = contrast_ratio(theme.foreground_u8(), theme.background_u8());
+        assert!(
+            ratio >= 4.5,
+            "{name}: default pair is {ratio:.2}:1, below the AA 4.5:1 floor"
+        );
+    }
+}
+
+/// The light theme was designed, not assumed: every ANSI slot keeps AA on
+/// the light background. Measured minimum: 5.07:1 (`bright green`).
+#[test]
+fn light_theme_keeps_aa_on_every_theme_owned_foreground() {
+    let (min, slot) = ThemeName::Light
+        .palette()
+        .min_contrast_on_default_background();
+    assert!(
+        min >= 4.5,
+        "light theme's worst slot ({slot}) is {min:.2}:1, below the AA 4.5:1 floor"
+    );
+}
+
+/// High-contrast genuinely exceeds the others: it clears AAA (7:1) and its
+/// measured minimum strictly beats both other themes' minima. Measured
+/// minimum: 7.84:1 (`bright black`), against light's 5.07:1 and dark's
+/// 1.06:1.
+#[test]
+fn high_contrast_meets_aaa_and_strictly_exceeds_the_other_themes() {
+    let (hc_min, hc_slot) = ThemeName::HighContrast
+        .palette()
+        .min_contrast_on_default_background();
+    assert!(
+        hc_min >= 7.0,
+        "high-contrast's worst slot ({hc_slot}) is {hc_min:.2}:1, below the AAA 7:1 floor"
+    );
+    let (light_min, _) = ThemeName::Light
+        .palette()
+        .min_contrast_on_default_background();
+    let (dark_min, _) = ThemeName::Dark
+        .palette()
+        .min_contrast_on_default_background();
+    assert!(
+        hc_min > light_min && hc_min > dark_min,
+        "high-contrast minimum {hc_min:.2}:1 must exceed light's {light_min:.2}:1 \
+         and dark's {dark_min:.2}:1"
+    );
+}
+
+/// The reported finding, pinned: the existing default palette's worst
+/// theme-owned foreground is ANSI black at 1.06:1 — far below AA — and four
+/// more slots (blue 2.10, red 3.38, bright blue 4.16, magenta 4.21) also
+/// fail. The value is pinned so that *any* change to the default palette —
+/// a fix or a regression — breaks this test and forces the decision into
+/// the open. Fixing it is follow-up work precisely because the defaults
+/// must keep rendering byte-identically to the pre-theme renderer.
+#[test]
+fn default_dark_palette_minimum_is_pinned_below_the_aa_floor() {
+    let (min, slot) = ThemeName::Dark
+        .palette()
+        .min_contrast_on_default_background();
+    assert_eq!(slot, "black", "the default's worst slot is ANSI black");
+    assert!(
+        (min - 1.0639).abs() < 0.001,
+        "default dark minimum moved to {min:.4}:1 (was 1.0639:1) — changing the \
+         shipped default palette is a deliberate decision, not a side effect"
+    );
+    assert!(
+        min < 4.5,
+        "if the default now passes AA, update the finding documentation"
+    );
+}
+
+/// The dark theme is the pre-theme renderer's exact colours: the raw shader
+/// floats, the xterm ANSI table, and the shared cube/grayscale tail. This
+/// is the palette-level half of the defaults-preservation contract; the
+/// frame oracle proves the pixel-level half.
+#[test]
+fn dark_theme_is_byte_identical_to_the_pre_theme_renderer() {
+    let dark = ThemeName::Dark.palette();
+    // The exact floats the fragment shader returned as constants before
+    // themes existed (issue #107/#112); the frame oracle pins their captured
+    // form at [204, 235, 209].
+    assert_eq!(dark.foreground(), [0.80, 0.92, 0.82]);
+    assert_eq!(dark.background(), [0.035, 0.045, 0.04]);
+    // The xterm sixteen.
+    assert_eq!(
+        dark.ansi(),
+        [
+            [0, 0, 0],
+            [205, 0, 0],
+            [0, 205, 0],
+            [205, 205, 0],
+            [0, 0, 238],
+            [205, 0, 205],
+            [0, 205, 205],
+            [229, 229, 229],
+            [127, 127, 127],
+            [255, 0, 0],
+            [0, 255, 0],
+            [255, 255, 0],
+            [92, 92, 255],
+            [255, 0, 255],
+            [0, 255, 255],
+            [255, 255, 255],
+        ]
+    );
+    // The shared tail: cube corners and grayscale endpoints.
+    let palette = dark.indexed_palette();
+    assert_eq!(palette[16], [0, 0, 0]);
+    assert_eq!(palette[196], [255, 0, 0]);
+    assert_eq!(palette[231], [255, 255, 255]);
+    assert_eq!(palette[232], [8, 8, 8]);
+    assert_eq!(palette[244], [128, 128, 128]);
+    assert_eq!(palette[255], [238, 238, 238]);
+    // The default theme is dark, and dark is the Theme default.
+    assert_eq!(Theme::default(), ThemeName::default().palette());
+    assert_eq!(ThemeName::default(), ThemeName::Dark);
+}
+
+/// The theme's reported 8-bit foreground/background are the values the
+/// RGBA8 target stores: `(channel * 255).round()`. Measuring anything else
+/// would hide the quantization every drawn pixel undergoes.
+#[test]
+fn theme_u8_values_match_the_drawn_quantization() {
+    for name in [ThemeName::Dark, ThemeName::Light, ThemeName::HighContrast] {
+        let theme = name.palette();
+        for (f, u) in theme.foreground().into_iter().zip(theme.foreground_u8()) {
+            assert_eq!(u, (f * 255.0).round() as u8, "{name} foreground");
+        }
+        for (f, u) in theme.background().into_iter().zip(theme.background_u8()) {
+            assert_eq!(u, (f * 255.0).round() as u8, "{name} background");
+        }
+    }
+    assert_eq!(ThemeName::Dark.palette().foreground_u8(), [204, 235, 209]);
+    assert_eq!(ThemeName::Dark.palette().background_u8(), [9, 11, 10]);
+}
+
+/// Theme names are a closed, case-sensitive vocabulary with no fallback:
+/// exactly the three documented spellings parse, and everything else —
+/// including near-misses like `Dark`, `highcontrast`, or the empty string —
+/// is rejected for the typed configuration error to report.
+#[test]
+fn theme_names_parse_exactly_the_documented_vocabulary() {
+    assert_eq!(ThemeName::parse("dark"), Some(ThemeName::Dark));
+    assert_eq!(ThemeName::parse("light"), Some(ThemeName::Light));
+    assert_eq!(
+        ThemeName::parse("high-contrast"),
+        Some(ThemeName::HighContrast)
+    );
+    for rejected in [
+        "Dark",
+        "LIGHT",
+        "highcontrast",
+        "high_contrast",
+        "",
+        "sepia",
+        " ",
+    ] {
+        assert_eq!(ThemeName::parse(rejected), None, "{rejected:?} parsed");
+    }
+    let names: Vec<&str> = ThemeName::NAMES.to_vec();
+    assert_eq!(names, ["dark", "light", "high-contrast"]);
+    for name in [ThemeName::Dark, ThemeName::Light, ThemeName::HighContrast] {
+        assert_eq!(ThemeName::parse(name.as_str()), Some(name));
+    }
+}
+
+/// The three themes are genuinely different palettes, not three names for
+/// one table — the property the frame oracle proves at the pixel level.
+#[test]
+fn the_built_in_themes_are_distinct_palettes() {
+    let themes = [
+        ThemeName::Dark.palette(),
+        ThemeName::Light.palette(),
+        ThemeName::HighContrast.palette(),
+    ];
+    for (index, first) in themes.iter().enumerate() {
+        for second in themes.iter().skip(index + 1) {
+            assert_ne!(first, second);
+            assert_ne!(first.ansi(), second.ansi());
+            assert_ne!(first.foreground(), second.foreground());
+            assert_ne!(first.background(), second.background());
+        }
+    }
+    // Every theme keeps the shared cube tail identical, so the two
+    // spellings of one indexed colour agree under every theme.
+    for (index, color) in themes[0].indexed_palette().iter().enumerate().skip(16) {
+        assert_eq!(themes[1].indexed_palette()[index], *color);
+        assert_eq!(themes[2].indexed_palette()[index], *color);
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,54 @@ Zellij corpus. Chords with modifiers dispatch on the exact modifier set; a
 modifier-free character binding also matches the character with any
 modifiers held, as the pre-configuration palette did.
 
+### `[theme]`
+
+Selects the built-in colour palette. The table is optional; an absent
+`[theme]` keeps `dark`, which is exactly the palette the app shipped with
+before themes existed — rendering stays byte-identical.
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `name` | string | `"dark"` | Which built-in palette drawing resolves colours through. |
+
+Accepted names, matched exactly (case-sensitive, closed vocabulary):
+
+- `dark` — the xterm default ANSI colours on the near-black background
+  (today's behaviour);
+- `light` — an off-white background with darkened ANSI entries; every
+  theme-owned foreground keeps WCAG AA (≥ 4.5:1) on the default
+  background;
+- `high-contrast` — pure white on pure black with pastel ANSI entries;
+  every theme-owned foreground keeps WCAG AAA (≥ 7:1), strictly exceeding
+  the other themes' measured minima.
+
+Rejections follow the hard-error discipline: a non-string value is an
+error naming the key, and an unknown name is a typed error naming the
+offending value (clipped to 120 characters, like the `[keys]` chord echo:
+a theme name is closed-vocabulary grammar text, never a credential) —
+never a silent fallback to `dark`. Near-misses such as `Dark` or
+`highcontrast` are rejected for the same reason.
+
+The contrast contract: the checked set is every theme-owned foreground —
+the default foreground and the sixteen ANSI entries — against the theme's
+default background, the colours programs use for ordinary text on the
+screen they are given. The floor is WCAG AA for normal text (4.5:1)
+because terminal glyphs are normal-size text; `high-contrast` targets AAA
+(7:1). Program-paired colours (`SGR 31;41`) and the shared 256-colour
+cube (`16..=255`) are outside any palette's control (identical colours
+are 1:1 by definition; the cube's black corner fails on every possible
+background) and are therefore not part of the checked set.
+
+**Known finding, reported not fixed:** the default `dark` palette fails
+the 4.5:1 floor for five ANSI slots on its own background — black at
+1.06:1, blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and
+magenta at 4.21:1. The values stay frozen because the no-`[theme]`
+default must render byte-identically to the pre-theme renderer; changing
+them is a separate, deliberate decision. Users who need AA on every slot
+today can select `high-contrast` (measured minimum 7.84:1). The measured
+minima are pinned by tests (`crates/noren-app/tests/theme.rs`), so any
+palette change — fix or regression — is a visible failure.
+
 ### Rejected keys, by design
 
 - **`[terminal]` / `scrollback_lines`.** Scrollback retention is enforced
@@ -114,6 +162,9 @@ cell_height = 24
 [keys]
 palette_open = "super+k"
 session_create = "ctrl+shift+t"
+
+[theme]
+name = "light"
 ```
 
 ## Error behavior

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -122,17 +122,28 @@ Each item states what you would actually see if you ran the build.
   word "cursor" does not appear anywhere in `renderer.rs`. In practice: you type, characters appear,
   and nothing shows you where the insertion point is. This is the first thing
   most people notice.
-- **Colours render, but the palette and theme are fixed.** `glyph_vertices`
-  reads each terminal cell's attributes: `resolve_foreground` and
-  `resolve_background` route ANSI and 256-colour values through
-  `DEFAULT_PALETTE`, while direct RGB truecolor passes through unchanged
-  (`crates/noren-app/src/renderer.rs`). Explicit backgrounds emit a full-cell
-  rectangle before the glyph. Each vertex now carries a `Float32x2` position
-  and `Float32x3` resolved colour on a 20-byte stride, and `fs_main` returns
-  that per-vertex colour. The defaults and xterm-style palette are compiled in;
-  `config.rs` exposes no palette or theme setting. In practice, SGR foreground
-  and explicit background colours appear, but users cannot select or customise
-  a light, dark, high-contrast, or colour-vision-friendly theme.
+- **Colours render through a selectable theme, but the default palette fails
+  WCAG AA on five slots.** `[theme] name` in `config.toml` selects one of
+  three built-in palettes — `dark` (the default, byte-identical to the
+  pre-theme colours), `light`, and `high-contrast` — and `glyph_vertices_for`
+  in `crates/noren-app/src/renderer.rs` resolves every SGR colour, the
+  default foreground, and the clear colour through it
+  (`resolve_foreground`/`resolve_background` route ANSI and 256-colour
+  values through the theme's table; truecolor passes through). **The known
+  contrast finding:** the default `dark` palette fails the WCAG AA normal-text
+  floor (4.5:1) for five of its sixteen ANSI slots on its own background —
+  black at 1.06:1, blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and
+  magenta at 4.21:1 — measured and pinned by
+  `default_dark_palette_minimum_is_pinned_below_the_aa_floor` in
+  `crates/noren-app/tests/theme.rs`. The values stay frozen because the
+  no-`[theme]` default must render byte-identically to the pre-theme
+  renderer (pinned by the frame oracle); fixing them is a separate
+  deliberate decision. `light` (measured minimum 5.07:1) and `high-contrast`
+  (7.84:1, above WCAG AAA) pass every slot. In practice: programs that emit
+  SGR red, blue, bright blue, magenta, or black text on the default dark
+  background draw below the AA floor until the dark palette is revisited;
+  selecting `high-contrast` avoids it. Themes are built-in only — there is
+  no custom-palette or colour-vision-friendly configuration.
 - **The bitmap font is coverage-bounded, and seven glyph pairs are visually
   identical.** Glyphs are a hand-built 5x7 bitmap in `glyph_rows`
   (`crates/noren-app/src/renderer.rs`): printable ASCII keeps distinct
@@ -318,8 +329,10 @@ key event into a live window and observes the result. The oracle guards
 structural shape, grid mapping, and resolved pixel colour, but not glyph
 identity or overall perceptual correctness, so the manual check above remains a
 smoke test of the window→grid→PTY chain rather than a perceptual proof of what
-appears on screen. The palette/theme has no user-configurable surface to test;
-IME and accessibility remain absent from both testing and the build.
+appears on screen. Theme selection is configurable and its drawing path is
+oracle-tested, but the built-in palettes are fixed tables — no custom theme
+surface exists to test; IME and accessibility remain absent from both
+testing and the build.
 
 ## What is deliberately delegated
 
@@ -352,6 +365,8 @@ shows no first-launch warning about any of this; verify any build yourself
 rather than trusting a copy from elsewhere. Nothing here should be
 read as "nearly done": the honest summary is that the foundation is tested, a
 first workspace slice is now real and visible, and what stands between this and
-a usable daily terminal is not workspace plumbing but the display itself —
-a user-configurable theme, a real font, and a cursor. SGR colour is now drawn,
-but its fixed defaults are not yet a usable theming system.
+a usable daily terminal is not workspace plumbing but the display itself — a
+theme whose default palette clears WCAG AA on every slot, a real font, and a
+cursor. SGR colour is drawn through selectable light/dark/high-contrast
+themes with verified contrast, but the built-in palettes are not yet a
+custom theming system.


### PR DESCRIPTION
Milestone 6's foundation: a `[theme]` config section selecting `dark` (today's behaviour, the default), `light`, or `high-contrast`, with every draw colour resolved through the chosen palette.

## The finding: the shipped default fails WCAG AA

Measuring contrast was the point of this slice, not decoration, and it found a real defect:

**`dark` — today's default — has a minimum contrast ratio of 1.06:1 against a 4.5:1 threshold.** Five of its sixteen ANSI entries fail on their own background.

I confirmed this independently rather than taking the lane's number: ANSI black is `[0, 0, 0]` and `DARK_BACKGROUND` resolves to `[9, 11, 10]`, giving `(0.0503)/(0.0474) = 1.06:1` by the WCAG formula. **Black text on a near-black background is effectively invisible.**

The threshold was not lowered to make it pass, and today's colours were not silently changed — both were forbidden, because either would have converted an accessibility defect into a green test. `high-contrast` measures **7.84:1**, so it genuinely exceeds the others rather than being a label.

That leaves a decision for the owner, deliberately not taken here: whether `dark`'s palette should change (it alters what every existing user sees) or whether `high-contrast` is the answer for users who need it. **Filing the measurement is the deliverable; changing the default is a product call.**

## The theme reaches drawing, proven by pixels

`a_configured_theme_changes_what_the_renderer_draws` runs through the frame oracle — the real pipeline, offscreen, reading pixels back. A cell drawn with a given SGR colour produces different pixels under `light` than under `dark`. A test that only checked the config parsed would prove nothing about what a user sees.

`defaults_identical=yes`: with no `[theme]` section, rendering is unchanged from today.

## Config discipline

An unknown theme name is a **typed error naming the offending value**, never a silent fallback to the default — the same rule `config.rs` already applies to `[terminal]` and `[keys]`.

## Mutations

| Mutation | Result |
| --- | --- |
| Theme setting ignored so the default always wins | test fails |
| One palette pair degraded below the threshold | test fails |

## Gates

`fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` **1,047 passing, 0 failed**. 22 tests added across 4 commits.
