### PR TITLE
fix(snapshot): share scrollback rows instead of deep-copying them (#172)

### DIFF
--- a/crates/noren-terminal/Cargo.toml
+++ b/crates/noren-terminal/Cargo.toml
@@ -13,3 +13,11 @@ unicode-width.workspace = true
 
 [lints]
 workspace = true
+
+# Report-only benchmark (issue #172). `harness = false` with no benching
+# dependency; `test = false` keeps `cargo test --workspace` from running the
+# timing loop as if it were a test.
+[[bench]]
+name = "snapshot_scrollback"
+harness = false
+test = false

--- a/crates/noren-terminal/benches/snapshot_scrollback.rs
+++ b/crates/noren-terminal/benches/snapshot_scrollback.rs
@@ -1,0 +1,68 @@
+//! Snapshot cost benchmark for issue #172.
+//!
+//! `TerminalEngine::snapshot()` is called on the per-frame render path
+//! (`noren-app`'s `redraw`), so its cost must not scale with data the user
+//! accumulates. This bench reports the two ends of that scaling:
+//! an empty scrollback and a scrollback filled to the
+//! [`MAX_SCROLLBACK_LINES`] cap.
+//!
+//! It is `harness = false` with no benchmarking dependency on purpose: it
+//! reports numbers and asserts nothing, so no wall clock can become a
+//! machine-dependent test gate here (#154/#159). The regression *guard* lives
+//! in the test suite as a copied-work assertion (row sharing), not a timer.
+//!
+//! Run with `cargo bench -p noren-terminal`.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use noren_terminal::{MAX_SCROLLBACK_LINES, TerminalState};
+
+/// Build a terminal whose scrollback holds exactly `lines` non-blank rows.
+///
+/// The renderer-shaped 60x160 grid measures the snapshot at the size a real
+/// frame uses. A `rows`-row grid absorbs `rows - 1` line feeds before the
+/// first eviction, so the script emits `lines + rows - 1` labelled lines and
+/// the assert pins the retained count exactly at `lines`.
+fn filled_scrollback(lines: usize) -> TerminalState {
+    let mut state = TerminalState::new(60, 160).expect("valid terminal size");
+    let rows = usize::from(state.size().0);
+    let total = lines + rows - 1;
+    let mut script = String::with_capacity(total * 8);
+    for index in 0..total {
+        script.push_str(&format!("{index:05}\r\n"));
+    }
+    state.feed_bytes(script.as_bytes());
+    assert_eq!(
+        state.scrollback_len(),
+        lines,
+        "fixture must retain exactly `lines` rows"
+    );
+    state
+}
+
+/// Measure `snapshot()` over a fixed iteration count and report ns/iter.
+fn bench_snapshot(label: &str, state: &TerminalState, iterations: u32) {
+    // Warm up once so the first allocation does not dominate a short loop.
+    black_box(state.snapshot());
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        black_box(state.snapshot());
+    }
+    let elapsed = start.elapsed();
+
+    let per_iter = elapsed.as_nanos() / u128::from(iterations);
+    let per_iter_us = f64::from(u32::try_from(per_iter).unwrap_or(u32::MAX)) / 1000.0;
+    println!("{label}: {per_iter_us:.3} µs/iter ({iterations} iterations, {elapsed:?} total)");
+}
+
+fn main() {
+    // Iteration counts are fixed work counts, not deadlines: the bench reports
+    // whatever time that work takes on whatever machine runs it.
+    let empty = TerminalState::new(60, 160).expect("valid terminal size");
+    bench_snapshot("snapshot_empty_scrollback", &empty, 2_000);
+
+    let full = filled_scrollback(MAX_SCROLLBACK_LINES);
+    bench_snapshot("snapshot_full_scrollback", &full, 200);
+}

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use std::collections::VecDeque;
 use std::fmt;
+use std::sync::Arc;
 
 /// Hard allocation bound for a visible Terminal Core screen.
 pub const MAX_SCREEN_CELLS: usize = 1024 * 1024;
@@ -735,7 +736,14 @@ pub struct TerminalState {
     parser: Parser,
     // Bounded history of lines that scrolled off the top of the primary screen.
     // The alternate screen never contributes; see `push_scrollback_rows`.
-    scrollback: VecDeque<Vec<Cell>>,
+    //
+    // Rows are shared, not copied: a row is immutable from the moment it is
+    // pushed (only push_back/pop_front ever touch the deque, and resize never
+    // reflows retained rows), so each row is a single `Arc<[Cell]>` that
+    // `snapshot` clones by handle. That keeps the per-frame snapshot cost at
+    // one pointer-sized clone per retained row instead of a deep copy that
+    // scales with the user's history (issue #172).
+    scrollback: VecDeque<Arc<[Cell]>>,
 }
 
 impl TerminalState {
@@ -834,7 +842,7 @@ impl TerminalState {
     /// [`TerminalSnapshot::scrollback`] for the cloned ordered view.
     #[must_use]
     pub fn scrollback_row(&self, index: usize) -> Option<&[Cell]> {
-        self.scrollback.get(index).map(Vec::as_slice)
+        self.scrollback.get(index).map(|row| row.as_ref())
     }
 
     /// Save the active screen's cursor position.
@@ -1126,7 +1134,7 @@ impl TerminalState {
             if self.scrollback.len() >= MAX_SCROLLBACK_LINES {
                 self.scrollback.pop_front();
             }
-            self.scrollback.push_back(row);
+            self.scrollback.push_back(Arc::from(row));
         }
     }
 
@@ -1473,6 +1481,14 @@ impl fmt::Debug for TerminalState {
 }
 
 /// Immutable snapshot passed to renderers and deterministic test oracles.
+///
+/// Scrollback rows are **shared** with the state, not copied: a retained row is
+/// immutable from the moment it scrolls off, so the snapshot holds an
+/// [`Arc`] handle per row and cloning the snapshot's history is one
+/// pointer-sized increment per row. Every accessor (including
+/// [`Debug`](std::fmt::Debug) and [`PartialEq`]) still observes the same cell
+/// contents as before the sharing change; only the ownership of unchanged rows
+/// differs (issue #172).
 #[derive(Clone, PartialEq, Eq)]
 pub struct TerminalSnapshot {
     screen: ScreenBuffer,
@@ -1482,12 +1498,12 @@ pub struct TerminalSnapshot {
     modes: TerminalModes,
     lines: Vec<String>,
     display_lines: Vec<String>,
-    scrollback: Vec<Vec<Cell>>,
+    scrollback: Vec<Arc<[Cell]>>,
 }
 
 impl fmt::Debug for TerminalSnapshot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let scrollback_cells = self.scrollback.iter().map(Vec::len).sum::<usize>();
+        let scrollback_cells = self.scrollback.iter().map(|row| row.len()).sum::<usize>();
         f.debug_struct("TerminalSnapshot")
             .field("size", &(self.rows(), self.cols()))
             .field("cursor", &self.cursor)
@@ -1607,8 +1623,13 @@ impl TerminalSnapshot {
     /// off the top of the visible grid, captured at the width it had when it
     /// left. The alternate screen never contributes. The slice length is bounded
     /// by [`MAX_SCROLLBACK_LINES`].
+    ///
+    /// Rows are shared with the state rather than deep-copied: each element is
+    /// an [`Arc`] handle to an immutable row, so building the snapshot copies
+    /// one handle per row (8 bytes) instead of `cols * size_of::<Cell>()` bytes
+    /// per row. Indexing and iteration deref to `&[Cell]` exactly as before.
     #[must_use]
-    pub fn scrollback(&self) -> &[Vec<Cell>] {
+    pub fn scrollback(&self) -> &[Arc<[Cell]>] {
         &self.scrollback
     }
 
@@ -1646,7 +1667,7 @@ impl TerminalSnapshot {
         let i = usize::try_from(index).ok()?;
         let sb = self.scrollback.len();
         if i < sb {
-            Some(self.scrollback[i].as_slice())
+            Some(self.scrollback[i].as_ref())
         } else {
             let v = i - sb;
             let cols = usize::from(self.screen.cols);

--- a/crates/noren-terminal/tests/scrollback.rs
+++ b/crates/noren-terminal/tests/scrollback.rs
@@ -10,6 +10,8 @@
 //! down (and scrolls) without returning to column 0, exactly like a real
 //! terminal, so CR is needed to start each label at the left margin.
 
+use std::sync::Arc;
+
 use noren_terminal::{Cell, MAX_SCROLLBACK_LINES, TerminalState};
 
 /// Text rendering of retained scrollback rows, oldest first.
@@ -19,7 +21,12 @@ fn scrollback_lines(state: &TerminalState) -> Vec<String> {
 
 /// Width (cell count) of each retained scrollback row, in order.
 fn scrollback_widths(state: &TerminalState) -> Vec<usize> {
-    state.snapshot().scrollback().iter().map(Vec::len).collect()
+    state
+        .snapshot()
+        .scrollback()
+        .iter()
+        .map(|row| row.len())
+        .collect()
 }
 
 #[test]
@@ -157,6 +164,110 @@ fn resize_does_not_reflow_or_corrupt_retained_lines() {
     let snapshot = state.snapshot();
     let row0 = &snapshot.scrollback()[0];
     assert_eq!(row0.iter().map(Cell::text).collect::<String>(), "AAAA");
+}
+
+/// Fill `state`'s scrollback to exactly the hard cap with labelled lines.
+///
+/// Shared fixture for the per-frame-cost guards below: a 1-row grid makes
+/// every CRLF evict one labelled row, so the retained history is exactly the
+/// last `MAX_SCROLLBACK_LINES` labels, oldest first.
+fn capped_scrollback_state() -> TerminalState {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    let mut script = String::with_capacity(MAX_SCROLLBACK_LINES * 8);
+    for index in 0..MAX_SCROLLBACK_LINES {
+        script.push_str(&format!("{index:05}\r\n"));
+    }
+    state.feed_bytes(script.as_bytes());
+    assert_eq!(state.scrollback_len(), MAX_SCROLLBACK_LINES);
+    state
+}
+
+/// Issue #172 regression guard: `snapshot()` must copy **zero** scrollback
+/// cells, at any history depth.
+///
+/// This is the copied-work assertion in the style #158 established for #137:
+/// the guard pins the amount of copying (a count), never the wall clock a
+/// copy takes, so it holds on every machine and in every build profile.
+/// Scrollback rows are immutable from the moment they scroll off, so the
+/// snapshot shares each row by `Arc` handle instead of cloning `cols *
+/// size_of::<Cell>()` bytes per row. Two snapshots of one state therefore
+/// reference the same row allocation iff the rows were shared: a deep copy
+/// (the pre-fix `from_state`, or any regression back to it) produces distinct
+/// allocations and fails the pointer equality below — at the full 10_000-row
+/// cap, the exact history depth where the 150x cost showed up.
+#[test]
+fn snapshot_copies_no_scrollback_cells_at_full_history() {
+    let state = capped_scrollback_state();
+
+    let first = state.snapshot();
+    let second = state.snapshot();
+    assert_eq!(first.scrollback().len(), MAX_SCROLLBACK_LINES);
+
+    let deep_copied: Vec<usize> = first
+        .scrollback()
+        .iter()
+        .zip(second.scrollback())
+        .filter(|(a, b)| !Arc::ptr_eq(a, b))
+        .map(|(a, _)| a.len())
+        .collect();
+    assert!(
+        deep_copied.is_empty(),
+        "snapshot deep-copied {} scrollback rows ({} cells) instead of sharing them",
+        deep_copied.len(),
+        deep_copied.iter().sum::<usize>(),
+    );
+
+    // Sharing must not change what the consumer reads: contents, order, and
+    // the text view still match the fixture exactly.
+    assert_eq!(
+        first.scrollback_lines().first().map(String::as_str),
+        Some("00000")
+    );
+    let last_label = format!("{:05}", MAX_SCROLLBACK_LINES - 1);
+    assert_eq!(
+        first.scrollback_lines().last().map(String::as_str),
+        Some(last_label.as_str())
+    );
+}
+
+/// Snapshot isolation under sharing (issue #172): sharing a row with the
+/// state is safe only because retained rows are immutable. This is the
+/// staleness counter-test — it fails if a future change ever lets a state
+/// mutation reach rows a live snapshot already handed out, which is the
+/// failure mode a cache-without-invalidation would have.
+#[test]
+fn snapshot_scrollback_rows_are_stable_after_further_scrolling() {
+    let state = capped_scrollback_state();
+    let frozen = state.snapshot();
+    let frozen_lines = frozen.scrollback_lines();
+
+    // Scroll a full cap of new lines past: every row the snapshot holds is
+    // evicted from the live state, and the visible screen is overwritten.
+    let mut state = state;
+    let mut script = String::with_capacity(MAX_SCROLLBACK_LINES * 8);
+    for index in 0..MAX_SCROLLBACK_LINES {
+        script.push_str(&format!("N{index:04}\r\n"));
+    }
+    state.feed_bytes(script.as_bytes());
+
+    // The live history moved on entirely...
+    assert_eq!(state.scrollback_len(), MAX_SCROLLBACK_LINES);
+    assert_eq!(
+        state
+            .snapshot()
+            .scrollback_lines()
+            .first()
+            .map(String::as_str),
+        Some("N0000")
+    );
+    // ...while the earlier snapshot still holds exactly what it captured:
+    // same length, same contents, unchanged.
+    assert_eq!(frozen.scrollback().len(), MAX_SCROLLBACK_LINES);
+    assert_eq!(frozen.scrollback_lines(), frozen_lines);
+    assert_eq!(
+        frozen.scrollback_lines().first().map(String::as_str),
+        Some("00000")
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #172. **87× faster** on the per-frame path with a full scrollback.

## The design question came first

Before optimising, the question was *why* the per-frame path needs the scrollback at all. Tracing all **5 consumers**: only **Search** and **Selection** need it. The renderer reads only the visible screen.

So the fix is to stop copying what the frame does not use — scrollback rows are now shared via `Arc` instead of deep-copied. **No caching**, because a stale frame is worse than a slow one.

| | before | after |
| --- | --- | --- |
| empty scrollback | 447 µs | 316 µs |
| **full scrollback** | **63,295 µs** | **724 µs** |

## Correctness first: the pixels are identical

A performance fix that changes what is drawn is a defect. The reviewer built a harness driving the real offscreen Metal pipeline and **hashed the RGBA readback**, comparing PR against `origin/main` across six scenarios — identical, and deterministic across repeated runs.

## No aliasing, no torn frames

`Arc` sharing raises the obvious risk: a row mutated while a live snapshot holds it. Every mutator was traced — `put`, `repair_row`, `erase_*`, `scroll_down`, `resize` write only the flat active-screen `Vec<Cell>`; `scroll_up` evicts via `.to_vec()`. `aliasing_paths=none`, `torn_frame_possible=no`.

Search and Selection were verified by **running** them, not reading: search across the scrollback boundary finds 26 matches spanning logical row 0 to the visible last line; a selection spanning scrollback and screen extracts 743 cells.

## The guard counts operations, not time

`snapshot_copies_no_scrollback_cells_at_full_history` uses `Arc::ptr_eq` copy counting — per #158, since #154 and #159 both had to undo wall-clock assertions. Verified by mutation:

- omission (`scrollback: Vec::new()`) → **5 failures**
- deep copy reintroduced (`Arc::from(row.to_vec())`) → guard fails: *"deep-copied 10000 scrollback rows (60000 cells)"*

## Noted

`scrollback()`'s public type changes `&[Vec<Cell>]` → `&[Arc<[Cell]>]`. Intentional — the guard relies on it — and all in-repo consumers are updated, but it does leak the sharing representation into the API.

Gates: `fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` green, frame_oracle 58 passed.