### PR TITLE
test(oracle): pin the CJK width contract end to end through real pixels (M6)

### DIFF
--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -23,7 +23,12 @@
 //! - two cells carrying different SGR foreground colours draw *different*
 //!   pixel colours, each matching the palette; a cell with no SGR colour keeps
 //!   the unchanged default; truecolor and 256-colour both resolve to their
-//!   expected values (issue #107).
+//!   expected values (issue #107);
+//! - a wide (CJK/emoji) character lights its lead column with the replacement
+//!   glyph, leaves its continuation column unlit, and the glyph after the
+//!   pair lands at its display column — the width contract whose loss corrupts
+//!   the rest of the line;
+//! - a combining mark is drawn over its base cell without consuming a cell.
 //!
 //! ## The lit/blank gate
 //!
@@ -236,21 +241,20 @@ fn default_foreground_rgb() -> [u8; 3] {
 /// is past the line end, or the cell is an ASCII space (the space glyph is the
 /// all-zero row, so it draws nothing).
 ///
-/// Reads `display_lines()` — the renderer's coordinate model — not `lines()`.
-/// They agree for ASCII; only `display_lines()` keeps a wide character's
-/// continuation column aligned with the renderer's per-column enumeration, so
-/// the first wide-character fixture is compared against the same columns the
-/// renderer actually draws.
+/// Reads `display_cells()` — one cell per display column, the renderer's
+/// coordinate model. `display_lines()` encodes the same columns for wide
+/// characters but gives a combining mark its own character index even though
+/// the mark consumes no column (it lives inside the lead cell's text), so a
+/// string index is not a display column once marks are present. Every cell of
+/// a display row is retained here (only whole trailing rows are dropped), so
+/// "past the line end" reduces to "the cell is blank" and absent rows stay
+/// blank.
 fn state_cell_blank(snapshot: &TerminalSnapshot, row: u32, col: u32) -> bool {
-    let line = snapshot
-        .display_lines()
-        .get(row as usize)
-        .map(String::as_str);
-    match line {
+    match snapshot.display_cells().nth(row as usize) {
         None => true,
-        Some(line) => match line.chars().nth(col as usize) {
-            None | Some(' ') => true,
-            Some(_) => false,
+        Some(cells) => match cells.get(col as usize) {
+            None => true,
+            Some(cell) => cell.is_continuation() || cell.text() == " ",
         },
     }
 }
@@ -895,6 +899,180 @@ fn colour_follows_the_cell_across_wide_characters_and_rows() {
         colors_match(cell_color(&frame, 1, 0), DARK.ansi()[4]),
         "'c' on row 1 must be blue"
     );
+}
+
+// ===========================================================================
+// Wide-character width contract (Milestone 6): the terminal state core has
+// modelled CJK/emoji display width since PR #53 (a width-two character is a
+// lead cell plus a continuation cell), and the renderer honours that model by
+// reserving the continuation column without drawing it. These tests drive the
+// whole chain — `feed_bytes` → state → real GPU pixels — because "the state
+// models it" and "the renderer draws it" are different claims, and the pinned
+// properties are exactly the ones whose loss corrupts every following column
+// on the line. The bitmap font carries no CJK glyphs (issue #141): the pinned
+// failure mode is a visible replacement glyph at correct columns, which is
+// the deliberate scope of this slice — width handled correctly, glyphs not.
+// ===========================================================================
+
+/// `日本語` end to end: each character occupies two cells in the state, the
+/// lead column draws the visible replacement glyph, the continuation column
+/// draws nothing, and the whole grid still agrees cell-for-cell between state
+/// and render.
+///
+/// The three leads drawing identical pixels is today's truth pinned on
+/// purpose — the bitmap font cannot distinguish CJK code points, so uniform
+/// replacement is the contract until a real font stack lands (its own
+/// milestone decision). Adding CJK glyphs means updating this assertion, not
+/// deleting the test.
+#[test]
+fn cjk_text_occupies_two_cells_per_character_and_fails_visibly_not_corruptingly() {
+    let Some(renderer) = renderer_or_skip(
+        "cjk_text_occupies_two_cells_per_character_and_fails_visibly_not_corruptingly",
+    ) else {
+        return;
+    };
+    let mut state = TerminalState::new(1, 8).expect("valid test terminal");
+    state.feed_bytes("日本語".as_bytes());
+    let snap = state.snapshot();
+
+    // State half of the claim: three width-two leads at columns 0/2/4, a
+    // continuation cell after each, and the cursor six columns on.
+    assert_eq!(
+        (state.cursor().row(), state.cursor().column()),
+        (0, 6),
+        "three wide characters must advance the cursor six columns"
+    );
+    let cells: Vec<_> = snap
+        .display_cells()
+        .next()
+        .expect("one display row")
+        .to_vec();
+    for (col, expected) in
+        [(0usize, "日"), (2, "本"), (4, "語")].map(|(col, text)| (col, Some(text)))
+    {
+        let cell = &cells[col];
+        assert_eq!(cell.text(), expected.unwrap(), "lead at column {col}");
+        assert_eq!(cell.width(), 2, "lead at column {col}");
+        assert!(!cell.is_continuation());
+        assert!(
+            cells[col + 1].is_continuation(),
+            "column {} must be the continuation of the wide lead before it",
+            col + 1
+        );
+    }
+
+    let frame = render(&renderer, &snap);
+    assert_cells_agree(&frame, &snap);
+
+    // The lead columns are lit, all with the same glyph (uniform replacement
+    // is the pinned boundary), and that glyph is not the '?' glyph.
+    let question = render(&renderer, &snapshot(1, 8, b"?"));
+    for col in [0u32, 2, 4] {
+        assert!(
+            cell_is_lit(&frame, 0, col),
+            "wide lead at column {col} drew nothing — the failure must be visible"
+        );
+        assert_eq!(
+            cell_pattern(&frame, 0, col),
+            cell_pattern(&frame, 0, 0),
+            "CJK leads must draw the uniform replacement glyph (pinned: no CJK coverage)"
+        );
+        assert_ne!(
+            cell_pattern(&frame, 0, col),
+            cell_pattern(&question, 0, 0),
+            "the replacement glyph must not impersonate a typed '?'"
+        );
+    }
+    // Continuation columns own their column without drawing, and everything
+    // after the three wide pairs is untouched.
+    for col in [1u32, 3, 5, 6, 7] {
+        assert!(!cell_is_lit(&frame, 0, col), "column {col} must stay unlit");
+    }
+}
+
+/// The width contract that protects the rest of the line: a wide character
+/// followed by ASCII must place the ASCII at display column 2 (the wide pair
+/// is columns 0–1). A renderer that lets the wide character claim one cell
+/// draws the follower at column 1 and every subsequent column is wrong.
+#[test]
+fn wide_character_then_ascii_keeps_the_ascii_at_its_display_column() {
+    let Some(renderer) =
+        renderer_or_skip("wide_character_then_ascii_keeps_the_ascii_at_its_display_column")
+    else {
+        return;
+    };
+    let b_reference = render(&renderer, &snapshot(1, 4, b"b"));
+    for (label, bytes) in [
+        ("CJK 日", "日b".as_bytes()),
+        ("wide emoji 😀", "😀b".as_bytes()),
+    ] {
+        let snap = snapshot(1, 4, bytes);
+        let frame = render(&renderer, &snap);
+        assert!(cell_is_lit(&frame, 0, 0), "{label}: wide lead drew nothing");
+        assert!(
+            !cell_is_lit(&frame, 0, 1),
+            "{label}: the continuation column must own its column without drawing"
+        );
+        assert_eq!(
+            cell_pattern(&frame, 0, 2),
+            cell_pattern(&b_reference, 0, 0),
+            "{label}: the ASCII after a wide character must land at display column 2"
+        );
+        assert!(
+            !cell_is_lit(&frame, 0, 3),
+            "{label}: column 3 must stay unlit"
+        );
+        assert_cells_agree(&frame, &snap);
+    }
+}
+
+/// A combining mark must not consume a cell: `e` + U+0301 + `f` keeps `f` at
+/// column 1 with its ordinary glyph, while the mark itself is drawn over the
+/// `e` (visible, not dropped) — both compared against a plain `ef` render.
+#[test]
+fn combining_marks_consume_no_cell_through_the_pipeline() {
+    let Some(renderer) = renderer_or_skip("combining_marks_consume_no_cell_through_the_pipeline")
+    else {
+        return;
+    };
+    let marked = snapshot(1, 4, "e\u{0301}f".as_bytes());
+    let plain = snapshot(1, 4, b"ef");
+
+    // State half: the mark lives inside column 0's cell (width unchanged),
+    // and `f` stays at column 1.
+    let cells: Vec<_> = marked
+        .display_cells()
+        .next()
+        .expect("one display row")
+        .to_vec();
+    assert_eq!(cells[0].text(), "e\u{0301}");
+    assert_eq!(cells[0].width(), 1);
+    assert_eq!(cells[1].text(), "f");
+
+    let marked_frame = render(&renderer, &marked);
+    let plain_frame = render(&renderer, &plain);
+    assert!(
+        cell_is_lit(&marked_frame, 0, 0),
+        "'e' with its attached mark drew nothing"
+    );
+    assert_ne!(
+        cell_pattern(&marked_frame, 0, 0),
+        cell_pattern(&plain_frame, 0, 0),
+        "the combining mark drew nothing — it must fail visibly, not vanish"
+    );
+    assert_eq!(
+        cell_pattern(&marked_frame, 0, 1),
+        cell_pattern(&plain_frame, 0, 1),
+        "'f' must land at column 1 exactly as without the mark — a combining \
+         mark must not consume a cell"
+    );
+    assert_cells_agree(&marked_frame, &marked);
+    for col in [2u32, 3] {
+        assert!(
+            !cell_is_lit(&marked_frame, 0, col),
+            "column {col} must stay unlit"
+        );
+    }
 }
 
 // ===========================================================================

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -150,9 +150,22 @@ Each item states what you would actually see if you ran the build.
   upper/lower case, the Latin-1 Supplement (`U+00A0..=U+00FF`) and Box
   Drawing (`U+2500..=U+257F`) blocks have per-character bitmaps, and every
   other code point draws a visible replacement glyph rather than `?` — so
-  CJK text and emoji still do not render, even though the terminal state
-  core measures their display width correctly (Unicode/CJK display width,
-  recorded in the [roadmap](../ROADMAP.md)). Coverage is deliberately **not**
+  CJK text and emoji still do not render. What **is** true end to end is
+  their layout: the terminal state core measures CJK and emoji display
+  width correctly (Unicode/CJK display width, recorded in the
+  [roadmap](../ROADMAP.md)), and the renderer honours that model — a wide
+  character occupies two columns (its lead draws the replacement glyph,
+  the continuation column stays blank), the glyph after the pair lands at
+  its correct display column, and a combining mark is drawn over its base
+  cell without consuming a cell. Japanese output therefore appears as
+  unreadable replacement boxes that keep every surrounding column aligned,
+  not as corrupted text; the frame oracle pins this width contract through
+  real pixels (`cjk_text_occupies_two_cells_per_character_and_fails_visibly_not_corruptingly`,
+  `wide_character_then_ascii_keeps_the_ascii_at_its_display_column`,
+  `combining_marks_consume_no_cell_through_the_pipeline` in
+  `crates/noren-app/tests/frame_oracle.rs`). Rendering actual CJK glyphs
+  needs a real font stack, which is its own milestone decision and is
+  deliberately not claimed here. Coverage is deliberately **not**
   claimed collision-free: seven pairs of distinct characters are visually
   identical because at 5x7 their pixel grids genuinely coincide —
   space/`U+00A0` (both blank), and hyphen/`─`, slash/`╱`, equals/`═`,
@@ -166,7 +179,14 @@ Each item states what you would actually see if you ran the build.
 - **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
   the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
   drops the event without forwarding it. Japanese, Chinese, and
-  Korean input methods produce nothing.
+  Korean input methods produce nothing. For a user typing Japanese into
+  Noren today this means: composing with an IME inserts no text at all
+  (the composition never reaches the PTY), and any Japanese that a running
+  program *outputs* (`cat`, `ls`, a build log) draws as unreadable
+  replacement boxes — laid out at the correct two-column width so the
+  surrounding ASCII stays aligned, but the characters themselves cannot be
+  read. Neither half works today; both are Milestone 6 scope, and the width
+  half is the only half that is verified.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
@@ -319,7 +339,11 @@ neighbours; the drawn grid matches the state grid; and per-cell lit/blank agrees
 with `TerminalSnapshot` across the FR-005 fixture classes. Its active
 colour-aware assertions also cover distinct SGR foregrounds, unchanged defaults,
 ANSI/256-colour and direct RGB resolution, explicit truecolor backgrounds,
-background-only spaces, and indexed/background equivalence. It does **not**
+background-only spaces, and indexed/background equivalence. The Milestone 6
+CJK slice added pixel-level pins of the wide-character width contract through
+the whole `feed_bytes` → state → GPU chain: `日本語` and a wide emoji occupy
+two cells per character with the follower at its display column, and a
+combining mark consumes no cell. It does **not**
 assert an `A` looks like an A — only that the structure and resolved pixel
 colours are right. Its two former defect specifications
 (`lowercase_distinct_from_uppercase`, `non_ascii_glyph_is_not_the_question_mark`)


### PR DESCRIPTION
Milestone 6's next piece after themes (#167). This is a **scope-honest** slice: it pins the CJK width contract at pixel level and states the true position for a user typing Japanese, rather than claiming CJK support that does not exist.

## What is actually true, measured end to end

The distinction matters and this repo has confused it before, so both halves are stated separately:

- **Terminal state models width correctly**: a wide character occupies 2 cells — a lead cell holding the character and a continuation cell.
- **The renderer draws a uniform replacement glyph** in the lead column, a blank continuation, and — the part that matters — **places following glyphs at the correct display columns**.

So `日本語` does not render as Japanese. It renders as placeholders **that occupy the right number of cells**.

## Why the width contract is the real deliverable

If the state says two cells and the renderer draws one, every subsequent column on that line is wrong and the user sees the rest of the line corrupted. That is a far worse failure than a placeholder glyph — corruption is silent and spreads, a placeholder is obvious and local.

`column_after_wide_correct=yes`, verified through the frame oracle on real pixels. Confirmed by mutation — making a wide character stop claiming its second cell:

```
colour_follows_the_cell_across_wide_characters_and_rows ... FAILED
wide_output_renders_like_the_equivalent_single_width_layout ... FAILED
```

Combining marks are zero-width and do not consume a cell.

## Scope explicitly declined

- **Real CJK glyph rendering** — a built-in bitmap font cannot carry CJK; that needs a font stack and is its own milestone decision.
- A spanning wide placeholder (one glyph drawn across both cells).
- IME forwarding.

`docs/known-limitations.md` now states the true end-to-end position for a Japanese-typing user, rather than leaving them to discover it.

## Gates

`fmt` clean, `clippy -D warnings` clean, `cargo test --workspace` **1,074 passing, 0 failed**. 3 tests added.
