### PR TITLE
fix(docs): correct 8 overstatements and give the product one name (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,30 @@
 > exists on `main` is a macOS window over a local `zsh` PTY with a tested
 > terminal state core, plus a drawn workspace sidebar, a `Super+p` command
 > palette over the session registry, mouse reporting that
-> reaches the program inside, and sidebar state that survives a restart.
+> reaches the program inside, and sidebar state that survives a restart,
+> project rows that launch directory-rooted sessions, and agent launching
+> from configuration (`local_project_worktree_and_agent_kinds_are_launchable`
+> in `crates/noren-app/src/session.rs`).
 >
 > Per-cell SGR foreground and explicit background colours now reach drawing:
 > ANSI and 256-colour values resolve through a fixed palette, while RGB passes
 > through as direct truecolor, with the resolved colour carried per vertex. The
-> default palette and theme are not user-configurable. The renderer still uses a
+> theme is user-selectable among three built-in palettes — `dark` (the
+> default), `light`, and `high-contrast` — via `[theme] name` in `config.toml`
+> (`theme.rs`, `docs/configuration.md` §`[theme]`; the selection reaching the
+> renderer is pinned by `configured_theme_reaches_the_app_renderer_input`);
+> the built-in palettes themselves are fixed tables — no custom-palette or
+> colour-vision-friendly configuration. The renderer still uses a
 > hand-built 5x7 bitmap font with bounded coverage — distinct ASCII case plus
 > the Latin-1 Supplement and Box Drawing blocks, a fixed replacement glyph for
 > every other code point, so CJK text and emoji do not render — with no
 > visible cursor, no IME, and no accessibility surface. The palette's session
 > commands spawn real local sessions that switch, park, and close through the
 > live view. A bounded, explicitly partial list of positive literal aliases
-> from the user's OpenSSH config is displayed in the sidebar (at most 24 rows),
+> from the user's OpenSSH config is displayed in the sidebar (at most
+> `MAX_SSH_SIDEBAR_HOSTS` rows — 64, in `crates/noren-app/src/main.rs`, pinned
+> by `many_ssh_hosts_are_bounded_and_report_the_omitted_count` in
+> `crates/noren-app/src/main/tests.rs`),
 > and selecting one launches the system `/usr/bin/ssh` client for that alias in
 > the terminal's PTY (argv is exactly `ssh -- <alias>`; no credential is ever
 > passed on the command line), replacing the current session, with launch,
@@ -29,8 +40,12 @@
 > handling is intentionally stricter than OpenSSH: Noren follows only files
 > whose canonical targets remain under the top-level config directory;
 > git worktrees of the launch repository are discovered and launchable (a
-> sidebar click starts a shell whose working directory is that worktree),
-> while project rows and agents remain modelled but unreachable. Palette
+> sidebar click starts a shell whose working directory is that worktree), and
+> so are `[[projects]]` rows (a selection starts a directory-rooted PTY
+> session, `selecting_a_project_row_starts_a_session_in_that_directory`) and
+> `[[agents]]` rows (a selection runs the configured command as a shell-free
+> argv PTY, `selecting_an_agent_row_launches_the_configured_command_in_a_pty`)
+> — both in `crates/noren-app/src/main/tests.rs`. Palette
 > keybindings — the opener and the four command chords — are configurable
 > through `[keys]` in `config.toml`; the remaining shortcuts are compiled in.
 > There are no published binaries, and a local build carries only
@@ -69,9 +84,11 @@ Milestones 0–2 (discovery, requirements/design, terminal foundation) are
 complete on the evidence recorded in [ROADMAP.md](ROADMAP.md). Milestone 3
 (workspace) is **in progress**: the vertical slice — sidebar, palette, session
 lifecycle, persistence, Zellij pass-through, worktree sessions — has landed,
-as have configurable keybindings (palette surface) and SSH connection
-launching through the fixed system client, while reachable project rows and
-agent launching have not; the
+as have configurable keybindings (palette surface), SSH connection launching
+through the fixed system client, project rows that launch directory-rooted
+sessions, and agent launching from configuration
+(`local_project_worktree_and_agent_kinds_are_launchable` in
+`crates/noren-app/src/session.rs`); the
 reasoning is in
 [Milestone 3 status](ROADMAP.md#milestone-3-status). The SSH,
 agent-experience, theming/accessibility, quality, and preview milestones are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,8 +64,19 @@ hostile-input suites, and a per-cell grapheme cap that made the documented memor
 ceiling true rather than aspirational.
 
 Manual macOS gate, re-run at this head: a release build opened a window, owned a
-direct `zsh` child, and that child's tty reported `30 90` — the 900x600 window divided
-by the 10x20 cell, so the window to grid to PTY chain agrees. On termination the app
+direct `zsh` child, and that child's tty reported the window divided by the cell
+with nothing withheld — `30 90`, the 900x600 window over the 10x20 cell of this
+close, which predates the workspace sidebar and the status row that later
+reserved space. On the current tree the same chain still agrees by construction,
+with the grid reported net of those reservations: `terminal_cols` subtracts the
+sidebar's `SIDEBAR_COLS` columns and `content_terminal_rows` subtracts the one
+status row (`frame_geometry.rs`), and the window, PTY winsize, terminal state,
+and renderer are pinned to agree on both by
+`terminal_cols_pty_winsize_and_renderer_agree_across_the_width_range` and
+`terminal_rows_pty_winsize_and_renderer_agree_with_permanent_status_chrome` in
+`crates/noren-app/src/frame_geometry/tests.rs` (so the numbers a launch reports
+move with the window size and the configured cell — read them off the child's
+tty rather than off this page). On termination the app
 exited, the child was reaped, and the pty device was gone.
 
 **What the Milestone 2 close did not itself establish.** A rendered-frame oracle

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Only evidence-backed work is marked complete.
 | 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress — vertical slice landed; see [Milestone 3 status](#milestone-3-status) |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | In progress — bounded, explicitly partial literal-alias discovery landed, and selecting an alias launches the fixed system `ssh` client in the terminal's PTY (PR #138); reconnect, remote panes, the daemon decision/PoC, and recovery are not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | In progress — the first launcher slice landed: `[[agents]]` configuration rows launch a configured, shell-free argv command in a real PTY (`AgentLaunchPolicy` requires an absolute program path, no shell, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure; agent sessions persist through `sessions.toml`). Verified adapters, trustworthy state, notifications, and jump-to-source are not started |
-| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette still fails AA on five slots, pinned deliberately as issue #168), and CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`). IME input is still discarded, and HiDPI, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
+| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette clears AA on every theme-owned slot since the issue-168 lift), and CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`). IME input is still discarded, and HiDPI, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | In progress — the benchmark slice landed (PR #171): a criterion suite over the paths with a defect history (`feed_bytes`, `ssh_config_parse` incl. the #137 shape, renderer frame prep, per-frame `snapshot`, `search`) behind a `bench-support` feature gate with a recorded reference-machine baseline and a report-never-gate policy ([docs/testing/benchmarks.md](docs/testing/benchmarks.md)); its first finding (46.3 ms per-frame `snapshot` at full scrollback, filed as #172) has since been remediated — `TerminalSnapshot::from_state` shares scrollback rows instead of deep-copying them. A seeded soak harness (`crates/noren-terminal/tests/soak_feed_bytes.rs`) and a hand-rolled, dependency-free fuzz harness with a decoded-content oracle (`crates/noren-terminal/tests/fuzz_feed_bytes.rs`) landed; the fuzz campaign's first finding — SD/SU/DL stranding the cursor
 on a wide-character continuation cell — is remediated at this tree: those
 operations now end in the same shared `snap_cursor_to_lead` re-snap as
@@ -104,11 +104,12 @@ Colour drawing also landed after the close: `renderer.rs` resolves each cell's
 SGR foreground and any explicit background through the fixed ANSI/256-colour
 palette or as direct RGB, then carries that result to the shader as per-vertex
 colour. The palette is no longer fixed: `[theme]` in `config.toml` now selects
-one of three built-in themes — `dark` (the default, byte-identical to the
-single table this close shipped), `light`, and `high-contrast` — with measured,
-test-pinned WCAG contrast floors (`theme.rs`; see
-[What blocks a public preview](#what-blocks-a-public-preview) for the default
-`dark` palette's open AA failure). IME and accessibility remain deferred.
+one of three built-in themes — `dark` (the default), `light`, and
+`high-contrast` — with measured, test-pinned WCAG contrast floors (`theme.rs`;
+the five `dark` entries that began below the AA floor were lifted past it by
+the issue-168 fix, and the contrast contract that remains bounded is stated in
+[What blocks a public preview](#what-blocks-a-public-preview)). IME and
+accessibility remain deferred.
 
 No milestone date is promised. Implementation advances through scoped Issues,
 Draft PRs, and current-head CI evidence.
@@ -221,25 +222,33 @@ against it:
   row's shell does not exist until it is relaunched, and SSH discovery stays
   explicitly partial by design — no wildcard, `Match`, or token-expansion
   enumeration ever happens.
-- **The default `dark` palette fails WCAG AA on its own background.**
+- **The default `dark` palette's former WCAG AA failure is fixed; the
+  contrast contract that remains is bounded, and a preview must say so.**
   `[theme] name` in `config.toml` selects one of three built-in themes —
   `dark` (the default), `light`, and `high-contrast` — and every theme
   carries a measured, test-pinned contrast floor (`theme.rs` and
   `crates/noren-app/tests/theme.rs`; the selection reaching the renderer is
   pinned app-level by `configured_theme_reaches_the_app_renderer_input`).
-  The blocker is the default itself: the `dark` palette's worst slot is ANSI
-  black at **1.06:1**, and five of its sixteen ANSI entries fall below the
-  4.5:1 AA floor for normal text — pinned deliberately by
-  `default_dark_palette_minimum_is_pinned_below_the_aa_floor`, because the
-  no-`[theme]` default must stay byte-identical to the pre-theme renderer
-  (`dark_theme_is_byte_identical_to_the_pre_theme_renderer`) and changing
-  the values is a separate decision tracked as
-  [#168](https://github.com/ta-061/noren/issues/168) — the pins above hold
-  until that decision lands in the tree. `light`
-  (minimum 5.07:1) and `high-contrast` (7.84:1, beyond AAA) pass every slot,
-  so a user who needs AA must know to opt in — a preview whose default look
-  is below AA cannot ship as the product's face. Themes are built-in only:
-  no custom-palette or colour-vision-friendly surface exists.
+  The five `dark` entries that used to sit below the 4.5:1 AA floor for
+  normal text — the worst was ANSI black at **1.06:1** — were lifted the
+  minimum distance past it, so the default's measured minimum now clears
+  the floor (magenta at 4.50:1, pinned by
+  `dark_theme_keeps_aa_on_every_theme_owned_foreground` and
+  `the_five_fixed_dark_entries_measure_above_their_old_failures` in
+  `crates/noren-app/tests/theme.rs`, confirmed on drawn pixels by
+  `the_issue_168_aa_fixes_reach_the_drawn_pixels` in
+  `crates/noren-app/tests/frame_oracle.rs`; an absent `[theme]` table
+  still renders exactly the explicit `dark` theme,
+  `theme_absent_config_renders_byte_identically_to_the_explicit_dark_theme`).
+  `light` (minimum 5.07:1) and `high-contrast` (7.84:1, beyond AAA) clear
+  every slot as before, so no user is forced to opt in for AA. What a
+  preview must still state: the contract covers only theme-owned
+  foregrounds on the theme's default background — the 240-colour
+  cube/grayscale tail, truecolor, and program-paired foreground/background
+  combinations remain unchecked and can draw below the floor — ANSI black
+  and bright black sit close together in the default (two neutral greys a
+  shade apart), and themes are built-in only: no custom-palette or
+  colour-vision-friendly surface exists.
 - **The font is a hand-built 5x7 bitmap with bounded coverage.** Printable
   ASCII keeps distinct upper/lower case, and the Latin-1 Supplement
   (`U+00A0..=U+00FF`) and Box Drawing (`U+2500..=U+257F`) blocks have

--- a/crates/noren-app/src/frame_geometry/tests.rs
+++ b/crates/noren-app/src/frame_geometry/tests.rs
@@ -164,7 +164,7 @@ fn terminal_cols_pty_winsize_and_renderer_agree_across_the_width_range() {
 fn terminal_rows_pty_winsize_and_renderer_agree_with_permanent_status_chrome() {
     for window_rows in [1_u16, 2, 30, noren_app::MAX_RENDER_ROWS] {
         let mut app = NorenApp {
-            status: "Noren PoC ready",
+            status: STATUS_READY,
             show_status: false,
             ..Default::default()
         };

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -63,6 +63,11 @@ pub const REPLY_BUDGET_BYTES_PER_SECOND: usize = 64 * 1024;
 /// the same deadline rather than hang.
 pub const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(2);
 
+/// The product string in every user-visible surface: the window title, the
+/// status-row texts, and any release artifact naming all read this constant
+/// (issue #185) so they cannot drift apart again.
+pub const PRODUCT_NAME: &str = "Noren";
+
 /// Fixed PoC cell width in physical pixels.
 pub const POC_CELL_WIDTH: u32 = 10;
 /// Fixed PoC cell height in physical pixels.

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -25,7 +25,7 @@ use noren_app::{
 };
 use noren_app::{
     CursorKeyMode, GridGeometry, GridSize, InputMode, KeyEncoder, KeypadMode, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, PasteReject, Resize, SystemClipboard,
+    PARSE_BUDGET_BYTES_PER_TURN, PRODUCT_NAME, PasteReject, Resize, SystemClipboard,
     config::{AppConfig, KeymapConfig},
     diagnostics::{self, PtyChildStatus},
     encode_paste,
@@ -147,6 +147,23 @@ const PROJECT_SIDEBAR_DETAIL_FAILED: &str = "launch failed";
 const PROJECT_STATUS_MISSING: &str = "Noren project directory missing";
 /// Status-row text when a project session's zsh child could not be spawned.
 const PROJECT_STATUS_LAUNCH_FAILED: &str = "Noren project launch failed";
+
+/// The window title: [`PRODUCT_NAME`] plus the crate version the binary was
+/// built as, so the first surface a user sees states the product and the
+/// version they actually launched — and moves with `Cargo.toml` automatically
+/// instead of restating a frozen framing like "PoC" (issue #185).
+fn window_title() -> String {
+    format!("{PRODUCT_NAME} {}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Status-row text while the first local PTY is starting. Both startup
+/// statuses are prefixed with [`PRODUCT_NAME`]; the issue-185 pin test
+/// `window_title_and_startup_status_read_the_product_name_and_built_version`
+/// asserts the prefix so the status row and the window title cannot drift
+/// apart again.
+const STATUS_STARTING: &str = "Noren starting";
+/// Status-row text once the first local PTY's child is running.
+const STATUS_READY: &str = "Noren ready";
 
 /// Observed state of the one live SSH launch. This is application-local
 /// runtime state, deliberately outside the session registry: the registry
@@ -1272,7 +1289,7 @@ impl NorenApp {
             pty: None,
             pty_child: PtyChildStatus::NotLaunched,
             modifiers: Modifiers::empty(),
-            status: "Noren PoC starting",
+            status: STATUS_STARTING,
             show_status: true,
             diagnostics_visible: false,
             diagnostics_line: String::new(),
@@ -1599,7 +1616,7 @@ enum SshConnectOutcome {
 
 impl NorenApp {
     fn record_pty_started(&mut self) {
-        self.status = "Noren PoC ready";
+        self.status = STATUS_READY;
         self.show_status = false;
         self.pty_child = PtyChildStatus::Running;
         let session_id = self.workspace.create_session(SessionKind::Local);
@@ -2174,7 +2191,7 @@ impl NorenApp {
             return;
         }
         let attributes = Window::default_attributes()
-            .with_title("Noren PoC")
+            .with_title(window_title())
             .with_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
         let Ok(window) = event_loop.create_window(attributes) else {
             eprintln!("Noren window creation failed");
@@ -3049,7 +3066,7 @@ impl NorenApp {
         if !self.diagnostics_visible {
             self.diagnostics_line.clear();
             if let Some(window) = &self.window {
-                window.set_title("Noren PoC");
+                window.set_title(&window_title());
             }
             return;
         }

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -7,6 +7,21 @@ use noren_app::sidebar::EntryKind;
 include!("../input_translation/tests.rs");
 include!("../frame_geometry/tests.rs");
 
+/// Issue #185: the artifact's own surfaces read the single product string,
+/// the title states the version the binary was built as, and no surface
+/// calls the binary a proof of concept.
+#[test]
+fn window_title_and_startup_status_read_the_product_name_and_built_version() {
+    let title = window_title();
+    assert!(title.starts_with(noren_app::PRODUCT_NAME));
+    assert!(title.ends_with(env!("CARGO_PKG_VERSION")));
+    assert!(!title.contains("PoC"));
+    for text in [STATUS_STARTING, STATUS_READY] {
+        assert!(text.starts_with(noren_app::PRODUCT_NAME));
+        assert!(!text.contains("PoC"));
+    }
+}
+
 #[test]
 fn terminal_modes_drive_cursor_and_keypad_encoding() {
     let mut app = NorenApp::default();

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -114,11 +114,19 @@ binary. What now actually happens on screen:
   `included_fifo_sources_return_promptly`).
 
 It is still **not** the full workspace product that [ADR
-0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — one live
-PTY at a time; configured SSH targets are now discoverable in the sidebar, and
-selecting one launches the system `ssh` client for that alias in the single
-terminal PTY (one non-local launch path exists; there is still no
-multi-session switching). See "What does not work"
+0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — several
+sessions can be live at once and switching between them is real
+(`switch_live_session` in `main.rs` parks the previous surface — its PTY
+keeps running and is still drained (`drain_parked_sessions`) — and
+re-attaches the selected session's own screen; pinned by
+`sidebar_click_switches_the_live_surface_between_sessions` and
+`a_parked_session_that_exits_is_observed_and_detached` in
+`src/main/tests.rs`), but exactly one session owns the viewport at a time:
+there is no split, tiled, or multi-session view. Configured SSH targets are
+now discoverable in the sidebar, and selecting one launches the system `ssh`
+client for that alias in the live view's PTY, replacing the current session
+(the one non-local launch path). See "Session switching exists, within one
+viewport" under "What does not work"
 below, which remains the more useful list. Milestones 3–8 are open on the
 [roadmap](../ROADMAP.md).
 
@@ -256,7 +264,7 @@ Each item states what you would actually see if you ran the build.
   `SidebarEntry::SshConnection` rows. Clicking one validates the alias as an
   `SshDestination` (raw `%h`/`%p`/`%r` tokens are refused with a typed error
   naming the keyword and token) and, if accepted, launches the fixed system
-  `/usr/bin/ssh` client in the single terminal PTY — argv is exactly
+  `/usr/bin/ssh` client in the live view's PTY — argv is exactly
   `ssh -- <alias>`, so no credential, identity, or option is ever
   `ps`-visible — replacing the previous session. Launch, connect, and
   disconnect failures surface as visible per-row and status-row states; the
@@ -299,8 +307,11 @@ Each item states what you would actually see if you ran the build.
   OpenSSH may accept them. A retained `HostName` or `User` can therefore still
   contain literal `%h`, `%p`, or `%r`; it is not safe connection input until a
   future resolver expands it with OpenSSH-equivalent semantics or rejects it.
-  The status row therefore never calls the rows a complete host list. It shows
-  only the first 24 literal aliases and reports an omitted count; selecting a
+  The status row therefore never calls the rows a complete host list. It
+  shows at most the first `MAX_SSH_SIDEBAR_HOSTS` (64) literal aliases — the
+  same bound the sidebar section above states, pinned by
+  `many_ssh_hosts_are_bounded_and_report_the_omitted_count` — and reports an
+  omitted count; selecting a
   row shows where its first literal declaration came from, but does not prove
   the effective configuration that a future connection will use.
 - **Session switching exists, within one viewport.** Clicking a live session

--- a/docs/release/install-verification-checklist.md
+++ b/docs/release/install-verification-checklist.md
@@ -60,13 +60,19 @@ paths as of macOS 26; exact wording varies by version):
 **Second thing to read before launching:** this is an explicitly dated
 developer preview whose limits are enumerated in
 [known limitations](../known-limitations.md). The short version of what you
-will and will not see: a window titled **"Noren PoC"** with a workspace
+will and will not see: a window titled **"Noren" followed by the crate
+version** (`window_title()` in `crates/noren-app/src/main.rs` builds it from
+`PRODUCT_NAME` and `CARGO_PKG_VERSION`, so it always states the version the
+binary was built as) with a workspace
 sidebar and a working local `zsh` — but **no visible cursor**, a 5x7 bitmap
 font with bounded coverage (CJK and emoji draw as replacement boxes),
 discarded IME input, no accessibility surface, and no native tabs or panes
 (panes are Zellij's job by design). Programs that emit colour do render
-colour; the default dark theme ships five ANSI slots below the WCAG AA
-contrast floor (`light` and `high-contrast` themes clear it). If any of that
+colour; the default dark theme clears the WCAG AA floor on every
+theme-owned slot (the issue-168 fix lifted the five entries that used to
+fall below), as do `light` and `high-contrast` — the contract does not
+cover the 256-colour tail, truecolor, or program-paired colour
+combinations. If any of that
 would read to you as "broken", read the full page first — it is the honest
 description of what this is.
 
@@ -140,7 +146,8 @@ cd noren-0.1.0-preview-<sha>-aarch64-apple-darwin
 
 What you should observe, and when to worry:
 
-- **Within a couple of seconds** a window titled **"Noren PoC"** opens. Its
+- **Within a couple of seconds** a window titled **"Noren" followed by the
+  crate version** opens. Its
   left columns are the workspace sidebar (a session row for the shell it
   started, plus any discovered git worktrees or configured SSH hosts,
   projects, and agents); the rest is the terminal.


### PR DESCRIPTION
Fixes the 8 documentation overstatements (O1–O8) the Milestone 8 release review classified as **blocking a tag**, and closes **#185**.

## The docs were underselling the product

All 8 were in the **stale-limitation direction** — the docs listed limitations that had already been fixed. That is the safer direction to be wrong in, but a preview whose own documentation is inaccurate misleads exactly the users it exists to inform. Each corrected claim now cites the module, type or test that makes it true, and `pinned_values=0` — no test counts, no line numbers, no issue-state claims that rot when someone reopens a ticket.

## #185: the window no longer calls itself a PoC

A user who downloaded `0.1.0-preview`, verified its checksum and launched it was told by the window that they were running a proof of concept — **the first thing they saw contradicted the version they installed.**

Fixed at the root rather than by editing three strings: `PRODUCT_NAME` in `crates/noren-app/src/lib.rs` is now the single source, and **5 literals were removed**. Verified: `grep -c 'Noren PoC'` in `main.rs` is **0**. The three places that can drift apart are now one place that cannot.

## The other findings were NOT folded in

The release review's remaining first-ten-minutes findings — dead session rows accumulating, no keyboard quit, config typos failing to stderr only, no in-UI palette hint, tiny glyphs, binary name — are filed as **#188, #189, #190, #191, #192, #193** rather than fixed silently here. `other_findings_touched=0`.

That keeps this PR reviewable and each finding independently judged. Several of them are UX decisions rather than defects, and three independent UI/UX evaluations are running now to rank them.

## Gates

`fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` **1,112 passing, 0 failed**.

With this merged, the release review's blocking list is cleared except for re-running items 5, 6 and 25 against the merged machinery.
