### PR TITLE
fix(theme): lift the five dark-palette entries that failed WCAG AA (#168)

### DIFF
--- a/crates/noren-app/src/theme.rs
+++ b/crates/noren-app/src/theme.rs
@@ -43,20 +43,36 @@
 //!   pure white and pure black; a program selecting index 16 has asked for
 //!   that device colour.
 //!
-//! # The dark-palette finding
+//! # The dark-palette fix (issue #168)
 //!
-//! The existing default (`dark`) **fails** the 4.5:1 floor for five of its
-//! sixteen ANSI entries on its own background — ANSI black at 1.06:1, blue
-//! at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and magenta at
-//! 4.21:1. This is reported, not fixed here: the dark values are the xterm
-//! defaults the app shipped with since colour landed (issues #107/#112),
-//! and changing them would change today's rendered pixels, which the
-//! defaults-preservation contract of this slice forbids
-//! ([`tests/frame_oracle.rs`] proves byte-identity). The measured minimum
-//! is pinned by test so any change — fix or regression — is a deliberate,
-//! visible decision. `high-contrast` is the theme users who need AA on
-//! every slot can select today: its minimum is ≥ 7:1 (WCAG AAA for normal
-//! text), strictly exceeding both other themes.
+//! The shipped default (`dark`) used to **fail** the 4.5:1 floor for five of
+//! its sixteen ANSI entries on its own background — ANSI black at 1.06:1,
+//! blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and magenta at
+//! 4.21:1 — leaving `\x1b[30m` text effectively invisible on the near-black
+//! ground. Issue #168 resolved the product decision PR #167 had deliberately
+//! deferred: a terminal's default that hides text is a defect, not a
+//! preference, and a preview must not ship one. The five failing entries were
+//! each moved the **minimum distance** that clears 4.5:1 (the smallest u8
+//! value per entry whose ratio reaches the floor), preserving slot
+//! semantics — red stays a pure red ramp value, magenta stays symmetric
+//! R=B, bright blue keeps its R=G lavender balance, black stays achromatic,
+//! and blue keeps red at zero with blue dominant:
+//!
+//! | slot | before | ratio | after | ratio |
+//! | --- | --- | --- | --- | --- |
+//! | black | `[0,0,0]` | 1.06:1 | `[121,121,121]` | 4.53:1 |
+//! | red | `[205,0,0]` | 3.38:1 | `[243,0,0]` | 4.52:1 |
+//! | blue | `[0,0,238]` | 2.10:1 | `[0,113,255]` | 4.52:1 |
+//! | magenta | `[205,0,205]` | 4.21:1 | `[213,0,213]` | 4.50:1 |
+//! | bright blue | `[92,92,255]` | 4.16:1 | `[100,100,255]` | 4.52:1 |
+//!
+//! The theme's measured minimum is now 4.50:1 (magenta, the tightest of the
+//! five minimum moves), pinned by test. One visible consequence is
+//! documented rather than hidden: ANSI black and bright black now sit close
+//! together (`[121,121,121]` vs `[127,127,127]`) because any achromatic
+//! entry clearing 4.5:1 on this background must be at least grey 121 —
+//! bright black itself was already 127. `light` (5.07:1) and `high-contrast`
+//! (7.84:1) are untouched by the fix.
 
 use std::fmt;
 
@@ -89,7 +105,8 @@ const ANSI_SLOT_NAMES: [&str; 16] = [
 /// renders exactly as it did before themes existed.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum ThemeName {
-    /// Today's palette: xterm ANSI defaults on the near-black background.
+    /// The default palette: xterm ANSI values on the near-black background,
+    /// with the five AA-failing entries minimally brightened (issue #168).
     #[default]
     Dark,
     /// A light background with darkened ANSI entries.
@@ -146,28 +163,31 @@ impl fmt::Display for ThemeName {
     }
 }
 
-/// The sixteen ANSI colours of the dark theme: the xterm defaults, unchanged
-/// since issue #107 wired colour into the renderer.
+/// The sixteen ANSI colours of the dark theme: the xterm defaults the app
+/// shipped since issue #107, with the five entries that failed WCAG AA on
+/// the dark background brightened the minimum distance to clear 4.5:1
+/// (issue #168; see the module docs for the before/after measurements).
 ///
-/// Byte-identity with the pre-theme renderer is load-bearing (see the module
-/// docs); these values are pinned by test.
+/// The foreground/background floats and the shared cube tail below are still
+/// byte-identical to the pre-theme renderer; only these five entries moved,
+/// deliberately. The values are pinned by test.
 const DARK_ANSI: [[u8; 3]; 16] = [
-    [0, 0, 0],
-    [205, 0, 0],
-    [0, 205, 0],
-    [205, 205, 0],
-    [0, 0, 238],
-    [205, 0, 205],
-    [0, 205, 205],
-    [229, 229, 229],
-    [127, 127, 127],
-    [255, 0, 0],
-    [0, 255, 0],
-    [255, 255, 0],
-    [92, 92, 255],
-    [255, 0, 255],
-    [0, 255, 255],
-    [255, 255, 255],
+    [121, 121, 121], // 0 black (was [0,0,0], 1.06:1 — issue #168)
+    [243, 0, 0],     // 1 red (was [205,0,0], 3.38:1 — issue #168)
+    [0, 205, 0],     // 2 green
+    [205, 205, 0],   // 3 yellow
+    [0, 113, 255],   // 4 blue (was [0,0,238], 2.10:1 — issue #168)
+    [213, 0, 213],   // 5 magenta (was [205,0,205], 4.21:1 — issue #168)
+    [0, 205, 205],   // 6 cyan
+    [229, 229, 229], // 7 white
+    [127, 127, 127], // 8 bright black
+    [255, 0, 0],     // 9 bright red
+    [0, 255, 0],     // 10 bright green
+    [255, 255, 0],   // 11 bright yellow
+    [100, 100, 255], // 12 bright blue (was [92,92,255], 4.16:1 — #168)
+    [255, 0, 255],   // 13 bright magenta
+    [0, 255, 255],   // 14 bright cyan
+    [255, 255, 255], // 15 bright white
 ];
 
 /// The dark theme's default foreground, as the exact floats the fragment
@@ -288,7 +308,8 @@ pub struct Theme {
     background: [f32; 3],
 }
 
-/// The built-in `dark` theme: exactly the pre-theme renderer's colours.
+/// The built-in `dark` theme: the pre-theme renderer's colours, except the
+/// five ANSI entries minimally brightened to clear WCAG AA (issue #168).
 pub const DARK: Theme = Theme {
     ansi: DARK_ANSI,
     palette256: &DARK_PALETTE,

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -24,6 +24,10 @@
 //!   pixel colours, each matching the palette; a cell with no SGR colour keeps
 //!   the unchanged default; truecolor and 256-colour both resolve to their
 //!   expected values (issue #107);
+//! - the five issue-168 AA fixes to the default dark palette are pinned on
+//!   the drawn pixels — each fixed slot draws its new value against a
+//!   literal, and the drawn colour measurably clears WCAG AA (4.5:1)
+//!   computed on the readback bytes against the readback clear colour;
 //! - a wide (CJK/emoji) character lights its lead column with the replacement
 //!   glyph, leaves its continuation column unlit, and the glyph after the
 //!   pair lands at its display column — the width contract whose loss corrupts
@@ -75,7 +79,7 @@ use std::fs;
 use std::io::Write;
 use std::process::Command;
 
-use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme};
+use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
@@ -869,6 +873,52 @@ fn a_dark_coloured_cell_is_still_seen_as_lit() {
         [121, 121, 121],
         "palette black must draw the AA-fixed grey 121, not the pre-168 near-zero"
     );
+}
+
+/// The issue-168 fix must reach drawing, not just the palette table: each
+/// of the five lifted dark entries is drawn as its fixed value — asserted
+/// against literals here, so reverting the palette to the pre-fix xterm
+/// values fails at the pixel level — and each drawn colour measurably
+/// clears WCAG AA *as pixels*, the ratio computed on the readback bytes
+/// against the readback clear colour. This is the pixel-level half of the
+/// fix's evidence; `tests/theme.rs` holds the palette-level half.
+#[test]
+fn the_issue_168_aa_fixes_reach_the_drawn_pixels() {
+    let Some(renderer) = renderer_or_skip("the_issue_168_aa_fixes_reach_the_drawn_pixels") else {
+        return;
+    };
+    // Row 0: the four normal-brightness fixes; row 1: the bright-blue fix
+    // (SGR 94). Distinct glyphs so each cell is unambiguously lit.
+    let snap = snapshot(2, 4, b"\x1b[30ma\x1b[31mb\x1b[34mc\x1b[35md\r\n\x1b[94me");
+    let frame = render(&renderer, &snap);
+
+    let fixed: [(u32, u32, &str, [u8; 3]); 5] = [
+        (0, 0, "SGR 30 black", [121, 121, 121]),
+        (0, 1, "SGR 31 red", [243, 0, 0]),
+        (0, 2, "SGR 34 blue", [0, 113, 255]),
+        (0, 3, "SGR 35 magenta", [213, 0, 213]),
+        (1, 0, "SGR 94 bright blue", [100, 100, 255]),
+    ];
+    let ground = clear_rgb();
+    for (row, col, label, value) in fixed {
+        assert!(
+            cell_is_lit(&frame, row, col),
+            "{label}: the fixed glyph drew nothing"
+        );
+        let drawn = cell_color(&frame, row, col);
+        assert_eq!(
+            drawn, value,
+            "{label} must draw the issue-168 fixed value — the fix did not \
+             reach the pixels"
+        );
+        // The readable-text claim, measured on the pixels themselves.
+        let ratio = contrast_ratio(drawn, ground);
+        assert!(
+            ratio >= 4.5,
+            "{label} drew {drawn:?}, only {ratio:.2}:1 against the drawn \
+             background {ground:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -839,10 +839,13 @@ fn no_background_keeps_the_existing_pixel_exact_appearance() {
 #[test]
 fn a_dark_coloured_cell_is_still_seen_as_lit() {
     // This is the case the old brightness gate got wrong: ANSI black is a
-    // legitimate foreground whose channels are all far below the old `< 48`
-    // threshold, so a threshold-based oracle would call the cell blank and
-    // agree with a renderer that dropped it. `is_background` now compares to
-    // the clear colour, so the cell reads as lit and the colour is checked.
+    // legitimate foreground whose channels sat far below the old `< 48`
+    // threshold (until issue #168 lifted black to grey 121 for AA), so a
+    // threshold-based oracle would call the cell blank and agree with a
+    // renderer that dropped it. `is_background` compares to the clear
+    // colour, so the cell reads as lit and the colour is checked — against
+    // the fixed palette value, pinned here as a literal so the issue-168
+    // fix is visible at the pixel level too.
     let Some(renderer) = renderer_or_skip("a_dark_coloured_cell_is_still_seen_as_lit") else {
         return;
     };
@@ -859,8 +862,13 @@ fn a_dark_coloured_cell_is_still_seen_as_lit() {
         "SGR 30 should draw palette black {:?}, drew {drawn:?}",
         DARK.ansi()[0]
     );
-    // The old gate would have mistaken this for background; the new one must not.
-    assert!(drawn.iter().all(|channel| *channel < 48));
+    // The issue-168 value: the smallest achromatic grey clearing WCAG AA
+    // (4.53:1) on the dark background — no longer below any brightness gate.
+    assert_eq!(
+        drawn,
+        [121, 121, 121],
+        "palette black must draw the AA-fixed grey 121, not the pre-168 near-zero"
+    );
 }
 
 #[test]

--- a/crates/noren-app/tests/theme.rs
+++ b/crates/noren-app/tests/theme.rs
@@ -25,14 +25,15 @@
 //! definition, and the cube's black corner fails on every possible
 //! background. See `src/theme.rs` for the full statement.
 //!
-//! # The dark-palette finding
+//! # The dark-palette fix (issue #168)
 //!
-//! The existing default (`dark`) fails 4.5:1 for five ANSI slots on its own
-//! background; its measured minimum, 1.06:1 (ANSI black), is pinned below.
-//! The colours are frozen anyway: this slice's contract is that no
-//! `[theme]` section renders byte-identically to the pre-theme renderer,
-//! and the frame oracle proves that at the pixel level. Changing the dark
-//! values to pass AA is a separate, deliberate decision for a follow-up.
+//! The default (`dark`) used to fail 4.5:1 for five ANSI slots on its own
+//! background, worst at ANSI black 1.06:1 — text a program could emit and a
+//! user could not see. Issue #168 made the product decision PR #167 deferred
+//! and moved exactly those five entries the minimum distance that clears AA;
+//! the before/after measurements are recorded in `src/theme.rs` and pinned
+//! below. The theme's measured minimum is now 4.50:1 (`magenta`, the
+//! tightest of the five minimum moves).
 
 use noren_app::theme::{Theme, ThemeName, contrast_ratio, relative_luminance};
 
@@ -63,7 +64,7 @@ fn contrast_ratio_matches_the_wcag_reference_values() {
 }
 
 /// The pair every unstyled character draws in — the reading path — clears
-/// AA for every theme, including the frozen dark default.
+/// AA for every theme, including the default dark theme.
 #[test]
 fn every_theme_default_pair_meets_aa() {
     for name in [ThemeName::Dark, ThemeName::Light, ThemeName::HighContrast] {
@@ -92,7 +93,7 @@ fn light_theme_keeps_aa_on_every_theme_owned_foreground() {
 /// High-contrast genuinely exceeds the others: it clears AAA (7:1) and its
 /// measured minimum strictly beats both other themes' minima. Measured
 /// minimum: 7.84:1 (`bright black`), against light's 5.07:1 and dark's
-/// 1.06:1.
+/// 4.50:1.
 #[test]
 fn high_contrast_meets_aaa_and_strictly_exceeds_the_other_themes() {
     let (hc_min, hc_slot) = ThemeName::HighContrast
@@ -115,59 +116,112 @@ fn high_contrast_meets_aaa_and_strictly_exceeds_the_other_themes() {
     );
 }
 
-/// The reported finding, pinned: the existing default palette's worst
-/// theme-owned foreground is ANSI black at 1.06:1 — far below AA — and four
-/// more slots (blue 2.10, red 3.38, bright blue 4.16, magenta 4.21) also
-/// fail. The value is pinned so that *any* change to the default palette —
-/// a fix or a regression — breaks this test and forces the decision into
-/// the open. Fixing it is follow-up work precisely because the defaults
-/// must keep rendering byte-identically to the pre-theme renderer.
+/// The dark theme now keeps AA on every theme-owned foreground — the fix
+/// issue #168 made after PR #167 had pinned the 1.06:1 failure. Every ANSI
+/// slot and the default foreground must clear 4.5:1 on the dark background;
+/// the measured minimum is pinned so a future palette edit — regression or
+/// further fix — is a deliberate, visible decision.
 #[test]
-fn default_dark_palette_minimum_is_pinned_below_the_aa_floor() {
+fn dark_theme_keeps_aa_on_every_theme_owned_foreground() {
     let (min, slot) = ThemeName::Dark
         .palette()
         .min_contrast_on_default_background();
-    assert_eq!(slot, "black", "the default's worst slot is ANSI black");
     assert!(
-        (min - 1.0639).abs() < 0.001,
-        "default dark minimum moved to {min:.4}:1 (was 1.0639:1) — changing the \
-         shipped default palette is a deliberate decision, not a side effect"
+        min >= 4.5,
+        "dark theme's worst slot ({slot}) is {min:.2}:1, below the AA 4.5:1 floor"
+    );
+    assert_eq!(
+        slot, "magenta",
+        "the fixed dark palette's worst slot moved — update this pin and the docs"
     );
     assert!(
-        min < 4.5,
-        "if the default now passes AA, update the finding documentation"
+        (min - 4.5025).abs() < 0.001,
+        "dark minimum moved to {min:.4}:1 (was 4.5025:1 after issue #168) — \
+         changing the shipped default palette is a deliberate decision, not a \
+         side effect"
     );
 }
 
-/// The dark theme is the pre-theme renderer's exact colours: the raw shader
-/// floats, the xterm ANSI table, and the shared cube/grayscale tail. This
-/// is the palette-level half of the defaults-preservation contract; the
-/// frame oracle proves the pixel-level half.
+/// Each of the five entries issue #168 fixed now measures above the floor it
+/// used to fail, by the minimum move: the pinned ratios are the before/after
+/// record of the fix, and reverting any entry to its pre-fix value fails
+/// here (and in the AA test above).
 #[test]
-fn dark_theme_is_byte_identical_to_the_pre_theme_renderer() {
+fn the_five_fixed_dark_entries_measure_above_their_old_failures() {
+    let dark = ThemeName::Dark.palette();
+    let ground = dark.background_u8();
+    let fixed = [
+        ("black", [121, 121, 121], [0, 0, 0], 1.0639),
+        ("red", [243, 0, 0], [205, 0, 0], 3.3800),
+        ("blue", [0, 113, 255], [0, 0, 238], 2.1005),
+        ("magenta", [213, 0, 213], [205, 0, 205], 4.2086),
+        ("bright blue", [100, 100, 255], [92, 92, 255], 4.1640),
+    ];
+    for (slot, after, before, old_ratio) in fixed {
+        let ratio = contrast_ratio(after, ground);
+        assert!(
+            ratio >= 4.5,
+            "{slot} at {after:?} measures {ratio:.4}:1 — the AA fix regressed"
+        );
+        // The old value must still fail, so the pin cannot be satisfied by
+        // reverting: the minimum move is what keeps this honest.
+        let old = contrast_ratio(before, ground);
+        assert!(
+            old < 4.5 && (old - old_ratio).abs() < 0.001,
+            "{slot}'s recorded pre-fix failure ({old_ratio:.4}:1) moved — the \
+             history pin is wrong"
+        );
+        // And each fixed value is minimal: one channel step down must fail,
+        // which is what "moved the minimum distance" means for these ramps.
+        let dimmer = after.map(|channel| channel.saturating_sub(1));
+        assert!(
+            contrast_ratio(dimmer, ground) < 4.5 || dimmer == after,
+            "{slot} at {after:?} is not the minimum passing value — {dimmer:?} \
+             already clears AA",
+        );
+    }
+    // The fixed values are what the theme actually serves.
+    assert_eq!(dark.ansi()[0], [121, 121, 121]);
+    assert_eq!(dark.ansi()[1], [243, 0, 0]);
+    assert_eq!(dark.ansi()[4], [0, 113, 255]);
+    assert_eq!(dark.ansi()[5], [213, 0, 213]);
+    assert_eq!(dark.ansi()[12], [100, 100, 255]);
+}
+
+/// The dark theme is the pre-theme renderer's colours except the five
+/// issue-168 fixes: the raw shader floats, the shared cube/grayscale tail,
+/// and eleven of the sixteen ANSI entries are still byte-identical, and the
+/// five that moved are pinned to their fixed values (blue kept red at zero,
+/// magenta stays symmetric R=B, bright blue keeps its R=G balance, black
+/// stays achromatic — slot semantics preserved). This is the palette-level
+/// half of the pin; the frame oracle proves the pixel-level half.
+#[test]
+fn dark_theme_palette_is_pinned_with_the_issue_168_aa_fixes() {
     let dark = ThemeName::Dark.palette();
     // The exact floats the fragment shader returned as constants before
     // themes existed (issue #107/#112); the frame oracle pins their captured
     // form at [204, 235, 209].
     assert_eq!(dark.foreground(), [0.80, 0.92, 0.82]);
     assert_eq!(dark.background(), [0.035, 0.045, 0.04]);
-    // The xterm sixteen.
+    // The xterm sixteen with the five AA fixes (issue #168): entries 0, 1,
+    // 4, 5, and 12 moved the minimum distance to clear 4.5:1; the other
+    // eleven are the untouched xterm values.
     assert_eq!(
         dark.ansi(),
         [
-            [0, 0, 0],
-            [205, 0, 0],
+            [121, 121, 121],
+            [243, 0, 0],
             [0, 205, 0],
             [205, 205, 0],
-            [0, 0, 238],
-            [205, 0, 205],
+            [0, 113, 255],
+            [213, 0, 213],
             [0, 205, 205],
             [229, 229, 229],
             [127, 127, 127],
             [255, 0, 0],
             [0, 255, 0],
             [255, 255, 0],
-            [92, 92, 255],
+            [100, 100, 255],
             [255, 0, 255],
             [0, 255, 255],
             [255, 255, 255],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,8 +96,9 @@ modifiers held, as the pre-configuration palette did.
 ### `[theme]`
 
 Selects the built-in colour palette. The table is optional; an absent
-`[theme]` keeps `dark`, which is exactly the palette the app shipped with
-before themes existed — rendering stays byte-identical.
+`[theme]` keeps `dark`, which is the palette the app shipped with before
+themes existed except for the five ANSI entries issue #168 lifted to
+clear WCAG AA.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
@@ -105,8 +106,10 @@ before themes existed — rendering stays byte-identical.
 
 Accepted names, matched exactly (case-sensitive, closed vocabulary):
 
-- `dark` — the xterm default ANSI colours on the near-black background
-  (today's behaviour);
+- `dark` — the xterm default ANSI colours on the near-black background,
+  with the five entries that failed WCAG AA minimally brightened to clear
+  4.5:1 (issue #168); every theme-owned foreground keeps AA on the
+  default background;
 - `light` — an off-white background with darkened ANSI entries; every
   theme-owned foreground keeps WCAG AA (≥ 4.5:1) on the default
   background;
@@ -131,15 +134,23 @@ cube (`16..=255`) are outside any palette's control (identical colours
 are 1:1 by definition; the cube's black corner fails on every possible
 background) and are therefore not part of the checked set.
 
-**Known finding, reported not fixed:** the default `dark` palette fails
-the 4.5:1 floor for five ANSI slots on its own background — black at
-1.06:1, blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and
-magenta at 4.21:1. The values stay frozen because the no-`[theme]`
-default must render byte-identically to the pre-theme renderer; changing
-them is a separate, deliberate decision. Users who need AA on every slot
-today can select `high-contrast` (measured minimum 7.84:1). The measured
-minima are pinned by tests (`crates/noren-app/tests/theme.rs`), so any
-palette change — fix or regression — is a visible failure.
+**Fixed with issue #168:** the default `dark` palette used to fail the
+4.5:1 floor for five ANSI slots on its own background — black at 1.06:1,
+blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and magenta at
+4.21:1. Issue #168 made the deliberate decision to move exactly those
+five entries the minimum distance that clears the floor (black
+`[0,0,0]`→`[121,121,121]`, red `[205,0,0]`→`[243,0,0]`, blue
+`[0,0,238]`→`[0,113,255]`, magenta `[205,0,205]`→`[213,0,213]`, bright
+blue `[92,92,255]`→`[100,100,255]`), preserving ANSI slot semantics; the
+default's measured minimum is now 4.50:1 (magenta) and `high-contrast`
+(7.84:1) remains the choice for AAA. The minima are pinned by tests
+(`crates/noren-app/tests/theme.rs`, plus a pixel-level pin in
+`tests/frame_oracle.rs`), so any further palette change — fix or
+regression — is a visible failure. Residual caveat: ANSI black and
+bright black now sit close together (`[121,121,121]` vs
+`[127,127,127]`), and the contract still excludes the shared 256-colour
+cube, truecolor, and program-paired colours — those can draw below the
+floor under any palette.
 
 ### `[[agents]]`
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -134,27 +134,41 @@ Each item states what you would actually see if you ran the build.
   word "cursor" does not appear anywhere in `renderer.rs`. In practice: you type, characters appear,
   and nothing shows you where the insertion point is. This is the first thing
   most people notice.
-- **Colours render through a selectable theme, but the default palette fails
-  WCAG AA on five slots.** `[theme] name` in `config.toml` selects one of
-  three built-in palettes — `dark` (the default, byte-identical to the
-  pre-theme colours), `light`, and `high-contrast` — and `glyph_vertices_for`
+- **Colours render through a selectable theme; the default palette now
+  clears WCAG AA on every slot, with two residual caveats.** `[theme] name`
+  in `config.toml` selects one of three built-in palettes — `dark` (the
+  default), `light`, and `high-contrast` — and `glyph_vertices_for`
   in `crates/noren-app/src/renderer.rs` resolves every SGR colour, the
   default foreground, and the clear colour through it
   (`resolve_foreground`/`resolve_background` route ANSI and 256-colour
-  values through the theme's table; truecolor passes through). **The known
-  contrast finding:** the default `dark` palette fails the WCAG AA normal-text
-  floor (4.5:1) for five of its sixteen ANSI slots on its own background —
-  black at 1.06:1, blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and
-  magenta at 4.21:1 — measured and pinned by
-  `default_dark_palette_minimum_is_pinned_below_the_aa_floor` in
-  `crates/noren-app/tests/theme.rs`. The values stay frozen because the
-  no-`[theme]` default must render byte-identically to the pre-theme
-  renderer (pinned by the frame oracle); fixing them is a separate
-  deliberate decision. `light` (measured minimum 5.07:1) and `high-contrast`
-  (7.84:1, above WCAG AAA) pass every slot. In practice: programs that emit
-  SGR red, blue, bright blue, magenta, or black text on the default dark
-  background draw below the AA floor until the dark palette is revisited;
-  selecting `high-contrast` avoids it. Themes are built-in only — there is
+  values through the theme's table; truecolor passes through). **The
+  issue-168 fix:** the default `dark` palette used to fail the WCAG AA
+  normal-text floor (4.5:1) on five of its sixteen ANSI slots — black at
+  1.06:1, blue at 2.10:1, red at 3.38:1, bright blue at 4.16:1, and
+  magenta at 4.21:1 — which left `\x1b[30m` text effectively invisible.
+  Issue #168 made the decision PR #167 had deliberately frozen and moved
+  exactly those five entries the minimum distance that clears 4.5:1
+  (black `[0,0,0]`→`[121,121,121]` 1.06→4.53, red `[205,0,0]`→`[243,0,0]`
+  3.38→4.52, blue `[0,0,238]`→`[0,113,255]` 2.10→4.52, magenta
+  `[205,0,205]`→`[213,0,213]` 4.21→4.50, bright blue
+  `[92,92,255]`→`[100,100,255]` 4.16→4.52), preserving ANSI slot
+  semantics. The default's measured minimum is now 4.50:1 (magenta),
+  pinned by `dark_theme_keeps_aa_on_every_theme_owned_foreground` and
+  `the_five_fixed_dark_entries_measure_above_their_old_failures` in
+  `crates/noren-app/tests/theme.rs`, and confirmed on drawn pixels by
+  `the_issue_168_aa_fixes_reach_the_drawn_pixels` in
+  `crates/noren-app/tests/frame_oracle.rs`. `light` (measured minimum
+  5.07:1) and `high-contrast` (7.84:1, above WCAG AAA) were untouched and
+  pass every slot. **The caveats:** (1) ANSI black and bright black now
+  sit close together — `[121,121,121]` vs `[127,127,127]` — because any
+  achromatic entry clearing AA on this background must be at least grey
+  121 and bright black was already 127; both remain neutral greys, but a
+  program relying on a large black/bright-black distinction will not find
+  one in the default theme. (2) The contrast contract still covers only
+  theme-owned foregrounds on the theme's default background: the shared
+  240-colour cube/grayscale tail (`16..=255`), truecolor, and
+  program-paired foreground/background combinations remain unchecked and
+  can still draw below the floor. Themes are built-in only — there is
   no custom-palette or colour-vision-friendly configuration.
 - **The bitmap font is coverage-bounded, and seven glyph pairs are visually
   identical.** Glyphs are a hand-built 5x7 bitmap in `glyph_rows`
@@ -422,7 +436,7 @@ rather than trusting a copy from elsewhere. Nothing here should be
 read as "nearly done": the honest summary is that the foundation is tested, a
 first workspace slice is now real and visible, and what stands between this and
 a usable daily terminal is not workspace plumbing but the display itself — a
-theme whose default palette clears WCAG AA on every slot, a real font, and a
-cursor. SGR colour is drawn through selectable light/dark/high-contrast
-themes with verified contrast, but the built-in palettes are not yet a
-custom theming system.
+real font and a cursor (the default theme's palette cleared WCAG AA on every
+slot with issue #168). SGR colour is drawn through selectable
+light/dark/high-contrast themes with verified contrast, but the built-in
+palettes are not yet a custom theming system.


### PR DESCRIPTION
Closes #168 — a **preview blocker**. Noren's shipped default palette rendered `\x1b[30m` text at **1.06:1**, effectively black-on-black, so any themed prompt or TUI status line using it was unreadable.

## Option 1: fix the failing entries, minimum distance

Of the two options the issue left open (fix `dark`, or keep it and document the failure), this takes the first. A terminal's job is showing text; a default that hides some of it is a defect rather than a preference. Lifting the background was already ruled out by #167's review (`background_option_viable=no`).

**5 of 16 ANSI entries changed, each moved the least needed to clear 4.5:1** — not a re-theme:

| Entry | Before | After | Ratio |
| --- | --- | --- | --- |
| 0 black | `[0,0,0]` | `[121,121,121]` | 1.06 → **4.53** |
| 1 red | `[205,0,0]` | `[243,0,0]` | 3.38 → **4.52** |
| 4 blue | `[0,0,238]` | `[0,113,255]` | 2.10 → **4.52** |
| 5 magenta | `[205,0,205]` | … | → **4.5+** |
| (fifth entry) | … | … | → **4.5+** |

I verified the arithmetic by hand from the constants rather than re-running the project's own function — a bug there would produce a consistent-looking wrong answer:

```
black 4.53:1   red 4.52:1   blue 4.52:1
```

Each clears 4.5:1 with almost nothing to spare, which is the evidence that they were moved the minimum distance.

## What did not change

- **The 4.5:1 threshold was not lowered.** Loosening it to make the default pass would convert an accessibility defect into a green test.
- **ANSI semantics preserved** — 1 stays red, 2 stays green. A palette that renames colours breaks every program assuming ANSI meaning.
- **`light` and `high-contrast` are unaffected**, with their minima reported before and after to prove it.
- The frame oracle confirms the change reaches **drawing**, not just config.

Reverting any one fixed entry fails the contrast test.

`docs/known-limitations.md` is updated to what is now true.

Gates: `fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` **1,111 passing, 0 failed**.
