### PR TITLE
feat(app): configured projects are launchable sidebar sessions (M3 scope item)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,7 +115,7 @@ Measured against it, item by item:
 | Scope item | State | Evidence |
 | --- | --- | --- |
 | Sidebar drawn | Done | `SIDEBAR_COLS` reserved in `renderer.rs`; `glyph_vertices` applies the column offset; `sidebar_text_lines` formats rows |
-| — projects, git worktrees | Worktrees launchable; projects modelled | Startup runs `git worktree list --porcelain` in the launch directory (`git_worktree.rs`) and shows at most 24 discovered worktrees as `EntryKind::Worktree` rows (beyond the cap the omitted count is reported); a registered-but-deleted worktree is listed with a `(missing)` marker and refused on selection; selecting a present row creates a `SessionKind::Worktree` session backed by a real `/bin/zsh` PTY whose child's working directory IS the worktree (verified by reading the child's own `pwd` back through the terminal), persisting and restoring through `sessions.toml` like a local session. `EntryKind::Project`/`SessionKind::Project` remain modelled-only with no runtime constructor |
+| — projects, git worktrees | Worktrees and projects launchable | Startup runs `git worktree list --porcelain` in the launch directory (`git_worktree.rs`) and shows at most 24 discovered worktrees as `EntryKind::Worktree` rows (beyond the cap the omitted count is reported); a registered-but-deleted worktree is listed with a `(missing)` marker and refused on selection; selecting a present row creates a `SessionKind::Worktree` session backed by a real `/bin/zsh` PTY whose child's working directory IS the worktree (verified by reading the child's own `pwd` back through the terminal), persisting and restoring through `sessions.toml` like a local session. `[[projects]]` configuration entries (`config.rs`, strict schema: absolute `root`, typed errors naming the offending key, no value echo) appear as at most 24 `EntryKind::Project` rows — the fixed `PRJ-` state prefix distinguishes them from prefix-less worktree rows — and selecting one whose root exists creates a `SessionKind::Project` session with the same directory-rooted launch shape and `pwd` proof; a configured-but-gone root is refused visibly like a deleted worktree. Project sessions persist and restore through `sessions.toml` like every other kind |
 | — SSH connections, agents | Connections run for discovered aliases; discovery explicitly partial; agents launchable from configuration | At most 24 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and clicking one launches the fixed system `/usr/bin/ssh` client in the terminal's single PTY (argv is exactly `ssh -- <alias>`; no credential is ever argv-visible), with launch, connect, and disconnect failures as visible per-row and status-row states (PR #138). Wildcard/dynamic destinations are not a complete host inventory. `[[agents]]` entries in `config.toml` become at most 24 `EntryKind::Agent` rows (beyond the cap the omitted count is reported); selecting one creates a `SessionKind::Agent` session backed by a real PTY running the configured command as a shell-free argv vector (absolute path, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure), persisting and restoring through `sessions.toml` like every other session kind |
 | — terminal sessions | Runtime for local sessions | Every palette `session_create` spawns a real `SessionKind::Local` PTY (`spawn_local_session`); sidebar clicks and the palette's `session_select` switch the live view between live sessions (`switch_live_session`, parked surfaces keep draining and resizing), and `session_close` reaps the closed child and repairs the view. Rows restored from disk come back `Restored` with no live surface and cannot take the live view |
 | Single-session view | Done | The active terminal is drawn beside the sidebar, narrowed to the remaining columns; switching swaps the active surface whole, and rows without a live surface cannot claim its selection or input owner |
@@ -125,11 +125,11 @@ Measured against it, item by item:
 | Configurable keybindings | Done for the palette surface | `[keys]` in `config.toml` (`KeymapConfig` in `config.rs`) rebinds the palette opener and the four palette command chords with the previous values as defaults; `palette_policy`/`handle_palette_key` in `main.rs` honor them, unparseable chords and unknown actions are typed errors, and the opener is validated against the pinned Zellij corpus and the exit leader. The exit leader, palette navigation keys, diagnostics chord, and clipboard shortcuts remain fixed |
 | Zellij pass-through | Done against a pinned corpus and a live installed Zellij | The shipped policy (`palette_policy` in `main.rs`) claims exactly two Super-modified chords — `Super+Escape` (exit leader) and `Super+p` (palette opener) — that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds, and `tests/zellij_live.rs` drives an INSTALLED Zellij in a real PTY through the same parser, gate, and key encoder: attach enables mouse tracking in `TerminalState`, gated `Ctrl+t`/`n`/`Ctrl+p` reach Zellij and render tab #2 and pane #2, typed text reaches the pane's shell, and the installed version's default keybinds bind nothing in the Super/Cmd/Meta space. The harness skips (visibly, on the real stderr) when no `zellij` is on `PATH`. Empirical wire-shape note: Zellij 0.44.3 sends `1002`/`1006` as separate single-parameter DECSETs across its whole lifecycle and does not forward a pane program's multi-parameter DECSET to the host terminal, so the multi-parameter form `CSI ? 1002;1006 h` (the PR #113 regression site) is pinned as a co-located regression guard beside the live assertions, with the live multi-parameter count printed as drift telemetry. Beyond the skip, the suite today runs only where a developer runs it — no gating machine executes it (issue #153) |
 
-Two named scope items remain unsatisfied: **projects are not reachable**
-and **host discovery is explicitly partial**. No runtime path constructs an
-`EntryKind::Project` row or a `SessionKind::Project` session — the model,
-`parse_session` for a hand-written `sessions.toml`, and the tests are the
-only constructors. Positive literal aliases appear in a bounded sidebar
+One named scope item remains unsatisfied: **host discovery is explicitly
+partial**. Projects are reachable now: a `[[projects]]` configuration entry
+constructs an `EntryKind::Project` row and selecting it creates a
+`SessionKind::Project` session backed by a real PTY whose child starts in
+the configured root. Positive literal aliases appear in a bounded sidebar
 list and a click launches a real system-ssh connection (PR #138), but
 wildcard or dynamic destinations are not presented as a complete host
 inventory. Agent entries are no longer fixtures: `[[agents]]`
@@ -139,10 +139,8 @@ PTY (the first Milestone 5 slice); the remaining agent-experience scope
 Milestone 5 work. Configurable keybindings are satisfied for the palette
 surface only; the exit leader, palette navigation, diagnostics chord, and
 clipboard shortcuts remain compiled in. Since "Only evidence-backed work
-is marked complete" and the scope line names the unsatisfied items,
-Milestone 3 stays **In progress**; whether the project row is retired from
-Milestone 3's scope or carried is an open scoping decision, not something to
-settle by relabelling the status.
+is marked complete" and the scope line names the unsatisfied item,
+Milestone 3 stays **In progress** on host discovery.
 
 Open engineering issues a reader of this section should know about: the
 behavior-preserving split of the oversized binary and SSH-parser modules
@@ -178,7 +176,9 @@ the Noren terminal." The reasoning and the decision are recorded in
   `git worktree list --porcelain`, shown as bounded rows, and launched as
   worktree-scoped sessions), configured agents are launchable through the
   `[[agents]]` section (a shell-free argv PTY launch with visible failure
-  states), while project rows remain unreachable; keybindings ARE
+  states), and configured projects are launchable through the
+  `[[projects]]` section (a directory-rooted PTY launch in the configured
+  root, with the same visible-failure discipline); keybindings ARE
   configurable through the `[keys]` section since this milestone (see
   [Milestone 3 status](#milestone-3-status)).
 - **Colour rendering exists, but themes are fixed.** `renderer.rs` resolves

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -46,15 +46,30 @@
 //! deliberately not performed, so a writable `PATH` entry cannot substitute a
 //! different binary.
 //!
+//! The `[[projects]]` array configures project sidebar entries: a display
+//! `name` and the absolute `root` directory a session starts in when the row
+//! is selected. Projects are configured, not discovered, because a project
+//! has no authoritative machine-readable source (unlike a worktree, whose
+//! source of truth is `git worktree list --porcelain`): scanning a directory
+//! tree for `.git` folders would be slow, unbounded, and would guess at the
+//! user's intent. The same discipline applies — unknown keys are rejected,
+//! every value is type- and range-checked, the root must be an absolute path
+//! (leading `/`; neither `~` expansion nor relative resolution against the
+//! launch directory is performed, so the configured text and the launched
+//! directory can never silently diverge), and the root text is never echoed
+//! in any error message or `Debug` output.
+//!
 //! # Privacy
 //!
 //! Configuration carries no secrets: no supported key names a credential,
-//! key, or other sensitive path, and the schema deliberately exposes no path
-//! keys at all. The shell program is **not** configurable: the threat model
-//! (TM-01) fixes the spawn at `/bin/zsh` with no configured additions. An
-//! agent `command` is a different surface: it names a program the user
-//! explicitly asked Noren to launch, and it is validated (absolute, bounded,
-//! shell-free argv) rather than forbidden.
+//! key, or other sensitive value. The shell program is **not** configurable:
+//! the threat model (TM-01) fixes the spawn at `/bin/zsh` with no configured
+//! additions. The two path-shaped surfaces — an agent `command` and a project
+//! `root` — are different in kind from a credential: each names a program or
+//! directory the user explicitly asked Noren to launch or open, and each is
+//! validated (absolute, bounded) rather than forbidden. A path can still
+//! embed a username or a private directory name, so neither surface is ever
+//! echoed through an error `Display` or a `Debug` rendering (issue #146).
 
 use crate::passthrough::{
     CLAIM_ID_PALETTE, Chord, ChordError, ChordSeq, KeyCode, Modifiers, PassthroughAction,
@@ -108,6 +123,17 @@ const MAX_ERROR_DETAIL_CHARS: usize = 120;
 /// policy re-enforces the same cap at its own layer — and a pin test
 /// below holds the two constants equal so the layers can never diverge.
 pub const MAX_AGENT_FIELD_BYTES: usize = 1024;
+
+/// Maximum accepted bytes for one `[[projects]]` string field (`name` or
+/// `root`).
+///
+/// Policy, like [`MAX_AGENT_FIELD_BYTES`] and [`MAX_CELL_EDGE`]: keeps a
+/// single field from monopolizing the bounded 64 KiB read, and gives the
+/// sidebar label arithmetic the same reasonable worst case as an agent name.
+/// Longer values are [`ConfigError::OutOfRange`] errors, never truncated.
+/// A pin test below holds this equal to [`MAX_AGENT_FIELD_BYTES`] so the
+/// two array-of-tables sections cannot drift apart.
+pub const MAX_PROJECT_FIELD_BYTES: usize = 1024;
 
 /// Font geometry settings.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -295,6 +321,51 @@ impl AgentConfig {
     }
 }
 
+/// One configured project: a display name plus the absolute root directory a
+/// session starts in when the project's sidebar row is selected.
+///
+/// The root is a directory path the user explicitly asked Noren to open, so
+/// it is validated (absolute, bounded) rather than forbidden — the same
+/// reasoning that admits an agent `command`. It is never checked for
+/// existence at load time: a configured-but-missing directory is a runtime
+/// fact, refused visibly when the row is selected (exactly like a
+/// registered-but-deleted worktree), not a load-time guess.
+///
+/// # Debug discipline
+///
+/// [`fmt::Debug`] is shape-only (issue #146): the name is user-authored file
+/// text, and a root can embed a username or a private directory name, so
+/// neither is printed. Use the accessors for real values.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ProjectConfig {
+    name: String,
+    root: String,
+}
+
+impl fmt::Debug for ProjectConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProjectConfig")
+            .field("name_chars", &self.name.chars().count())
+            .field("root_chars", &self.root.chars().count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProjectConfig {
+    /// The display name shown on the project's sidebar row.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The absolute root directory, as the configuration spelled it. The
+    /// launch layer validates it (absolute, existing directory) again.
+    #[must_use]
+    pub fn root(&self) -> &str {
+        &self.root
+    }
+}
+
 /// Validated application configuration.
 ///
 /// [`AppConfig::default`] is byte-for-byte the behavior the app had before
@@ -305,6 +376,7 @@ pub struct AppConfig {
     keys: KeymapConfig,
     theme: ThemeConfig,
     agents: Vec<AgentConfig>,
+    projects: Vec<ProjectConfig>,
 }
 
 impl AppConfig {
@@ -330,6 +402,12 @@ impl AppConfig {
     #[must_use]
     pub fn agents(&self) -> &[AgentConfig] {
         &self.agents
+    }
+
+    /// Configured projects, in file order. Empty when `[projects]` is absent.
+    #[must_use]
+    pub fn projects(&self) -> &[ProjectConfig] {
+        &self.projects
     }
 
     /// Load configuration from the standard path or the [`CONFIG_ENV_VAR`]
@@ -377,9 +455,11 @@ impl AppConfig {
         let mut config = Self::default();
         for (key, item) in document.as_table().iter() {
             match key {
-                // `[[agents]]` is an array of tables, not a table, so it is
-                // matched before the table-like conversion below.
+                // `[[agents]]` and `[[projects]]` are arrays of tables, not
+                // tables, so they are matched before the table-like
+                // conversion below.
                 "agents" => parse_agents(item, &mut config.agents)?,
+                "projects" => parse_projects(item, &mut config.projects)?,
                 _ => {
                     let table = item
                         .as_table_like()
@@ -464,6 +544,56 @@ fn agent_string_field(key: &str, item: &Item) -> Result<String, ConfigError> {
         .as_str()
         .ok_or_else(|| ConfigError::AgentFieldNotAString { key: clip(key) })?;
     if text.is_empty() || text.len() > MAX_AGENT_FIELD_BYTES {
+        return Err(ConfigError::OutOfRange { key: clip(key) });
+    }
+    Ok(text.to_owned())
+}
+
+/// Apply the `[[projects]]` array to the configured project list.
+///
+/// The array spelling is the only accepted form (`projects = [...]` with
+/// inline tables is rejected, not silently reinterpreted), every entry must
+/// carry a string `name` and a string absolute `root`, and unknown entry keys
+/// are rejected like every other unknown key in this schema. The root must
+/// start with `/`: neither `~` expansion nor resolution against the launch
+/// directory is performed, so the configured text and the directory the
+/// session starts in can never silently diverge.
+fn parse_projects(item: &Item, projects: &mut Vec<ProjectConfig>) -> Result<(), ConfigError> {
+    let entries = item
+        .as_array_of_tables()
+        .ok_or_else(|| ConfigError::ProjectTableNotAnArray {
+            key: clip("projects"),
+        })?;
+    for entry in entries.iter() {
+        let mut name: Option<String> = None;
+        let mut root: Option<String> = None;
+        for (key, value) in entry.iter() {
+            match key {
+                "name" => name = Some(project_string_field(key, value)?),
+                "root" => {
+                    let root_text = project_string_field(key, value)?;
+                    if !root_text.starts_with('/') {
+                        return Err(ConfigError::ProjectRootNotAbsolute { key: clip(key) });
+                    }
+                    root = Some(root_text);
+                }
+                _ => return Err(ConfigError::UnknownKey(clip(key))),
+            }
+        }
+        let name = name.ok_or_else(|| ConfigError::ProjectFieldMissing { key: clip("name") })?;
+        let root = root.ok_or_else(|| ConfigError::ProjectFieldMissing { key: clip("root") })?;
+        projects.push(ProjectConfig { name, root });
+    }
+    Ok(())
+}
+
+/// Read one required `[[projects]]` string field (`name` or `root`),
+/// enforcing the shared type and length rules.
+fn project_string_field(key: &str, item: &Item) -> Result<String, ConfigError> {
+    let text = item
+        .as_str()
+        .ok_or_else(|| ConfigError::ProjectFieldNotAString { key: clip(key) })?;
+    if text.is_empty() || text.len() > MAX_PROJECT_FIELD_BYTES {
         return Err(ConfigError::OutOfRange { key: clip(key) });
     }
     Ok(text.to_owned())
@@ -1095,6 +1225,23 @@ pub enum ConfigError {
     /// and `PATH` lookup is deliberately not performed, so the only accepted
     /// shape is a leading `/`.
     AgentCommandNotAbsolute { key: String },
+    /// `projects` is present but is not an array of tables spelled
+    /// `[[projects]]`.
+    ///
+    /// No file text appears beyond the fixed key name.
+    ProjectTableNotAnArray { key: String },
+    /// A `[[projects]]` entry omits a required key (`name` or `root`).
+    ProjectFieldMissing { key: String },
+    /// A `[[projects]]` string field holds the wrong TOML type.
+    ProjectFieldNotAString { key: String },
+    /// The `root` of a `[[projects]]` entry is not an absolute path.
+    ///
+    /// The rejected text never appears: neither `~` expansion nor resolution
+    /// against the launch directory is performed, so the only accepted shape
+    /// is a leading `/`. A root can embed a username or a private directory
+    /// name, so echoing it would leak exactly what this schema keeps out of
+    /// diagnostics.
+    ProjectRootNotAbsolute { key: String },
 }
 
 impl fmt::Display for ConfigError {
@@ -1176,6 +1323,25 @@ impl fmt::Display for ConfigError {
                 f,
                 "configuration key {key} inside [[agents]] must be an absolute path with a \
                  leading '/'; PATH lookup is deliberately not performed"
+            ),
+            Self::ProjectTableNotAnArray { key } => write!(
+                f,
+                "configuration key {key} must be an array of tables spelled [[projects]]"
+            ),
+            Self::ProjectFieldMissing { key } => {
+                write!(f, "a [[projects]] entry is missing required key: {key}")
+            }
+            Self::ProjectFieldNotAString { key } => {
+                write!(
+                    f,
+                    "configuration key {key} inside [[projects]] must be a string"
+                )
+            }
+            Self::ProjectRootNotAbsolute { key } => write!(
+                f,
+                "configuration key {key} inside [[projects]] must be an absolute path with a \
+                 leading '/'; neither '~' expansion nor resolution against the launch \
+                 directory is performed"
             ),
         }
     }
@@ -2301,5 +2467,191 @@ mod tests {
         let policy = noren_pty::AgentLaunchPolicy::new(&command, &[arg])
             .expect("a schema-accepted element always fits the policy");
         assert_eq!(policy.args().len(), 1);
+    }
+
+    // ── [[projects]] tests ─────────────────────────────────────────────
+
+    /// With no `[[projects]]` entries the configured list is empty — exactly
+    /// the pre-projects behavior.
+    #[test]
+    fn default_config_has_no_projects() {
+        assert!(AppConfig::default().projects().is_empty());
+        assert!(
+            AppConfig::parse("# nothing\n")
+                .expect("valid")
+                .projects()
+                .is_empty()
+        );
+        // A bare `[[projects]]` header is one empty entry, and an entry
+        // without its required keys is a typed error, not a skipped row.
+        assert!(
+            AppConfig::parse("[[projects]]\n")
+                .expect_err("an empty entry lacks required keys")
+                .to_string()
+                .contains("missing required key")
+        );
+    }
+
+    #[test]
+    fn projects_parse_in_file_order_with_name_and_root() {
+        let config = AppConfig::parse(
+            "[[projects]]\nname = \"noren\"\nroot = \"/Users/dev/noren\"\n\
+             [[projects]]\nname = \"zellij\"\nroot = \"/Users/dev/tooling/zellij\"\n",
+        )
+        .expect("valid projects configuration");
+        let projects = config.projects();
+        assert_eq!(projects.len(), 2, "file order is preserved");
+        assert_eq!(projects[0].name(), "noren");
+        assert_eq!(projects[0].root(), "/Users/dev/noren");
+        assert_eq!(projects[1].name(), "zellij");
+        assert_eq!(projects[1].root(), "/Users/dev/tooling/zellij");
+        // The rest of the configuration is untouched.
+        assert_eq!(config.font(), FontConfig::default());
+        assert_eq!(config.keys(), KeymapConfig::default());
+        // Projects compose with agents in one file.
+        let combined = AppConfig::parse(
+            "[[agents]]\nname = \"a\"\ncommand = \"/bin/true\"\n\
+             [[projects]]\nname = \"p\"\nroot = \"/srv/p\"\n",
+        )
+        .expect("both arrays are valid together");
+        assert_eq!(combined.agents().len(), 1);
+        assert_eq!(combined.projects().len(), 1);
+    }
+
+    #[test]
+    fn project_entries_reject_each_malformed_shape_with_a_typed_error() {
+        let cases = [
+            (
+                "projects = 3\n",
+                ConfigError::ProjectTableNotAnArray {
+                    key: "projects".to_owned(),
+                },
+            ),
+            (
+                "[projects]\nname = \"x\"\n",
+                ConfigError::ProjectTableNotAnArray {
+                    key: "projects".to_owned(),
+                },
+            ),
+            (
+                "projects = [{ name = \"x\", root = \"/srv/x\" }]\n",
+                ConfigError::ProjectTableNotAnArray {
+                    key: "projects".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nroot = \"/srv/x\"\n",
+                ConfigError::ProjectFieldMissing {
+                    key: "name".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nname = \"x\"\n",
+                ConfigError::ProjectFieldMissing {
+                    key: "root".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nname = 5\nroot = \"/srv/x\"\n",
+                ConfigError::ProjectFieldNotAString {
+                    key: "name".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nname = \"x\"\nroot = \"srv/x\"\n",
+                ConfigError::ProjectRootNotAbsolute {
+                    key: "root".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nname = \"x\"\nroot = \"~/dev/x\"\n",
+                ConfigError::ProjectRootNotAbsolute {
+                    key: "root".to_owned(),
+                },
+            ),
+            (
+                "[[projects]]\nname = \"x\"\nroot = \"/srv/x\"\nextra = 1\n",
+                ConfigError::UnknownKey("extra".to_owned()),
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(AppConfig::parse(text), Err(expected), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn project_string_fields_are_range_checked_like_every_other_value() {
+        let oversize = "a".repeat(MAX_PROJECT_FIELD_BYTES + 1);
+        for hostile in [
+            "[[projects]]\nname = \"\"\nroot = \"/srv/x\"\n".to_owned(),
+            "[[projects]]\nname = \"x\"\nroot = \"\"\n".to_owned(),
+            format!("[[projects]]\nname = \"{oversize}\"\nroot = \"/srv/x\"\n"),
+            format!("[[projects]]\nname = \"x\"\nroot = \"/{oversize}\"\n"),
+        ] {
+            let result = AppConfig::parse(&hostile);
+            assert!(
+                matches!(result, Err(ConfigError::OutOfRange { .. })),
+                "{hostile:.60?}… must be rejected as out of range, got {result:?}"
+            );
+        }
+        // The cap itself is accepted; a root's cap includes its leading `/`,
+        // like an agent command's.
+        let at_cap = "a".repeat(MAX_PROJECT_FIELD_BYTES);
+        let root_at_cap = "a".repeat(MAX_PROJECT_FIELD_BYTES - 1);
+        assert!(
+            AppConfig::parse(&format!(
+                "[[projects]]\nname = \"{at_cap}\"\nroot = \"/{root_at_cap}\"\n"
+            ))
+            .is_ok()
+        );
+    }
+
+    /// Project fields are file values: no error surface may echo them, and
+    /// the configuration's own Debug is shape-only (issue #146).
+    #[test]
+    fn project_values_never_reach_errors_or_config_debug() {
+        const SENTINEL: &str = "NOREN-PROJECT-VALUE-hunter2";
+        let cases = [
+            // Relative root: the typed refusal names the key, not the text.
+            format!("[[projects]]\nname = \"x\"\nroot = \"{SENTINEL}\"\n"),
+            // Tilde root: still not absolute, still key-only.
+            format!("[[projects]]\nname = \"x\"\nroot = \"~/{SENTINEL}\"\n"),
+            // Wrong-typed fields name the key only.
+            format!("[[projects]]\nname = \"{SENTINEL}\"\nroot = 5\n"),
+            format!("[[projects]]\nname = 5\nroot = \"/{SENTINEL}\"\n"),
+        ];
+        for text in cases {
+            let error = AppConfig::parse(&text).expect_err("every sentinel fixture fails");
+            let display = error.to_string();
+            assert!(
+                !display.contains(SENTINEL),
+                "Display must not echo project values: {display}"
+            );
+            let debug = format!("{error:?}");
+            assert!(
+                !debug.contains(SENTINEL),
+                "Debug must not echo project values: {debug}"
+            );
+        }
+        // A VALID configuration never prints its fields through Debug either.
+        let config = AppConfig::parse(&format!(
+            "[[projects]]\nname = \"{SENTINEL}\"\nroot = \"/Users/{SENTINEL}/p\"\n"
+        ))
+        .expect("valid");
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains(SENTINEL),
+            "ProjectConfig Debug leaked file text: {rendered}"
+        );
+    }
+
+    /// The two array-of-tables field caps are one policy: a project field can
+    /// never outgrow the bound an agent field is held to, and vice versa.
+    #[test]
+    fn project_field_cap_matches_the_agent_field_cap() {
+        assert_eq!(
+            MAX_PROJECT_FIELD_BYTES, MAX_AGENT_FIELD_BYTES,
+            "the [[projects]] and [[agents]] field caps must not drift apart"
+        );
     }
 }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -123,6 +123,22 @@ const AGENT_SIDEBAR_DETAIL_FAILED: &str = "launch failed";
 /// spawned (missing or non-executable program). Fixed text: the command is
 /// configuration content and never appears on the status row.
 const AGENT_STATUS_LAUNCH_FAILED: &str = "Noren agent launch failed";
+/// Keep configured-project memory and identity work bounded independently of
+/// the frame height, exactly like the agent and SSH bounds. Project rows
+/// share the sidebar's scroll window over this bounded list.
+const MAX_PROJECT_SIDEBAR_ROWS: usize = 24;
+/// ASCII-only project row state that is always inside the first 16 columns.
+/// Eight characters, like the SSH and agent prefixes, so the label
+/// arithmetic is the shared [`sidebar_state_label`] helper.
+const PROJECT_SIDEBAR_PREFIX_IDLE: &str = "PRJ-OFF ";
+const PROJECT_SIDEBAR_PREFIX_FAILED: &str = "PRJ-ERR ";
+const PROJECT_SIDEBAR_DETAIL_IDLE: &str = "not running";
+const PROJECT_SIDEBAR_DETAIL_FAILED: &str = "launch failed";
+/// Status-row text when a project row whose root directory no longer exists
+/// is selected: the launch is refused before any session or child exists.
+const PROJECT_STATUS_MISSING: &str = "Noren project directory missing";
+/// Status-row text when a project session's zsh child could not be spawned.
+const PROJECT_STATUS_LAUNCH_FAILED: &str = "Noren project launch failed";
 
 /// Observed state of the one live SSH launch. This is application-local
 /// runtime state, deliberately outside the session registry: the registry
@@ -283,6 +299,31 @@ fn agent_sidebar_detail(failed: bool) -> &'static str {
     }
 }
 
+/// Build the bounded sidebar label for a configured project row. `failed`
+/// selects the fixed state prefix; the project's display name is bounded
+/// exactly like an SSH target or an agent name. The fixed `PRJ-` prefix is
+/// what distinguishes a project row from a worktree row at a glance: a
+/// worktree row has no state prefix and shows a branch as its detail.
+fn project_sidebar_label(failed: bool, name: &str) -> String {
+    sidebar_state_label(
+        if failed {
+            PROJECT_SIDEBAR_PREFIX_FAILED
+        } else {
+            PROJECT_SIDEBAR_PREFIX_IDLE
+        },
+        name,
+    )
+}
+
+/// The fixed detail text for a configured project row.
+fn project_sidebar_detail(failed: bool) -> &'static str {
+    if failed {
+        PROJECT_SIDEBAR_DETAIL_FAILED
+    } else {
+        PROJECT_SIDEBAR_DETAIL_IDLE
+    }
+}
+
 fn ssh_status_source_label(label: &str) -> String {
     let (path, tag) = label
         .rsplit_once(' ')
@@ -367,6 +408,37 @@ impl fmt::Debug for ConfiguredAgent {
     }
 }
 
+/// One configured project held by the workspace: the display name shown on
+/// its sidebar row plus the absolute root directory a session starts in when
+/// the row is selected.
+///
+/// Sidebar fact until a row is selected, exactly like the configured agents
+/// and SSH hosts and the discovered worktrees. The root was validated at
+/// configuration load (absolute, bounded); copying it here preserves it
+/// verbatim, and it is never displayed — the row shows the configured name
+/// and a fixed state detail — nor debug-printed. Only the launched session's
+/// [`SessionKind::Project`] root reaches `sessions.toml`.
+#[derive(Clone, PartialEq, Eq)]
+struct ConfiguredProject {
+    /// Display name from configuration.
+    name: String,
+    /// Absolute root directory of the project; the working directory of a
+    /// launched session's child.
+    root: PathBuf,
+}
+
+/// Shape-only [`Debug`] (issue #146): the name is user-authored
+/// configuration text, and a root can embed a username or a private
+/// directory name, so neither is printed — only their lengths.
+impl fmt::Debug for ConfiguredProject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConfiguredProject")
+            .field("name_chars", &self.name.chars().count())
+            .field("root_chars", &self.root.as_os_str().len())
+            .finish_non_exhaustive()
+    }
+}
+
 /// The dispatchable intent behind each palette command.
 ///
 /// The palette module is action-agnostic by design ([`Palette`] is generic
@@ -433,6 +505,18 @@ fn session_state_path() -> Option<PathBuf> {
 struct WorkspaceState {
     registry: SessionRegistry,
     sidebar: SidebarView,
+    /// Configured projects (`[[projects]]`), bounded by
+    /// [`MAX_PROJECT_SIDEBAR_ROWS`]. Sidebar facts until a row is selected:
+    /// no registry entry or child exists for one. Selecting a row creates a
+    /// `SessionKind::Project` session, which is the shape that persists.
+    projects: Vec<ConfiguredProject>,
+    /// How many configured projects the bounded sidebar policy omitted.
+    projects_omitted: usize,
+    /// Names of configured projects whose most recent launch FAILED.
+    /// Best-effort row marker bounded by the configured project count; the
+    /// session rows the registry owns remain the authority for a launch's
+    /// observed status.
+    project_launch_failures: std::collections::HashSet<String>,
     /// Worktrees discovered in the launch repository at startup: sidebar
     /// facts only until a row is selected, exactly like the configured SSH
     /// hosts. Selecting a row creates a `SessionKind::Worktree` session,
@@ -485,6 +569,12 @@ impl fmt::Debug for WorkspaceState {
             .field("registry", &self.registry.len())
             .field("registry_selection", &self.registry.selected())
             .field("sidebar", &self.sidebar)
+            .field("projects", &self.projects.len())
+            .field("projects_omitted", &self.projects_omitted)
+            .field(
+                "project_launch_failures",
+                &self.project_launch_failures.len(),
+            )
             .field("worktrees", &self.worktrees.len())
             .field("worktrees_omitted", &self.worktrees_omitted)
             .field("ssh_hosts", &self.ssh_hosts.len())
@@ -528,6 +618,9 @@ impl WorkspaceState {
         Self {
             registry: SessionRegistry::new(),
             sidebar: SidebarView::build(&[], None),
+            projects: Vec::new(),
+            projects_omitted: 0,
+            project_launch_failures: std::collections::HashSet::new(),
             worktrees: Vec::new(),
             worktrees_omitted: 0,
             ssh_hosts: Vec::new(),
@@ -670,6 +763,44 @@ impl WorkspaceState {
         Ok(())
     }
 
+    /// Replace the configured project facts without creating sessions. Rows
+    /// are bounded by [`MAX_PROJECT_SIDEBAR_ROWS`] and the omitted count is
+    /// retained for the status notice, exactly like the agent, SSH host, and
+    /// worktree bounds. Returns the number omitted.
+    fn load_projects(&mut self, projects: &[noren_app::config::ProjectConfig]) -> usize {
+        self.projects = projects
+            .iter()
+            .take(MAX_PROJECT_SIDEBAR_ROWS)
+            .map(|project| ConfiguredProject {
+                name: project.name().to_owned(),
+                root: PathBuf::from(project.root()),
+            })
+            .collect();
+        self.projects_omitted = projects.len().saturating_sub(self.projects.len());
+        self.project_launch_failures.clear();
+        self.rebuild_sidebar();
+        self.projects_omitted
+    }
+
+    /// The configured project fact at a stable sidebar position, if that
+    /// position is a project row. Session rows precede project rows; worktree
+    /// rows follow them.
+    fn project_sidebar_row(&self, row_index: usize) -> Option<&ConfiguredProject> {
+        let index = row_index.checked_sub(self.registry.len())?;
+        self.projects.get(index)
+    }
+
+    /// Mark a configured project's most recent launch as failed, so its row
+    /// carries the visible `PRJ-ERR` state.
+    fn record_project_launch_failure(&mut self, name: &str) {
+        self.project_launch_failures.insert(name.to_owned());
+    }
+
+    /// Clear a configured project's failure marker after a successful launch.
+    fn clear_project_launch_failure(&mut self, name: &str) {
+        self.project_launch_failures.remove(name);
+    }
+
     /// Replace the discovered worktree facts without creating sessions.
     /// Rows are bounded by [`git_worktree::MAX_WORKTREE_SIDEBAR_ROWS`] and
     /// the omitted count is retained for the status notice.
@@ -680,10 +811,10 @@ impl WorkspaceState {
     }
 
     /// The worktree fact at a stable sidebar position, if that position is
-    /// a worktree row. Session rows precede worktree rows; SSH host rows
-    /// follow them.
+    /// a worktree row. Session rows and project rows precede worktree rows;
+    /// SSH host rows follow them.
     fn worktree_sidebar_row(&self, row_index: usize) -> Option<&DiscoveredWorktree> {
-        let index = row_index.checked_sub(self.registry.len())?;
+        let index = row_index.checked_sub(self.registry.len() + self.projects.len())?;
         self.worktrees.get(index)
     }
 
@@ -714,8 +845,9 @@ impl WorkspaceState {
     /// Select an SSH row as a pending UI choice, never as a live session.
     fn select_ssh_sidebar_row(&mut self, row_index: usize) -> bool {
         let session_rows = self.registry.len();
+        let project_rows = self.projects.len();
         let worktree_rows = self.worktrees.len();
-        let host_index = row_index.checked_sub(session_rows + worktree_rows);
+        let host_index = row_index.checked_sub(session_rows + project_rows + worktree_rows);
         let Some(Some(ConfiguredSshHost {
             kind: SessionKind::Ssh { target },
             source_label,
@@ -750,12 +882,14 @@ impl WorkspaceState {
     }
 
     /// The configured agent fact at a stable sidebar position, if that
-    /// position is an agent row. Session rows precede worktree rows, SSH
-    /// host rows follow them, and agent rows follow the SSH hosts; the
-    /// subtraction chain mirrors the order the sidebar renders.
+    /// position is an agent row. Session rows precede project rows, project
+    /// rows precede worktree rows, SSH host rows follow them, and agent rows
+    /// follow the SSH hosts; the subtraction chain mirrors the order the
+    /// sidebar renders.
     fn agent_sidebar_row(&self, row_index: usize) -> Option<&ConfiguredAgent> {
-        let index = row_index
-            .checked_sub(self.registry.len() + self.worktrees.len() + self.ssh_hosts.len())?;
+        let index = row_index.checked_sub(
+            self.registry.len() + self.projects.len() + self.worktrees.len() + self.ssh_hosts.len(),
+        )?;
         self.agents.get(index)
     }
 
@@ -815,8 +949,9 @@ impl WorkspaceState {
     /// Rebuild the sidebar from the registry's current sessions and selection.
     ///
     /// Called after every mutation so the view never lags the model. Row
-    /// order is stable: session rows first, then discovered worktree facts,
-    /// then configured SSH host facts, then configured agent facts.
+    /// order is stable: session rows first, then configured project facts,
+    /// then discovered worktree facts, then configured SSH host facts, then
+    /// configured agent facts.
     fn rebuild_sidebar(&mut self) {
         let entries: Vec<SidebarEntry> = self
             .registry
@@ -825,6 +960,17 @@ impl WorkspaceState {
             .map(SidebarEntry::Session)
             .collect();
         let mut entries = entries;
+        // A project row shows its configured name behind the fixed `PRJ-`
+        // state prefix and a fixed state detail — never the root path — so
+        // it is distinguishable at a glance from a worktree row (final path
+        // component plus branch, no state prefix).
+        entries.extend(self.projects.iter().map(|project| {
+            let failed = self.project_launch_failures.contains(&project.name);
+            SidebarEntry::Project {
+                name: project_sidebar_label(failed, &project.name),
+                root: project_sidebar_detail(failed).to_owned(),
+            }
+        }));
         entries.extend(
             self.worktrees
                 .iter()
@@ -952,6 +1098,9 @@ struct NorenApp {
     ssh_selection_status: Option<String>,
     /// Bounded, content-free worktree-discovery notice (cap or failure).
     worktree_diagnostic: Option<String>,
+    /// Bounded, content-free configured-projects notice (cap only; project
+    /// launch failures surface as runtime statuses and row markers instead).
+    project_diagnostic: Option<String>,
     /// Bounded, content-free configured-agents notice (cap only; agent
     /// launch failures surface as runtime statuses instead).
     agent_diagnostic: Option<String>,
@@ -1027,6 +1176,7 @@ enum StatusRowSource {
     Runtime,
     SshSelection,
     WorktreeDiagnostic,
+    ProjectDiagnostic,
     AgentDiagnostic,
     SshDiagnostic,
 }
@@ -1037,6 +1187,7 @@ impl StatusRowSource {
         runtime: &'a str,
         ssh_selection_status: Option<&'a str>,
         worktree_diagnostic: Option<&'a str>,
+        project_diagnostic: Option<&'a str>,
         agent_diagnostic: Option<&'a str>,
         ssh_diagnostic: Option<&'a str>,
     ) -> &'a str {
@@ -1047,6 +1198,9 @@ impl StatusRowSource {
             }
             Self::WorktreeDiagnostic => {
                 worktree_diagnostic.expect("worktree diagnostic source requires diagnostic text")
+            }
+            Self::ProjectDiagnostic => {
+                project_diagnostic.expect("project diagnostic source requires diagnostic text")
             }
             Self::AgentDiagnostic => {
                 agent_diagnostic.expect("agent diagnostic source requires diagnostic text")
@@ -1071,10 +1225,17 @@ impl NorenApp {
         let geometry =
             GridGeometry::with_cells(config.font().cell_width(), config.font().cell_height())
                 .unwrap_or_else(GridGeometry::poc);
-        // Configured agents are sidebar facts from the same validated file:
-        // the names come from configuration (already bounded), the sidebar
-        // bound applies on top, and the omitted count reaches the status row.
+        // Configured agents and projects are sidebar facts from the same
+        // validated file: the names come from configuration (already
+        // bounded), the sidebar bound applies on top, and the omitted count
+        // reaches the status row.
         let mut workspace = WorkspaceState::new();
+        let projects_omitted = workspace.load_projects(config.projects());
+        let project_diagnostic = (projects_omitted > 0).then(|| {
+            format!(
+                "Noren projects: showing first {MAX_PROJECT_SIDEBAR_ROWS}; {projects_omitted} omitted"
+            )
+        });
         let agents_omitted = workspace.load_agents(config.agents());
         let agent_diagnostic = (agents_omitted > 0).then(|| {
             format!(
@@ -1097,6 +1258,7 @@ impl NorenApp {
             ssh_diagnostic: None,
             ssh_selection_status: None,
             worktree_diagnostic: None,
+            project_diagnostic,
             agent_diagnostic,
             ssh_eof_since: None,
             ssh_spawn_enabled: true,
@@ -1132,6 +1294,8 @@ impl NorenApp {
             StatusRowSource::SshSelection
         } else if self.worktree_diagnostic.is_some() {
             StatusRowSource::WorktreeDiagnostic
+        } else if self.project_diagnostic.is_some() {
+            StatusRowSource::ProjectDiagnostic
         } else if self.agent_diagnostic.is_some() {
             StatusRowSource::AgentDiagnostic
         } else if self.ssh_diagnostic.is_some() {
@@ -1524,28 +1688,28 @@ impl NorenApp {
         }
     }
 
-    /// Spawn the PTY for a worktree session, whose working directory is the
-    /// worktree itself.
+    /// Spawn the PTY for a directory-scoped session (a worktree or a
+    /// configured project root), whose working directory is that directory.
     ///
     /// Production inherits `HOME` unchanged so the user's own shell
-    /// configuration applies inside the worktree checkout. Tests that drive
-    /// the shell by typing redirect the child's `HOME` to the isolated
-    /// empty home (see [`NorenApp::test_pty_home`]) for the same reason as
+    /// configuration applies inside the directory. Tests that drive the
+    /// shell by typing redirect the child's `HOME` to the isolated empty
+    /// home (see [`NorenApp::test_pty_home`]) for the same reason as
     /// [`Self::spawn_pty_session`]: a developer's real `$HOME` may carry
     /// startup files that take arbitrarily long or read the terminal, which
     /// would make every shell-driving test depend on personal configuration.
-    /// The working directory is the worktree in both shapes, so the child's
-    /// actual cwd stays observable through its own `pwd` answer.
-    fn spawn_worktree_pty_session(
+    /// The working directory is the supplied directory in both shapes, so
+    /// the child's actual cwd stays observable through its own `pwd` answer.
+    fn spawn_directory_pty_session(
         &self,
-        path: &std::path::Path,
+        dir: &std::path::Path,
         size: PtySize,
     ) -> Result<PtySession, noren_pty::PtyError> {
         #[cfg(test)]
         if let Some(home) = &self.test_pty_home {
-            return PtySession::spawn_in_dir_with_home(path, home, size);
+            return PtySession::spawn_in_dir_with_home(dir, home, size);
         }
-        PtySession::spawn_in_dir(path, size)
+        PtySession::spawn_in_dir(dir, size)
     }
 
     /// Spawn a real PTY session whose working directory is the worktree at
@@ -1571,7 +1735,7 @@ impl NorenApp {
             );
             return None;
         };
-        match self.spawn_worktree_pty_session(path, pty_size) {
+        match self.spawn_directory_pty_session(path, pty_size) {
             Ok(pty) => {
                 self.workspace.observe_session(id, SessionStatus::Running);
                 self.park_active_session();
@@ -1597,6 +1761,73 @@ impl NorenApp {
                     },
                 );
                 self.status = WORKTREE_STATUS_LAUNCH_FAILED;
+                self.show_status = true;
+                self.redraw_needed = true;
+                None
+            }
+        }
+    }
+
+    /// Spawn a real PTY session whose working directory is the configured
+    /// project root, and give it the live view.
+    ///
+    /// This is the project-row runtime: the new sidebar row is a
+    /// `SessionKind::Project` registry session backed by an actual `/bin/zsh`
+    /// PTY whose child starts *in* the project root (HOME inherited, so the
+    /// user's shell configuration still applies) — the same launch shape and
+    /// conventions as a worktree session, distinguished by the kind that
+    /// persists. The registry observes `Running` when the spawn succeeds and
+    /// `Failed` when it does not. A configured root whose directory no longer
+    /// exists is refused before this method runs (the caller checks), exactly
+    /// like a registered-but-deleted worktree.
+    fn spawn_project_session(&mut self, project: &ConfiguredProject) -> Option<SessionId> {
+        let id = self.workspace.create_session(SessionKind::Project {
+            root: project.root.clone(),
+        });
+        let Some((terminal, pty_size)) = self.session_surfaces() else {
+            self.workspace.observe_session(
+                id,
+                SessionStatus::Failed {
+                    reason: "terminal surface unavailable".to_owned(),
+                },
+            );
+            self.workspace.record_project_launch_failure(&project.name);
+            self.workspace.rebuild_sidebar();
+            self.redraw_needed = true;
+            return None;
+        };
+        match self.spawn_directory_pty_session(&project.root, pty_size) {
+            Ok(pty) => {
+                self.workspace.observe_session(id, SessionStatus::Running);
+                self.workspace.clear_project_launch_failure(&project.name);
+                self.park_active_session();
+                self.pty = Some(pty);
+                self.terminal = Some(terminal);
+                self.active_session = Some(id);
+                self.pty_child = PtyChildStatus::Running;
+                self.selection = None;
+                self.drag_origin = None;
+                self.exited_surface_session = None;
+                self.workspace
+                    .select_session(id)
+                    .expect("freshly spawned session is live");
+                self.ssh_selection_status = None;
+                self.redraw_needed = true;
+                Some(id)
+            }
+            Err(_) => {
+                self.workspace.observe_session(
+                    id,
+                    SessionStatus::Failed {
+                        reason: "PTY spawn failed".to_owned(),
+                    },
+                );
+                // observe_session already rebuilt once; recording the row
+                // marker after it needs a second rebuild or the configured
+                // row keeps its idle label.
+                self.workspace.record_project_launch_failure(&project.name);
+                self.workspace.rebuild_sidebar();
+                self.status = PROJECT_STATUS_LAUNCH_FAILED;
                 self.show_status = true;
                 self.redraw_needed = true;
                 None
@@ -2399,6 +2630,24 @@ impl NorenApp {
             }
             return true;
         }
+        if let Some(project) = self.workspace.project_sidebar_row(row_index) {
+            // A project row whose configured root still exists launches a
+            // real session rooted at that directory; a configured-but-gone
+            // root is refused before any session or child exists — exactly
+            // like a registered-but-deleted worktree. Both are first-class,
+            // visible outcomes.
+            let project = project.clone();
+            if project.root.is_dir() {
+                self.spawn_project_session(&project);
+            } else {
+                self.workspace.record_project_launch_failure(&project.name);
+                self.workspace.rebuild_sidebar();
+                self.status = PROJECT_STATUS_MISSING;
+                self.show_status = true;
+            }
+            self.redraw_needed = true;
+            return true;
+        }
         if let Some(worktree) = self.workspace.worktree_sidebar_row(row_index) {
             // A present worktree row launches a real session rooted at the
             // worktree directory; a registered-but-deleted one is refused
@@ -3021,6 +3270,7 @@ impl NorenApp {
                 self.status,
                 self.ssh_selection_status.as_deref(),
                 self.worktree_diagnostic.as_deref(),
+                self.project_diagnostic.as_deref(),
                 self.agent_diagnostic.as_deref(),
                 self.ssh_diagnostic.as_deref(),
             )

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -6150,3 +6150,116 @@ fn project_paths_never_reach_debug_or_status_surfaces() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+/// Quitting with a project session beside a local, a worktree, and an agent
+/// session persists ALL FOUR creatable kinds through the real sessions.toml
+/// path — quit does not erase them — and the next launch restores every kind
+/// intact. (The fifth kind, SSH, never enters the registry by design; its
+/// round-trip is covered by the persistence suite's five-kind test,
+/// `round_trip_preserves_every_entry_kind_and_the_selection`.) This is also
+/// the direct guard that the project launch path did not reintroduce the
+/// historic quit-path erase: teardown must save exactly the sessions it had.
+#[cfg(target_os = "macos")]
+#[test]
+fn quitting_persists_project_sessions_beside_every_creatable_kind() {
+    let project_paths = project_directories(1);
+    let worktree_paths = mixed_worktree_directories(1);
+    let worktree_records =
+        git_worktree::parse_worktree_porcelain(&synthetic_porcelain(&worktree_paths))
+            .expect("synthetic porcelain parses");
+    let config = AppConfig::parse(&format!(
+        "{}[[agents]]\nname = \"persist-agent\"\ncommand = \"/bin/echo\"\nargs = [\"NOREN-PERSIST\"]\n",
+        projects_toml(&project_paths)
+    ))
+    .expect("valid projects and agents configuration");
+    let path = temp_state_path();
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..app_with_deterministic_ssh_seam_and_config(config)
+    };
+    app.workspace.state_path = Some(path.clone());
+    app.workspace
+        .load_worktrees(WorktreeDiscovery::from_records(worktree_records));
+
+    // One local session (palette), then the project row (row 1), the
+    // worktree row (row 3 after the project launch), and the agent row
+    // (row 5 after the worktree launch).
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    assert!(click_sidebar_row(&mut app, 1), "the project row launches");
+    assert!(click_sidebar_row(&mut app, 3), "the worktree row launches");
+    assert!(click_sidebar_row(&mut app, 5), "the agent row launches");
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 4);
+    for id in &ids {
+        assert_eq!(session_status(&app, *id), SessionStatus::Running);
+    }
+
+    app.teardown();
+
+    let text = std::fs::read_to_string(&path).expect("state saved on quit");
+    assert_eq!(
+        text.matches("kind = \"local\"").count(),
+        1,
+        "the local session still persists: {text}"
+    );
+    assert_eq!(
+        text.matches("kind = \"project\"").count(),
+        1,
+        "the project session persists with its kind: {text}"
+    );
+    assert!(
+        text.contains(&format!("root = \"{}\"", project_paths[0].display())),
+        "the project entry carries its root for restoration: {text}"
+    );
+    assert_eq!(
+        text.matches("kind = \"worktree\"").count(),
+        1,
+        "the worktree session persists with its kind: {text}"
+    );
+    assert_eq!(
+        text.matches("kind = \"agent\"").count(),
+        1,
+        "the agent session persists with its kind: {text}"
+    );
+
+    // The next launch restores all four rows as Restored with intact kinds —
+    // the project root survives the round-trip byte for byte.
+    let relaunched = sidebar_after_relaunch(&path);
+    assert_eq!(relaunched.registry().len(), 4);
+    let kinds: Vec<SessionKind> = relaunched
+        .registry()
+        .sessions()
+        .iter()
+        .map(|descriptor| descriptor.kind().clone())
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            SessionKind::Local,
+            SessionKind::Project {
+                root: project_paths[0].clone()
+            },
+            SessionKind::Worktree {
+                path: worktree_paths[0].clone()
+            },
+            SessionKind::Agent {
+                name: "persist-agent".to_owned()
+            },
+        ]
+    );
+    for descriptor in relaunched.registry().sessions() {
+        assert_eq!(
+            descriptor.status(),
+            &SessionStatus::Restored,
+            "a relaunched row must be Restored, never a phantom Running"
+        );
+    }
+    cleanup_state_file(&path);
+    for path in &worktree_paths {
+        let _ = std::fs::remove_dir(path);
+    }
+    for path in &project_paths {
+        let _ = std::fs::remove_dir(path);
+    }
+}

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -5049,15 +5049,17 @@ fn worktree_session_paths(app: &NorenApp) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Row order is FIXED — sessions first, then discovered worktree facts, then
-/// configured SSH hosts, then configured agents — and the click-path offset
-/// arithmetic silently depends on it, so the rendered order is pinned here
-/// with all four kinds present at once, including each kind's internal order
-/// (registry order, git listing order, config order). Agent-kind sessions
-/// render as ordinary session rows; a configured agent row (`EntryKind::Agent`)
-/// appears only for `[[agents]]` configuration entries.
+/// Row order is FIXED — sessions first, then configured project facts, then
+/// discovered worktree facts, then configured SSH hosts, then configured
+/// agents — and the click-path offset arithmetic silently depends on it, so
+/// the rendered order is pinned here with all five kinds present at once,
+/// including each kind's internal order (registry order, configuration
+/// order, git listing order). Agent-kind sessions render as ordinary
+/// session rows; a configured agent row (`EntryKind::Agent`) appears only
+/// for `[[agents]]` configuration entries, and a configured project row
+/// (`EntryKind::Project`) only for `[[projects]]` entries.
 #[test]
-fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
+fn sidebar_rows_render_sessions_then_projects_worktrees_ssh_hosts_agents() {
     let fixture = SshConfigFixture::new();
     fixture.write_new(b"Host zulu\nHost alpha\n");
     let records = git_worktree::parse_worktree_porcelain(
@@ -5066,11 +5068,13 @@ fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
          \nworktree /srv/mix-b\ndetached\n",
     )
     .expect("synthetic porcelain parses");
-    let config = AppConfig::parse(
-        "[[agents]]\nname = \"m-one\"\ncommand = \"/bin/true\"\n\
+    let project_roots = project_directories(2);
+    let config = AppConfig::parse(&format!(
+        "{}\n[[agents]]\nname = \"m-one\"\ncommand = \"/bin/true\"\n\
          [[agents]]\nname = \"m-two\"\ncommand = \"/bin/true\"\n",
-    )
-    .expect("valid agents configuration");
+        projects_toml(&project_roots),
+    ))
+    .expect("valid projects and agents configuration");
 
     let mut app = NorenApp::new(config);
     app.workspace
@@ -5089,6 +5093,8 @@ fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
         vec![
             EntryKind::Session,
             EntryKind::Session,
+            EntryKind::Project,
+            EntryKind::Project,
             EntryKind::Worktree,
             EntryKind::Worktree,
             EntryKind::Worktree,
@@ -5097,11 +5103,21 @@ fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
             EntryKind::Agent,
             EntryKind::Agent,
         ],
-        "the fixed order is sessions, worktrees, SSH hosts, then agents"
+        "the fixed order is sessions, projects, worktrees, SSH hosts, agents"
     );
+    // Project rows keep the configuration's declaration order and carry the
+    // fixed state prefix and detail, never the root path.
+    assert_eq!(
+        rows[2..4]
+            .iter()
+            .map(|row| row.label().to_owned())
+            .collect::<Vec<_>>(),
+        vec!["PRJ-OFF pr-00", "PRJ-OFF pr-01"]
+    );
+    assert_eq!(rows[2].detail(), Some("not running"));
     // Worktree rows keep git's listing order (main first).
     assert_eq!(
-        rows[2..5]
+        rows[4..7]
             .iter()
             .map(|row| row.label().to_owned())
             .collect::<Vec<_>>(),
@@ -5109,7 +5125,7 @@ fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
     );
     // SSH rows keep the config's declaration order.
     assert_eq!(
-        rows[5..7]
+        rows[7..9]
             .iter()
             .map(|row| row.label().to_owned())
             .collect::<Vec<_>>(),
@@ -5118,35 +5134,63 @@ fn sidebar_rows_render_sessions_then_worktrees_then_ssh_hosts_then_agents() {
     // Agent rows keep the configuration's declaration order (short names:
     // the label target budget is six characters, like an SSH target's).
     assert_eq!(
-        rows[7..9]
+        rows[9..11]
             .iter()
             .map(|row| row.label().to_owned())
             .collect::<Vec<_>>(),
         vec!["AGT-OFF m-one", "AGT-OFF m-two"]
     );
-    assert_eq!(rows[7].detail(), Some("not running"));
+    assert_eq!(rows[9].detail(), Some("not running"));
     assert!(
         app.agent_diagnostic.is_none(),
         "an in-cap agent list adds no notice"
     );
+    assert!(
+        app.project_diagnostic.is_none(),
+        "an in-cap project list adds no notice"
+    );
+    for root in &project_roots {
+        let _ = std::fs::remove_dir(root);
+    }
+}
+
+/// The roots of every registry session launched from a project row, in
+/// registry order — the observable identity of WHICH project row a click
+/// selected. (A model-only Project-kind session created directly by a test
+/// also appears here, exactly as the registry records it.)
+fn project_session_roots(app: &NorenApp) -> Vec<PathBuf> {
+    app.workspace
+        .registry()
+        .sessions()
+        .iter()
+        .filter_map(|descriptor| match descriptor.kind() {
+            SessionKind::Project { root } => Some(root.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Clicking each row kind in a mixed sidebar must select the row the user
 /// actually clicked — the default sidebar shape of this repository, which
-/// holds sessions, worktrees, SSH hosts, and configured agents at once. The
-/// boundaries are asserted explicitly: the last worktree row, the first SSH
-/// row, the last SSH row, the first and last agent rows, and the row
-/// immediately after the last agent row (a dead click that must select
-/// nothing, not wrap).
+/// holds sessions, configured projects, worktrees, SSH hosts, and configured
+/// agents at once. The boundaries are asserted explicitly: the first and
+/// last project rows, the last worktree row, the first SSH row, the last SSH
+/// row, the first and last agent rows, and the row immediately after the
+/// last agent row (a dead click that must select nothing, not wrap).
 ///
 /// Mutation checks:
-/// - dropping `+ worktree_rows` from `select_ssh_sidebar_row` makes the
+/// - dropping `+ self.projects.len()` (the project offset) from
+///   `worktree_sidebar_row` makes a worktree click resolve to a PROJECT row
+///   or dead-click instead of the worktree the user pointed at;
+/// - dropping `+ project_rows` from `select_ssh_sidebar_row` makes the
 ///   first-SSH-row click resolve to a DIFFERENT host (the host list here is
 ///   longer than the worktree list, so the misresolved index lands on a
 ///   real host, not a dead click);
-/// - dropping `+ self.ssh_hosts.len()` from `agent_sidebar_row` (the agent
+/// - dropping `+ self.projects.len()` from `agent_sidebar_row` (the agent
 ///   block's offset arithmetic) makes the first-agent-row click a dead
-///   click or an SSH connect instead of an agent launch;
+///   click, a project launch, or an SSH connect instead of an agent launch;
+/// - dropping the session-row offset from `project_sidebar_row` resolves a
+///   session click to a project row and launches instead of selecting;
 /// - dropping the session-row offset from `worktree_sidebar_row` resolves a
 ///   worktree click to another worktree's row;
 /// - dropping the session bound from `local_sidebar_session` makes
@@ -5161,17 +5205,22 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
     let worktree_paths = mixed_worktree_directories(3);
     let records = git_worktree::parse_worktree_porcelain(&synthetic_porcelain(&worktree_paths))
         .expect("synthetic porcelain parses");
+    // Two configured projects whose launches are real; their observable
+    // identity is the launched session's root directory.
+    let project_paths = project_directories(2);
     // Two configured agents whose launches are real, cheap, and immediate.
     let config = AppConfig::parse(&format!(
-        "[[agents]]\nname = \"mix-agent-one\"\ncommand = \"/bin/echo\"\nargs = [\"{}\"]\n\
+        "{}[[agents]]\nname = \"mix-agent-one\"\ncommand = \"/bin/echo\"\nargs = [\"{}\"]\n\
          [[agents]]\nname = \"mix-agent-two\"\ncommand = \"/bin/echo\"\nargs = [\"{}\"]\n",
-        "MIX-AGENT-ONE", "MIX-AGENT-TWO"
+        projects_toml(&project_paths),
+        "MIX-AGENT-ONE",
+        "MIX-AGENT-TWO"
     ))
-    .expect("valid agents configuration");
+    .expect("valid projects and agents configuration");
 
     // The deterministic seam keeps SSH row clicks from spawning any process;
-    // worktree and agent row clicks really launch (that is their observable
-    // identity).
+    // project, worktree, and agent row clicks really launch (that is their
+    // observable identity).
     let mut app = app_with_deterministic_ssh_seam_and_config(config);
     app.workspace
         .load_worktrees(WorktreeDiscovery::from_records(records));
@@ -5183,12 +5232,13 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
         }),
     ];
 
-    // Layout: rows 0-1 sessions, rows 2-4 worktrees, rows 5-9 SSH hosts,
-    // rows 10-11 configured agents.
+    // Layout: rows 0-1 sessions, rows 2-3 configured projects, rows 4-6
+    // worktrees, rows 7-11 SSH hosts, rows 12-13 configured agents.
     assert_eq!(
         app.workspace.sidebar().rows().len(),
-        12,
-        "two session rows, three worktree rows, five SSH rows, two agent rows"
+        14,
+        "two session rows, two project rows, three worktree rows, five SSH \
+         rows, two agent rows"
     );
 
     // Session rows select their own session, first and last alike.
@@ -5197,32 +5247,59 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
     assert!(click_sidebar_row(&mut app, 1), "the last session row");
     assert_eq!(app.workspace.registry().selected(), Some(sessions[1]));
 
-    // First SSH row (row 5): selects the FIRST host, and never moves the
-    // registry selection.
-    assert!(click_sidebar_row(&mut app, 5), "the first SSH row");
+    // First project row (row 2): launches a session rooted at the FIRST
+    // configured root — the created session's Project root is the observable
+    // identity of WHICH row the click resolved to. (The second session row
+    // is itself a model-only Project-kind row at /srv/noren, so it leads the
+    // recorded roots.)
+    assert!(click_sidebar_row(&mut app, 2), "the first project row");
+    assert_eq!(
+        project_session_roots(&app),
+        vec![PathBuf::from("/srv/noren"), project_paths[0].clone()],
+        "the click launches the project the user pointed at"
+    );
+
+    // Each launch adds a session row, shifting the rows below: with three
+    // sessions the project block occupies rows 3-4. Last project row (4):
+    // launches the SECOND configured root.
+    assert!(click_sidebar_row(&mut app, 4), "the last project row");
+    assert_eq!(
+        project_session_roots(&app),
+        vec![
+            PathBuf::from("/srv/noren"),
+            project_paths[0].clone(),
+            project_paths[1].clone(),
+        ],
+        "the last project row launches the second project, not the first again"
+    );
+
+    // With four sessions the layout is sessions 0-3, projects 4-5, worktrees
+    // 6-8, SSH 9-13, agents 14-15. First SSH row (9): selects the FIRST
+    // host, and never moves the registry selection (still the last launched
+    // project's own session).
+    let selected_before_ssh = app.workspace.registry().selected();
+    assert!(click_sidebar_row(&mut app, 9), "the first SSH row");
     assert_eq!(app.workspace.selected_ssh_target(), Some("alpha"));
     assert_eq!(
         app.workspace.registry().selected(),
-        Some(sessions[1]),
+        selected_before_ssh,
         "an SSH row click never selects a registry session"
     );
-    // Last SSH row (row 9): selects the LAST host.
-    assert!(click_sidebar_row(&mut app, 9), "the last SSH row");
+    // Last SSH row (13): selects the LAST host.
+    assert!(click_sidebar_row(&mut app, 13), "the last SSH row");
     assert_eq!(app.workspace.selected_ssh_target(), Some("echo"));
 
-    // First agent row (row 10): launches the FIRST configured agent — the
-    // created session's Agent name is the observable identity of WHICH row
-    // the click resolved to.
-    assert!(click_sidebar_row(&mut app, 10), "the first agent row");
+    // First agent row (14): launches the FIRST configured agent.
+    assert!(click_sidebar_row(&mut app, 14), "the first agent row");
     assert_eq!(
         agent_session_names(&app),
         vec!["mix-agent-one".to_owned()],
         "the click launches the agent the user pointed at"
     );
 
-    // Each launch adds a session row, shifting the rows below: with three
-    // sessions the agent block occupies rows 11-12. Last agent row.
-    assert!(click_sidebar_row(&mut app, 12), "the last agent row");
+    // Each launch adds a session row, shifting the rows below: with five
+    // sessions the agent block occupies rows 15-16. Last agent row.
+    assert!(click_sidebar_row(&mut app, 16), "the last agent row");
     assert_eq!(
         agent_session_names(&app),
         vec!["mix-agent-one".to_owned(), "mix-agent-two".to_owned()],
@@ -5233,16 +5310,17 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
         "the two agent clicks resolved to two DIFFERENT agents"
     );
 
-    // Row 14 — immediately after the last agent row (with four sessions the
-    // layout is sessions 0-3, worktrees 4-6, SSH 7-11, agents 12-13) —
-    // selects nothing: not a session, not a host, not an agent, no
-    // wrap-around, and no state changes at all. (The agent launches already
-    // cleared the pending SSH choice by selecting their own sessions, so
-    // the invariant here is that a dead click changes NOTHING.)
+    // Row 18 — immediately after the last agent row (with six sessions the
+    // layout is sessions 0-5, projects 6-7, worktrees 8-10, SSH 11-15,
+    // agents 16-17) — selects nothing: not a session, not a project, not a
+    // host, not an agent, no wrap-around, and no state changes at all. (The
+    // launches already cleared the pending SSH choice by selecting their own
+    // sessions, so the invariant here is that a dead click changes NOTHING.)
     let registry_len = app.workspace.registry().len();
     let selected = app.workspace.registry().selected();
+    let project_roots = project_session_roots(&app);
     assert!(
-        !click_sidebar_row(&mut app, 14),
+        !click_sidebar_row(&mut app, 18),
         "the row after the last agent row is a dead click"
     );
     assert_eq!(
@@ -5255,28 +5333,33 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
         registry_len,
         "a dead click must not create a session"
     );
+    assert_eq!(
+        project_session_roots(&app),
+        project_roots,
+        "a dead click must not launch a project"
+    );
 
-    // Last worktree row (row 6 with four sessions): launches a session
+    // Last worktree row (row 10 with six sessions): launches a session
     // rooted at the THIRD worktree — the row the user clicked, not the one
     // an offset error would resolve to.
-    assert!(click_sidebar_row(&mut app, 6), "the last worktree row");
+    assert!(click_sidebar_row(&mut app, 10), "the last worktree row");
     assert_eq!(
         worktree_session_paths(&app),
         vec![worktree_paths[2].clone()],
         "the click launches the worktree the user pointed at"
     );
 
-    // With five sessions the worktree block occupies rows 5-7. First
+    // With seven sessions the worktree block occupies rows 9-11. First
     // worktree row.
-    assert!(click_sidebar_row(&mut app, 5), "the first worktree row");
+    assert!(click_sidebar_row(&mut app, 9), "the first worktree row");
     assert_eq!(
         worktree_session_paths(&app),
         vec![worktree_paths[2].clone(), worktree_paths[0].clone()]
     );
 
-    // With six sessions the worktree block occupies rows 6-8; the middle
-    // worktree is row 7.
-    assert!(click_sidebar_row(&mut app, 7), "a middle worktree row");
+    // With eight sessions the worktree block occupies rows 10-12; the middle
+    // worktree is row 11.
+    assert!(click_sidebar_row(&mut app, 11), "a middle worktree row");
     assert_eq!(
         worktree_session_paths(&app),
         vec![
@@ -5286,26 +5369,42 @@ fn mixed_sidebar_clicks_select_the_row_the_user_clicked() {
         ]
     );
 
-    // After the launches the accumulated counts changed (seven sessions),
-    // so the SSH and agent boundaries are re-asserted at their new offsets:
-    // sessions 0-6, worktrees 7-9, SSH 10-14, agents 15-16.
+    // After the launches the accumulated counts changed (nine sessions), so
+    // the project, SSH, and agent boundaries are re-asserted at their new
+    // offsets: sessions 0-8, projects 9-10, worktrees 11-13, SSH 14-18,
+    // agents 19-20.
     assert_eq!(
         app.workspace.sidebar().rows().len(),
-        17,
-        "seven session rows, three worktree rows, five SSH rows, two agent rows"
+        21,
+        "nine session rows, two project rows, three worktree rows, five SSH \
+         rows, two agent rows"
     );
-    assert!(click_sidebar_row(&mut app, 10), "the first SSH row again");
+    assert!(
+        click_sidebar_row(&mut app, 9),
+        "the first project row again"
+    );
+    assert_eq!(
+        project_session_roots(&app).last(),
+        Some(&project_paths[0]),
+        "the project offset must track the grown session block"
+    );
+    // That launch grew the session block again (ten sessions): sessions
+    // 0-9, projects 10-11, worktrees 12-14, SSH 15-19, agents 20-21.
+    assert!(click_sidebar_row(&mut app, 15), "the first SSH row again");
     assert_eq!(
         app.workspace.selected_ssh_target(),
         Some("alpha"),
         "the SSH offset must track the grown session block"
     );
     assert!(
-        !click_sidebar_row(&mut app, 17),
+        !click_sidebar_row(&mut app, 22),
         "the row after the last agent row stays dead after the shifts"
     );
 
     for path in &worktree_paths {
+        let _ = std::fs::remove_dir(path);
+    }
+    for path in &project_paths {
         let _ = std::fs::remove_dir(path);
     }
 }
@@ -5728,13 +5827,12 @@ fn agent_commands_never_reach_debug_status_or_state_surfaces() {
 
 // ── Configured projects ([[projects]]) ──────────────────────────────────
 
-/// A synthetic `[[projects]]` configuration with one entry per root, each
-/// with a real temp directory so a row click can launch into it. The roots
-/// are canonicalized before they are written, so the configured text, the
+/// The `[[projects]]` TOML body for one entry per root. The roots are
+/// canonicalized before they are written, so the configured text, the
 /// session's launch shape, and the child's own `pwd` answer all name the
 /// same directory (`std::env::temp_dir` on macOS is a symlink whose
 /// canonical form is what a shell reports).
-fn many_projects_config(roots: &[PathBuf]) -> AppConfig {
+fn projects_toml(roots: &[PathBuf]) -> String {
     let mut text = String::new();
     for (index, root) in roots.iter().enumerate() {
         let canonical = std::fs::canonicalize(root).expect("canonicalize project root");
@@ -5743,12 +5841,21 @@ fn many_projects_config(roots: &[PathBuf]) -> AppConfig {
             canonical.display()
         ));
     }
-    AppConfig::parse(&text).expect("synthetic projects configuration parses")
+    text
+}
+
+/// A synthetic `[[projects]]` configuration with one entry per root, each
+/// with a real temp directory so a row click can launch into it.
+fn many_projects_config(roots: &[PathBuf]) -> AppConfig {
+    AppConfig::parse(&projects_toml(roots)).expect("synthetic projects configuration parses")
 }
 
 /// Real directories for configured projects: a project row click launches a
 /// session rooted at the configured directory, so the directory must exist
-/// for the launch to succeed.
+/// for the launch to succeed. The returned paths are canonical, so a
+/// launched session's root and the fixture path compare equal
+/// (`std::env::temp_dir` on macOS is a symlink whose canonical form is what
+/// a shell reports).
 fn project_directories(count: usize) -> Vec<PathBuf> {
     (0..count)
         .map(|index| {
@@ -5758,7 +5865,7 @@ fn project_directories(count: usize) -> Vec<PathBuf> {
                 WT_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             ));
             std::fs::create_dir(&path).expect("create project directory fixture");
-            path
+            std::fs::canonicalize(&path).expect("canonicalize project directory fixture")
         })
         .collect()
 }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1979,6 +1979,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
             app.status,
             app.ssh_selection_status.as_deref(),
             app.worktree_diagnostic.as_deref(),
+            app.project_diagnostic.as_deref(),
             app.agent_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
@@ -2012,6 +2013,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
         app.status,
         app.ssh_selection_status.as_deref(),
         app.worktree_diagnostic.as_deref(),
+        app.project_diagnostic.as_deref(),
         app.agent_diagnostic.as_deref(),
         app.ssh_diagnostic.as_deref(),
     );
@@ -2098,6 +2100,7 @@ fn post_startup_ssh_diagnostic_status_row_agrees_with_hit_testing_and_yields_to_
             app.status,
             app.ssh_selection_status.as_deref(),
             app.worktree_diagnostic.as_deref(),
+            app.project_diagnostic.as_deref(),
             app.agent_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
@@ -2168,6 +2171,7 @@ fn selecting_an_ssh_row_keeps_a_pending_choice_and_never_a_registry_connection()
             app.status,
             app.ssh_selection_status.as_deref(),
             app.worktree_diagnostic.as_deref(),
+            app.project_diagnostic.as_deref(),
             app.agent_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
@@ -5414,6 +5418,7 @@ fn many_configured_agents_are_capped_and_the_omitted_count_is_reported() {
             app.status,
             app.ssh_selection_status.as_deref(),
             app.worktree_diagnostic.as_deref(),
+            app.project_diagnostic.as_deref(),
             app.agent_diagnostic.as_deref(),
             app.ssh_diagnostic.as_deref(),
         ),
@@ -5719,4 +5724,322 @@ fn agent_commands_never_reach_debug_status_or_state_surfaces() {
         "the agent NAME is the persisted identity, like a worktree path: {text}"
     );
     cleanup_state_file(&path);
+}
+
+// ── Configured projects ([[projects]]) ──────────────────────────────────
+
+/// A synthetic `[[projects]]` configuration with one entry per root, each
+/// with a real temp directory so a row click can launch into it. The roots
+/// are canonicalized before they are written, so the configured text, the
+/// session's launch shape, and the child's own `pwd` answer all name the
+/// same directory (`std::env::temp_dir` on macOS is a symlink whose
+/// canonical form is what a shell reports).
+fn many_projects_config(roots: &[PathBuf]) -> AppConfig {
+    let mut text = String::new();
+    for (index, root) in roots.iter().enumerate() {
+        let canonical = std::fs::canonicalize(root).expect("canonicalize project root");
+        text.push_str(&format!(
+            "[[projects]]\nname = \"pr-{index:02}\"\nroot = \"{}\"\n",
+            canonical.display()
+        ));
+    }
+    AppConfig::parse(&text).expect("synthetic projects configuration parses")
+}
+
+/// Real directories for configured projects: a project row click launches a
+/// session rooted at the configured directory, so the directory must exist
+/// for the launch to succeed.
+fn project_directories(count: usize) -> Vec<PathBuf> {
+    (0..count)
+        .map(|index| {
+            let path = std::env::temp_dir().join(format!(
+                "noren-app-project-{}-{}-{index}",
+                std::process::id(),
+                WT_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&path).expect("create project directory fixture");
+            path
+        })
+        .collect()
+}
+
+/// Configured projects appear as `EntryKind::Project` rows in configuration
+/// order with bounded labels — and are distinguishable at a glance from
+/// worktree rows shown beside them: a project row carries the fixed
+/// `PRJ-OFF` state prefix and a fixed state detail, while a worktree row
+/// shows its checkout's final path component and its branch. The row kinds
+/// are distinct discriminants, so they can never collide.
+#[test]
+fn configured_projects_appear_as_rows_distinguishable_from_worktrees() {
+    let roots = project_directories(2);
+    let config = many_projects_config(&roots);
+    let mut app = NorenApp::new(config);
+    // Worktree facts beside the project rows (pure parsing; no git child).
+    let records = git_worktree::parse_worktree_porcelain(
+        "worktree /srv/pr-main\nbranch refs/heads/pr-main\n\
+         \nworktree /srv/pr-linked\nbranch refs/heads/pr-linked\n",
+    )
+    .expect("synthetic porcelain parses");
+    app.workspace
+        .load_worktrees(WorktreeDiscovery::from_records(records));
+
+    let rows = app.workspace.sidebar().rows();
+    let kinds: Vec<EntryKind> = rows.iter().map(|row| row.kind()).collect();
+    assert_eq!(
+        kinds,
+        vec![
+            EntryKind::Project,
+            EntryKind::Project,
+            EntryKind::Worktree,
+            EntryKind::Worktree,
+        ],
+        "project rows render before worktree rows, kinds never colliding"
+    );
+    // Configuration order is preserved; the label is the shared
+    // state-prefix + name shape; the detail is a fixed state, never the
+    // configured root path.
+    assert_eq!(rows[0].label(), "PRJ-OFF pr-00");
+    assert_eq!(rows[0].detail(), Some("not running"));
+    assert_eq!(rows[1].label(), "PRJ-OFF pr-01");
+    // A worktree row beside them has no state prefix and a branch detail:
+    // the two kinds of directory-rooted rows are visually distinct. (The
+    // synthetic worktree directories do not exist, so the detail carries the
+    // honest missing-directory marker.)
+    assert_eq!(rows[2].label(), "pr-main");
+    assert_eq!(rows[2].detail(), Some("pr-main (missing)"));
+    assert_ne!(rows[0].kind(), rows[2].kind());
+    assert!(
+        !rows[2].label().starts_with("PRJ-"),
+        "a worktree row never carries the project state prefix"
+    );
+    for root in &roots {
+        let _ = std::fs::remove_dir(root);
+    }
+}
+
+/// An overlong project name is truncated with the shared ASCII marker
+/// inside the label budget, exactly like an agent name or an SSH target.
+#[test]
+fn configured_project_labels_are_bounded_like_agent_labels() {
+    let roots = project_directories(1);
+    let config = AppConfig::parse(&format!(
+        "[[projects]]\nname = \"a-very-long-project-name-that-exceeds-the-budget\"\nroot = \"{}\"\n",
+        roots[0].display()
+    ))
+    .expect("valid configuration");
+    let app = NorenApp::new(config);
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].label(), "PRJ-OFF a-v...");
+    let _ = std::fs::remove_dir(&roots[0]);
+}
+
+/// More configured projects than the sidebar cap keep the first rows in
+/// configuration order and report the cap and the omitted count on the
+/// status row, exactly like the bounded agent, SSH host, and worktree lists.
+#[test]
+fn many_configured_projects_are_capped_and_the_omitted_count_is_reported() {
+    let cap = MAX_PROJECT_SIDEBAR_ROWS;
+    let roots = project_directories(cap + 2);
+    let config = many_projects_config(&roots);
+    let mut app = NorenApp::new(config);
+
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(
+        rows.len(),
+        cap,
+        "the sidebar keeps exactly the capped row count"
+    );
+    assert_eq!(rows[0].label(), "PRJ-OFF pr-00");
+    assert_eq!(
+        rows[cap - 1].label(),
+        format!("PRJ-OFF pr-{:02}", cap - 1),
+        "the retained block is the FIRST {cap} in configuration order"
+    );
+    assert_eq!(
+        app.workspace.projects_omitted, 2,
+        "beyond-cap projects are counted, not silently dropped"
+    );
+    let notice = app
+        .project_diagnostic
+        .as_deref()
+        .expect("the cap is reported on the status row");
+    assert!(
+        notice.contains("showing first 24") && notice.contains("2 omitted"),
+        "the notice names the cap and the omitted count: {notice}"
+    );
+    // The notice owns the status row whenever no runtime status shows.
+    app.show_status = false;
+    assert_eq!(app.status_row(), StatusRowSource::ProjectDiagnostic);
+    for root in &roots {
+        let _ = std::fs::remove_dir(root);
+    }
+}
+
+/// Selecting a project row must START a session whose working directory IS
+/// the configured root — verified by reading the child's own `pwd` answer
+/// back through the terminal, never by inferring it from the code path.
+///
+/// Mutation checks: making the click add a model row without spawning (no
+/// PTY, no `Running` observation), or starting the child anywhere other
+/// than the configured root, fails the assertions below.
+#[cfg(target_os = "macos")]
+#[test]
+fn selecting_a_project_row_starts_a_session_in_that_directory() {
+    let roots = project_directories(1);
+    let config = many_projects_config(&roots);
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..NorenApp::new(config)
+    };
+
+    assert!(
+        click_sidebar_row(&mut app, 0),
+        "the project row is consumed"
+    );
+
+    // The launch created a real Project-kind session that owns the live
+    // surface and is observed Running, carrying the configured root (the
+    // configuration wrote the canonical form, so every surface agrees).
+    let canonical = std::fs::canonicalize(&roots[0]).expect("canonicalize the project root");
+    let ids = registry_ids(&app);
+    assert_eq!(ids.len(), 1, "one registry session from the project row");
+    let id = ids[0];
+    assert_eq!(
+        app.workspace.registry().get(id).map(|d| d.kind().clone()),
+        Some(SessionKind::Project {
+            root: canonical.clone()
+        }),
+        "the session's launch shape carries the configured project root"
+    );
+    assert_eq!(session_status(&app, id), SessionStatus::Running);
+    assert_eq!(app.active_session, Some(id));
+    assert!(app.pty.is_some(), "the project session owns a real PTY");
+
+    // Read the child's ACTUAL working directory back: wait for the shell,
+    // ask it, and search the terminal text for its own answer. The path the
+    // session claims and the directory the child reports must agree. The
+    // grid wraps long lines across rows, so the comparison strips the row
+    // separators a wrap inserts — a wrapped path must still match whole.
+    wait_for_shell_output(&mut app);
+    app.send_input(b"pwd\n");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        app.drain_pty();
+        let answered = app.terminal.as_ref().is_some_and(|terminal| {
+            let unwrapped = terminal_text(terminal).replace(['\r', '\n'], "");
+            unwrapped.contains(canonical.display().to_string().as_str())
+        });
+        if answered {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the child's own pwd never reported the project root\n\
+             expected: the terminal text to contain the project root {}\n\
+             received: terminal said: {}",
+            canonical.display(),
+            app.terminal.as_ref().map(terminal_text).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = std::fs::remove_dir(&roots[0]);
+}
+
+/// A configured root whose directory no longer exists is refused before any
+/// session or child exists — a visible failure on the row and the status
+/// row, exactly like a registered-but-deleted worktree. Never a hang, never
+/// a session row, never a silent no-op.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_project_row_with_a_missing_directory_is_a_visible_failure_never_a_session() {
+    let missing_root =
+        std::env::temp_dir().join(format!("noren-missing-project-{}", std::process::id()));
+    let config = AppConfig::parse(&format!(
+        "[[projects]]\nname = \"ghost\"\nroot = \"{}\"\n",
+        missing_root.display()
+    ))
+    .expect("valid configuration");
+    let mut app = NorenApp::new(config);
+
+    // The click returns promptly (a hang fails the test runner's deadline);
+    // nothing was spawned and no session exists.
+    assert!(
+        click_sidebar_row(&mut app, 0),
+        "the project row is consumed even when the launch is refused"
+    );
+
+    // The refusal is first-class on every surface a user can see.
+    assert_eq!(app.status, "Noren project directory missing");
+    assert!(app.show_status, "the refusal must be visible");
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows[0].kind(), EntryKind::Project);
+    assert_eq!(rows[0].label(), "PRJ-ERR ghost");
+    assert_eq!(rows[0].detail(), Some("launch failed"));
+    assert!(
+        app.workspace.registry().is_empty(),
+        "a refused launch must not create a session row"
+    );
+    assert!(
+        app.pty.is_none(),
+        "a refused launch must leave no PTY behind"
+    );
+}
+
+/// A project root (and name) can embed a username or a private directory
+/// name. Every debug and status surface the configured-project flow can
+/// reach must stay free of the root. The persisted sessions.toml file
+/// deliberately DOES carry the root of a launched session — it is the
+/// user's own private state and exactly what restoration needs, the same
+/// class as a worktree path; the redaction discipline governs Debug and
+/// error output, not the state file.
+#[cfg(target_os = "macos")]
+#[test]
+fn project_paths_never_reach_debug_or_status_surfaces() {
+    let secret = format!("NOREN-PRJ-hunter2-{}", std::process::id());
+    let root = std::env::temp_dir().join(format!("{secret}/proj"));
+    std::fs::create_dir_all(&root).expect("create secret-shaped project root");
+    let config = AppConfig::parse(&format!(
+        "[[projects]]\nname = \"{secret}\"\nroot = \"{}\"\n",
+        root.display()
+    ))
+    .expect("valid configuration");
+
+    let home = AppTestHome::new();
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..NorenApp::new(config)
+    };
+
+    // The workspace (configured projects, sidebar view) never prints it.
+    assert!(
+        !format!("{:?}", app.workspace).contains(&secret),
+        "workspace debug leaked the project root"
+    );
+
+    // A launch selects the session and persists the structural change; the
+    // app-level debug surface still never prints it.
+    assert!(
+        click_sidebar_row(&mut app, 0),
+        "the project row is consumed"
+    );
+    assert!(
+        !format!("{:?}", app.workspace).contains(&secret),
+        "workspace debug leaked the project root after the launch"
+    );
+    // A registry session of this shape (the state a launch or a restore
+    // leaves behind) never prints it through the descriptor either.
+    let ids = registry_ids(&app);
+    let rendered = format!("{:?}", app.workspace.registry().get(ids[0]));
+    assert!(
+        !rendered.contains(&secret),
+        "descriptor debug leaked the project root: {rendered}"
+    );
+    assert!(
+        rendered.contains("Project"),
+        "not vacuous — the descriptor still names its shape: {rendered}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/noren-app/src/session.rs
+++ b/crates/noren-app/src/session.rs
@@ -64,12 +64,13 @@ impl fmt::Display for SessionId {
 
 /// The launch shape of a session.
 ///
-/// Conforms to D-M3-001: five variants. [`Local`], [`Worktree`], and
-/// [`Agent`] have implemented launch paths (a worktree session is a local
-/// PTY whose working directory is the worktree checkout; an agent session is
-/// a PTY running a configured, shell-free argv vector); [`Project`] and
-/// [`Ssh`] are carried as data so the enum is stable for exhaustive
-/// matching.
+/// Conforms to D-M3-001: five variants. [`Local`], [`Project`],
+/// [`Worktree`], and [`Agent`] have implemented launch paths (a project
+/// session and a worktree session are local PTYs whose working directory is
+/// the configured root / the worktree checkout; an agent session is a PTY
+/// running a configured, shell-free argv vector); [`Ssh`] is carried as
+/// data — its launch runs the system ssh client through a separate
+/// connection path, not the spawn layer this gate guards.
 ///
 /// D-M3-001 records the concrete payloads used here: `root`/`path` for the
 /// local-rooted kinds and `target`/`name` for the remote/agent kinds.
@@ -133,17 +134,20 @@ impl fmt::Debug for SessionKind {
 impl SessionKind {
     /// Whether this kind has an implemented launch path.
     ///
-    /// [`Local`](SessionKind::Local), [`Worktree`](SessionKind::Worktree),
-    /// and [`Agent`](SessionKind::Agent) do today — a worktree session
-    /// launches the fixed zsh policy in the worktree directory, and an agent
-    /// session launches a configured, shell-free argv vector in a PTY. The
-    /// spawn layer gates on this rather than guessing; the other kinds are
-    /// carried as reserved data.
+    /// [`Local`](SessionKind::Local), [`Project`](SessionKind::Project),
+    /// [`Worktree`](SessionKind::Worktree), and
+    /// [`Agent`](SessionKind::Agent) do today — a project session launches
+    /// the fixed zsh policy in the configured root directory, a worktree
+    /// session launches it in the worktree directory, and an agent session
+    /// launches a configured, shell-free argv vector in a PTY. The spawn
+    /// layer gates on this rather than guessing; the other kinds are carried
+    /// as reserved data (an SSH launch runs the system client through its
+    /// own connection path, never this gate).
     #[must_use]
     pub const fn is_launchable(&self) -> bool {
         matches!(
             self,
-            Self::Local | Self::Worktree { .. } | Self::Agent { .. }
+            Self::Local | Self::Project { .. } | Self::Worktree { .. } | Self::Agent { .. }
         )
     }
 }
@@ -528,13 +532,20 @@ mod tests {
     }
 
     #[test]
-    fn local_worktree_and_agent_kinds_are_launchable() {
-        // The worktree kind gained a real launch path (a local PTY whose
-        // working directory is the worktree checkout) and the agent kind a
-        // configured shell-free argv launch; the other kinds stay reserved
-        // data. A mutation reverting either to non-launchable fails this
-        // test.
+    fn local_project_worktree_and_agent_kinds_are_launchable() {
+        // The project kind gained a real launch path (a local PTY whose
+        // working directory is the configured root), like the worktree kind
+        // before it and the agent kind's configured shell-free argv launch;
+        // the SSH kind stays reserved data here — its launch runs the system
+        // client through the connection path, not this gate. A mutation
+        // reverting any launchable kind to non-launchable fails this test.
         assert!(SessionKind::Local.is_launchable());
+        assert!(
+            SessionKind::Project {
+                root: PathBuf::from("/p")
+            }
+            .is_launchable()
+        );
         assert!(
             SessionKind::Worktree {
                 path: PathBuf::from("/w")
@@ -544,12 +555,6 @@ mod tests {
         assert!(
             SessionKind::Agent {
                 name: "a".to_owned()
-            }
-            .is_launchable()
-        );
-        assert!(
-            !SessionKind::Project {
-                root: PathBuf::from("/p")
             }
             .is_launchable()
         );

--- a/crates/noren-app/tests/error_echo_contract.rs
+++ b/crates/noren-app/tests/error_echo_contract.rs
@@ -57,7 +57,7 @@ enum ValueEcho {
 
 /// Pinned variant count of [`ConfigError`]; a new variant must extend both
 /// the classifier and the sample table.
-const CONFIG_ERROR_VARIANTS: usize = 22;
+const CONFIG_ERROR_VARIANTS: usize = 26;
 /// Pinned variant count of [`SessionPersistenceError`].
 const SESSION_ERROR_VARIANTS: usize = 14;
 /// Pinned variant count of [`ChordParseError`].
@@ -119,6 +119,13 @@ fn classify_config(error: &ConfigError) -> ValueEcho {
         ConfigError::AgentArgsNotAnArray { .. } => ValueEcho::Never,
         ConfigError::AgentArgNotAString { .. } => ValueEcho::Never,
         ConfigError::AgentCommandNotAbsolute { .. } => ValueEcho::Never,
+        // `[[projects]]` variants carry only key names; the name and root
+        // values never appear (a project root can embed a username or a
+        // private directory name).
+        ConfigError::ProjectTableNotAnArray { .. } => ValueEcho::Never,
+        ConfigError::ProjectFieldMissing { .. } => ValueEcho::Never,
+        ConfigError::ProjectFieldNotAString { .. } => ValueEcho::Never,
+        ConfigError::ProjectRootNotAbsolute { .. } => ValueEcho::Never,
     }
 }
 
@@ -303,6 +310,22 @@ fn config_samples() -> Vec<(ConfigError, ValueEcho)> {
         ),
         (
             ConfigError::AgentCommandNotAbsolute { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::ProjectTableNotAnArray { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::ProjectFieldMissing { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::ProjectFieldNotAString { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::ProjectRootNotAbsolute { key: key() },
             ValueEcho::Never,
         ),
     ]
@@ -630,6 +653,11 @@ fn config_values_outside_keys_never_reach_display_or_debug() {
         format!("[[agents]]\nname = \"x\"\ncommand = \"{SENTINEL}\"\n"),
         format!("[[agents]]\nname = \"{SENTINEL}\"\ncommand = 5\n"),
         format!("[[agents]]\nname = \"x\"\ncommand = \"/bin/true\"\nargs = [\"{SENTINEL}\", 1]\n"),
+        // `[[projects]]` values: a root can embed a private path, so its
+        // rejections name the key, never the text.
+        format!("[[projects]]\nname = \"x\"\nroot = \"{SENTINEL}\"\n"),
+        format!("[[projects]]\nname = \"{SENTINEL}\"\nroot = 5\n"),
+        format!("[[projects]]\nname = \"x\"\nroot = \"~/{SENTINEL}\"\n"),
     ];
     for text in cases {
         let error = AppConfig::parse(&text).expect_err("every sentinel fixture must fail");

--- a/crates/noren-app/tests/session_domain.rs
+++ b/crates/noren-app/tests/session_domain.rs
@@ -520,7 +520,7 @@ fn a_descriptor_has_a_generated_title_for_every_kind() {
 // ── Reserved session kinds ──────────────────────────────────────────────
 
 #[test]
-fn project_and_ssh_kinds_can_be_bookkept_but_are_not_launchable() {
+fn ssh_and_other_reserved_kinds_can_be_bookkept_but_are_not_launchable() {
     let mut registry = SessionRegistry::new();
     let project = registry.create(SessionKind::Project {
         root: PathBuf::from("/p"),
@@ -533,10 +533,11 @@ fn project_and_ssh_kinds_can_be_bookkept_but_are_not_launchable() {
     });
 
     // The registry accepts reserved shapes as entries (bookkeeping only); it
-    // never launches anything, so this stays pure data. Project and SSH stay
-    // reserved; the agent kind gained a launch path (pinned separately
-    // below) but is still bookkept here exactly like every other kind.
-    assert!(!registry.get(project).unwrap().kind().is_launchable());
+    // never launches anything, so this stays pure data. SSH stays reserved
+    // here; the project and agent kinds gained launch paths (pinned
+    // separately below) but are still bookkept exactly like every other
+    // kind.
+    assert!(registry.get(project).unwrap().kind().is_launchable());
     assert!(!registry.get(ssh).unwrap().kind().is_launchable());
     assert!(registry.get(agent).unwrap().kind().is_launchable());
     let local = registry.create(SessionKind::Local);
@@ -561,6 +562,20 @@ fn the_worktree_kind_is_launchable() {
         path: PathBuf::from("/w"),
     });
     assert!(registry.get(worktree).unwrap().kind().is_launchable());
+}
+
+#[test]
+fn the_project_kind_is_launchable() {
+    // The project kind gained a real launch path: a local PTY whose working
+    // directory is the configured project root. The registry still only
+    // bookkeeps (it never spawns); this pins that the launch gate classifies
+    // the kind as launchable so a mutation reverting it to reserved data
+    // fails here.
+    let mut registry = SessionRegistry::new();
+    let project = registry.create(SessionKind::Project {
+        root: PathBuf::from("/srv/noren"),
+    });
+    assert!(registry.get(project).unwrap().kind().is_launchable());
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,48 @@ offending key. The `agents` table must be spelled as an array of tables
 (`[[agents]]`); `agents = [...]` with inline tables is rejected. Error
 messages never echo the field values.
 
+### `[[projects]]`
+
+Configured project entries: each `[[projects]]` table names one project
+with a display `name` and the absolute `root` directory a session starts in
+when the row is selected. Entries appear in file order, between the session
+rows and the worktree rows, capped at 24 rows (the omitted count is reported
+on the status row, exactly like the other bounded lists).
+
+Projects are **configured, not discovered**. A git worktree has an
+authoritative machine-readable source (`git worktree list --porcelain`), so
+worktrees are discovered; a project has no such source — any directory can
+be one — and scanning a directory tree for `.git` folders would be slow,
+unbounded, and would guess at the user's intent. A `[[projects]]` entry is
+the user telling Noren what counts.
+
+| Key | Type | Required | Accepted range | Meaning |
+| --- | --- | --- | --- | --- |
+| `name` | string | yes | 1..=1024 bytes | Display name on the sidebar row. |
+| `root` | string | yes | 1..=1024 bytes, absolute path | Directory the session's shell starts in when the row is selected. |
+
+The `root` must be an absolute path with a leading `/`: neither `~`
+expansion nor resolution against the launch directory is performed, so the
+configured text and the directory the session starts in can never silently
+diverge. Existence is deliberately not checked at load time — a configured
+root whose directory is gone is a runtime fact, refused visibly when the
+row is selected (exactly like a registered-but-deleted worktree), not a
+load-time guess.
+
+A project row is visually distinguishable from a worktree row: it carries
+the fixed eight-character state prefix (`PRJ-OFF` idle, `PRJ-ERR` after a
+refused launch) like the SSH and agent rows, while a worktree row shows its
+checkout's final path component and branch.
+
+Rejections follow the same hard-error discipline: an entry missing `name`
+or `root`, a wrong-typed field, a relative or tilde-relative `root`, an
+empty or oversized field, or an unknown key inside an entry is an error
+naming the offending key. The table must be spelled as an array of tables
+(`[[projects]]`); `projects = [...]` with inline tables is rejected. Error
+messages never echo the field values — a root can embed a username or a
+private directory name, so neither `Debug` output nor any error `Display`
+prints it.
+
 ### Rejected keys, by design
 
 - **`[terminal]` / `scrollback_lines`.** Scrollback retention is enforced
@@ -201,6 +243,14 @@ session_create = "ctrl+shift+t"
 
 [theme]
 name = "light"
+
+[[projects]]
+name = "noren"
+root = "/Users/dev/noren"
+
+[[projects]]
+name = "zellij"
+root = "/Users/dev/tooling/zellij"
 
 [[agents]]
 name = "claude"
@@ -231,12 +281,14 @@ command = "/opt/homebrew/bin/aider"
 
 - **No shell selection.** The threat model (TM-01) fixes the shell spawn at
   `/bin/zsh` with structured argv and accepts no configured additions, so
-  there is no shell key and none may be added. The `[[agents]]` `command` is
-  a different, explicit surface: a program the user asks Noren to launch,
-  executed as a shell-free argv vector with an absolute path (see the
-  `[[agents]]` section above).
-- **No credentials.** No key names a credential, key, or sensitive path; the
-  schema exposes no path keys at all.
+  there is no shell key and none may be added. The `[[agents]]` `command`
+  and the `[[projects]]` `root` are different, explicit surfaces: a program
+  the user asks Noren to launch and a directory the user asks Noren to open,
+  validated (absolute, bounded) and never echoed in errors or `Debug`
+  output.
+- **No credentials.** No key names a credential, key, or other sensitive
+  value; the only path-shaped keys are the agent `command` and the project
+  `root` described above.
 - **No raised ceilings.** `MAX_SCROLLBACK_LINES` and `MAX_SCREEN_CELLS` stay
   hard caps. Configuration has no key that touches the scrollback ceiling
   (the rejected `[terminal]` table), and every grid derived from cell sizes

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -199,10 +199,13 @@ Each item states what you would actually see if you ran the build.
   The PTY launches `/bin/zsh` with a fixed policy and no caller-controlled
   arguments (`ZSH_PROGRAM` in `crates/noren-pty/src/lib.rs`). Linux support is roadmap intent
   (Milestone 6), not current capability.
-- **Project and agent sessions are not launched.** `SessionKind` models
+- **Worktree, project, and agent sessions launch; the SSH kind does not go
+  through the spawn gate.** `SessionKind` models
   `Local`, `Project`, `Worktree`, `Ssh`, and `Agent`, and `EntryKind` in
   `sidebar.rs` can describe project, worktree, SSH-connection, and agent rows —
-  `Local`, `Worktree`, and `Ssh` have launch paths. The running binary reads bounded
+  `Local`, `Project`, `Worktree`, and `Agent` have launch paths (an SSH
+  launch runs the system client through its own connection path). The
+  running binary reads bounded
   OpenSSH configuration facts and displays configured targets as
   `SidebarEntry::SshConnection` rows. Clicking one validates the alias as an
   `SshDestination` (raw `%h`/`%p`/`%r` tokens are refused with a typed error
@@ -227,15 +230,21 @@ Each item states what you would actually see if you ran the build.
   `(missing)` marker
   and refused on selection — no panic, no child. Worktree sessions persist
   and restore through `sessions.toml` exactly like local ones.
-  Project and agent kinds remain modelled, while agent entries remain
-  reserved fixtures and no agent is launched. In practice: startup owns exactly
-  one local `zsh`, the palette's "New Session" spawns another real local `zsh`,
-  and every local row can take the live view; a restored row cannot (its shell
-  died with the previous launch). Selecting an SSH host row now launches the
-  system `ssh` client in the terminal's PTY (see the SSH section); selecting a
-  worktree row starts a shell in that worktree. A project row or an agent
-  still cannot be opened from the workspace. Milestones 4
-  and 5 own the remaining work.
+  `[[projects]]` configuration entries appear as `EntryKind::Project` rows
+  (at most 24, capped like every other list; the fixed `PRJ-` state prefix
+  distinguishes them from prefix-less worktree rows), and selecting one
+  whose root still exists starts a real `SessionKind::Project` session — the
+  same directory-rooted launch shape as a worktree, with the child's own
+  `pwd` proof; a configured-but-gone root is refused visibly like a deleted
+  worktree. `[[agents]]` entries launch their configured, shell-free argv in
+  a PTY (PR #169). Project and agent sessions persist and restore through
+  `sessions.toml` exactly like every other kind. In practice: startup owns
+  exactly one local `zsh`, the palette's "New Session" spawns another real
+  local `zsh`, and every local row can take the live view; a restored row
+  cannot (its shell died with the previous launch). Selecting an SSH host
+  row launches the system `ssh` client in the terminal's PTY (see the SSH
+  section); selecting a worktree, project, or agent row starts a real
+  session rooted at that row's identity.
 - **The SSH list is not OpenSSH-equivalent discovery.** A readable config can
   legitimately name destinations that do not appear: wildcard or negated
   patterns are matching policy rather than concrete aliases, `Match` and token


### PR DESCRIPTION
**This is the last item keeping Milestone 3 open.** Worktrees landed in #156, agents in #169, and `SessionKind::Project` was the only scope item left with no runtime creation path — a dead type to a user.

## Config, not discovery — and the reasoning matters

Worktrees are discovered because `git worktree list --porcelain` is an authoritative source. Projects have no equivalent: scanning a tree for `.git` directories is unbounded, slow, and **guesses at the user's intent**. So projects are configured in `[[projects]]`, the same argument that made agents configured in #169.

`config.rs`'s discipline is followed exactly: absolute-root validation, typed errors naming the offending key, no silent fallback.

## Telling a project from a worktree

A git worktree IS a directory containing `.git`, so the two row kinds can look identical to a user. They are distinguished by a fixed `PRJ` prefix plus a state detail, against the prefixless branch row a worktree shows — and by distinct `EntryKind`s, so they cannot collide in the index arithmetic.

## A fifth row kind moves the arithmetic again

#156 proved that removing one offset left every test green; #169 added a fourth kind. **5 index sites** were touched and the mixed-sidebar click matrix is extended across project rows.

Verified by mutation — dropping the registry offset from `project_sidebar_row`:

```
tests::mixed_sidebar_clicks_select_the_row_the_user_clicked ... FAILED
tests::quitting_persists_project_sessions_beside_every_creatable_kind ... FAILED
```

Two independent tests catch it.

## All five kinds round-trip

`all_five_kinds_roundtrip=yes`, `quit_preserves=yes` — local, worktree, SSH, agent and project sessions persist and survive quit together. This repo has prior history of a quit path erasing the sessions it had just saved, so that is tested rather than assumed.

The child's working directory is verified by reading its own `pwd` answer back through the terminal, not inferred from the code path.

Redaction follows #142/#146/#148/#155/#169: a project path can carry a username, so Debug is shape-only and the new error type is **classified** in `tests/error_echo_contract.rs`, not merely mentioned.

## Gates

`fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` **1,085 passing, 0 failed**. 14 tests added.
