### PR TITLE
fix(terminal): re-snap the cursor off wide-char continuations on row shifts (#176)

### DIFF
--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -919,11 +919,15 @@ impl TerminalState {
 
     /// Re-snap the active cursor onto a lead cell.
     ///
-    /// Every row-changing control path (LF, IND, NEL, RI) keeps the cursor
-    /// column while the row or the row's content changes, so each of them can
-    /// land the cursor on the continuation half of a wide character. Routing
-    /// all of them through this shared helper keeps the cursor off
-    /// continuations, so a path added later cannot forget the re-snap.
+    /// Every row-changing control path that keeps content under the cursor
+    /// column (LF, IND, NEL, RI, SU, SD, DL) keeps the cursor column while
+    /// the row or the row's content changes, so each of them can land the
+    /// cursor on the continuation half of a wide character. Routing all of
+    /// them through this shared helper keeps the cursor off continuations,
+    /// so a path added later cannot forget the re-snap. IL needs no re-snap
+    /// because it blanks the cursor's own row; every other content-changing
+    /// path (ICH, DCH, ECH, EL, ED) blanks or repairs the cursor cell
+    /// itself.
     fn snap_cursor_to_lead(&mut self) {
         self.active.cursor = snap_to_lead(&self.active.screen, self.active.cursor);
     }
@@ -1113,9 +1117,14 @@ impl TerminalState {
         self.snap_cursor_to_lead();
     }
 
+    /// Scroll the whole scroll region up (`CSI Ps S`, SU) under the
+    /// stationary cursor, ending in the shared lead re-snap: the row that
+    /// moves under the cursor column can carry a wide character's
+    /// continuation half there.
     fn scroll_up(&mut self, count: u16) {
         self.active.wrap_pending = false;
         self.scroll_up_capturing(self.active.scroll_region, count);
+        self.snap_cursor_to_lead();
     }
 
     /// Scroll the active screen's region up and, when rows actually leave the
@@ -1138,11 +1147,16 @@ impl TerminalState {
         }
     }
 
+    /// Scroll the whole scroll region down (`CSI Ps T`, SD) under the
+    /// stationary cursor, ending in the shared lead re-snap: the row that
+    /// moves under the cursor column can carry a wide character's
+    /// continuation half there.
     fn scroll_down(&mut self, count: u16) {
         self.active.wrap_pending = false;
         self.active
             .screen
             .scroll_down(self.active.scroll_region, count);
+        self.snap_cursor_to_lead();
     }
 
     fn erase_in_display(&mut self, mode: EraseMode) {
@@ -1178,6 +1192,12 @@ impl TerminalState {
             .delete_characters(self.active.cursor, count);
     }
 
+    /// Insert `count` blank lines at the cursor row (`CSI Ps L`, IL),
+    /// shifting the rows below it down. No lead re-snap is needed: the shift
+    /// blanks the cursor's own row, so what lands under the cursor column is
+    /// always a blank cell, never a continuation —
+    /// `insert_lines_keeps_the_cursor_off_continuations_and_moves_wide_rows_whole`
+    /// pins that contract.
     fn insert_lines(&mut self, count: u16) {
         self.active.wrap_pending = false;
         let cursor_row = self.active.cursor.row;
@@ -1193,6 +1213,10 @@ impl TerminalState {
         }
     }
 
+    /// Delete `count` lines at the cursor row (`CSI Ps M`, DL), shifting the
+    /// rows below it up under the stationary cursor, and end in the shared
+    /// lead re-snap: the row that moves under the cursor column can carry a
+    /// wide character's continuation half there.
     fn delete_lines(&mut self, count: u16) {
         self.active.wrap_pending = false;
         let cursor_row = self.active.cursor.row;
@@ -1206,6 +1230,7 @@ impl TerminalState {
                 count,
             );
         }
+        self.snap_cursor_to_lead();
     }
 
     fn select_graphic_rendition(&mut self, params: &[u16], separators: &[u8]) {

--- a/crates/noren-terminal/tests/fuzz_feed_bytes.rs
+++ b/crates/noren-terminal/tests/fuzz_feed_bytes.rs
@@ -143,23 +143,55 @@
 //! FUZZ_CASE_INDEX=1336 cargo test -p noren-terminal --test fuzz_feed_bytes
 //! fuzz_feed_bytes_generated_streams -- --nocapture` (failed at "feed byte
 //! 23" pre-fix). The fix routes SU/SD/DL through the same shared
-//! `snap_cursor_to_lead`; the deterministic pin is
-//! `scroll_down_up_and_delete_lines_snap_the_cursor_off_continuations` in
-//! `tests/unicode_width.rs`, and re-injecting the defect (deleting the
-//! three re-snaps) is still caught at exactly case 1336 by this oracle —
-//! a fix that disabled its own detector would be worse than the defect.
+//! `snap_cursor_to_lead`; the deterministic pins are
+//! `scroll_down_up_and_delete_lines_snap_the_cursor_off_continuations` plus
+//! a dedicated per-operation test each, all in `tests/unicode_width.rs`:
+//! `scroll_down_alone_snaps_the_cursor_off_continuations`,
+//! `scroll_up_alone_snaps_the_cursor_off_continuations`,
+//! `delete_lines_alone_snaps_the_cursor_off_continuations` — and
+//! re-injecting the defect (deleting the three re-snaps) is still caught at
+//! exactly case 1336 by this oracle — a fix that disabled its own detector
+//! would be worse than the defect.
 //! A sweep of every other row-shifting / column-occupancy operation (IL,
 //! ICH, DCH, ECH, EL, ED, DECSTBM, resize, alternate-screen switching)
 //! found no further stranding: IL blanks the cursor's own row, the
 //! character ops blank or `repair_row` the cursor cell, and the remaining
 //! paths home, restore, or resize the cursor already snapped.
 //!
+//! Coverage boundary of the clean campaign numbers (measured 2026-08-28 by
+//! single-snap injection — delete exactly one of the three re-snaps and run
+//! the campaign): the generator reaches only ONE of the three arrangements
+//! itself. Re-injected SD alone is caught at exactly case 1336 (the
+//! original finding). Re-injected SU alone stays GREEN for 703_809 cases
+//! (seed `0xC0FF_EE42_DEAD_BEEF`, 60 s). Re-injected DL alone stays GREEN
+//! for 703_622 + 351_793 + 352_292 = 1_407_707 cases (seeds
+//! `0xC0FF_EE42_DEAD_BEEF` 60 s, `0xF00F_BEEF_5EED_0A11` 30 s, `0x1` 30 s).
+//! The generator DOES emit `CSI S` and `CSI M` (`S` and `M` are in
+//! `gen_csi_standard`'s final-byte alphabet) and prints wide characters,
+//! but never composes them into the stranding arrangement: SD stranding is
+//! cheap to reach because LF + backspace parks the cursor on the wide
+//! row's continuation column with no positioning sequence, while SU/DL
+//! stranding needs a wide row BELOW the cursor at the exact continuation
+//! column, which demands a correctly parameterised CUP plus the shift
+//! before anything else disturbs the grid. So the campaign's clean totals
+//! do NOT cover the SU and DL re-snaps; those are defended only by the
+//! pinned host tests above, each verified by mutation against exactly its
+//! own snap site (removing any one of the twelve snap call sites in
+//! `state.rs` fails at least one host test, except the saved-cursor
+//! re-snap inside resize, which is unobservable through the public API
+//! because every restore re-snaps — its removal together with
+//! restore_cursor's snap IS caught by
+//! `restoring_the_cursor_onto_a_continuation_snaps_to_the_lead`).
+//!
 //! Campaign evidence after the Issue #176 fix (2026-08-28, macOS arm64
 //! debug): seed `0xC0FF_EE42_DEAD_BEEF` `FUZZ_SECONDS=60`: 704_053 cases /
 //! ~67.0 MiB, ZERO panics, ZERO violations (previously halted at 1336).
 //! Seed `0xF00F_BEEF_5EED_0A11` 20 s: 203_369 cases, ZERO violations.
 //! Seed `0x1` 20 s: 176_358 cases, ZERO violations. Combined 1_083_780
-//! cases past the finding seed's halt point.
+//! cases past the finding seed's halt point. After adding the
+//! per-operation regression tests and the resize/restore guards, same
+//! three seeds and budgets: 704_959 + 235_001 + 235_290 = 1_175_250 cases,
+//! ZERO panics, ZERO violations.
 
 use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};

--- a/crates/noren-terminal/tests/fuzz_feed_bytes.rs
+++ b/crates/noren-terminal/tests/fuzz_feed_bytes.rs
@@ -111,21 +111,20 @@
 //! `0xF00F_BEEF_5EED_0A11`: 46_126 cases / ~4.2 MiB, ZERO panics, ZERO
 //! violations. Seed `0x1`: 77_008 cases / ~7.0 MiB, ZERO panics, ZERO
 //! violations. Seed `0xC0FF_EE42_DEAD_BEEF`: HALTED at case 1336 by the
-//! open defect below (1 violation). Iteration rates are lower than the
+//! defect below (1 violation). Iteration rates are lower than the
 //! shape-only revision (718k+ cases in 60 s there) because every case now
 //! also runs the any-input state oracles per feed and the full content
 //! probe suite; the machine was also under heavy load (load average ~58).
 //! The committed default seed/bound (2500 cases) stays green. Future
 //! campaigns should append their totals here.
 //!
-//! # OPEN DEFECT FOUND BY THE CONTENT ORACLES (unfixed, pre-existing on
-//! # main, reported for its own issue/review)
+//! # DEFECT FOUND BY THE CONTENT ORACLES (fixed in Issue #176; record kept)
 //!
 //! The "cursor never rests on a wide-character continuation cell"
 //! invariant — which `move_cursor` documents and which LF/IND/NEL/RI
 //! maintain via `snap_cursor_to_lead` ("a path added later cannot forget
-//! the re-snap") — is VIOLATED by the three content-scrolling paths that
-//! shift rows under a STATIONARY cursor and do not re-snap:
+//! the re-snap") — was VIOLATED by the three content-scrolling paths that
+//! shift rows under a STATIONARY cursor and did not re-snap:
 //!
 //! - `CSI Ps T` (SD, scroll down): `TerminalState::new(2,4)` +
 //!   `feed_bytes(b"\xf0\x9f\x98\x80\n\x08\x1b[1T")` — the emoji pair from
@@ -142,9 +141,25 @@
 //! destroyed one column to the left of where a snapped cursor would have
 //! replaced it. Fuzz repro: `FUZZ_ROOT_SEED=0xc0ffee42deadbeef
 //! FUZZ_CASE_INDEX=1336 cargo test -p noren-terminal --test fuzz_feed_bytes
-//! fuzz_feed_bytes_generated_streams -- --nocapture` (fails at "feed byte
-//! 23"). The oracle stays enabled on purpose; the committed default bound
-//! does not reach a triggering case.
+//! fuzz_feed_bytes_generated_streams -- --nocapture` (failed at "feed byte
+//! 23" pre-fix). The fix routes SU/SD/DL through the same shared
+//! `snap_cursor_to_lead`; the deterministic pin is
+//! `scroll_down_up_and_delete_lines_snap_the_cursor_off_continuations` in
+//! `tests/unicode_width.rs`, and re-injecting the defect (deleting the
+//! three re-snaps) is still caught at exactly case 1336 by this oracle —
+//! a fix that disabled its own detector would be worse than the defect.
+//! A sweep of every other row-shifting / column-occupancy operation (IL,
+//! ICH, DCH, ECH, EL, ED, DECSTBM, resize, alternate-screen switching)
+//! found no further stranding: IL blanks the cursor's own row, the
+//! character ops blank or `repair_row` the cursor cell, and the remaining
+//! paths home, restore, or resize the cursor already snapped.
+//!
+//! Campaign evidence after the Issue #176 fix (2026-08-28, macOS arm64
+//! debug): seed `0xC0FF_EE42_DEAD_BEEF` `FUZZ_SECONDS=60`: 704_053 cases /
+//! ~67.0 MiB, ZERO panics, ZERO violations (previously halted at 1336).
+//! Seed `0xF00F_BEEF_5EED_0A11` 20 s: 203_369 cases, ZERO violations.
+//! Seed `0x1` 20 s: 176_358 cases, ZERO violations. Combined 1_083_780
+//! cases past the finding seed's halt point.
 
 use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};

--- a/crates/noren-terminal/tests/scrollback.rs
+++ b/crates/noren-terminal/tests/scrollback.rs
@@ -51,6 +51,40 @@ fn lines_scrolled_off_the_top_are_retained_in_order() {
     assert_eq!(first_row[0].text(), "A");
 }
 
+/// Rows evict whole, so a wide character's lead and continuation halves
+/// always travel into scrollback together: the retained row keeps both
+/// cells, and a cursor parked above the eviction can never face a
+/// continuation whose lead left the screen (Issue #176 neighbouring
+/// invariant).
+#[test]
+fn a_scrolled_off_wide_row_is_retained_with_both_halves() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes("😀".as_bytes());
+    state.feed_bytes(b"\x1b[2;4H");
+    assert_eq!(state.cursor().column(), 3);
+
+    // SU evicts the emoji row under the stationary cursor.
+    state.feed_bytes(b"\x1b[1S");
+    assert_eq!(state.scrollback_len(), 1);
+    let retained = state.scrollback_row(0).expect("retained wide row");
+    assert_eq!(retained[0].text(), "\u{1f600}");
+    assert_eq!(retained[0].width(), 2);
+    assert!(retained[1].is_continuation());
+    assert_eq!(retained.len(), 4);
+
+    // The cursor stayed in bounds and off the shifted content's
+    // continuations (the blank row under it has none).
+    let cursor = state.cursor();
+    assert_eq!(cursor.column(), 3);
+    assert!(
+        !state
+            .screen()
+            .cell(cursor.row(), cursor.column())
+            .is_some_and(Cell::is_continuation)
+    );
+    assert_eq!(scrollback_widths(&state), [4]);
+}
+
 #[test]
 fn the_bound_holds_and_evicts_the_oldest_lines() {
     // One-row grid: every CRLF evicts the just-printed row. Emit well past the

--- a/crates/noren-terminal/tests/unicode_width.rs
+++ b/crates/noren-terminal/tests/unicode_width.rs
@@ -382,6 +382,54 @@ fn scroll_down_up_and_delete_lines_snap_the_cursor_off_continuations() {
     assert!(cell(&state, 0, 1).is_continuation());
 }
 
+/// SD (`CSI T`) alone must re-snap: the wide pair scrolls down under the
+/// stationary cursor's column. This is the fuzz-found arrangement (fuzz case
+/// 1336) pinned as its OWN test so that removing only the `scroll_down`
+/// re-snap fails exactly here — the combined three-operation test above
+/// stops at its first failing section and cannot prove which snap mattered.
+#[test]
+fn scroll_down_alone_snaps_the_cursor_off_continuations() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\xf0\x9f\x98\x80\n\x08\x1b[1T");
+    // Without the re-snap the cursor rests on (1,1), the continuation half.
+    assert_eq!(cursor(&state), (1, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 1, 0).text(), "\u{1f600}");
+    assert_eq!(cell(&state, 1, 0).width(), 2);
+    assert!(cell(&state, 1, 1).is_continuation());
+}
+
+/// SU (`CSI S`) alone must re-snap: the wide row below the stationary
+/// cursor scrolls up under its column. Pinned separately from SD and DL so
+/// removing only the `scroll_up` re-snap fails exactly here.
+#[test]
+fn scroll_up_alone_snaps_the_cursor_off_continuations() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1S");
+    // Without the re-snap the cursor rests on (0,1), the continuation half.
+    assert_eq!(cursor(&state), (0, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 0).text(), "\u{1f600}");
+    assert_eq!(cell(&state, 0, 0).width(), 2);
+    assert!(cell(&state, 0, 1).is_continuation());
+}
+
+/// DL (`CSI M`) alone must re-snap: deleting the row above the stationary
+/// cursor shifts the wide row up under its column. Pinned separately from
+/// SD and SU so removing only the `delete_lines` re-snap fails exactly
+/// here.
+#[test]
+fn delete_lines_alone_snaps_the_cursor_off_continuations() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1M");
+    // Without the re-snap the cursor rests on (0,1), the continuation half.
+    assert_eq!(cursor(&state), (0, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 0).text(), "\u{1f600}");
+    assert_eq!(cell(&state, 0, 0).width(), 2);
+    assert!(cell(&state, 0, 1).is_continuation());
+}
+
 /// IL (`CSI L`) blanks the cursor's own row, so it cannot strand the cursor
 /// by itself — this test pins that it stays off continuations and moves the
 /// wide row below it down with both halves intact, so the contract holds if
@@ -435,6 +483,47 @@ fn delete_lines_evicting_a_wide_row_to_scrollback_keeps_the_pair_whole() {
     assert!(column < cols);
     assert!(row < 3);
     assert_cursor_off_continuation(&state);
+}
+
+/// Shrinking the grid clamps the cursor column; the clamped column can be
+/// the continuation half of a wide pair that survived the shrink intact, so
+/// resize must re-snap the cursor onto its lead. Guards the active-cursor
+/// re-snap in `ScreenState::resize` (mutation-checked: removing that snap
+/// alone fails exactly this test).
+#[test]
+fn resize_clamping_the_cursor_onto_a_continuation_snaps_to_the_lead() {
+    let mut state = TerminalState::new(2, 5).expect("valid terminal");
+    state.feed_bytes("A\u{1f600}B".as_bytes());
+    state.resize(2, 3).expect("valid resize");
+
+    // The pair fits in 3 columns; only `B` is truncated away. The cursor
+    // clamps from column 4 to column 2 — the continuation — and must land
+    // on the lead at column 1.
+    assert_eq!(cursor(&state), (0, 1));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 1).text(), "\u{1f600}");
+    assert!(cell(&state, 0, 2).is_continuation());
+}
+
+/// DECRC (`CSI u` / `ESC 7`+`ESC 8`) restores a saved column onto content
+/// that changed while the position was saved: if a wide character's
+/// continuation half now occupies that column, the restore must re-snap to
+/// the lead. Guards the re-snap in `ScreenState::restore_cursor`
+/// (mutation-checked: removing that snap alone fails exactly this test, and
+/// it also catches the double removal of that snap together with the
+/// saved-cursor re-snap in `resize` — the saved-cursor resize snap alone is
+/// unobservable through the public API because every restore re-snaps).
+#[test]
+fn restoring_the_cursor_onto_a_continuation_snaps_to_the_lead() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"A\x1b7\r\xf0\x9f\x98\x80\x1b[u");
+
+    // The save point (0,1) became the emoji's continuation half; the
+    // restore lands on the lead instead.
+    assert_eq!(cursor(&state), (0, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 0).text(), "\u{1f600}");
+    assert!(cell(&state, 0, 1).is_continuation());
 }
 
 #[test]

--- a/crates/noren-terminal/tests/unicode_width.rs
+++ b/crates/noren-terminal/tests/unicode_width.rs
@@ -346,6 +346,97 @@ fn reverse_index_at_the_top_margin_keeps_wide_rows_intact() {
     assert!(cell(&state, 2, 3).is_continuation());
 }
 
+/// Issue #176 (fuzz case 1336, seed 0xc0ffee42deadbeef): the three
+/// content-scrolling paths that shift rows under a STATIONARY cursor — SD
+/// (`CSI T`), SU (`CSI S`), and DL (`CSI M`) — must re-snap through the same
+/// `snap_cursor_to_lead` the vertical-movement paths use, because the row
+/// landing under the cursor column can carry the continuation half of a wide
+/// character.
+#[test]
+fn scroll_down_up_and_delete_lines_snap_the_cursor_off_continuations() {
+    // SD (CSI T): the fuzz-found arrangement verbatim — the emoji pair from
+    // row 0 scrolls down under the cursor at (1,1), its continuation column.
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\xf0\x9f\x98\x80\n\x08\x1b[1T");
+    assert_eq!(cursor(&state), (1, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 1, 0).text(), "\u{1f600}");
+    assert_eq!(cell(&state, 1, 0).width(), 2);
+    assert!(cell(&state, 1, 1).is_continuation());
+
+    // SU (CSI S): the wide row below scrolls up under the cursor at (0,1).
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1S");
+    assert_eq!(cursor(&state), (0, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 0).text(), "\u{1f600}");
+    assert!(cell(&state, 0, 1).is_continuation());
+
+    // DL (CSI M): deleting the line above shifts the wide row up under the
+    // cursor at (0,1).
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1M");
+    assert_eq!(cursor(&state), (0, 0));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 0, 0).text(), "\u{1f600}");
+    assert!(cell(&state, 0, 1).is_continuation());
+}
+
+/// IL (`CSI L`) blanks the cursor's own row, so it cannot strand the cursor
+/// by itself — this test pins that it stays off continuations and moves the
+/// wide row below it down with both halves intact, so the contract holds if
+/// its semantics ever change.
+#[test]
+fn insert_lines_keeps_the_cursor_off_continuations_and_moves_wide_rows_whole() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1L");
+    assert_eq!(cursor(&state), (0, 1));
+    assert_cursor_off_continuation(&state);
+    assert_eq!(cell(&state, 2, 0).text(), "\u{1f600}");
+    assert_eq!(cell(&state, 2, 0).width(), 2);
+    assert!(cell(&state, 2, 1).is_continuation());
+}
+
+/// The corruption the stranding caused: a print at a stranded cursor blanks
+/// the lead from the continuation side and leaves a hole one column left of
+/// the glyph it replaced. With the re-snap the print replaces the pair at
+/// its lead column.
+#[test]
+fn printing_after_a_snapped_delete_lines_replaces_the_pair_at_the_lead() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\n\xf0\x9f\x98\x80\x1b[1;2H\x1b[1MX");
+
+    assert_eq!(cursor(&state), (0, 1));
+    assert_eq!(cell(&state, 0, 0).text(), "X");
+    assert_eq!(cell(&state, 0, 1).text(), " ");
+    assert!(!cell(&state, 0, 1).is_continuation());
+    assert_cursor_off_continuation(&state);
+}
+
+/// Neighbouring invariant: DL evicting a wide row into scrollback must keep
+/// the pair whole there (rows evict atomically, so a continuation's lead can
+/// never strand behind in the live grid), and the cursor column stays in
+/// bounds and off continuations.
+#[test]
+fn delete_lines_evicting_a_wide_row_to_scrollback_keeps_the_pair_whole() {
+    let mut state = TerminalState::new(3, 4).expect("valid terminal");
+    state.feed_bytes(b"\xf0\x9f\x98\x80");
+    state.feed_bytes(b"\r\n\r\n");
+    state.feed_bytes(b"\x1b[1;1H");
+    state.feed_bytes(b"\x1b[1M");
+    assert_eq!(state.scrollback_len(), 1);
+
+    let retained = state.scrollback_row(0).expect("retained row");
+    assert_eq!(retained[0].text(), "\u{1f600}");
+    assert_eq!(retained[0].width(), 2);
+    assert!(retained[1].is_continuation());
+    let (row, column) = cursor(&state);
+    let (_, cols) = state.size();
+    assert!(column < cols);
+    assert!(row < 3);
+    assert_cursor_off_continuation(&state);
+}
+
 #[test]
 fn printing_after_a_snapped_line_feed_replaces_the_pair_at_the_lead() {
     let mut state = reproduction_state();


### PR DESCRIPTION
Closes #176, found by the parser fuzzer at case 1336 of a seeded campaign.

## The defect

`CSI T` (SD), `CSI S` (SU) and `CSI M` (DL) shift rows under a **stationary cursor** without the `snap_cursor_to_lead` re-snap that `LF`, `IND`, `NEL` and `RI` apply — so the cursor could be left on the **continuation cell of a wide character**, the second half of a two-cell CJK glyph.

A cursor stranded mid-glyph is where wide-character corruption starts: the next write at that column either splits a character or silently repairs over it, and the line drifts from there. Reachable by any pager or TUI that scrolls a region while CJK text is on screen.

## The sweep, not the three

The fuzzer reached SD/SU/DL, but those are what it *happened* to reach. **19 row-changing operations were examined**; 3 needed the snap and all 3 are fixed, reusing the existing shared mechanism rather than inventing a second one. `other_unguarded_snaps=0` — the operations that already had a snap are each defended by a test.

## Each operation is guarded independently

The first round had all three named in one test, and I found that **removing DL's snap left every test green**. Now each has its own case:

| Operation | Test |
| --- | --- |
| SD | `scroll_down_alone_snaps_the_cursor_off_continuations` |
| SU | `scroll_up_alone_snaps_the_cursor_off_continuations` |
| DL | `delete_lines_alone_snaps_the_cursor_off_continuations` |

Verified by removing each snap in turn — DL's removal now fails its test, which it did not before.

## An honest boundary, recorded

`fuzz_reaches_dl=no` — the generator does **not** reach DL with a wide character under the cursor, so the campaign's clean result never covered that path. That is documented alongside the fuzzer's other unasserted invariants rather than left for someone to rediscover.

This is the same lesson as the oracle gap: a clean campaign only covers what it can reach and what it asserts.

Campaign after the fix: **1,175,250 iterations, 0 violations.**

Gates: `fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` **1,103 passing, 0 failed**.
