### PR TITLE
feat(ssh): count and explain wildcard hosts instead of dropping them (#175)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,7 @@ Measured against it, item by item:
 | --- | --- | --- |
 | Sidebar drawn | Done | `SIDEBAR_COLS` reserved in `renderer.rs`; `glyph_vertices` applies the column offset; `sidebar_text_lines` formats rows |
 | — projects, git worktrees | Worktrees and projects launchable | Startup runs `git worktree list --porcelain` in the launch directory (`git_worktree.rs`) and shows at most 24 discovered worktrees as `EntryKind::Worktree` rows (beyond the cap the omitted count is reported); a registered-but-deleted worktree is listed with a `(missing)` marker and refused on selection; selecting a present row creates a `SessionKind::Worktree` session backed by a real `/bin/zsh` PTY whose child's working directory IS the worktree (verified by reading the child's own `pwd` back through the terminal), persisting and restoring through `sessions.toml` like a local session. `[[projects]]` configuration entries (`config.rs`, strict schema: absolute `root`, typed errors naming the offending key, no value echo) appear as at most 24 `EntryKind::Project` rows — the fixed `PRJ-` state prefix distinguishes them from prefix-less worktree rows — and selecting one whose root exists creates a `SessionKind::Project` session with the same directory-rooted launch shape and `pwd` proof; a configured-but-gone root is refused visibly like a deleted worktree. Project sessions persist and restore through `sessions.toml` like every other kind |
-| — SSH connections, agents | Connections run for discovered aliases; discovery explicitly partial; agents launchable from configuration | At most 24 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and clicking one launches the fixed system `/usr/bin/ssh` client in the terminal's single PTY (argv is exactly `ssh -- <alias>`; no credential is ever argv-visible), with launch, connect, and disconnect failures as visible per-row and status-row states (PR #138). Wildcard/dynamic destinations are not a complete host inventory. `[[agents]]` entries in `config.toml` become at most 24 `EntryKind::Agent` rows (beyond the cap the omitted count is reported); selecting one creates a `SessionKind::Agent` session backed by a real PTY running the configured command as a shell-free argv vector (absolute path, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure), persisting and restoring through `sessions.toml` like every other session kind |
+| — SSH connections, agents | Connections run for discovered aliases; discovery explicitly partial with every absence explained; agents launchable from configuration | At most 64 positive literal OpenSSH aliases become `SessionKind::Ssh` and `SidebarEntry::SshConnection` rows; the status identifies partial discovery, and past the cap it reports how many are shown of how many and why (`showing first 64 of 70; 6 past sidebar bound`). Wildcard `Host` patterns never become rows — a pattern is a rule, not a connectable destination — but they are counted per occurrence (including through followed `Include` files) and the notice reports `N wildcard patterns not listed`, so a pattern-built config is never silently under-represented (issue #175). Negations are filters: they suppress matches and add no row and no absence count. Clicking a row launches the fixed system `/usr/bin/ssh` client in the terminal's single PTY (argv is exactly `ssh -- <alias>`; no credential is ever argv-visible), with launch, connect, and disconnect failures as visible per-row and status-row states (PR #138). Wildcard/dynamic destinations still cannot be enumerated as a complete host inventory; that boundary is now stated with counts rather than silence. `[[agents]]` entries in `config.toml` become at most 24 `EntryKind::Agent` rows (beyond the cap the omitted count is reported); selecting one creates a `SessionKind::Agent` session backed by a real PTY running the configured command as a shell-free argv vector (absolute path, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure), persisting and restoring through `sessions.toml` like every other session kind |
 | — terminal sessions | Runtime for local sessions | Every palette `session_create` spawns a real `SessionKind::Local` PTY (`spawn_local_session`); sidebar clicks and the palette's `session_select` switch the live view between live sessions (`switch_live_session`, parked surfaces keep draining and resizing), and `session_close` reaps the closed child and repairs the view. Rows restored from disk come back `Restored` with no live surface and cannot take the live view |
 | Single-session view | Done | The active terminal is drawn beside the sidebar, narrowed to the remaining columns; switching swaps the active surface whole, and rows without a live surface cannot claim its selection or input owner |
 | Session lifecycle | Done | `SessionStatus` advances `Starting -> Running -> Exited/Failed` via `SessionRegistry::observe`, wired in `main.rs` for spawned, parked, closed, and restored sessions alike |
@@ -125,22 +125,32 @@ Measured against it, item by item:
 | Configurable keybindings | Done for the palette surface | `[keys]` in `config.toml` (`KeymapConfig` in `config.rs`) rebinds the palette opener and the four palette command chords with the previous values as defaults; `palette_policy`/`handle_palette_key` in `main.rs` honor them, unparseable chords and unknown actions are typed errors, and the opener is validated against the pinned Zellij corpus and the exit leader. The exit leader, palette navigation keys, diagnostics chord, and clipboard shortcuts remain fixed |
 | Zellij pass-through | Done against a pinned corpus and a live installed Zellij | The shipped policy (`palette_policy` in `main.rs`) claims exactly two Super-modified chords — `Super+Escape` (exit leader) and `Super+p` (palette opener) — that the pinned Zellij `v0.44.3` default corpus (`ZELLIJ_FIXTURE_TAG`) never binds, and `tests/zellij_live.rs` drives an INSTALLED Zellij in a real PTY through the same parser, gate, and key encoder: attach enables mouse tracking in `TerminalState`, gated `Ctrl+t`/`n`/`Ctrl+p` reach Zellij and render tab #2 and pane #2, typed text reaches the pane's shell, and the installed version's default keybinds bind nothing in the Super/Cmd/Meta space. The harness skips (visibly, on the real stderr) when no `zellij` is on `PATH`. Empirical wire-shape note: Zellij 0.44.3 sends `1002`/`1006` as separate single-parameter DECSETs across its whole lifecycle and does not forward a pane program's multi-parameter DECSET to the host terminal, so the multi-parameter form `CSI ? 1002;1006 h` (the PR #113 regression site) is pinned as a co-located regression guard beside the live assertions, with the live multi-parameter count printed as drift telemetry. Beyond the skip, the suite today runs only where a developer runs it — no gating machine executes it (issue #153) |
 
-One named scope item remains unsatisfied: **host discovery is explicitly
-partial**. Projects are reachable now: a `[[projects]]` configuration entry
+The host-discovery gap that issue
+[#175](https://github.com/ta-061/noren/issues/175) named is closed: positive
+literal aliases appear in a bounded sidebar list (now 64 rows) and a click
+launches a real system-ssh connection (PR #138); wildcard and negation
+patterns are resolved with OpenSSH semantics and, because a pattern is a rule
+rather than a connectable destination, are counted and explained in the
+status notice instead of vanishing; `Include` files feed the same block list
+to discovery and resolution, so an alias declared only in an included file is
+discovered like a top-level one; and past the sidebar cap the notice reports
+how many are shown of how many and why. Discovery is still *explicitly
+partial* by design — no destination enumeration happens here — but no absence
+is silent. Projects are reachable now: a `[[projects]]` configuration entry
 constructs an `EntryKind::Project` row and selecting it creates a
 `SessionKind::Project` session backed by a real PTY whose child starts in
-the configured root. Positive literal aliases appear in a bounded sidebar
-list and a click launches a real system-ssh connection (PR #138), but
-wildcard or dynamic destinations are not presented as a complete host
-inventory. Agent entries are no longer fixtures: `[[agents]]`
+the configured root. Agent entries are no longer fixtures: `[[agents]]`
 configuration rows launch a configured, shell-free argv command in a real
 PTY (the first Milestone 5 slice); the remaining agent-experience scope
 (verified adapters, trustworthy state, notifications, jump-to-source) is
-Milestone 5 work. Configurable keybindings are satisfied for the palette
-surface only; the exit leader, palette navigation, diagnostics chord, and
-clipboard shortcuts remain compiled in. Since "Only evidence-backed work
-is marked complete" and the scope line names the unsatisfied item,
-Milestone 3 stays **In progress** on host discovery.
+Milestone 5 work. Milestone 3 nonetheless stays **In progress**:
+configurable keybindings are satisfied for the palette
+surface only — the exit leader, palette navigation, diagnostics chord, and
+clipboard shortcuts remain compiled in — and the live-Zellij pass-through
+evidence still gates no machine
+([#153](https://github.com/ta-061/noren/issues/153)). Since "Only
+evidence-backed work is marked complete", those items, not host discovery,
+now hold the milestone open.
 
 Open engineering issues a reader of this section should know about: the
 behavior-preserving split of the oversized binary and SSH-parser modules

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -72,8 +72,16 @@ const WINDOW_WIDTH: u32 = 900;
 const WINDOW_HEIGHT: u32 = 600;
 const POLL_INTERVAL: Duration = Duration::from_millis(16);
 /// Keep configured-host memory and identity work bounded independently of the
-/// frame height. The sidebar exposes a scroll window over this bounded list.
-const MAX_SSH_SIDEBAR_HOSTS: usize = 24;
+/// frame height, with the same named-constant discipline as the worktree,
+/// project, and agent row caps. The sidebar exposes a scroll window over this
+/// bounded list. 64 rows of already-bounded labels retain a few KiB and keep
+/// rebuild identity scans O(64) — deliberately above the largest
+/// human-maintained alias lists (issue #175's example is 60 hosts) so the
+/// bound exists for safety, not as the effective size of a real config.
+/// Anything past it is reported with a reason, never dropped silently. The
+/// parse-side DoS budgets in `ssh_config.rs` (#137) bound untrusted input
+/// independently of this view cap and are unchanged by it.
+const MAX_SSH_SIDEBAR_HOSTS: usize = 64;
 /// Sidebar rows begin with a selection marker and one separating space.
 const SIDEBAR_ROW_PREFIX_CHARS: usize = 2;
 /// ASCII-only connection state that is always inside the first 16 columns.
@@ -235,6 +243,19 @@ const SSH_STATUS_SOURCE_CHARS: usize = 40;
 /// target budget solely to decide whether the ASCII marker is needed.
 fn ssh_sidebar_label(target: &str) -> String {
     ssh_state_label(SshConnectionPhase::Closed, target)
+}
+
+/// Fixed-text, count-only clause explaining why wildcard pattern groups are
+/// absent from the sidebar: a pattern is a matching rule, not a connectable
+/// destination, so it never becomes a row. The count says the configuration
+/// was still read. Only the number varies — pattern text is file content and
+/// must never reach the status row (TM-08, issue #155).
+fn ssh_unlisted_wildcard_clause(count: usize) -> String {
+    match count {
+        0 => String::new(),
+        1 => "; 1 wildcard pattern not listed".to_owned(),
+        count => format!("; {count} wildcard patterns not listed"),
+    }
 }
 
 /// Build a bounded sidebar label: an eight-character ASCII state `prefix`
@@ -1413,20 +1434,28 @@ impl NorenApp {
 
     fn apply_ssh_config(&mut self, config: &SshConfig) {
         let omitted = self.workspace.load_ssh_config(config);
+        let total = config.hosts().len();
+        let shown = total.saturating_sub(omitted);
+        let unlisted = ssh_unlisted_wildcard_clause(config.unlisted_wildcard_patterns());
         self.ssh_selection_status = None;
         if config.sources().is_empty() {
             self.ssh_diagnostic = None;
         } else {
             self.ssh_diagnostic = Some(match config.discovery_kind() {
-                HostDiscoveryKind::PartialLiteralPatterns if config.hosts().is_empty() => {
-                    "Noren SSH: partial literal aliases; none found".to_owned()
+                HostDiscoveryKind::PartialLiteralPatterns if total == 0 => {
+                    let mut line = "Noren SSH: partial literal aliases; none found".to_owned();
+                    line.push_str(&unlisted);
+                    line
                 }
                 HostDiscoveryKind::PartialLiteralPatterns if omitted == 0 => {
-                    "Noren SSH: partial literal aliases; select one for source".to_owned()
+                    let mut line =
+                        "Noren SSH: partial literal aliases; select one for source".to_owned();
+                    line.push_str(&unlisted);
+                    line
                 }
                 HostDiscoveryKind::PartialLiteralPatterns => format!(
-                    "Noren SSH: partial literal aliases; showing first \
-                     {MAX_SSH_SIDEBAR_HOSTS}; {omitted} omitted"
+                    "Noren SSH: partial literal aliases; showing first {shown} of {total}; \
+                     {omitted} past sidebar bound{unlisted}"
                 ),
             });
         }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1737,7 +1737,34 @@ fn readable_config_without_literal_aliases_reports_none_found() {
     assert!(app.workspace.sidebar().rows().is_empty());
     assert_eq!(
         app.ssh_diagnostic.as_deref(),
-        Some("Noren SSH: partial literal aliases; none found")
+        Some(
+            "Noren SSH: partial literal aliases; none found; \
+             1 wildcard pattern not listed"
+        )
+    );
+}
+
+#[test]
+fn wildcard_patterns_add_no_rows_but_the_notice_explains_them() {
+    let fixture = SshConfigFixture::new();
+    fixture.write_new(b"Host build\nHost *.internal\n  User dee\nHost prod-?\n");
+    let mut app = NorenApp::default();
+
+    app.load_ssh_hosts_from(fixture.path());
+
+    let rows = app.workspace.sidebar().rows();
+    assert_eq!(rows.len(), 1, "only the literal alias becomes a row");
+    assert_eq!(rows[0].label(), "SSH-OFF build");
+    assert!(
+        rows.iter().all(|row| !row.label().contains(['*', '?'])),
+        "a wildcard pattern is a rule, not a launchable destination"
+    );
+    assert_eq!(
+        app.ssh_diagnostic.as_deref(),
+        Some(
+            "Noren SSH: partial literal aliases; select one for source; \
+             2 wildcard patterns not listed"
+        )
     );
 }
 
@@ -2430,7 +2457,7 @@ fn rebuild_sidebar_skips_non_ssh_host_facts_without_panicking() {
 #[test]
 fn many_ssh_hosts_are_bounded_and_report_the_omitted_count() {
     let fixture = SshConfigFixture::new();
-    let config: String = (0..30)
+    let config: String = (0..70)
         .map(|index| format!("Host configured-host-{index:02}-with-long-alias\n"))
         .collect();
     fixture.write_new(config);
@@ -2449,13 +2476,13 @@ fn many_ssh_hosts_are_bounded_and_report_the_omitted_count() {
     assert_eq!(
         app.workspace.ssh_hosts.last().map(|host| &host.kind),
         Some(&SessionKind::Ssh {
-            target: "configured-host-23-with-long-alias".to_owned(),
+            target: "configured-host-63-with-long-alias".to_owned(),
         })
     );
     assert!(app.workspace.ssh_hosts.iter().all(|host| {
         host.kind
             != SessionKind::Ssh {
-                target: "configured-host-24-with-long-alias".to_owned(),
+                target: "configured-host-64-with-long-alias".to_owned(),
             }
     }));
     assert!(rows.iter().all(|row| {
@@ -2475,13 +2502,14 @@ fn many_ssh_hosts_are_bounded_and_report_the_omitted_count() {
     assert!(
         app.ssh_diagnostic
             .as_deref()
-            .is_some_and(|line| line.contains("showing first 24; 6 omitted"))
+            .is_some_and(|line| line.contains("showing first 64 of 70; 6 past sidebar bound")),
+        "the notice names how many are shown of how many, and why the rest are absent"
     );
 }
 
 #[test]
-fn ssh_host_cap_is_exact_at_twenty_four() {
-    for count in [23_usize, 24, 25] {
+fn ssh_host_cap_is_exact_at_sixty_four() {
+    for count in [63_usize, 64, 65] {
         let fixture = SshConfigFixture::new();
         let config: String = (0..count)
             .map(|index| format!("Host host-{index:02}\n"))
@@ -2513,9 +2541,12 @@ fn ssh_host_cap_is_exact_at_twenty_four() {
             assert!(notice.contains("select one for source"));
             assert!(!notice.contains("showing first"));
         } else {
-            assert!(notice.contains("showing first 24; 1 omitted"));
+            assert!(
+                notice.contains("showing first 64 of 65; 1 past sidebar bound"),
+                "the notice reports the shown-of-total split and the bound: {notice}"
+            );
             assert!(app.workspace.ssh_hosts.iter().all(|host| {
-                !matches!(&host.kind, SessionKind::Ssh { target } if target == "host-24")
+                !matches!(&host.kind, SessionKind::Ssh { target } if target == "host-64")
             }));
         }
     }

--- a/crates/noren-app/src/ssh_config.rs
+++ b/crates/noren-app/src/ssh_config.rs
@@ -108,6 +108,12 @@ const DEFAULT_LIMITS: ParserLimits = ParserLimits {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum HostDiscoveryKind {
     /// Only positive literal aliases written in `Host` directives are listed.
+    ///
+    /// Positive wildcard patterns cannot become rows — a pattern is a rule,
+    /// not a destination — so instead of vanishing silently they are counted
+    /// and reported through [`SshConfig::unlisted_wildcard_patterns`].
+    /// Negations are filters under OpenSSH semantics and never denote a
+    /// host, so they add neither a row nor an absence count.
     #[default]
     PartialLiteralPatterns,
 }
@@ -277,6 +283,7 @@ pub struct SshConfig {
     hosts: Vec<SshHost>,
     sources: Vec<SshSource>,
     discovery_kind: HostDiscoveryKind,
+    unlisted_wildcard_patterns: usize,
 }
 
 impl SshConfig {
@@ -365,6 +372,20 @@ impl SshConfig {
         self.discovery_kind
     }
 
+    /// Positive `Host` patterns containing wildcards that cannot become
+    /// browseable rows, counted per occurrence across the top-level source
+    /// and every followed `Include`.
+    ///
+    /// A wildcard pattern is a matching rule, not a connectable destination,
+    /// so it is excluded from [`Self::hosts`] by design. This count exists so
+    /// callers can say how many pattern groups are absent and why, instead of
+    /// dropping them silently. Negation patterns are filters and are not
+    /// counted. The number carries no source content.
+    #[must_use]
+    pub const fn unlisted_wildcard_patterns(&self) -> usize {
+        self.unlisted_wildcard_patterns
+    }
+
     /// Bounded provenance for a parse-local `id` produced by this config.
     ///
     /// IDs are ordinal tokens, so an ID from another parse with the same
@@ -436,6 +457,7 @@ impl SshConfig {
         let mut fallback_head_masks = Vec::new();
         let mut fallback_pattern_work = 0_u128;
         let mut fallback_setting_work = 0_u128;
+        let mut unlisted_wildcard_patterns = 0_usize;
 
         // Literal-only blocks can be looked up by alias. Blocks with a wildcard
         // (and global blocks) remain in their original order for every alias.
@@ -448,6 +470,16 @@ impl SshConfig {
                 fallback_setting_work = fallback_setting_work.saturating_add(block.settings_work());
                 continue;
             };
+
+            // A positive wildcard pattern can never become a row: it is a
+            // rule, not a destination. Count every occurrence — including in
+            // blocks that also name literals — so the sidebar can explain the
+            // absence instead of dropping the pattern silently (issue #175).
+            // Negations stay uncounted: they are filters, not absent hosts.
+            unlisted_wildcard_patterns += patterns
+                .iter()
+                .filter(|pattern| !pattern.starts_with('!') && has_wildcard(pattern))
+                .count();
 
             let negative_patterns: Vec<_> = patterns
                 .iter()
@@ -600,6 +632,7 @@ impl SshConfig {
             hosts,
             sources,
             discovery_kind: HostDiscoveryKind::PartialLiteralPatterns,
+            unlisted_wildcard_patterns,
         })
     }
 }

--- a/crates/noren-app/src/ssh_config/tests.rs
+++ b/crates/noren-app/src/ssh_config/tests.rs
@@ -487,6 +487,60 @@ fn negation_only_block_does_not_match_other_hosts() {
 }
 
 #[test]
+fn positive_wildcard_patterns_are_counted_but_never_listed() {
+    let config =
+        SshConfig::parse("Host alpha\nHost *.internal\n  User dee\nHost prod-?\nHost beta\n")
+            .expect("wildcard fixture parses");
+
+    let aliases: Vec<_> = config.hosts().iter().map(SshHost::alias).collect();
+    assert_eq!(aliases, ["alpha", "beta"]);
+    assert_eq!(config.unlisted_wildcard_patterns(), 2);
+}
+
+#[test]
+fn a_global_default_block_is_counted_as_one_unlisted_wildcard_pattern() {
+    let config = SshConfig::parse("Host build\nHost *\n  User nobody\n")
+        .expect("global-default fixture parses");
+
+    assert_eq!(config.hosts().len(), 1);
+    assert_eq!(config.unlisted_wildcard_patterns(), 1);
+}
+
+#[test]
+fn negation_patterns_are_filters_not_missing_hosts() {
+    let config = SshConfig::parse("Host blocked\nHost !blocked\nHost !*.jump\n")
+        .expect("negation fixture parses");
+
+    assert_eq!(config.hosts().len(), 1);
+    assert_eq!(
+        config.unlisted_wildcard_patterns(),
+        0,
+        "a negation filters matches; it is not an absent host, wildcard or not"
+    );
+}
+
+#[test]
+fn repeated_wildcard_patterns_are_counted_per_occurrence() {
+    let config = SshConfig::parse("Host *.a\nHost *.a\n").expect("duplicate fixture parses");
+
+    assert!(config.hosts().is_empty());
+    assert_eq!(config.unlisted_wildcard_patterns(), 2);
+}
+
+#[test]
+fn wildcard_patterns_from_followed_includes_are_counted() {
+    let fixture = Fixture::new("include-wildcard-count");
+    fixture.write("config", "Include wild.conf\nHost literal\n");
+    fixture.write("wild.conf", "Host *.included\n");
+
+    let config = SshConfig::read(&fixture.root.join("config")).expect("include fixture parses");
+
+    let aliases: Vec<_> = config.hosts().iter().map(SshHost::alias).collect();
+    assert_eq!(aliases, ["literal"]);
+    assert_eq!(config.unlisted_wildcard_patterns(), 1);
+}
+
+#[test]
 fn mixed_literal_and_wildcard_blocks_preserve_resolution_order() {
     let config = SshConfig::parse(
             "Host exact\n  HostName exact.example\n  User exact\nHost *.example\n  HostName wildcard.example\n  User wildcard\nHost api.example\n  User api\nHost db.example !api.example\n  Port 2200\nHost *\n  HostName general.example\n  User nobody\n",

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -74,19 +74,31 @@ binary. What now actually happens on screen:
   spawn and `Exited { code }` on child exit.
 - **The SSH sidebar is bounded and explicitly partial.** `SshConfig` labels its
   scope as `HostDiscoveryKind::PartialLiteralPatterns`: only positive literal
-  aliases written in `Host` directives become browseable targets. `HostName`,
+  aliases written in `Host` directives become browseable targets. Wildcard
+  patterns never become rows — a pattern is a matching rule, not a connectable
+  destination — but they are counted per occurrence (including patterns inside
+  blocks that also name literals, and patterns reached through followed
+  Includes) and reported as `N wildcard patterns not listed` in the status
+  notice, so a pattern-built config is never silently under-represented
+  (issue #175). Negations are OpenSSH filters rather than destinations: they
+  suppress matches during resolution and self-negated literals during
+  discovery, and they add no row and no absence count. `HostName`,
   `User`, and `Port` participate in bounded first-value resolution, but
   `HostName` and `User` remain literal: `%h`, `%p`, `%r`, and other percent
   tokens are not expanded. Those values are discovery metadata and must be
   resolved with OpenSSH-equivalent semantics or rejected before any future
   connection use. Root-relative `Include` files are followed in lexical order
   only when their canonical targets remain below the top-level config
-  directory. That canonical-root confinement is intentionally stricter than
-  OpenSSH: absolute, `~`, `..`, and symlinked targets outside the root are
-  ignored. `Match`, wildcard-only destinations, system configuration, token
+  directory — the same block list feeds discovery and resolution, so a host
+  declared only in an included file is discovered exactly like one in the
+  top-level file. That canonical-root confinement is intentionally stricter
+  than OpenSSH: absolute, `~`, `..`, and symlinked targets outside the root are
+  ignored. `Match`, system configuration, token
   expansion, and other dynamic OpenSSH behaviour cannot make this a complete
   host inventory. The UI says `partial literal aliases`, retains at most
-  `MAX_SSH_SIDEBAR_HOSTS` (24), and shows the selected alias's stable source tag
+  `MAX_SSH_SIDEBAR_HOSTS` (64), and beyond the cap reports how many are shown
+  of how many and why (`showing first 64 of 70; 6 past sidebar bound`); it
+  shows the selected alias's stable source tag
   plus a bounded root-relative label; it never retains or displays the
   canonical HOME prefix. Hostile configuration fails closed rather than
   hanging: every budget in `ssh_config.rs` (`MAX_FILE_BYTES`,


### PR DESCRIPTION
Closes #175 — the SSH host-discovery half of Milestone 3's remaining scope.

## What a user sees now

Before: at most **24** positive literal aliases became rows, and anything else — patterns, negations, hosts past the cap — **vanished silently**. A user with `Host *.internal` in their config had no way to know Noren had seen it and skipped it.

Now: the cap is **64**, and wildcard entries are **counted and explained** rather than dropped. Silence was the defect; a count the user can act on is the fix.

## Why wildcards are excluded rather than listed

`Host *.internal` is not a host you can click — it is a rule that applies to hosts. Listing it as a row would promise a connection that cannot be made. So they are excluded from the rows *and named in the omitted clause*, which tells the user their config was read correctly and why those entries are not clickable.

Negations are handled. `Include` directives were verified consistent between resolution and discovery — the inconsistency I asked about does not exist.

## The cap

Raised 24 → **64** (`MAX_SSH_SIDEBAR_HOSTS`), a view-side bound matching the worktree and agent slices. The parse-side bounds from #137 are untouched — that DoS was a *parse* cost, and this is a *display* limit, so raising it does not reopen it.

## Verified by the coordinator

Silencing the wildcard explanation (`ssh_unlisted_wildcard_clause` returning empty) **fails 3 tests** — the "do not drop silently" requirement is enforced, not just intended.

`cargo test --workspace`: **1,099 passing, 0 failed**. Both required mutations fail as specified.

## Milestone 3 is still not complete — and this PR does not claim otherwise

The lane reports `m3_complete=no`, citing two items that remain after this:

1. **Keybindings are palette-surface-only.** `[keys]` exists and parses (#136), but the configurable chords cover the palette rather than every binding.
2. **The live-Zellij suite gates no machine** — that is #153, whose CI job landed in #163 as *advisory*, so it does not block a merge.

The host-discovery defect itself is closed. I have asked for a milestone judgement rather than a completion claim ever since #173's title turned out to be wrong, and this is the same discipline applied.
