### PR TITLE
feat(renderer): draw the terminal cursor (#197, #200)

### DIFF
--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -71,6 +71,7 @@
 //! embed a username or a private directory name, so neither surface is ever
 //! echoed through an error `Display` or a `Debug` rendering (issue #146).
 
+use crate::cursor::CursorShape;
 use crate::passthrough::{
     CLAIM_ID_PALETTE, Chord, ChordError, ChordSeq, KeyCode, Modifiers, PassthroughAction,
     PassthroughClaim, PassthroughPolicy, default_exit_claim,
@@ -263,6 +264,48 @@ impl ThemeConfig {
     }
 }
 
+/// Cursor appearance settings (issues #197/#200).
+///
+/// [`CursorConfig::default`] is a visible block in the theme's cursor
+/// colour: the caret is drawn with no configuration, and this table only
+/// changes *how* it looks. Visibility is not a setting — it belongs to the
+/// program through DECTCEM, never to a user preference that could quietly
+/// reproduce the every-keystroke-blind defect.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CursorConfig {
+    shape: CursorShape,
+    color: Option<[u8; 3]>,
+}
+
+impl CursorConfig {
+    /// The configured shape; defaults to [`CursorShape::Block`].
+    #[must_use]
+    pub const fn shape(self) -> CursorShape {
+        self.shape
+    }
+
+    /// The configured colour override as `#rrggbb` channels; `None` keeps
+    /// the theme's cursor colour.
+    #[must_use]
+    pub const fn color(self) -> Option<[u8; 3]> {
+        self.color
+    }
+}
+
+/// Parse one `#rrggbb` colour value. Returns `None` for any other shape —
+/// wrong length, missing `#`, or non-hexadecimal characters — so a typo is
+/// the caller's typed error, never a guess.
+fn parse_hex_color(value: &str) -> Option<[u8; 3]> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 7 || bytes[0] != b'#' {
+        return None;
+    }
+    let channel = |start: usize| -> Option<u8> {
+        u8::from_str_radix(std::str::from_utf8(&bytes[start..start + 2]).ok()?, 16).ok()
+    };
+    Some([channel(1)?, channel(3)?, channel(5)?])
+}
+
 /// One configured agent: a display name plus the argv vector of its launch.
 ///
 /// The command is executed **without a shell** (see [`crate::config`]'s
@@ -375,6 +418,7 @@ pub struct AppConfig {
     font: FontConfig,
     keys: KeymapConfig,
     theme: ThemeConfig,
+    cursor: CursorConfig,
     agents: Vec<AgentConfig>,
     projects: Vec<ProjectConfig>,
 }
@@ -396,6 +440,12 @@ impl AppConfig {
     #[must_use]
     pub const fn theme(&self) -> ThemeConfig {
         self.theme
+    }
+
+    /// Cursor appearance settings.
+    #[must_use]
+    pub const fn cursor(&self) -> CursorConfig {
+        self.cursor
     }
 
     /// Configured agents, in file order. Empty when `[agents]` is absent.
@@ -468,6 +518,7 @@ impl AppConfig {
                         "font" => parse_font(table, &mut config.font)?,
                         "keys" => parse_keys(table, &mut config.keys)?,
                         "theme" => parse_theme(table, &mut config.theme)?,
+                        "cursor" => parse_cursor(table, &mut config.cursor)?,
                         // `[terminal]` historically attracted a `scrollback_lines` key.
                         // The terminal foundation has no configurable retention cap yet,
                         // so the table is rejected instead of parsed-and-ignored.
@@ -652,6 +703,39 @@ fn parse_theme(table: &dyn TableLike, theme: &mut ThemeConfig) -> Result<(), Con
                     .ok_or_else(|| ConfigError::ThemeNotAString { key: clip(key) })?;
                 theme.name = ThemeName::parse(value)
                     .ok_or_else(|| ConfigError::UnknownTheme { value: clip(value) })?;
+            }
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    Ok(())
+}
+
+/// Apply the `[cursor]` table to the cursor appearance.
+///
+/// Shape names are a closed vocabulary matched exactly, like `[theme]`
+/// names; an unknown shape is [`ConfigError::UnknownCursorShape`] naming the
+/// offending value, never a fallback to `block`. The colour must be one
+/// `#rrggbb` string; its rejections name the key only — unlike a shape or
+/// theme name, a malformed colour is freeform text with no grammar
+/// bounding what it can hold.
+fn parse_cursor(table: &dyn TableLike, cursor: &mut CursorConfig) -> Result<(), ConfigError> {
+    for (key, item) in table.iter() {
+        match key {
+            "shape" => {
+                let value = item
+                    .as_str()
+                    .ok_or_else(|| ConfigError::CursorShapeNotAString { key: clip(key) })?;
+                cursor.shape = CursorShape::parse(value)
+                    .ok_or_else(|| ConfigError::UnknownCursorShape { value: clip(value) })?;
+            }
+            "color" => {
+                let value = item
+                    .as_str()
+                    .ok_or_else(|| ConfigError::CursorColorNotAString { key: clip(key) })?;
+                cursor.color = Some(
+                    parse_hex_color(value)
+                        .ok_or_else(|| ConfigError::InvalidCursorColor { key: clip(key) })?,
+                );
             }
             _ => return Err(ConfigError::UnknownKey(clip(key))),
         }
@@ -1166,6 +1250,24 @@ pub enum ConfigError {
     /// chord echo is: an error that cannot say which name failed is not
     /// actionable.
     UnknownTheme { value: String },
+    /// A `[cursor]` shape value is not a TOML string.
+    CursorShapeNotAString { key: String },
+    /// A `[cursor]` shape is not one of the accepted shapes.
+    ///
+    /// **Echo allowlist**: `value` carries the `[cursor]` shape text,
+    /// clipped to 120 characters by [`clip`], for the same reason
+    /// [`ConfigError::UnknownTheme`] echoes: a shape name is drawn from a
+    /// closed, published vocabulary (`block`, `bar`, `underline`), and an
+    /// error that cannot say which shape failed is not actionable.
+    UnknownCursorShape { value: String },
+    /// A `[cursor]` colour value is not a TOML string.
+    CursorColorNotAString { key: String },
+    /// A `[cursor]` colour is not one `#rrggbb` value.
+    ///
+    /// No file text appears: a malformed colour is freeform text with no
+    /// grammar bounding what it can hold, and the message states the one
+    /// accepted shape, so the key alone identifies the fix.
+    InvalidCursorColor { key: String },
     /// A `[keys]` value does not parse as a chord.
     ///
     /// **Echo allowlist** (issue #150): `value` and `reason` carry `[keys]`
@@ -1275,6 +1377,24 @@ impl fmt::Display for ConfigError {
                 f,
                 "configuration theme {value} is not a built-in theme; expected one of \
                  dark, light, high-contrast"
+            ),
+            Self::CursorShapeNotAString { key } => write!(
+                f,
+                "configuration key {key} must be a cursor shape string like \"block\""
+            ),
+            Self::UnknownCursorShape { value } => write!(
+                f,
+                "configuration cursor shape {value} is not a known shape; expected one of \
+                 block, bar, underline"
+            ),
+            Self::CursorColorNotAString { key } => write!(
+                f,
+                "configuration key {key} must be a colour string like \"#3fb27f\""
+            ),
+            Self::InvalidCursorColor { key } => write!(
+                f,
+                "configuration key {key} must be one #rrggbb colour value; it is not a \
+                 colour, and no fallback colour is guessed"
             ),
             Self::InvalidChord { key, value, reason } => write!(
                 f,
@@ -2238,6 +2358,144 @@ mod tests {
             config.keys().session_create(),
             chord(KeyCode::Char('t'), Modifiers::empty())
         );
+    }
+
+    // ── [cursor] tests ─────────────────────────────────────────────────
+
+    /// With no `[cursor]` surface at all the caret is a visible block in
+    /// the theme's colour — the drawn-by-default contract of issues
+    /// #197/#200: a user who reads nothing still gets a caret.
+    #[test]
+    fn default_cursor_is_a_visible_block_with_no_colour_override() {
+        assert_eq!(CursorConfig::default().shape(), CursorShape::Block);
+        assert_eq!(CursorConfig::default().color(), None);
+        assert_eq!(AppConfig::default().cursor(), CursorConfig::default());
+        assert_eq!(
+            AppConfig::parse("# nothing\n")
+                .expect("valid")
+                .cursor()
+                .shape(),
+            CursorShape::Block
+        );
+    }
+
+    /// An empty `[cursor]` table is presence without content: the default.
+    #[test]
+    fn empty_cursor_table_keeps_the_default_appearance() {
+        let config = AppConfig::parse("[cursor]\n").expect("an empty table is valid");
+        assert_eq!(config.cursor(), CursorConfig::default());
+    }
+
+    /// Each documented shape is selected by its exact name.
+    #[test]
+    fn every_documented_cursor_shape_is_selected_by_exact_name() {
+        for (text, shape) in [
+            ("block", CursorShape::Block),
+            ("bar", CursorShape::Bar),
+            ("underline", CursorShape::Underline),
+        ] {
+            let config =
+                AppConfig::parse(&format!("[cursor]\nshape = \"{text}\"\n")).expect("valid");
+            assert_eq!(config.cursor().shape(), shape, "{text:?}");
+        }
+    }
+
+    /// An unknown shape is a typed error naming the offending value —
+    /// never a fallback to `block`. The vocabulary is closed and
+    /// case-sensitive, like `[theme]` names.
+    #[test]
+    fn unknown_cursor_shapes_are_rejected_naming_the_offending_value() {
+        for text in [
+            "[cursor]\nshape = \"box\"\n",
+            "[cursor]\nshape = \"Block\"\n",
+            "[cursor]\nshape = \"\"\n",
+        ] {
+            let error = AppConfig::parse(text).expect_err("must not parse");
+            assert!(
+                matches!(&error, ConfigError::UnknownCursorShape { .. }),
+                "{text:?} must be UnknownCursorShape, got {error:?}"
+            );
+        }
+        assert_eq!(
+            AppConfig::parse("[cursor]\nshape = \"box\"\n"),
+            Err(ConfigError::UnknownCursorShape {
+                value: "box".to_owned()
+            })
+        );
+    }
+
+    /// A well-formed `#rrggbb` colour overrides the theme's cursor colour;
+    /// anything else is a typed error naming the key, and the boundary
+    /// cases (missing `#`, wrong length, non-hex) are all rejected rather
+    /// than guessed at.
+    #[test]
+    fn cursor_color_accepts_exact_hex_and_rejects_everything_else() {
+        let config = AppConfig::parse("[cursor]\ncolor = \"#3fb27f\"\n").expect("valid");
+        assert_eq!(config.cursor().color(), Some([0x3f, 0xb2, 0x7f]));
+
+        for text in [
+            "[cursor]\ncolor = \"orange\"\n",
+            "[cursor]\ncolor = \"3fb27f\"\n",
+            "[cursor]\ncolor = \"#3fb2\"\n",
+            "[cursor]\ncolor = \"#3fb27f0\"\n",
+            "[cursor]\ncolor = \"#zzb27f\"\n",
+            "[cursor]\ncolor = \"\"\n",
+        ] {
+            let error = AppConfig::parse(text).expect_err("must not parse");
+            assert!(
+                matches!(&error, ConfigError::InvalidCursorColor { .. }),
+                "{text:?} must be InvalidCursorColor, got {error:?}"
+            );
+        }
+        // Case-insensitive hex is accepted: `#RRGGBB` spells the same
+        // channels, unlike a shape or theme name where case is a second
+        // spelling of a closed vocabulary.
+        let config = AppConfig::parse("[cursor]\ncolor = \"#3FB27F\"\n").expect("valid");
+        assert_eq!(config.cursor().color(), Some([0x3f, 0xb2, 0x7f]));
+    }
+
+    /// Wrong value types and unknown keys are rejected with the section's
+    /// own typed errors.
+    #[test]
+    fn cursor_table_rejects_wrong_types_and_unknown_keys() {
+        let cases = [
+            (
+                "[cursor]\nshape = 3\n",
+                ConfigError::CursorShapeNotAString {
+                    key: "shape".to_owned(),
+                },
+            ),
+            (
+                "[cursor]\ncolor = 12.5\n",
+                ConfigError::CursorColorNotAString {
+                    key: "color".to_owned(),
+                },
+            ),
+            (
+                "[cursor]\nblink = true\n",
+                ConfigError::UnknownKey("blink".to_owned()),
+            ),
+            (
+                "cursor = \"bar\"\n",
+                ConfigError::WrongType {
+                    key: "cursor".to_owned(),
+                },
+            ),
+        ];
+        for (text, expected) in cases {
+            assert_eq!(AppConfig::parse(text), Err(expected), "{text:?}");
+        }
+    }
+
+    /// `[cursor]` composes with the other sections without interference.
+    #[test]
+    fn cursor_applies_alongside_theme_and_font() {
+        let text = "[font]\ncell_width = 12\n\n[theme]\nname = \"light\"\n\n[cursor]\nshape = \"underline\"\ncolor = \"#101010\"\n";
+        let config = AppConfig::parse(text).expect("all sections are valid together");
+        assert_eq!(config.font().cell_width(), 12);
+        assert_eq!(config.theme().name(), ThemeName::Light);
+        assert_eq!(config.cursor().shape(), CursorShape::Underline);
+        assert_eq!(config.cursor().color(), Some([0x10, 0x10, 0x10]));
     }
 
     // ── [[agents]] tests ───────────────────────────────────────────────

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -266,11 +266,11 @@ impl ThemeConfig {
 
 /// Cursor appearance settings (issues #197/#200).
 ///
-/// [`CursorConfig::default`] is a visible block in the theme's cursor
-/// colour: the caret is drawn with no configuration, and this table only
-/// changes *how* it looks. Visibility is not a setting — it belongs to the
-/// program through DECTCEM, never to a user preference that could quietly
-/// reproduce the every-keystroke-blind defect.
+/// [`CursorConfig::default`] is a visible inverse-video block: the caret is
+/// drawn with no configuration, and this table only changes *how* it looks.
+/// Visibility is not a setting — it belongs to the program through DECTCEM,
+/// never to a user preference that could quietly reproduce the
+/// every-keystroke-blind defect.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CursorConfig {
     shape: CursorShape,
@@ -284,8 +284,9 @@ impl CursorConfig {
         self.shape
     }
 
-    /// The configured colour override as `#rrggbb` channels; `None` keeps
-    /// the theme's cursor colour.
+    /// The configured preferred colour as `#rrggbb` channels; `None` keeps
+    /// cell-relative inverse video. The renderer uses a preference only where
+    /// it clears 4.5:1 against the actual cursor-cell background.
     #[must_use]
     pub const fn color(self) -> Option<[u8; 3]> {
         self.color
@@ -2424,10 +2425,9 @@ mod tests {
         );
     }
 
-    /// A well-formed `#rrggbb` colour overrides the theme's cursor colour;
-    /// anything else is a typed error naming the key, and the boundary
-    /// cases (missing `#`, wrong length, non-hex) are all rejected rather
-    /// than guessed at.
+    /// A well-formed `#rrggbb` colour becomes the cursor preference; anything
+    /// else is a typed error naming the key, and the boundary cases (missing
+    /// `#`, wrong length, non-hex) are all rejected rather than guessed at.
     #[test]
     fn cursor_color_accepts_exact_hex_and_rejects_everything_else() {
         let config = AppConfig::parse("[cursor]\ncolor = \"#3fb27f\"\n").expect("valid");

--- a/crates/noren-app/src/cursor.rs
+++ b/crates/noren-app/src/cursor.rs
@@ -1,0 +1,62 @@
+//! Cursor shape vocabulary shared by configuration and the renderer
+//! (issues #197/#200).
+//!
+//! A visible cursor ships as the default: the caret is drawn with no
+//! configuration, and this vocabulary only changes *how* it is drawn —
+//! shape and colour are user choices, visibility of the product is not.
+//! The `[cursor]` configuration table selects a shape here; the renderer
+//! resolves it against the active theme.
+
+use std::fmt;
+
+/// The shape the cursor is drawn in, as selected by the `[cursor]`
+/// configuration table.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CursorShape {
+    /// A filled cell rectangle; the glyph beneath draws inverted (in the
+    /// theme background colour) so the character under the caret stays
+    /// readable. The default.
+    #[default]
+    Block,
+    /// A narrow vertical stroke on the left edge of the lead cell.
+    Bar,
+    /// A horizontal stroke along the bottom of the cell span.
+    Underline,
+}
+
+impl CursorShape {
+    /// Every accepted `[cursor]` shape name, in documentation order.
+    pub const NAMES: [&'static str; 3] = ["block", "bar", "underline"];
+
+    /// Resolve one configuration value to a shape.
+    ///
+    /// Matching is exact (case-sensitive), the same closed-vocabulary rule
+    /// theme names follow: accepting `Block` or `BLOCK` would be a second
+    /// spelling of one setting, and an unknown value is the caller's typed
+    /// error, never a fallback.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "block" => Some(Self::Block),
+            "bar" => Some(Self::Bar),
+            "underline" => Some(Self::Underline),
+            _ => None,
+        }
+    }
+
+    /// The canonical configuration name of this shape.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Block => "block",
+            Self::Bar => "bar",
+            Self::Underline => "underline",
+        }
+    }
+}
+
+impl fmt::Display for CursorShape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/noren-app/src/cursor.rs
+++ b/crates/noren-app/src/cursor.rs
@@ -60,3 +60,26 @@ impl fmt::Display for CursorShape {
         f.write_str(self.as_str())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CursorShape;
+
+    /// The closed vocabulary round-trips through its exact names, and the
+    /// case-sensitive rule rejects second spellings.
+    #[test]
+    fn shape_names_parse_exactly_and_round_trip() {
+        for name in CursorShape::NAMES {
+            let shape = CursorShape::parse(name).expect("a documented name parses");
+            assert_eq!(shape.as_str(), name);
+            assert_eq!(shape.to_string(), name);
+        }
+        assert_eq!(CursorShape::default(), CursorShape::Block);
+        for near_miss in ["Block", "BLOCK", "bars", "under-line", ""] {
+            assert!(
+                CursorShape::parse(near_miss).is_none(),
+                "{near_miss:?} must not parse — the vocabulary is closed"
+            );
+        }
+    }
+}

--- a/crates/noren-app/src/cursor.rs
+++ b/crates/noren-app/src/cursor.rs
@@ -5,7 +5,7 @@
 //! configuration, and this vocabulary only changes *how* it is drawn —
 //! shape and colour are user choices, visibility of the product is not.
 //! The `[cursor]` configuration table selects a shape here; the renderer
-//! resolves it against the active theme.
+//! resolves its ink against the actual terminal cell.
 
 use std::fmt;
 
@@ -13,9 +13,8 @@ use std::fmt;
 /// configuration table.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum CursorShape {
-    /// A filled cell rectangle; the glyph beneath draws inverted (in the
-    /// theme background colour) so the character under the caret stays
-    /// readable. The default.
+    /// A filled cell rectangle; the glyph beneath draws in the resolved cell
+    /// background so the inverse pair stays readable. The default.
     #[default]
     Block,
     /// A narrow vertical stroke on the left edge of the lead cell.

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod clipboard;
 pub mod config;
+pub mod cursor;
 pub mod diagnostics;
 pub mod git_worktree;
 mod input;

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1198,6 +1198,11 @@ struct NorenApp {
     /// resolution, clear colour — follows the `[theme]` selection. The
     /// default (`dark`) is exactly the pre-theme palette.
     theme: Theme,
+    /// The configured cursor appearance (`[cursor]` shape and colour over
+    /// the theme's cursor colour), handed to the renderer at creation.
+    /// Visibility is not part of it: the caret ships drawn and only DECTCEM
+    /// hides it (issues #197/#200).
+    cursor_style: renderer::CursorStyle,
 }
 
 /// Which application-owned line, if any, occupies the renderer's status row.
@@ -1321,6 +1326,15 @@ impl NorenApp {
             passthrough_policy: palette_policy(config.keys()),
             keys: config.keys(),
             theme: config.theme().palette(),
+            cursor_style: renderer::CursorStyle::theme_default(&config.theme().palette())
+                .with_shape(config.cursor().shape())
+                .with_color_override(config.cursor().color().map(|[r, g, b]| {
+                    [
+                        f32::from(r) / 255.0,
+                        f32::from(g) / 255.0,
+                        f32::from(b) / 255.0,
+                    ]
+                })),
         }
     }
 
@@ -2230,6 +2244,7 @@ impl NorenApp {
             Arc::clone(&window),
             self.geometry.cell_metrics(),
             self.theme,
+            self.cursor_style,
         ) {
             Ok(renderer) => Some(renderer),
             Err(_) => {

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1198,10 +1198,10 @@ struct NorenApp {
     /// resolution, clear colour — follows the `[theme]` selection. The
     /// default (`dark`) is exactly the pre-theme palette.
     theme: Theme,
-    /// The configured cursor appearance (`[cursor]` shape and colour over
-    /// the theme's cursor colour), handed to the renderer at creation.
-    /// Visibility is not part of it: the caret ships drawn and only DECTCEM
-    /// hides it (issues #197/#200).
+    /// The configured cursor appearance (`[cursor]` shape and preferred
+    /// colour), handed to the renderer at creation. Final ink is resolved
+    /// against the actual cursor cell; visibility is not part of this style:
+    /// the caret ships drawn and only DECTCEM hides it (issues #197/#200).
     cursor_style: renderer::CursorStyle,
 }
 

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3395,6 +3395,15 @@ impl ApplicationHandler for NorenApp {
         match event {
             WindowEvent::CloseRequested => self.close(event_loop),
             WindowEvent::Resized(physical) => self.handle_resize(physical),
+            WindowEvent::Focused(focused) => {
+                // Focus loss must be visible in the caret (issue #200): the
+                // renderer switches between the focused mark and the
+                // unfocused hollow outline.
+                if let Some(renderer) = self.renderer.as_mut() {
+                    renderer.set_focused(focused);
+                }
+                self.redraw_needed = true;
+            }
             WindowEvent::ModifiersChanged(modifiers) => self.update_modifiers(modifiers.state()),
             WindowEvent::CursorMoved { position, .. } => self.handle_mouse_move(position),
             WindowEvent::MouseInput { state, button, .. } => {

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -17,13 +17,16 @@
 //! that exists in configuration changes what is drawn.
 //!
 //! The cursor is drawn, not configured into existence (issues #197/#200):
-//! the caret appears at the tracked position with no configuration, in the
-//! theme's cursor colour, honouring DECTCEM (`CSI ?25l` hides it, `?25h`
-//! restores it) because programs like vim rely on both directions. A block
-//! cursor spans both columns of the wide character it sits on (#174/#176),
-//! and the glyph beneath draws inverted so the character stays readable.
-//! `[cursor]` configuration may change shape and colour — never whether a
-//! user who reads nothing still gets a caret.
+//! the caret appears at the tracked position with no configuration, honouring
+//! DECTCEM (`CSI ?25l` hides it, `?25h` restores it) because programs like vim
+//! rely on both directions. Its default is inverse video against the actual
+//! cell pair, not a fixed colour measured only on the theme background. A
+//! background-only SGR can make that pair unusable, so black/white fallback
+//! keeps at least 4.5:1 contrast on every sRGB background. A block spans both
+//! columns of the wide character it sits on (#174/#176), and the glyph beneath
+//! draws in the resolved cell background so it stays readable. `[cursor]`
+//! configuration may change shape and prefer a colour — never whether a user
+//! who reads nothing still gets a usable caret.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -36,9 +39,9 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use noren_app::cursor::CursorShape;
-use noren_app::theme::Theme;
+use noren_app::theme::{Theme, contrast_ratio};
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
-use noren_terminal::{CellAttributes, Color, TerminalSnapshot};
+use noren_terminal::{Cell, CellAttributes, Color, TerminalSnapshot};
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_GLYPH_PIXELS: usize = 35;
@@ -47,6 +50,10 @@ const VERTICES_PER_RECT: usize = 6;
 /// cursor's hollow outline, in pixels — the same granularity glyph pixels
 /// draw at.
 const CURSOR_STROKE: u32 = 2;
+/// A cursor is both a typing target and, for a block, the ground behind a
+/// small text glyph. Keep both sides of that pair at the normal-text WCAG AA
+/// floor used by the theme contract (issue #168).
+const CURSOR_MIN_CONTRAST: f64 = 4.5;
 /// One cell can emit one background rectangle plus the largest 5x7 glyph.
 /// The bound is `MAX_RENDER_ROWS * MAX_RENDER_COLS * (1 + 35) * 6`.
 const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize)
@@ -581,7 +588,6 @@ fn glyph_vertices_with_budget(
         return Vec::new();
     }
     let cell_width = metrics.width();
-    let cell_height = metrics.height();
     let window_cols = usize::try_from(width / cell_width).unwrap_or(usize::MAX);
 
     let has_sidebar = sidebar.is_some();
@@ -671,117 +677,62 @@ fn glyph_vertices_with_budget(
                 let cells = rows
                     .get(line_index)
                     .expect("terminal layout only names display rows");
-                for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
-                    // The cursor cell, when this is it. Both sides of the
-                    // glyph emission below need this: the focused block
-                    // draws under the glyph (which inverts over it), every
-                    // other mark draws over the glyph.
-                    let cursor_here =
-                        cursor_plan.is_some_and(|plan| plan.frame_row == row && plan.column == col);
-                    let invert_glyph = cursor_here
-                        && target.cursor.shape == CursorShape::Block
-                        && target.cursor.focused;
-                    if let Some(color) = resolve_background(&theme, cell.attributes()) {
-                        push_rect(
-                            &mut vertices,
-                            u32::try_from(col_offset + col).unwrap_or(u32::MAX) * cell_width,
-                            u32::try_from(row).unwrap_or(u32::MAX) * cell_height,
-                            cell_width,
-                            cell_height,
-                            color,
-                            target,
-                        );
-                    }
-                    if vertices.len() >= vertex_budget {
+                let visible_len = cells.len().min(terminal_cols);
+                let visible = &cells[..visible_len];
+                if let Some(plan) = cursor_plan
+                    && plan.frame_row == row
+                    && plan.column < visible_len
+                {
+                    // Split out the one cursor-bearing span. Ordinary cells
+                    // therefore do not pay a cursor-position/shape branch on
+                    // every iteration — important on dense frames, where the
+                    // caret affects one cell out of thousands.
+                    let (before, cursor_and_after) = visible.split_at(plan.column);
+                    if push_terminal_cells(
+                        &mut vertices,
+                        before,
+                        0,
+                        row,
+                        col_offset,
+                        target,
+                        vertex_budget,
+                    ) {
                         return vertices;
                     }
-                    if invert_glyph && let Some(plan) = cursor_plan {
-                        push_cursor_block(
-                            &mut vertices,
-                            plan,
-                            col_offset,
-                            target.cursor.color,
-                            target,
-                        );
-                        if vertices.len() >= vertex_budget {
-                            return vertices;
-                        }
+                    let cursor_len = plan.columns.min(cursor_and_after.len());
+                    let (cursor_cells, after) = cursor_and_after.split_at(cursor_len);
+                    if push_cursor_cells(
+                        &mut vertices,
+                        cursor_cells,
+                        plan,
+                        row,
+                        col_offset,
+                        target,
+                        vertex_budget,
+                    ) {
+                        return vertices;
                     }
-                    // A continuation cell draws no glyph but still owns its
-                    // column, exactly as the placeholder space did in
-                    // `display_lines`. A block cursor on the lead already
-                    // covered this column via its two-column span.
-                    if cell.is_continuation() {
-                        continue;
+                    if push_terminal_cells(
+                        &mut vertices,
+                        after,
+                        plan.column + cursor_len,
+                        row,
+                        col_offset,
+                        target,
+                        vertex_budget,
+                    ) {
+                        return vertices;
                     }
-                    // Inside a focused block the glyph draws in the theme
-                    // background — the reading pair inverted — so the
-                    // character under the caret stays readable.
-                    let color = if invert_glyph {
-                        theme.background()
-                    } else {
-                        resolve_foreground(&theme, cell.attributes())
-                    };
-                    for character in cell.text().chars() {
-                        push_glyph(
-                            &mut vertices,
-                            character,
-                            color,
-                            col_offset + col,
-                            row,
-                            target,
-                        );
-                        if vertices.len() >= vertex_budget {
-                            return vertices;
-                        }
-                    }
-                    // Marks that draw over the glyph: the focused bar and
-                    // underline strokes, and the unfocused hollow outline.
-                    if cursor_here
-                        && !invert_glyph
-                        && let Some(plan) = cursor_plan
-                    {
-                        if target.cursor.focused {
-                            match target.cursor.shape {
-                                CursorShape::Block => {}
-                                CursorShape::Bar => {
-                                    push_cursor_bar(
-                                        &mut vertices,
-                                        plan,
-                                        col_offset,
-                                        target.cursor.color,
-                                        target,
-                                    );
-                                    if vertices.len() >= vertex_budget {
-                                        return vertices;
-                                    }
-                                }
-                                CursorShape::Underline => {
-                                    push_cursor_underline(
-                                        &mut vertices,
-                                        plan,
-                                        col_offset,
-                                        target.cursor.color,
-                                        target,
-                                    );
-                                    if vertices.len() >= vertex_budget {
-                                        return vertices;
-                                    }
-                                }
-                            }
-                        } else {
-                            push_cursor_hollow(
-                                &mut vertices,
-                                plan,
-                                col_offset,
-                                target.cursor.color,
-                                target,
-                            );
-                            if vertices.len() >= vertex_budget {
-                                return vertices;
-                            }
-                        }
-                    }
+                } else if push_terminal_cells(
+                    &mut vertices,
+                    visible,
+                    0,
+                    row,
+                    col_offset,
+                    target,
+                    vertex_budget,
+                ) {
+                    return vertices;
                 }
             }
             FrameRow::Status => {
@@ -808,6 +759,173 @@ fn glyph_vertices_with_budget(
         }
     }
     vertices
+}
+
+/// Draw a run of ordinary terminal cells. Cursor-bearing rows are split
+/// around their one affected span before reaching this helper, so this hot
+/// path contains no per-cell cursor checks.
+#[inline(always)]
+fn push_terminal_cells(
+    vertices: &mut Vec<Vertex>,
+    cells: &[Cell],
+    start_column: usize,
+    row: usize,
+    col_offset: usize,
+    target: Target,
+    vertex_budget: usize,
+) -> bool {
+    for (offset, cell) in cells.iter().enumerate() {
+        if push_terminal_cell(
+            vertices,
+            cell,
+            start_column + offset,
+            row,
+            col_offset,
+            target,
+            vertex_budget,
+        ) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Draw one ordinary terminal cell, returning whether the vertex budget has
+/// been reached after a complete emitted primitive.
+#[inline(always)]
+fn push_terminal_cell(
+    vertices: &mut Vec<Vertex>,
+    cell: &Cell,
+    column: usize,
+    row: usize,
+    col_offset: usize,
+    target: Target,
+    vertex_budget: usize,
+) -> bool {
+    if let Some(color) = resolve_background(&target.theme, cell.attributes()) {
+        push_rect(
+            vertices,
+            u32::try_from(col_offset + column).unwrap_or(u32::MAX) * target.metrics.width(),
+            u32::try_from(row).unwrap_or(u32::MAX) * target.metrics.height(),
+            target.metrics.width(),
+            target.metrics.height(),
+            color,
+            target,
+        );
+    }
+    if vertices.len() >= vertex_budget {
+        return true;
+    }
+    // A continuation cell owns its display column and background but never
+    // emits a second glyph for the wide character's trailing half.
+    if cell.is_continuation() {
+        return false;
+    }
+    let color = resolve_foreground(&target.theme, cell.attributes());
+    for character in cell.text().chars() {
+        push_glyph(vertices, character, color, col_offset + column, row, target);
+        if vertices.len() >= vertex_budget {
+            return true;
+        }
+    }
+    false
+}
+
+/// Draw the single cell span carrying the cursor. A focused block is inverse
+/// video: its ink becomes the block and the resolved cell background becomes
+/// the glyph colour. Other shapes leave the cell glyph untouched and add
+/// their contrast-safe mark after it.
+fn push_cursor_cells(
+    vertices: &mut Vec<Vertex>,
+    cells: &[Cell],
+    plan: CursorPlacement,
+    row: usize,
+    col_offset: usize,
+    target: Target,
+    vertex_budget: usize,
+) -> bool {
+    let Some(lead) = cells.first() else {
+        return false;
+    };
+    let foreground = resolve_foreground(&target.theme, lead.attributes());
+    let inverse_foreground = if lead.attributes().foreground() == Color::Default {
+        target.cursor.theme_color
+    } else {
+        foreground
+    };
+    let background =
+        resolve_background(&target.theme, lead.attributes()).unwrap_or(target.theme.background());
+    let cursor_color = target.cursor.visible_color(inverse_foreground, background);
+
+    if target.cursor.focused && target.cursor.shape == CursorShape::Block {
+        // Preserve the established background-first emission order and paint
+        // every column of a wide cell before covering the complete span. In
+        // particular, a continuation background must not overwrite half of
+        // the cursor after the block has been drawn.
+        for (offset, cell) in cells.iter().enumerate() {
+            if let Some(color) = resolve_background(&target.theme, cell.attributes()) {
+                push_rect(
+                    vertices,
+                    u32::try_from(col_offset + plan.column + offset).unwrap_or(u32::MAX)
+                        * target.metrics.width(),
+                    u32::try_from(row).unwrap_or(u32::MAX) * target.metrics.height(),
+                    target.metrics.width(),
+                    target.metrics.height(),
+                    color,
+                    target,
+                );
+                if vertices.len() >= vertex_budget {
+                    return true;
+                }
+            }
+        }
+        push_cursor_block(vertices, plan, col_offset, cursor_color, target);
+        if vertices.len() >= vertex_budget {
+            return true;
+        }
+        if !lead.is_continuation() {
+            for character in lead.text().chars() {
+                push_glyph(
+                    vertices,
+                    character,
+                    background,
+                    col_offset + plan.column,
+                    row,
+                    target,
+                );
+                if vertices.len() >= vertex_budget {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    if push_terminal_cells(
+        vertices,
+        cells,
+        plan.column,
+        row,
+        col_offset,
+        target,
+        vertex_budget,
+    ) {
+        return true;
+    }
+    if target.cursor.focused {
+        match target.cursor.shape {
+            CursorShape::Block => {}
+            CursorShape::Bar => {
+                push_cursor_bar(vertices, plan, col_offset, cursor_color, target);
+            }
+            CursorShape::Underline => {
+                push_cursor_underline(vertices, plan, col_offset, cursor_color, target);
+            }
+        }
+    } else {
+        push_cursor_hollow(vertices, plan, col_offset, cursor_color, target);
+    }
+    vertices.len() >= vertex_budget
 }
 
 /// Where the cursor marks this frame: the frame row and lead display
@@ -1024,27 +1142,34 @@ impl Target {
     }
 }
 
-/// The resolved cursor drawing style for one frame: shape, colour, focus.
+/// The resolved cursor drawing style for one frame: shape, optional preferred
+/// colour, and focus.
 ///
-/// The colour arrives already resolved — the theme's cursor colour unless a
-/// configuration override named another — because one frame draws against
-/// one theme. Focus changes the treatment, not the colour: the focused
-/// caret is the shape itself; the unfocused caret is a hollow outline of
-/// the block footprint, the classic terminal signal that the window no
+/// The final ink is cell-relative and therefore resolved only when drawing
+/// the cursor-bearing cell. With no override, inverse video starts from that
+/// cell's foreground. An override is preferred where it clears the same 4.5:1
+/// floor; otherwise drawing falls back to the usable inverse foreground or to
+/// contrast-maximising black/white. Focus changes the treatment, not that
+/// safety rule: the focused caret is the shape itself; the unfocused caret is
+/// a hollow block outline, the classic terminal signal that the window no
 /// longer receives keys (issue #200's focused/unfocused requirement).
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CursorStyle {
     shape: CursorShape,
-    color: [f32; 3],
+    theme_color: [f32; 3],
+    color_override: Option<[f32; 3]>,
     focused: bool,
 }
 
 impl CursorStyle {
-    /// The default cursor: a focused block in the theme's cursor colour.
+    /// The default cursor: a focused inverse-video block. Every built-in
+    /// theme's cursor colour equals its default foreground, so an unstyled
+    /// cell remains pixel-identical to the theme-owned default.
     pub(crate) fn theme_default(theme: &Theme) -> Self {
         Self {
             shape: CursorShape::Block,
-            color: theme.cursor(),
+            theme_color: theme.cursor(),
+            color_override: None,
             focused: true,
         }
     }
@@ -1055,12 +1180,10 @@ impl CursorStyle {
         self
     }
 
-    /// Replace the colour when a configuration override named one; `None`
-    /// keeps the theme's cursor colour.
+    /// Prefer a configured colour where it is usable against the cursor
+    /// cell. `None` keeps inverse-video colour selection.
     pub(crate) fn with_color_override(mut self, color: Option<[f32; 3]>) -> Self {
-        if let Some(color) = color {
-            self.color = color;
-        }
+        self.color_override = color;
         self
     }
 
@@ -1069,6 +1192,42 @@ impl CursorStyle {
         self.focused = focused;
         self
     }
+
+    /// Resolve visible cursor ink against the cell it actually covers.
+    ///
+    /// The configured colour gets first refusal. If it misses AA, the cell's
+    /// foreground supplies normal inverse video when that pair is itself
+    /// readable. A background-only SGR can make even that foreground vanish;
+    /// choosing the better of black and white then guarantees at least 4.5:1
+    /// for every possible sRGB background. A block redraws its glyph in the
+    /// same background used here, so cursor and glyph share this guarantee.
+    fn visible_color(self, foreground: [f32; 3], background: [f32; 3]) -> [f32; 3] {
+        if let Some(color) = self.color_override
+            && color_contrast(color, background) >= CURSOR_MIN_CONTRAST
+        {
+            return color;
+        }
+        if color_contrast(foreground, background) >= CURSOR_MIN_CONTRAST {
+            return foreground;
+        }
+
+        const BLACK: [f32; 3] = [0.0, 0.0, 0.0];
+        const WHITE: [f32; 3] = [1.0, 1.0, 1.0];
+        if color_contrast(BLACK, background) >= color_contrast(WHITE, background) {
+            BLACK
+        } else {
+            WHITE
+        }
+    }
+}
+
+/// Contrast as it will be measured on the frame oracle's RGBA8 readback.
+fn color_contrast(first: [f32; 3], second: [f32; 3]) -> f64 {
+    contrast_ratio(quantize_color(first), quantize_color(second))
+}
+
+fn quantize_color(color: [f32; 3]) -> [u8; 3] {
+    color.map(|channel| (channel * 255.0).round() as u8)
 }
 
 /// Emit the 5×7 bitmap glyph for `character` at grid cell `(col, row)`.
@@ -1677,6 +1836,105 @@ mod tests {
         assert_eq!(
             (dark.r, dark.g, dark.b, dark.a),
             (CLEAR_COLOR.r, CLEAR_COLOR.g, CLEAR_COLOR.b, CLEAR_COLOR.a)
+        );
+    }
+
+    #[test]
+    fn cursor_ink_uses_inversion_then_contrast_safe_fallbacks() {
+        let style = CursorStyle::theme_default(&DARK);
+        let default_foreground = DARK.foreground();
+        let default_background = DARK.background();
+        assert_eq!(
+            style.visible_color(default_foreground, default_background),
+            default_foreground,
+            "a readable cell pair uses ordinary inverse video"
+        );
+
+        for background in [
+            [229, 229, 229],
+            [121, 121, 121],
+            [204, 235, 209],
+            [17, 119, 221],
+        ] {
+            let background = channels_to_floats(background);
+            let ink = style.visible_color(default_foreground, background);
+            assert!(
+                color_contrast(ink, background) >= CURSOR_MIN_CONTRAST,
+                "cursor {ink:?} must clear AA on {background:?}"
+            );
+        }
+
+        let readable_foreground = channels_to_floats([20, 30, 40]);
+        let light_background = channels_to_floats([240, 240, 240]);
+        let unsafe_override =
+            CursorStyle::theme_default(&DARK).with_color_override(Some(light_background));
+        assert_eq!(
+            unsafe_override.visible_color(readable_foreground, light_background),
+            readable_foreground,
+            "an unusable override falls back to inverse video"
+        );
+
+        let dark_background = channels_to_floats([8, 18, 28]);
+        let white = [1.0, 1.0, 1.0];
+        let safe_override = CursorStyle::theme_default(&DARK).with_color_override(Some(white));
+        assert_eq!(
+            safe_override.visible_color(default_foreground, dark_background),
+            white,
+            "a usable override must remain under user control"
+        );
+    }
+
+    #[test]
+    fn focused_block_keeps_every_glyph_vertex_in_the_inverted_background() {
+        const BYTES: &[u8] = b"\x1b[38;2;20;30;40;48;2;240;240;240mA\r";
+        let shown = snapshot(1, 2, BYTES);
+        let mut hidden_bytes = BYTES.to_vec();
+        hidden_bytes.extend_from_slice(b"\x1b[?25l");
+        let hidden = snapshot(1, 2, &hidden_bytes);
+        let shown_vertices = frame_vertices(Some(&shown), None, None, 900, 600, poc_metrics());
+        let hidden_vertices = frame_vertices(Some(&hidden), None, None, 900, 600, poc_metrics());
+        let foreground = channels_to_floats([20, 30, 40]);
+        let background = channels_to_floats([240, 240, 240]);
+
+        assert!(
+            hidden_vertices.len() > VERTICES_PER_RECT,
+            "the hidden-cursor control must contain a background and glyph"
+        );
+        assert!(
+            shown_vertices.len() > 2 * VERTICES_PER_RECT,
+            "the visible frame must contain a background, block, and glyph"
+        );
+        assert!(
+            shown_vertices[..VERTICES_PER_RECT]
+                .iter()
+                .all(|vertex| vertex.color == background),
+            "the cell background must be emitted first"
+        );
+        assert!(
+            shown_vertices[VERTICES_PER_RECT..2 * VERTICES_PER_RECT]
+                .iter()
+                .all(|vertex| vertex.color == foreground),
+            "the inverse foreground must fill the cursor block"
+        );
+
+        let hidden_glyph = &hidden_vertices[VERTICES_PER_RECT..];
+        let shown_glyph = &shown_vertices[2 * VERTICES_PER_RECT..];
+        assert_eq!(
+            shown_glyph.len(),
+            hidden_glyph.len(),
+            "inversion must retain every glyph rectangle"
+        );
+        assert!(
+            hidden_glyph.iter().all(|vertex| vertex.color == foreground),
+            "the control glyph must use the cell foreground"
+        );
+        assert!(
+            shown_glyph.iter().all(|vertex| vertex.color == background),
+            "the block glyph must swap to the cell background"
+        );
+        assert!(
+            color_contrast(foreground, background) >= CURSOR_MIN_CONTRAST,
+            "the inverted glyph/block pair must remain readable"
         );
     }
 

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -15,6 +15,15 @@
 //! owned by the [`Renderer`]; every colour decision below — palette
 //! resolution, default foreground, clear colour — reads from it, so a theme
 //! that exists in configuration changes what is drawn.
+//!
+//! The cursor is drawn, not configured into existence (issues #197/#200):
+//! the caret appears at the tracked position with no configuration, in the
+//! theme's cursor colour, honouring DECTCEM (`CSI ?25l` hides it, `?25h`
+//! restores it) because programs like vim rely on both directions. A block
+//! cursor spans both columns of the wide character it sits on (#174/#176),
+//! and the glyph beneath draws inverted so the character stays readable.
+//! `[cursor]` configuration may change shape and colour — never whether a
+//! user who reads nothing still gets a caret.
 
 use std::borrow::Cow;
 use std::future::Future;
@@ -26,6 +35,7 @@ use wgpu::CurrentSurfaceTexture;
 use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
+use noren_app::cursor::CursorShape;
 use noren_app::theme::Theme;
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::{CellAttributes, Color, TerminalSnapshot};
@@ -33,6 +43,10 @@ const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_GLYPH_PIXELS: usize = 35;
 const VERTICES_PER_RECT: usize = 6;
+/// Thickness of the bar/underline cursor strokes and of the unfocused
+/// cursor's hollow outline, in pixels — the same granularity glyph pixels
+/// draw at.
+const CURSOR_STROKE: u32 = 2;
 /// One cell can emit one background rectangle plus the largest 5x7 glyph.
 /// The bound is `MAX_RENDER_ROWS * MAX_RENDER_COLS * (1 + 35) * 6`.
 const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize)
@@ -305,6 +319,7 @@ pub(crate) struct Renderer {
     device_lost: Arc<AtomicBool>,
     metrics: CellMetrics,
     theme: Theme,
+    cursor: CursorStyle,
 }
 
 impl Renderer {
@@ -402,8 +417,15 @@ impl Renderer {
             vertex_capacity,
             device_lost,
             metrics,
+            cursor: CursorStyle::theme_default(&theme),
             theme,
         })
+    }
+
+    /// Record the window's focus state so the caret switches between its
+    /// focused mark and the unfocused hollow outline (issue #200).
+    pub(crate) fn set_focused(&mut self, focused: bool) {
+        self.cursor = self.cursor.with_focus(focused);
     }
 
     pub(crate) fn resize(&mut self, size: PhysicalSize<u32>) {
@@ -430,7 +452,8 @@ impl Renderer {
             self.config.width,
             self.config.height,
             self.metrics,
-        );
+        )
+        .with_cursor_style(self.cursor);
         let vertices = glyph_vertices_for(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
@@ -585,11 +608,30 @@ fn glyph_vertices_with_budget(
     // column, so the cell index below is the display column for every glyph —
     // the same coordinate model the string path used, now carrying the
     // attributes that path threw away.
-    let rows: Vec<&[noren_terminal::Cell]> = terminal
+    let mut rows: Vec<&[noren_terminal::Cell]> = terminal
         .map(|snapshot| snapshot.display_cells().collect())
         .unwrap_or_default();
+    // A visible cursor makes its row content (issues #197/#200): the display
+    // model trims trailing blank rows, so without this extension the caret
+    // would vanish on a fresh screen — exactly the row typing lands in. A
+    // hidden cursor skips the extension, keeping hidden-cursor frames
+    // byte-identical to the pre-cursor renderer.
+    if let Some(snapshot) = terminal
+        && snapshot.is_cursor_visible()
+    {
+        let cursor_row = usize::from(snapshot.cursor().row())
+            .min(usize::from(snapshot.rows()).saturating_sub(1));
+        for line in rows.len()..=cursor_row {
+            rows.push(
+                snapshot
+                    .screen()
+                    .row(u16::try_from(line).unwrap_or(u16::MAX)),
+            );
+        }
+    }
     let layout = FrameRowLayout::new(height, metrics, rows.len(), status.is_some())
         .expect("non-zero frame height has a row layout");
+    let cursor_plan = terminal.and_then(|snapshot| plan_cursor(snapshot, &layout, terminal_cols));
     let mut vertices = Vec::new();
 
     // The sidebar is chrome, not terminal content: it carries no cell
@@ -629,6 +671,15 @@ fn glyph_vertices_with_budget(
                     .get(line_index)
                     .expect("terminal layout only names display rows");
                 for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
+                    // The cursor cell, when this is it. Both sides of the
+                    // glyph emission below need this: the focused block
+                    // draws under the glyph (which inverts over it), every
+                    // other mark draws over the glyph.
+                    let cursor_here =
+                        cursor_plan.is_some_and(|plan| plan.frame_row == row && plan.column == col);
+                    let invert_glyph = cursor_here
+                        && target.cursor.shape == CursorShape::Block
+                        && target.cursor.focused;
                     if let Some(color) = resolve_background(&theme, cell.attributes()) {
                         push_rect(
                             &mut vertices,
@@ -643,13 +694,33 @@ fn glyph_vertices_with_budget(
                     if vertices.len() >= vertex_budget {
                         return vertices;
                     }
+                    if invert_glyph && let Some(plan) = cursor_plan {
+                        push_cursor_block(
+                            &mut vertices,
+                            plan,
+                            col_offset,
+                            target.cursor.color,
+                            target,
+                        );
+                        if vertices.len() >= vertex_budget {
+                            return vertices;
+                        }
+                    }
                     // A continuation cell draws no glyph but still owns its
                     // column, exactly as the placeholder space did in
-                    // `display_lines`.
+                    // `display_lines`. A block cursor on the lead already
+                    // covered this column via its two-column span.
                     if cell.is_continuation() {
                         continue;
                     }
-                    let color = resolve_foreground(&theme, cell.attributes());
+                    // Inside a focused block the glyph draws in the theme
+                    // background — the reading pair inverted — so the
+                    // character under the caret stays readable.
+                    let color = if invert_glyph {
+                        theme.background()
+                    } else {
+                        resolve_foreground(&theme, cell.attributes())
+                    };
                     for character in cell.text().chars() {
                         push_glyph(
                             &mut vertices,
@@ -661,6 +732,53 @@ fn glyph_vertices_with_budget(
                         );
                         if vertices.len() >= vertex_budget {
                             return vertices;
+                        }
+                    }
+                    // Marks that draw over the glyph: the focused bar and
+                    // underline strokes, and the unfocused hollow outline.
+                    if cursor_here
+                        && !invert_glyph
+                        && let Some(plan) = cursor_plan
+                    {
+                        if target.cursor.focused {
+                            match target.cursor.shape {
+                                CursorShape::Block => {}
+                                CursorShape::Bar => {
+                                    push_cursor_bar(
+                                        &mut vertices,
+                                        plan,
+                                        col_offset,
+                                        target.cursor.color,
+                                        target,
+                                    );
+                                    if vertices.len() >= vertex_budget {
+                                        return vertices;
+                                    }
+                                }
+                                CursorShape::Underline => {
+                                    push_cursor_underline(
+                                        &mut vertices,
+                                        plan,
+                                        col_offset,
+                                        target.cursor.color,
+                                        target,
+                                    );
+                                    if vertices.len() >= vertex_budget {
+                                        return vertices;
+                                    }
+                                }
+                            }
+                        } else {
+                            push_cursor_hollow(
+                                &mut vertices,
+                                plan,
+                                col_offset,
+                                target.cursor.color,
+                                target,
+                            );
+                            if vertices.len() >= vertex_budget {
+                                return vertices;
+                            }
                         }
                     }
                 }
@@ -691,6 +809,183 @@ fn glyph_vertices_with_budget(
     vertices
 }
 
+/// Where the cursor marks this frame: the frame row and lead display
+/// column, plus how many columns the mark spans.
+///
+/// The span is two columns when the caret sits on a wide character's lead
+/// (#174/#176): a block cursor must cover the character, not half of it,
+/// and an underline must run under both of its columns.
+#[derive(Clone, Copy, Debug)]
+struct CursorPlacement {
+    frame_row: usize,
+    column: usize,
+    columns: usize,
+}
+
+/// Resolve the cursor's draw placement for one frame, or `None` when no
+/// cursor mark is drawn: DECTCEM-hidden (`CSI ?25l`), scrolled above the
+/// visible slice, or past the column budget.
+///
+/// The tracked row/column (the position the terminal state already
+/// maintains — this is a rendering gap being filled, not new state) is a
+/// *display* position: the screen buffer gives a wide character's
+/// continuation its own column, and the cursor counts columns the same way.
+fn plan_cursor(
+    snapshot: &TerminalSnapshot,
+    layout: &FrameRowLayout,
+    terminal_cols: usize,
+) -> Option<CursorPlacement> {
+    if !snapshot.is_cursor_visible() {
+        return None;
+    }
+    let cursor = snapshot.cursor();
+    let line = usize::from(cursor.row());
+    let frame_row =
+        (0..layout.rendered_rows()).find(|&row| layout.content_line_at(row) == Some(line))?;
+    let column = usize::from(cursor.column());
+    if column >= terminal_cols {
+        return None;
+    }
+    let screen = snapshot.screen();
+    let (lead_column, columns) = match screen.cell(cursor.row(), cursor.column()) {
+        // The state keeps the tracked cursor off continuation cells (#176);
+        // if a future path strands it there, cover the whole character
+        // rather than half of it.
+        Some(cell) if cell.is_continuation() => {
+            let mut lead = cursor.column().saturating_sub(1);
+            while lead > 0
+                && screen
+                    .cell(cursor.row(), lead)
+                    .is_some_and(|cell| cell.is_continuation())
+            {
+                lead -= 1;
+            }
+            (usize::from(lead), 2)
+        }
+        Some(cell) if cell.width() == 2 => (column, 2),
+        _ => (column, 1),
+    };
+    Some(CursorPlacement {
+        frame_row,
+        column: lead_column,
+        columns,
+    })
+}
+
+/// The pixel origin and width of the cursor's column span.
+fn cursor_span(plan: CursorPlacement, col_offset: usize, cell_width: u32) -> (u32, u32) {
+    let x = u32::try_from(col_offset + plan.column).unwrap_or(u32::MAX) * cell_width;
+    let width = cell_width.saturating_mul(u32::try_from(plan.columns).unwrap_or(u32::MAX));
+    (x, width)
+}
+
+/// A filled block covering the cursor's whole cell span. Emitted *before*
+/// the cell's glyph so the glyph inverts over it.
+fn push_cursor_block(
+    vertices: &mut Vec<Vertex>,
+    plan: CursorPlacement,
+    col_offset: usize,
+    color: [f32; 3],
+    target: Target,
+) {
+    let cell_height = target.metrics.height();
+    let (x, width) = cursor_span(plan, col_offset, target.metrics.width());
+    push_rect(
+        vertices,
+        x,
+        u32::try_from(plan.frame_row).unwrap_or(u32::MAX) * cell_height,
+        width,
+        cell_height,
+        color,
+        target,
+    );
+}
+
+/// A vertical stroke on the left edge of the lead cell. Emitted after the
+/// glyph so glyph pixels cannot overwrite the stroke.
+fn push_cursor_bar(
+    vertices: &mut Vec<Vertex>,
+    plan: CursorPlacement,
+    col_offset: usize,
+    color: [f32; 3],
+    target: Target,
+) {
+    let cell_height = target.metrics.height();
+    let (x, _) = cursor_span(plan, col_offset, target.metrics.width());
+    push_rect(
+        vertices,
+        x,
+        u32::try_from(plan.frame_row).unwrap_or(u32::MAX) * cell_height,
+        CURSOR_STROKE,
+        cell_height,
+        color,
+        target,
+    );
+}
+
+/// A horizontal stroke under the cursor's whole cell span. Emitted after
+/// the glyph, like the bar.
+fn push_cursor_underline(
+    vertices: &mut Vec<Vertex>,
+    plan: CursorPlacement,
+    col_offset: usize,
+    color: [f32; 3],
+    target: Target,
+) {
+    let cell_height = target.metrics.height();
+    let (x, width) = cursor_span(plan, col_offset, target.metrics.width());
+    let y = u32::try_from(plan.frame_row)
+        .unwrap_or(u32::MAX)
+        .saturating_mul(cell_height)
+        .saturating_add(cell_height)
+        .saturating_sub(CURSOR_STROKE);
+    push_rect(vertices, x, y, width, CURSOR_STROKE, color, target);
+}
+
+/// A hollow outline of the block footprint — the unfocused treatment. The
+/// shape configuration is a *focused* typing aid; focus loss is signalled
+/// the way terminals classically signal it, with a hollow caret.
+fn push_cursor_hollow(
+    vertices: &mut Vec<Vertex>,
+    plan: CursorPlacement,
+    col_offset: usize,
+    color: [f32; 3],
+    target: Target,
+) {
+    let cell_height = target.metrics.height();
+    let (x, width) = cursor_span(plan, col_offset, target.metrics.width());
+    let y = u32::try_from(plan.frame_row).unwrap_or(u32::MAX) * cell_height;
+    let inner = cell_height.saturating_sub(CURSOR_STROKE.saturating_mul(2));
+    push_rect(vertices, x, y, width, CURSOR_STROKE, color, target);
+    push_rect(
+        vertices,
+        x,
+        y.saturating_add(cell_height).saturating_sub(CURSOR_STROKE),
+        width,
+        CURSOR_STROKE,
+        color,
+        target,
+    );
+    push_rect(
+        vertices,
+        x,
+        y.saturating_add(CURSOR_STROKE),
+        CURSOR_STROKE,
+        inner,
+        color,
+        target,
+    );
+    push_rect(
+        vertices,
+        x.saturating_add(width).saturating_sub(CURSOR_STROKE),
+        y.saturating_add(CURSOR_STROKE),
+        CURSOR_STROKE,
+        inner,
+        color,
+        target,
+    );
+}
+
 /// The draw surface a frame is laid out against: the selected theme plus the
 /// pixel dimensions and cell size the grid is drawn at.
 ///
@@ -705,6 +1000,7 @@ pub(crate) struct Target {
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) metrics: CellMetrics,
+    pub(crate) cursor: CursorStyle,
 }
 
 impl Target {
@@ -715,7 +1011,47 @@ impl Target {
             width,
             height,
             metrics,
+            cursor: CursorStyle::theme_default(theme),
         }
+    }
+
+    /// Replace the cursor drawing style (a `[cursor]` configuration
+    /// selection and the window's focus state).
+    pub(crate) fn with_cursor_style(mut self, cursor: CursorStyle) -> Self {
+        self.cursor = cursor;
+        self
+    }
+}
+
+/// The resolved cursor drawing style for one frame: shape, colour, focus.
+///
+/// The colour arrives already resolved — the theme's cursor colour unless a
+/// configuration override named another — because one frame draws against
+/// one theme. Focus changes the treatment, not the colour: the focused
+/// caret is the shape itself; the unfocused caret is a hollow outline of
+/// the block footprint, the classic terminal signal that the window no
+/// longer receives keys (issue #200's focused/unfocused requirement).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CursorStyle {
+    shape: CursorShape,
+    color: [f32; 3],
+    focused: bool,
+}
+
+impl CursorStyle {
+    /// The default cursor: a focused block in the theme's cursor colour.
+    pub(crate) fn theme_default(theme: &Theme) -> Self {
+        Self {
+            shape: CursorShape::Block,
+            color: theme.cursor(),
+            focused: true,
+        }
+    }
+
+    /// Record the window's focus state.
+    pub(crate) fn with_focus(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
     }
 }
 
@@ -1391,7 +1727,12 @@ mod tests {
             glyph_budget,
         );
 
-        let background_terminal = snapshot(1, 1, b"\x1b[48;2;12;98;201mA");
+        // The terminal fixtures below hide the cursor (`CSI ?25l`): their
+        // subject is a specific glyph/background emission, and a visible
+        // caret would add its own primitives ahead of it. The cursor is its
+        // own emission path with its own guard, exercised by the dedicated
+        // case at the end.
+        let background_terminal = snapshot(1, 1, b"\x1b[?25l\x1b[48;2;12;98;201mA");
         assert_truncated(
             "terminal background rectangle",
             glyph_vertices_for(
@@ -1414,7 +1755,7 @@ mod tests {
         // guard: the background-path check runs before the second cell and
         // could stop it instead. A combining mark shares the first cell, so
         // only the guard inside this cell's character loop can suppress it.
-        let terminal_glyphs = snapshot(1, 1, "A\u{0301}".as_bytes());
+        let terminal_glyphs = snapshot(1, 1, "\x1b[?25lA\u{0301}".as_bytes());
         let rows: Vec<_> = terminal_glyphs.display_cells().collect();
         assert_eq!(
             rows[0][0].text(),
@@ -1456,6 +1797,30 @@ mod tests {
                 glyph_budget,
             ),
             glyph_budget,
+        );
+
+        // The cursor block is its own emission path (issues #197/#200): with
+        // the caret moved back onto the 'A' it is the *first* primitive of
+        // the cell (block, then the inverted glyph), so a one-rect budget
+        // must stop exactly at it. A caret with no guard would run on into
+        // the glyph it shares the cell with.
+        let cursor_over_glyph = snapshot(1, 2, b"A\r\x1b[?25h");
+        assert_truncated(
+            "terminal cursor block",
+            glyph_vertices_for(
+                Target::new(&Theme::default(), 2 * metrics.width(), height, metrics),
+                Some(&cursor_over_glyph),
+                None,
+                None,
+            ),
+            glyph_vertices_with_budget(
+                Target::new(&Theme::default(), 2 * metrics.width(), height, metrics),
+                Some(&cursor_over_glyph),
+                None,
+                None,
+                VERTICES_PER_RECT,
+            ),
+            VERTICES_PER_RECT,
         );
     }
 
@@ -1568,7 +1933,11 @@ mod tests {
 
     #[test]
     fn empty_and_zero_sized_inputs_have_no_vertices() {
-        let empty = snapshot(1, 1, b"");
+        // A contentless screen with the cursor hidden: a *visible* cursor on
+        // a blank screen now correctly emits its block (issues #197/#200),
+        // so the no-vertices contract is asserted on a DECTCEM-hidden
+        // cursor and on zero-sized frames.
+        let empty = snapshot(1, 1, b"\x1b[?25l");
         let text = snapshot(1, 8, b"text");
         assert!(frame_vertices(Some(&empty), None, None, 900, 600, poc_metrics()).is_empty());
         assert!(frame_vertices(Some(&text), None, None, 0, 600, poc_metrics()).is_empty());
@@ -1631,7 +2000,9 @@ mod tests {
 
     #[test]
     fn explicit_background_emits_a_full_rect_before_the_glyph() {
-        let terminal = snapshot(1, 1, b"\x1b[38;2;241;207;33;48;2;12;98;201mA");
+        // The cursor is hidden so the cell's own primitives are the subject:
+        // background rectangle, then glyph, nothing between.
+        let terminal = snapshot(1, 1, b"\x1b[?25l\x1b[38;2;241;207;33;48;2;12;98;201mA");
         let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         let background = channels_to_floats([12, 98, 201]);
         let foreground = channels_to_floats([241, 207, 33]);
@@ -1664,7 +2035,9 @@ mod tests {
 
     #[test]
     fn default_background_emits_no_extra_vertices() {
-        let terminal = snapshot(1, 1, b"A");
+        // Cursor hidden: a visible caret would correctly add its block, and
+        // this test pins the *cell's* emission, not the caret's.
+        let terminal = snapshot(1, 1, b"\x1b[?25lA");
         let vertices = frame_vertices(Some(&terminal), None, None, 900, 600, poc_metrics());
         let glyph_pixels = glyph_rows('A')
             .iter()

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -327,6 +327,7 @@ impl Renderer {
         window: Arc<Window>,
         metrics: CellMetrics,
         theme: Theme,
+        cursor: CursorStyle,
     ) -> Result<Self, RendererError> {
         let size = window.inner_size();
         let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
@@ -417,7 +418,7 @@ impl Renderer {
             vertex_capacity,
             device_lost,
             metrics,
-            cursor: CursorStyle::theme_default(&theme),
+            cursor,
             theme,
         })
     }
@@ -1046,6 +1047,21 @@ impl CursorStyle {
             color: theme.cursor(),
             focused: true,
         }
+    }
+
+    /// Replace the shape (a `[cursor]` configuration selection).
+    pub(crate) fn with_shape(mut self, shape: CursorShape) -> Self {
+        self.shape = shape;
+        self
+    }
+
+    /// Replace the colour when a configuration override named one; `None`
+    /// keeps the theme's cursor colour.
+    pub(crate) fn with_color_override(mut self, color: Option<[f32; 3]>) -> Self {
+        if let Some(color) = color {
+            self.color = color;
+        }
+        self
     }
 
     /// Record the window's focus state.

--- a/crates/noren-app/src/theme.rs
+++ b/crates/noren-app/src/theme.rs
@@ -12,7 +12,7 @@
 //!
 //! - the default foreground (unstyled text, sidebar, status line),
 //! - the default background (the render target's clear colour),
-//! - the cursor colour (the block drawn at the tracked cursor position),
+//! - the cursor colour (the inverse-video baseline on an unstyled cell),
 //! - the sixteen ANSI palette entries (`SGR 30..37`, `90..97`, `40..47`,
 //!   `100..107`) that programs select by name.
 //!
@@ -380,24 +380,26 @@ impl Theme {
         quantize(self.background)
     }
 
-    /// The cursor colour as shader floats: the block, bar, or underline
-    /// drawn at the tracked cursor position.
+    /// The cursor colour as shader floats: the inverse-video baseline for a
+    /// cursor on a cell with the default foreground.
     ///
     /// Every built-in theme sets this to its default foreground, so the
-    /// caret inverts the reading pair (cursor block in the foreground
-    /// colour, glyph inside it in the background colour) and inherits the
-    /// measured default-pair WCAG contrast — the order-independent ratio is
-    /// identical in both directions. A user configuration may override the
-    /// colour; the override is applied at render-target construction, not
-    /// by editing the theme.
+    /// caret inverts the reading pair (cursor block in the foreground colour,
+    /// glyph inside it in the background colour) and inherits the measured
+    /// default-pair WCAG contrast — the order-independent ratio is identical
+    /// in both directions. On an SGR foreground/background pair the renderer
+    /// instead starts from that cell's resolved foreground; if either the
+    /// inverse foreground or a configured override misses 4.5:1 against the
+    /// actual cell background, it falls back to the better of black/white.
+    /// The theme value therefore remains the unstyled default without making
+    /// a fixed-colour promise on backgrounds the theme did not choose.
     #[must_use]
     pub const fn cursor(self) -> [f32; 3] {
         self.cursor
     }
 
-    /// The cursor colour as the 8-bit triple actually stored by the RGBA8
-    /// render target — the value cursor contrast is measured on; see
-    /// [`Theme::foreground_u8`].
+    /// The unstyled cursor baseline as the 8-bit triple actually stored by
+    /// the RGBA8 render target; see [`Theme::foreground_u8`].
     #[must_use]
     pub fn cursor_u8(self) -> [u8; 3] {
         quantize(self.cursor)

--- a/crates/noren-app/src/theme.rs
+++ b/crates/noren-app/src/theme.rs
@@ -12,6 +12,7 @@
 //!
 //! - the default foreground (unstyled text, sidebar, status line),
 //! - the default background (the render target's clear colour),
+//! - the cursor colour (the block drawn at the tracked cursor position),
 //! - the sixteen ANSI palette entries (`SGR 30..37`, `90..97`, `40..47`,
 //!   `100..107`) that programs select by name.
 //!
@@ -306,15 +307,22 @@ pub struct Theme {
     palette256: &'static [[u8; 3]; 256],
     foreground: [f32; 3],
     background: [f32; 3],
+    cursor: [f32; 3],
 }
 
 /// The built-in `dark` theme: the pre-theme renderer's colours, except the
 /// five ANSI entries minimally brightened to clear WCAG AA (issue #168).
+///
+/// The cursor colour is the theme's default foreground: the caret is drawn
+/// as the exact inverse of ordinary text (block in the foreground colour,
+/// glyph inside it in the background colour), so it inherits the measured
+/// default-pair contrast instead of introducing an unchecked colour.
 pub const DARK: Theme = Theme {
     ansi: DARK_ANSI,
     palette256: &DARK_PALETTE,
     foreground: DARK_FOREGROUND,
     background: DARK_BACKGROUND,
+    cursor: DARK_FOREGROUND,
 };
 
 /// The built-in `light` theme.
@@ -323,6 +331,7 @@ pub const LIGHT: Theme = Theme {
     palette256: &LIGHT_PALETTE,
     foreground: LIGHT_FOREGROUND,
     background: LIGHT_BACKGROUND,
+    cursor: LIGHT_FOREGROUND,
 };
 
 /// The built-in `high-contrast` theme.
@@ -331,6 +340,7 @@ pub const HIGH_CONTRAST: Theme = Theme {
     palette256: &HIGH_CONTRAST_PALETTE,
     foreground: HIGH_CONTRAST_FOREGROUND,
     background: HIGH_CONTRAST_BACKGROUND,
+    cursor: HIGH_CONTRAST_FOREGROUND,
 };
 
 impl Default for Theme {
@@ -368,6 +378,29 @@ impl Theme {
     #[must_use]
     pub fn background_u8(self) -> [u8; 3] {
         quantize(self.background)
+    }
+
+    /// The cursor colour as shader floats: the block, bar, or underline
+    /// drawn at the tracked cursor position.
+    ///
+    /// Every built-in theme sets this to its default foreground, so the
+    /// caret inverts the reading pair (cursor block in the foreground
+    /// colour, glyph inside it in the background colour) and inherits the
+    /// measured default-pair WCAG contrast — the order-independent ratio is
+    /// identical in both directions. A user configuration may override the
+    /// colour; the override is applied at render-target construction, not
+    /// by editing the theme.
+    #[must_use]
+    pub const fn cursor(self) -> [f32; 3] {
+        self.cursor
+    }
+
+    /// The cursor colour as the 8-bit triple actually stored by the RGBA8
+    /// render target — the value cursor contrast is measured on; see
+    /// [`Theme::foreground_u8`].
+    #[must_use]
+    pub fn cursor_u8(self) -> [u8; 3] {
+        quantize(self.cursor)
     }
 
     /// The theme's sixteen ANSI palette entries, in palette-index order.

--- a/crates/noren-app/tests/error_echo_contract.rs
+++ b/crates/noren-app/tests/error_echo_contract.rs
@@ -53,11 +53,14 @@ enum ValueEcho {
     /// Echo allowlist: the variant may carry `[theme]` name text, clipped
     /// to 120 characters, for the reason documented on the variant itself.
     ThemeName,
+    /// Echo allowlist: the variant may carry `[cursor]` shape text, clipped
+    /// to 120 characters, for the reason documented on the variant itself.
+    CursorShapeName,
 }
 
 /// Pinned variant count of [`ConfigError`]; a new variant must extend both
 /// the classifier and the sample table.
-const CONFIG_ERROR_VARIANTS: usize = 26;
+const CONFIG_ERROR_VARIANTS: usize = 30;
 /// Pinned variant count of [`SessionPersistenceError`].
 const SESSION_ERROR_VARIANTS: usize = 14;
 /// Pinned variant count of [`ChordParseError`].
@@ -74,6 +77,9 @@ const CHORD_ALLOWLIST_SIZE: usize = 6;
 /// Pinned size of the `[theme]` name echo allowlist; see
 /// [`CHORD_ALLOWLIST_SIZE`] for the policy.
 const THEME_NAME_ALLOWLIST_SIZE: usize = 1;
+/// Pinned size of the `[cursor]` shape echo allowlist; see
+/// [`CHORD_ALLOWLIST_SIZE`] for the policy.
+const CURSOR_SHAPE_ALLOWLIST_SIZE: usize = 1;
 /// Sample payload convention (policed by the pin test): key-shaped sample
 /// fields carry `sample_key` and may render; any **value-shaped** sample
 /// field must carry this sentinel so the test can check the classification
@@ -100,6 +106,15 @@ fn classify_config(error: &ConfigError) -> ValueEcho {
         // publishes — and naming the failed value is the point of the
         // error, exactly the `[keys]` chord argument.
         ConfigError::UnknownTheme { .. } => ValueEcho::ThemeName,
+        // Allowlist: the `[cursor]` shape vocabulary — the same closed-set
+        // argument as the theme name.
+        ConfigError::UnknownCursorShape { .. } => ValueEcho::CursorShapeName,
+        // The `[cursor]` shape/colour type and format rejections name the
+        // key only: a malformed colour is freeform text, and a wrong-typed
+        // value could be anything.
+        ConfigError::CursorShapeNotAString { .. } => ValueEcho::Never,
+        ConfigError::CursorColorNotAString { .. } => ValueEcho::Never,
+        ConfigError::InvalidCursorColor { .. } => ValueEcho::Never,
         // Allowlist: unparsed chord text plus its clipped parse reason —
         // naming the failed binding is the point of the error.
         ConfigError::InvalidChord { .. } => ValueEcho::ChordText,
@@ -257,6 +272,24 @@ fn config_samples() -> Vec<(ConfigError, ValueEcho)> {
                 value: VALUE_SENTINEL.to_owned(),
             },
             ValueEcho::ThemeName,
+        ),
+        (
+            ConfigError::CursorShapeNotAString { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::UnknownCursorShape {
+                value: VALUE_SENTINEL.to_owned(),
+            },
+            ValueEcho::CursorShapeName,
+        ),
+        (
+            ConfigError::CursorColorNotAString { key: key() },
+            ValueEcho::Never,
+        ),
+        (
+            ConfigError::InvalidCursorColor { key: key() },
+            ValueEcho::Never,
         ),
         (
             ConfigError::InvalidChord {
@@ -550,6 +583,12 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
                 "an allowlisted variant must echo its theme name text: {sample}"
             );
         }
+        ValueEcho::CursorShapeName => {
+            assert!(
+                sample.contains(VALUE_SENTINEL),
+                "an allowlisted variant must echo its cursor shape text: {sample}"
+            );
+        }
     };
     for (sample, class) in &config {
         assert_rendering(sample.to_string(), format!("{sample:?}"), *class);
@@ -596,6 +635,18 @@ fn every_file_derived_variant_is_classified_and_the_allowlist_is_pinned() {
     assert_eq!(
         theme_allowlist, THEME_NAME_ALLOWLIST_SIZE,
         "the [theme] name echo allowlist changed size; admitting a new value \
+         echo is a reviewed decision (update this pin and the variant docs \
+         together)"
+    );
+
+    let cursor_shape_allowlist = config
+        .iter()
+        .map(|(_, class)| *class)
+        .filter(|class| *class == ValueEcho::CursorShapeName)
+        .count();
+    assert_eq!(
+        cursor_shape_allowlist, CURSOR_SHAPE_ALLOWLIST_SIZE,
+        "the [cursor] shape echo allowlist changed size; admitting a new value \
          echo is a reviewed decision (update this pin and the variant docs \
          together)"
     );
@@ -658,6 +709,11 @@ fn config_values_outside_keys_never_reach_display_or_debug() {
         format!("[[projects]]\nname = \"x\"\nroot = \"{SENTINEL}\"\n"),
         format!("[[projects]]\nname = \"{SENTINEL}\"\nroot = 5\n"),
         format!("[[projects]]\nname = \"x\"\nroot = \"~/{SENTINEL}\"\n"),
+        // `[cursor]` colour values: freeform text with no grammar bounding
+        // what a paste can hold, so its rejections name the key only.
+        format!("[cursor]\ncolor = \"{SENTINEL}\"\n"),
+        format!("[cursor]\ncolor = {SENTINEL}\n"),
+        format!("[cursor]\nshape = {SENTINEL}\n"),
     ];
     for text in cases {
         let error = AppConfig::parse(&text).expect_err("every sentinel fixture must fail");
@@ -774,6 +830,48 @@ fn unknown_theme_echoes_the_offending_name_and_wrong_types_name_only_the_key() {
     assert!(
         display.contains("name") && !display.contains("12345"),
         "ThemeNotAString must name the key and not the value: {display}"
+    );
+}
+
+/// The cursor-shape allowlist mirrors the theme-name one: an unknown shape
+/// echoes the offending name (bounded) and names the accepted vocabulary,
+/// while the colour rejections stay key-only.
+#[test]
+fn unknown_cursor_shape_echoes_the_offending_name_and_colour_errors_name_only_the_key() {
+    let error = AppConfig::parse("[cursor]\nshape = \"box\"\n")
+        .expect_err("an unknown cursor shape must fail");
+    let display = error.to_string();
+    assert!(
+        display.contains("box"),
+        "UnknownCursorShape must show the offending shape: {display}"
+    );
+    assert!(
+        display.contains("block") && display.contains("bar") && display.contains("underline"),
+        "UnknownCursorShape must name the accepted vocabulary: {display}"
+    );
+
+    // A hostile value stays bounded in the rendered message.
+    let mut hostile = String::new();
+    hostile.extend(std::iter::repeat_n('a', 10_000));
+    let error = AppConfig::parse(&format!("[cursor]\nshape = \"{hostile}\"\n"))
+        .expect_err("a hostile shape value must fail");
+    assert!(
+        error.to_string().chars().count() < 1024,
+        "the rendered message must stay bounded: {} chars",
+        error.to_string().chars().count()
+    );
+
+    // A malformed colour names the key and the accepted shape, never the text.
+    let error =
+        AppConfig::parse("[cursor]\ncolor = \"orange\"\n").expect_err("a non-hex colour must fail");
+    let display = error.to_string();
+    assert!(
+        display.contains("color") && !display.contains("orange"),
+        "InvalidCursorColor must name the key and not the value: {display}"
+    );
+    assert!(
+        display.contains("#rrggbb"),
+        "InvalidCursorColor must state the accepted shape: {display}"
     );
 }
 

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -83,6 +83,7 @@ use std::fs;
 use std::io::Write;
 use std::process::Command;
 
+use noren_app::cursor::CursorShape;
 use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
@@ -1740,6 +1741,89 @@ fn the_cursor_colour_comes_from_the_theme_and_clears_contrast_in_pixels() {
     }
 }
 
+/// Shape is configuration, not existence: bar and underline marks draw their
+/// strokes without inverting the glyph beneath them (only the focused block
+/// inverts), over the glyph so the mark stays solid.
+#[test]
+fn bar_and_underline_shapes_mark_the_cell_without_inverting_the_glyph() {
+    let Some(renderer) =
+        renderer_or_skip("bar_and_underline_shapes_mark_the_cell_without_inverting_the_glyph")
+    else {
+        return;
+    };
+    let stroke = 2_u32; // CURSOR_STROKE in the renderer
+
+    // A bar on a blank cell: the left stroke runs the full cell height in
+    // the cursor colour; the rest of the cell stays clear.
+    let blank = snapshot(1, 4, b"");
+    let bar = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_shape(CursorShape::Bar),
+        &blank,
+    );
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = bar.pixel(x, y);
+            let rgb = [pixel[0], pixel[1], pixel[2]];
+            let in_bar = x < stroke;
+            assert_eq!(
+                colors_match(rgb, cursor_rgb(&DARK)),
+                in_bar,
+                "bar cursor: pixel ({x},{y}) must be {} — bar pixels are the \
+                 left {stroke} columns only",
+                if in_bar { "cursor-coloured" } else { "clear" }
+            );
+        }
+    }
+
+    // An underline on a blank cell: the bottom stroke spans the cell width.
+    let underline = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_shape(CursorShape::Underline),
+        &blank,
+    );
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = underline.pixel(x, y);
+            let rgb = [pixel[0], pixel[1], pixel[2]];
+            let in_underline = y >= CELL_HEIGHT - stroke;
+            assert_eq!(
+                colors_match(rgb, cursor_rgb(&DARK)),
+                in_underline,
+                "underline cursor: pixel ({x},{y}) must be {} — underline \
+                 pixels are the bottom {stroke} rows only",
+                if in_underline {
+                    "cursor-coloured"
+                } else {
+                    "clear"
+                }
+            );
+        }
+    }
+
+    // Neither shape inverts the glyph it shares a cell with: the 'A' under
+    // a bar keeps the default foreground outside the stroke.
+    let over_a = snapshot(1, 4, b"A\r");
+    let bar_over_a = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_shape(CursorShape::Bar),
+        &over_a,
+    );
+    let colors = cell_colors(&bar_over_a, 0, 0);
+    for color in colors {
+        assert!(
+            colors_match(color, cursor_rgb(&DARK)) || colors_match(color, default_foreground_rgb()),
+            "a bar must not invert the glyph beneath it; found {color:?}"
+        );
+    }
+    // And both differ from the block default.
+    let block = render(&renderer, &over_a);
+    assert_ne!(bar_over_a.rgba, block.rgba);
+}
+
 /// Focus loss is visible (issue #200): the unfocused caret is a hollow
 /// outline of the block footprint — border lit, interior clear — and the
 /// two treatments differ in pixels.
@@ -1791,6 +1875,36 @@ fn an_unfocused_cursor_is_a_hollow_outline_and_differs_from_focused() {
             );
         }
     }
+}
+
+/// A colour override is the power-user half of the contract: the theme
+/// colour is the default, and `[cursor]` colour configuration replaces it
+/// without touching any other drawn colour.
+#[test]
+fn a_cursor_colour_override_replaces_only_the_caret_colour() {
+    let Some(renderer) =
+        renderer_or_skip("a_cursor_colour_override_replaces_only_the_caret_colour")
+    else {
+        return;
+    };
+    let orange: [f32; 3] = [255.0 / 255.0, 140.0 / 255.0, 0.0];
+    let snap = snapshot(1, 4, b"a");
+    let overridden = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_color_override(Some(orange)),
+        &snap,
+    );
+    let orange_u8 = orange.map(|channel| (channel * 255.0).round() as u8);
+    assert!(
+        cell_is_solid(&overridden, 0, 1, orange_u8),
+        "the override colour {orange_u8:?} must draw the caret"
+    );
+    // The 'a' keeps the theme's default foreground.
+    assert!(colors_match(
+        cell_color(&overridden, 0, 0),
+        default_foreground_rgb()
+    ));
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -32,7 +32,11 @@
 //!   glyph, leaves its continuation column unlit, and the glyph after the
 //!   pair lands at its display column — the width contract whose loss corrupts
 //!   the rest of the line;
-//! - a combining mark is drawn over its base cell without consuming a cell.
+//! - a combining mark is drawn over its base cell without consuming a cell;
+//! - the cursor is drawn by default at the tracked position, in the theme's
+//!   cursor colour, spanning both columns of a wide character, hidden by
+//!   DECTCEM (`CSI ?25l`) and restored by `CSI ?25h`, with focused and
+//!   unfocused treatments that differ in pixels (issues #197/#200).
 //!
 //! ## The lit/blank gate
 //!
@@ -85,7 +89,7 @@ use noren_app::{
     POC_CELL_WIDTH as CELL_WIDTH,
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
-use renderer_capture::renderer_source::{CLEAR_COLOR, SIDEBAR_COLS, Target};
+use renderer_capture::renderer_source::{CLEAR_COLOR, CursorStyle, SIDEBAR_COLS, Target};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// The PoC default cell metrics, used by every frame-oracle capture call so
@@ -265,21 +269,55 @@ fn state_cell_blank(snapshot: &TerminalSnapshot, row: u32, col: u32) -> bool {
 
 /// Assert every visible cell agrees: state-blank ⟺ render-unlit. Returns the
 /// number of cells checked so the oracle can report coverage.
+/// The cells the cursor mark covers this frame: `(row, column span)`.
+///
+/// Mirrors the renderer's placement rule: nothing when DECTCEM hides the
+/// caret; the lead column plus two columns when the caret sits on a wide
+/// character (#174/#176 — the block must cover the character, not half of
+/// it), one column otherwise.
+fn cursor_cell_span(snapshot: &TerminalSnapshot) -> Option<(u32, std::ops::Range<u32>)> {
+    if !snapshot.is_cursor_visible() {
+        return None;
+    }
+    let cursor = snapshot.cursor();
+    let (row, column) = (u32::from(cursor.row()), u32::from(cursor.column()));
+    let span = match snapshot.screen().cell(cursor.row(), cursor.column()) {
+        Some(cell) if cell.is_continuation() || cell.width() == 2 => 2,
+        _ => 1,
+    };
+    Some((row, column..column + span))
+}
+
+/// Assert every visible cell agrees: state-blank ⟺ render-unlit, with the
+/// cursor cell as the one sanctioned exception — a visible caret is
+/// *supposed* to light an otherwise blank cell (issues #197/#200). Returns
+/// the number of cells checked so the oracle can report coverage.
 fn assert_cells_agree(frame: &CapturedFrame, snapshot: &TerminalSnapshot) -> usize {
     let rows = u32::from(snapshot.rows());
     let cols = u32::from(snapshot.cols());
+    let cursor = cursor_cell_span(snapshot);
     let mut checked = 0;
     for row in 0..rows {
         for col in 0..cols {
             let state_blank = state_cell_blank(snapshot, row, col);
             let render_blank = !cell_is_lit(frame, row, col);
-            assert_eq!(
-                state_blank,
-                render_blank,
-                "cell ({row},{col}): state says {}, renderer drew {}",
-                if state_blank { "blank" } else { "char" },
-                if render_blank { "blank" } else { "lit" },
-            );
+            let is_cursor_cell = cursor
+                .as_ref()
+                .is_some_and(|(cursor_row, columns)| *cursor_row == row && columns.contains(&col));
+            if is_cursor_cell {
+                assert!(
+                    !render_blank,
+                    "cursor cell ({row},{col}) must be lit — the caret ships drawn"
+                );
+            } else {
+                assert_eq!(
+                    state_blank,
+                    render_blank,
+                    "cell ({row},{col}): state says {}, renderer drew {}",
+                    if state_blank { "blank" } else { "char" },
+                    if render_blank { "blank" } else { "lit" },
+                );
+            }
             checked += 1;
         }
     }
@@ -364,10 +402,13 @@ fn offscreen_wgpu_pipeline_initialises() {
 
 #[test]
 fn blank_screen_has_no_lit_pixels() {
+    // With the cursor hidden (`CSI ?25l`) a blank screen must still draw
+    // nothing at all — the visible-cursor cases, including the blank screen,
+    // have their own tests below (issues #197/#200).
     let Some(renderer) = renderer_or_skip("blank_screen_has_no_lit_pixels") else {
         return;
     };
-    let snap = snapshot(3, 8, b"");
+    let snap = snapshot(3, 8, b"\x1b[?25l");
     let frame = render(&renderer, &snap);
 
     for row in 0..u32::from(snap.rows()) {
@@ -386,7 +427,10 @@ fn an_ascii_cell_is_lit_and_its_neighbours_are_blank() {
     else {
         return;
     };
-    let snap = snapshot(1, 4, b"A");
+    // Each fixture hides the cursor: this test pins glyph containment, and
+    // the caret — which by design lights the cell typing lands in — has its
+    // own tests.
+    let snap = snapshot(1, 4, b"A\x1b[?25l");
     let frame = render(&renderer, &snap);
 
     // The 'A' must light its own cell ...
@@ -399,7 +443,7 @@ fn an_ascii_cell_is_lit_and_its_neighbours_are_blank() {
         );
     }
     // Vertical neighbours across a row boundary too.
-    let snap2 = snapshot(2, 4, b"A");
+    let snap2 = snapshot(2, 4, b"A\x1b[?25l");
     let frame2 = render(&renderer, &snap2);
     assert!(cell_is_lit(&frame2, 0, 0));
     assert!(
@@ -411,7 +455,7 @@ fn an_ascii_cell_is_lit_and_its_neighbours_are_blank() {
     // neighbours exist and must stay blank. The corner placements above can
     // only reach rightward and downward; this additionally catches upward and
     // leftward bleed from a sub-cell origin offset at interior positions.
-    let snap3 = snapshot(3, 3, b"\x1b[2;2HA");
+    let snap3 = snapshot(3, 3, b"\x1b[2;2HA\x1b[?25l");
     let frame3 = render(&renderer, &snap3);
     assert!(
         cell_is_lit(&frame3, 1, 1),
@@ -459,7 +503,9 @@ fn drawn_grid_dimensions_match_state_dimensions() {
     // width) lights the trailing cells the state leaves blank; one that shifts
     // the column or row origin lights the wrong cell entirely. Both surface as
     // a lit/blank disagreement below.
-    let snap = snapshot(rows, cols, b"ABCDE\r\nFGHI\r\nKL");
+    // Cursor hidden: this test pins the *grid* mapping of glyphs, and the
+    // caret is not grid content.
+    let snap = snapshot(rows, cols, b"ABCDE\r\nFGHI\r\nKL\x1b[?25l");
     let frame = render(&renderer, &snap);
 
     for row in 0..u32::from(rows) {
@@ -744,7 +790,9 @@ fn truecolor_background_paints_the_whole_cell_and_keeps_glyph_foreground() {
     };
     let background = [12, 98, 201];
     let foreground = [241, 207, 33];
-    let snap = snapshot(1, 1, b"\x1b[38;2;241;207;33;48;2;12;98;201mA");
+    // One column: the cursor would wrap onto this very cell, so hide it —
+    // the subject here is the background/glyph pair, not the caret.
+    let snap = snapshot(1, 1, b"\x1b[?25l\x1b[38;2;241;207;33;48;2;12;98;201mA");
     let frame = render(&renderer, &snap);
 
     let mut background_pixels = 0;
@@ -793,7 +841,8 @@ fn background_on_a_space_paints_even_without_glyph_strokes() {
         return;
     };
     let background = [73, 18, 146];
-    let snap = snapshot(1, 1, b"\x1b[48;2;73;18;146m ");
+    // Cursor hidden: the subject is the background rect on an empty cell.
+    let snap = snapshot(1, 1, b"\x1b[?25l\x1b[48;2;73;18;146m ");
     let frame = render(&renderer, &snap);
 
     for y in 0..CELL_HEIGHT {
@@ -991,6 +1040,7 @@ fn cjk_text_occupies_two_cells_per_character_and_fails_visibly_not_corruptingly(
     };
     let mut state = TerminalState::new(1, 8).expect("valid test terminal");
     state.feed_bytes("日本語".as_bytes());
+    state.feed_bytes(b"\x1b[?25l");
     let snap = state.snapshot();
 
     // State half of the claim: three width-two leads at columns 0/2/4, a
@@ -1059,12 +1109,15 @@ fn wide_character_then_ascii_keeps_the_ascii_at_its_display_column() {
     else {
         return;
     };
-    let b_reference = render(&renderer, &snapshot(1, 4, b"b"));
+    // Cursor hidden in every fixture: this test pins where the *glyph*
+    // after a wide character lands, and the caret would light exactly the
+    // kind of trailing cell asserted blank here.
+    let b_reference = render(&renderer, &snapshot(1, 4, b"b\x1b[?25l"));
     for (label, bytes) in [
         ("CJK 日", "日b".as_bytes()),
         ("wide emoji 😀", "😀b".as_bytes()),
     ] {
-        let snap = snapshot(1, 4, bytes);
+        let snap = snapshot(1, 4, &[bytes, b"\x1b[?25l"].concat());
         let frame = render(&renderer, &snap);
         assert!(cell_is_lit(&frame, 0, 0), "{label}: wide lead drew nothing");
         assert!(
@@ -1093,8 +1146,10 @@ fn combining_marks_consume_no_cell_through_the_pipeline() {
     else {
         return;
     };
-    let marked = snapshot(1, 4, "e\u{0301}f".as_bytes());
-    let plain = snapshot(1, 4, b"ef");
+    // Cursor hidden in both fixtures: the subject is cell consumption, and
+    // the trailing columns asserted blank are exactly where the caret lands.
+    let marked = snapshot(1, 4, "e\u{0301}f\x1b[?25l".as_bytes());
+    let plain = snapshot(1, 4, b"ef\x1b[?25l");
 
     // State half: the mark lives inside column 0's cell (width unchanged),
     // and `f` stays at column 1.
@@ -1226,8 +1281,10 @@ fn a_configured_theme_changes_what_the_renderer_draws() {
         return;
     };
     // red 'b', green 'c', unstyled 'a', red-background 'd' (default fg), and
-    // two empty columns whose pixels show the theme's clear colour.
-    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md");
+    // two empty columns whose pixels show the theme's clear colour. The
+    // cursor is hidden: the empty columns must stay clear, and the caret
+    // has its own theme tests below.
+    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md\x1b[?25l");
 
     let theme_for = |text: &str| {
         noren_app::config::AppConfig::parse(text)
@@ -1328,7 +1385,7 @@ fn high_contrast_theme_draws_its_own_verified_palette() {
     else {
         return;
     };
-    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md");
+    let snap = snapshot(1, 6, b"\x1b[31mb\x1b[32mc\x1b[0ma\x1b[41md\x1b[?25l");
 
     let hc = noren_app::config::AppConfig::parse("[theme]\nname = \"high-contrast\"\n")
         .expect("high-contrast is a valid theme name")
@@ -1364,6 +1421,376 @@ fn high_contrast_theme_draws_its_own_verified_palette() {
         [0, 0, 0],
         "high-contrast clear must be pure black"
     );
+}
+
+// ===========================================================================
+// The cursor (issues #197/#200): every terminal a user has ever used draws a
+// caret; Noren drew none, so every keystroke edited blind. The tests below
+// prove the caret through the frame oracle — real pixels from the real
+// pipeline — not by asserting state flags. The default is *drawn*: a user
+// who reads nothing gets a caret with no configuration, and `[cursor]`
+// configuration only changes how it looks (shape, colour), never whether it
+// is there.
+// ===========================================================================
+
+/// Render a snapshot under an explicit theme and cursor style.
+fn render_with_cursor_style(
+    renderer: &OffscreenRenderer,
+    theme: &Theme,
+    cursor: CursorStyle,
+    snapshot: &TerminalSnapshot,
+) -> CapturedFrame {
+    let width = u32::from(snapshot.cols()) * CELL_WIDTH;
+    let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
+    renderer.capture(
+        Target::new(theme, width, height, poc_metrics()).with_cursor_style(cursor),
+        Some(snapshot),
+        None,
+        None,
+    )
+}
+
+/// Whether every pixel of cell `(row, col)` is the given colour — the shape
+/// of a focused block cursor over an otherwise blank cell.
+fn cell_is_solid(frame: &CapturedFrame, row: u32, col: u32, color: [u8; 3]) -> bool {
+    (0..CELL_HEIGHT).all(|y| {
+        (0..CELL_WIDTH).all(|x| {
+            colors_match(
+                {
+                    let pixel = frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y);
+                    [pixel[0], pixel[1], pixel[2]]
+                },
+                color,
+            )
+        })
+    })
+}
+
+/// The theme's cursor colour as captured bytes (the same quantization
+/// `Theme::cursor_u8` performs).
+fn cursor_rgb(theme: &Theme) -> [u8; 3] {
+    theme.cursor_u8()
+}
+
+/// The headline assertion of issues #197/#200: with no configuration of any
+/// kind, the caret is drawn at the tracked position. A renderer that stops
+/// drawing the cursor fails here at the pixel level — mutation (a) of the
+/// cursor work, run before trusting this test.
+#[test]
+fn the_cursor_is_drawn_by_default_at_the_tracked_position() {
+    let Some(renderer) = renderer_or_skip("the_cursor_is_drawn_by_default_at_the_tracked_position")
+    else {
+        return;
+    };
+    // 'ab' leaves the tracked cursor at display column 2; nothing else on
+    // row 1 or columns 3+.
+    let snap = snapshot(2, 4, b"ab");
+    assert_eq!(
+        (snap.cursor().row(), snap.cursor().column()),
+        (0, 2),
+        "fixture must leave the cursor at (0,2)"
+    );
+    let frame = render(&renderer, &snap);
+
+    // The cursor cell is a solid block of the dark theme's cursor colour.
+    assert!(
+        cell_is_solid(&frame, 0, 2, cursor_rgb(&DARK)),
+        "the cursor cell (0,2) must be a solid block in the theme cursor \
+         colour {:?} — found pixels: see failure",
+        cursor_rgb(&DARK)
+    );
+    // The text cells are untouched by the caret.
+    assert!(cell_is_lit(&frame, 0, 0) && cell_is_lit(&frame, 0, 1));
+    // Everything past the caret, and every other row, stays clear.
+    assert!(!cell_is_lit(&frame, 0, 3));
+    for col in 0..u32::from(snap.cols()) {
+        assert!(
+            !cell_is_lit(&frame, 1, col),
+            "row 1 col {col} must stay clear — the caret is on row 0"
+        );
+    }
+}
+
+/// The fresh-screen case the display model used to trim away: a completely
+/// blank screen still shows its caret at (0,0) — exactly the row typing
+/// lands in. With DECTCEM hiding it, the screen returns to fully clear.
+#[test]
+fn blank_screen_draws_only_the_cursor() {
+    let Some(renderer) = renderer_or_skip("blank_screen_draws_only_the_cursor") else {
+        return;
+    };
+    let snap = snapshot(3, 8, b"");
+    let frame = render(&renderer, &snap);
+    assert!(
+        cell_is_solid(&frame, 0, 0, cursor_rgb(&DARK)),
+        "a blank screen must still draw its caret at (0,0)"
+    );
+    for row in 0..u32::from(snap.rows()) {
+        for col in 0..u32::from(snap.cols()) {
+            if row == 0 && col == 0 {
+                continue;
+            }
+            assert!(
+                !cell_is_lit(&frame, row, col),
+                "cell ({row},{col}) must stay clear on a blank screen"
+            );
+        }
+    }
+
+    let hidden = snapshot(3, 8, b"\x1b[?25l");
+    let hidden_frame = render(&renderer, &hidden);
+    for row in 0..u32::from(hidden.rows()) {
+        for col in 0..u32::from(hidden.cols()) {
+            assert!(
+                !cell_is_lit(&hidden_frame, row, col),
+                "with the caret hidden, cell ({row},{col}) must be clear"
+            );
+        }
+    }
+}
+
+/// Issue #200's own proposed guard: moving the cursor must change pixels.
+/// The same text with the caret in two positions yields two different
+/// frames, and each caret cell is exactly where its snapshot says.
+#[test]
+fn moving_the_cursor_changes_pixels() {
+    let Some(renderer) = renderer_or_skip("moving_the_cursor_changes_pixels") else {
+        return;
+    };
+    // Same text, caret moved between two blank cells (a caret on a glyph
+    // inverts it — covered by the wide-character and shape tests below).
+    let at_third = snapshot(1, 4, b"hi\x1b[1;3H");
+    let at_fourth = snapshot(1, 4, b"hi\x1b[1;4H");
+    assert_eq!(
+        (at_third.cursor().column(), at_fourth.cursor().column()),
+        (2, 3)
+    );
+
+    let frame_third = render(&renderer, &at_third);
+    let frame_fourth = render(&renderer, &at_fourth);
+    assert_ne!(
+        frame_third.rgba, frame_fourth.rgba,
+        "moving the cursor must change the drawn pixels"
+    );
+    // Each caret is where its snapshot tracks it, and only there.
+    assert!(
+        cell_is_solid(&frame_third, 0, 2, cursor_rgb(&DARK)),
+        "caret at column 2 must mark cell (0,2)"
+    );
+    assert!(
+        !cell_is_solid(&frame_third, 0, 3, cursor_rgb(&DARK)),
+        "the caret is not at column 3 in the first frame"
+    );
+    assert!(
+        cell_is_solid(&frame_fourth, 0, 3, cursor_rgb(&DARK)),
+        "caret at column 3 must mark cell (0,3)"
+    );
+    assert!(
+        !cell_is_solid(&frame_fourth, 0, 2, cursor_rgb(&DARK)),
+        "the caret is not at column 2 in the second frame"
+    );
+    // The typed text is identical in both frames.
+    for col in 0..2_u32 {
+        assert_eq!(
+            cell_pattern(&frame_third, 0, col),
+            cell_pattern(&frame_fourth, 0, col)
+        );
+    }
+}
+
+/// The wide-character contract for the caret (#174/#176): a block cursor
+/// after a wide character sits at its *display* column (two past the lead),
+/// and a caret on the wide character itself covers both columns — never
+/// half a character. A renderer that counts cells instead of display
+/// columns draws the block one column early and fails both halves below;
+/// that is mutation (b) of the cursor work, run before trusting this test.
+#[test]
+fn a_block_cursor_on_a_wide_character_covers_both_columns() {
+    let Some(renderer) = renderer_or_skip("a_block_cursor_on_a_wide_character_covers_both_columns")
+    else {
+        return;
+    };
+    // 界 (columns 0–1), red 'X' (column 2), tracked cursor at display
+    // column 3. The X is deliberately SGR-red so the glyph colour differs
+    // from the cursor colour and a misdrawn block cannot hide in the match.
+    let snap = snapshot(1, 6, "界\x1b[31mX".as_bytes());
+    assert_eq!((snap.cursor().row(), snap.cursor().column()), (0, 3));
+    let frame = render(&renderer, &snap);
+
+    assert!(
+        cell_is_solid(&frame, 0, 3, cursor_rgb(&DARK)),
+        "the caret must sit at display column 3 — the columns a wide \
+         character actually occupies are 0 and 1, not 0 alone"
+    );
+    assert!(
+        !cell_is_solid(&frame, 0, 2, cursor_rgb(&DARK)),
+        "the block must not cover the X at column 2"
+    );
+    let x_color = cell_color(&frame, 0, 2);
+    assert!(
+        colors_match(x_color, DARK.ansi()[1]),
+        "the X at column 2 must keep its red glyph, found {x_color:?}"
+    );
+
+    // Now the caret on the wide character itself: it must cover BOTH
+    // columns — the continuation column is solid cursor colour (it has no
+    // glyph of its own), and the lead column shows the inverted glyph over
+    // the block (cursor colour and background colour only).
+    let on_wide = snapshot(1, 6, "界\x1b[31mX\x1b[1;1H".as_bytes());
+    assert_eq!(on_wide.cursor().column(), 0);
+    let on_wide_frame = render(&renderer, &on_wide);
+    assert!(
+        cell_is_solid(&on_wide_frame, 0, 1, cursor_rgb(&DARK)),
+        "the continuation column of the wide character must be covered by \
+         the block — covering only the lead is half a character"
+    );
+    let lead_colors = cell_colors(&on_wide_frame, 0, 0);
+    for color in lead_colors {
+        assert!(
+            colors_match(color, cursor_rgb(&DARK)) || colors_match(color, DARK.background_u8()),
+            "the inverted glyph over the block may draw only the cursor \
+             colour and the background colour, found {color:?}"
+        );
+    }
+    // The X past the pair is untouched.
+    assert!(colors_match(
+        cell_color(&on_wide_frame, 0, 2),
+        DARK.ansi()[1]
+    ));
+}
+
+/// DECTCEM is a contract with programs, not a preference: vim hides the
+/// caret during redraw (`CSI ?25l`) and a caret painted over a hidden state
+/// is worse than none. Hidden draws no mark anywhere; `CSI ?25h` restores
+/// it — and the hidden frame is byte-identical to one that never knew the
+/// cursor existed.
+#[test]
+fn dectcem_hides_and_restores_the_cursor_in_pixels() {
+    let Some(renderer) = renderer_or_skip("dectcem_hides_and_restores_the_cursor_in_pixels") else {
+        return;
+    };
+    let hidden = snapshot(2, 4, b"ab\x1b[?25l");
+    let shown = snapshot(2, 4, b"ab\x1b[?25h");
+    let hidden_frame = render(&renderer, &hidden);
+    let shown_frame = render(&renderer, &shown);
+
+    // Hidden: the cursor cell reverts to clear; nothing else may appear.
+    assert!(
+        !cell_is_lit(&hidden_frame, 0, 2),
+        "a DECTCEM-hidden cursor must not be drawn at its tracked position"
+    );
+    for row in 0..2 {
+        for col in 0..4 {
+            let expected_lit = row == 0 && col < 2;
+            assert_eq!(
+                cell_is_lit(&hidden_frame, row, col),
+                expected_lit,
+                "hidden-cursor frame ({row},{col}): only the typed 'ab' may be lit"
+            );
+        }
+    }
+    // Restored: the caret is back exactly at the tracked position.
+    assert!(
+        cell_is_solid(&shown_frame, 0, 2, cursor_rgb(&DARK)),
+        "CSI ?25h must restore the caret at the tracked position"
+    );
+    assert_ne!(
+        hidden_frame.rgba, shown_frame.rgba,
+        "hide and show must differ in pixels"
+    );
+}
+
+/// The cursor colour is theme-owned, so the caret must be visible — with
+/// measured WCAG contrast — on every theme's background, asserted on the
+/// readback bytes themselves (dark 15.39:1, light 14.56:1, high-contrast
+/// 21.0:1; `tests/theme.rs` pins the same numbers at the palette level).
+#[test]
+fn the_cursor_colour_comes_from_the_theme_and_clears_contrast_in_pixels() {
+    let Some(renderer) =
+        renderer_or_skip("the_cursor_colour_comes_from_the_theme_and_clears_contrast_in_pixels")
+    else {
+        return;
+    };
+    for theme in [&DARK, &LIGHT, &HIGH_CONTRAST] {
+        let snap = snapshot(1, 4, b"\x1b[?25h");
+        let frame = render_with_theme(&renderer, theme, &snap);
+        assert!(
+            cell_is_solid(&frame, 0, 0, cursor_rgb(theme)),
+            "the caret must draw this theme's cursor colour {:?}",
+            cursor_rgb(theme)
+        );
+        // The centre of the block, read back as bytes, against this
+        // theme's readback ground: the visibility claim, measured.
+        let block = {
+            let pixel = frame.pixel(CELL_WIDTH / 2, CELL_HEIGHT / 2);
+            [pixel[0], pixel[1], pixel[2]]
+        };
+        assert!(colors_match(block, cursor_rgb(theme)));
+        let ground = {
+            let pixel = frame.pixel(3 * CELL_WIDTH, CELL_HEIGHT / 2);
+            [pixel[0], pixel[1], pixel[2]]
+        };
+        assert!(colors_match(ground, theme.background_u8()));
+        let ratio = contrast_ratio(block, ground);
+        let floor = if *theme == HIGH_CONTRAST { 7.0 } else { 4.5 };
+        assert!(
+            ratio >= floor,
+            "{theme:?} cursor {block:?} on {ground:?} is {ratio:.2}:1, below {floor}:1"
+        );
+    }
+}
+
+/// Focus loss is visible (issue #200): the unfocused caret is a hollow
+/// outline of the block footprint — border lit, interior clear — and the
+/// two treatments differ in pixels.
+#[test]
+fn an_unfocused_cursor_is_a_hollow_outline_and_differs_from_focused() {
+    let Some(renderer) =
+        renderer_or_skip("an_unfocused_cursor_is_a_hollow_outline_and_differs_from_focused")
+    else {
+        return;
+    };
+    let stroke = 2_u32; // CURSOR_STROKE in the renderer
+    let snap = snapshot(1, 4, b"");
+    let focused = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_focus(true),
+        &snap,
+    );
+    let unfocused = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_focus(false),
+        &snap,
+    );
+
+    assert_ne!(
+        focused.rgba, unfocused.rgba,
+        "focused and unfocused carets must differ in pixels"
+    );
+    assert!(cell_is_solid(&focused, 0, 0, cursor_rgb(&DARK)));
+
+    // Hollow: the border ring is cursor-coloured, the interior is clear.
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = unfocused.pixel(x, y);
+            let rgb = [pixel[0], pixel[1], pixel[2]];
+            let on_border =
+                x < stroke || y < stroke || x >= CELL_WIDTH - stroke || y >= CELL_HEIGHT - stroke;
+            assert_eq!(
+                colors_match(rgb, cursor_rgb(&DARK)),
+                on_border,
+                "unfocused caret: pixel ({x},{y}) must be {} — a hollow ring of \
+                 {stroke}px around a clear interior",
+                if on_border {
+                    "cursor-coloured"
+                } else {
+                    "clear"
+                }
+            );
+        }
+    }
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -33,10 +33,11 @@
 //!   pair lands at its display column — the width contract whose loss corrupts
 //!   the rest of the line;
 //! - a combining mark is drawn over its base cell without consuming a cell;
-//! - the cursor is drawn by default at the tracked position, in the theme's
-//!   cursor colour, spanning both columns of a wide character, hidden by
-//!   DECTCEM (`CSI ?25l`) and restored by `CSI ?25h`, with focused and
-//!   unfocused treatments that differ in pixels (issues #197/#200).
+//! - the cursor is drawn by default at the tracked position, inverse to its
+//!   actual cell with a 4.5:1 safety fallback on arbitrary SGR backgrounds,
+//!   spanning both columns of a wide character, hidden by DECTCEM (`CSI ?25l`)
+//!   and restored by `CSI ?25h`, with focused and unfocused treatments that
+//!   differ in pixels (issues #197/#200).
 //!
 //! ## The lit/blank gate
 //!
@@ -236,6 +237,20 @@ fn cell_color(frame: &CapturedFrame, row: u32, col: u32) -> [u8; 3] {
         "cell ({row},{col}) should hold exactly one lit colour, found {colors:?}"
     );
     colors[0]
+}
+
+/// Number of pixels inside one cell matching a concrete rendered colour.
+fn cell_color_pixel_count(frame: &CapturedFrame, row: u32, col: u32, color: [u8; 3]) -> usize {
+    let mut count = 0;
+    for y in 0..CELL_HEIGHT {
+        for x in 0..CELL_WIDTH {
+            let pixel = frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y);
+            if colors_match([pixel[0], pixel[1], pixel[2]], color) {
+                count += 1;
+            }
+        }
+    }
+    count
 }
 
 /// The default foreground as captured bytes, derived from the renderer's own
@@ -1467,8 +1482,8 @@ fn cell_is_solid(frame: &CapturedFrame, row: u32, col: u32, color: [u8; 3]) -> b
     })
 }
 
-/// The theme's cursor colour as captured bytes (the same quantization
-/// `Theme::cursor_u8` performs).
+/// The theme's unstyled cursor baseline as captured bytes (the same
+/// quantization `Theme::cursor_u8` performs).
 fn cursor_rgb(theme: &Theme) -> [u8; 3] {
     theme.cursor_u8()
 }
@@ -1701,10 +1716,11 @@ fn dectcem_hides_and_restores_the_cursor_in_pixels() {
     );
 }
 
-/// The cursor colour is theme-owned, so the caret must be visible — with
-/// measured WCAG contrast — on every theme's background, asserted on the
-/// readback bytes themselves (dark 15.39:1, light 14.56:1, high-contrast
-/// 21.0:1; `tests/theme.rs` pins the same numbers at the palette level).
+/// On an unstyled cell the cursor baseline is theme-owned, so the caret must
+/// be visible — with measured WCAG contrast — on every theme's background,
+/// asserted on the readback bytes themselves (dark 15.39:1, light 14.56:1,
+/// high-contrast 21.0:1; `tests/theme.rs` pins the same numbers at the palette
+/// level). SGR cells have their separate cell-relative regression below.
 #[test]
 fn the_cursor_colour_comes_from_the_theme_and_clears_contrast_in_pixels() {
     let Some(renderer) =
@@ -1739,6 +1755,165 @@ fn the_cursor_colour_comes_from_the_theme_and_clears_contrast_in_pixels() {
             "{theme:?} cursor {block:?} on {ground:?} is {ratio:.2}:1, below {floor}:1"
         );
     }
+}
+
+/// Regression for the SGR-background defect found after issues #197/#200:
+/// cursor ink is resolved against the cell it covers, not the theme ground.
+/// These are real terminal attributes driven through the parser and real
+/// readback pixels from the shipped render pipeline.
+#[test]
+fn cursor_contrast_tracks_four_real_sgr_backgrounds() {
+    let Some(renderer) = renderer_or_skip("cursor_contrast_tracks_four_real_sgr_backgrounds")
+    else {
+        return;
+    };
+    let cases: [(&str, &[u8], [u8; 3]); 4] = [
+        ("light ANSI SGR 47", b"\x1b[47m", DARK.ansi()[7]),
+        ("dark ANSI SGR 40", b"\x1b[40m", DARK.ansi()[0]),
+        (
+            "background equal to the theme cursor",
+            b"\x1b[48;2;204;235;209m",
+            cursor_rgb(&DARK),
+        ),
+        (
+            "truecolor SGR 48;2;17;119;221",
+            b"\x1b[48;2;17;119;221m",
+            [17, 119, 221],
+        ),
+    ];
+
+    for (label, sgr, expected_background) in cases {
+        // Two background-painted spaces, then return the cursor to the first:
+        // cell 0 is the caret and cell 1 exposes the actual comparison ground.
+        let mut bytes = sgr.to_vec();
+        bytes.extend_from_slice(b"  \r\x1b[?25h");
+        let snap = snapshot(1, 3, &bytes);
+        let frame = render(&renderer, &snap);
+
+        assert!(
+            cell_is_solid(&frame, 0, 0, [0, 0, 0]),
+            "{label}: the unusable inverse foreground must fall back to black"
+        );
+        assert!(
+            cell_is_solid(&frame, 0, 1, expected_background),
+            "{label}: comparison cell must expose SGR background {expected_background:?}"
+        );
+        let ink_pixel = frame.pixel(CELL_WIDTH / 2, CELL_HEIGHT / 2);
+        let ground_pixel = frame.pixel(CELL_WIDTH + CELL_WIDTH / 2, CELL_HEIGHT / 2);
+        let ink = [ink_pixel[0], ink_pixel[1], ink_pixel[2]];
+        let ground = [ground_pixel[0], ground_pixel[1], ground_pixel[2]];
+        let ratio = contrast_ratio(ink, ground);
+        eprintln!("cursor SGR oracle: {label} ink={ink:?} ground={ground:?} ratio={ratio:.6}:1");
+        assert!(
+            ratio >= 4.5,
+            "{label}: cursor {ink:?} on actual cell ground {ground:?} is only {ratio:.6}:1"
+        );
+    }
+}
+
+/// A focused block swaps the readable cell pair: cell foreground becomes the
+/// block and cell background becomes the glyph. The glyph keeps the same
+/// raster coverage it has without a cursor, proving readability rather than
+/// merely proving that two colours occur somewhere in the cell.
+#[test]
+fn block_cursor_keeps_the_sgr_glyph_readable_after_inversion() {
+    let Some(renderer) =
+        renderer_or_skip("block_cursor_keeps_the_sgr_glyph_readable_after_inversion")
+    else {
+        return;
+    };
+    const FOREGROUND: [u8; 3] = [20, 30, 40];
+    const BACKGROUND: [u8; 3] = [240, 240, 240];
+    let visible = snapshot(1, 3, b"\x1b[38;2;20;30;40;48;2;240;240;240mA\r\x1b[?25h");
+    let hidden = snapshot(1, 3, b"\x1b[38;2;20;30;40;48;2;240;240;240mA\r\x1b[?25l");
+    let visible_frame = render(&renderer, &visible);
+    let hidden_frame = render(&renderer, &hidden);
+
+    let ordinary_glyph_pixels = cell_color_pixel_count(&hidden_frame, 0, 0, FOREGROUND);
+    let inverted_glyph_pixels = cell_color_pixel_count(&visible_frame, 0, 0, BACKGROUND);
+    assert!(ordinary_glyph_pixels > 0, "the control A must draw a glyph");
+    assert_eq!(
+        inverted_glyph_pixels, ordinary_glyph_pixels,
+        "the inverted A must retain every glyph pixel"
+    );
+    assert_eq!(
+        cell_color_pixel_count(&visible_frame, 0, 0, FOREGROUND) + inverted_glyph_pixels,
+        (CELL_WIDTH * CELL_HEIGHT) as usize,
+        "the cursor cell may contain only its block and readable glyph"
+    );
+    let ratio = contrast_ratio(FOREGROUND, BACKGROUND);
+    assert!(ratio >= 4.5, "fixture pair must itself be readable");
+}
+
+/// `[cursor] color` remains meaningful, but cannot command invisible output:
+/// a safe colour is used exactly, while a colour matching the cell background
+/// falls back first to the cell's readable inverse foreground.
+#[test]
+fn cursor_override_is_used_when_safe_and_falls_back_when_not() {
+    let Some(renderer) =
+        renderer_or_skip("cursor_override_is_used_when_safe_and_falls_back_when_not")
+    else {
+        return;
+    };
+    let white = [1.0, 1.0, 1.0];
+    let dark = snapshot(1, 3, b"\x1b[48;2;8;18;28m  \r");
+    let safe = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_color_override(Some(white)),
+        &dark,
+    );
+    assert!(
+        cell_is_solid(&safe, 0, 0, [255, 255, 255]),
+        "a safe override must be drawn exactly"
+    );
+
+    let light = snapshot(1, 3, b"\x1b[38;2;20;30;40;48;2;240;240;240m  \r");
+    let matching_background = [240.0 / 255.0; 3];
+    let fallback = render_with_cursor_style(
+        &renderer,
+        &DARK,
+        CursorStyle::theme_default(&DARK).with_color_override(Some(matching_background)),
+        &light,
+    );
+    assert!(
+        cell_is_solid(&fallback, 0, 0, [20, 30, 40]),
+        "an invisible override must fall back to the readable inverse foreground"
+    );
+    assert!(
+        !cell_is_solid(&fallback, 0, 0, [240, 240, 240]),
+        "an override equal to the ground must never erase the caret"
+    );
+}
+
+/// Vim could not be driven in the independent review's WindowServer-less UI,
+/// so exercise the relevant contract directly: DECTCEM hide and show while
+/// the cursor sits on an SGR-painted light cell.
+#[test]
+fn dectcem_hide_and_show_work_on_an_sgr_background() {
+    let mut terminal = TerminalState::new(1, 3).expect("valid test terminal");
+    terminal.feed_bytes(b"\x1b[47m  \r\x1b[?25l");
+    let hidden = terminal.snapshot();
+    assert!(!hidden.is_cursor_visible());
+
+    terminal.feed_bytes(b"\x1b[?25h");
+    let shown = terminal.snapshot();
+    assert!(shown.is_cursor_visible());
+
+    // Keep the parser/state half of this contract live even on hosts where
+    // the rendered-frame half must skip because no GPU adapter is exposed.
+    let Some(renderer) = renderer_or_skip("dectcem_hide_and_show_work_on_an_sgr_background") else {
+        return;
+    };
+    let hidden_frame = render(&renderer, &hidden);
+    let shown_frame = render(&renderer, &shown);
+
+    let light = DARK.ansi()[7];
+    assert!(cell_is_solid(&hidden_frame, 0, 0, light));
+    assert!(cell_is_solid(&shown_frame, 0, 0, [0, 0, 0]));
+    assert!(cell_is_solid(&hidden_frame, 0, 1, light));
+    assert!(cell_is_solid(&shown_frame, 0, 1, light));
+    assert_ne!(hidden_frame.rgba, shown_frame.rgba);
 }
 
 /// Shape is configuration, not existence: bar and underline marks draw their
@@ -1877,9 +2052,9 @@ fn an_unfocused_cursor_is_a_hollow_outline_and_differs_from_focused() {
     }
 }
 
-/// A colour override is the power-user half of the contract: the theme
-/// colour is the default, and `[cursor]` colour configuration replaces it
-/// without touching any other drawn colour.
+/// A safe colour preference is the power-user half of the contract: on this
+/// dark unstyled cell the configured orange clears 4.5:1 and therefore
+/// replaces the inverse default without touching any other drawn colour.
 #[test]
 fn a_cursor_colour_override_replaces_only_the_caret_colour() {
     let Some(renderer) =
@@ -2135,12 +2310,17 @@ fn empty_state_message_is_drawn_in_the_sidebar() {
 
 /// Re-run one adapter-dependent oracle test in this very binary under a
 /// forced adapter mode, returning its exit status plus both captured streams:
-/// the harness prints its failure report (panic text included) to stdout,
-/// while the skip notice bypasses capture and lands on real stderr.
+/// The successful adapter-absence case needs `--nocapture` so libtest does not
+/// suppress its skip notice before the parent can inspect stderr. The failing
+/// device case deliberately keeps normal capture so libtest places its panic
+/// report on stdout, preserving the two externally distinct contracts.
 fn rerun_forced(test: &str, mode: &str) -> (bool, String, String) {
-    let output = Command::new(std::env::current_exe().expect("locate the test binary"))
-        .arg("--exact")
-        .arg(test)
+    let mut command = Command::new(std::env::current_exe().expect("locate the test binary"));
+    command.arg("--exact").arg(test);
+    if mode == "absent" {
+        command.arg("--nocapture");
+    }
+    let output = command
         .env("NOREN_FRAME_ORACLE_ADAPTER", mode)
         .output()
         .unwrap_or_else(|error| panic!("re-run `{test}` with adapter mode `{mode}`: {error}"));

--- a/crates/noren-app/tests/theme.rs
+++ b/crates/noren-app/tests/theme.rs
@@ -77,6 +77,39 @@ fn every_theme_default_pair_meets_aa() {
     }
 }
 
+/// The cursor colour is theme-owned and therefore inside the contrast
+/// contract (issues #197/#200): a caret a user cannot locate is as much a
+/// defect as text they cannot read. Every built-in theme draws the cursor
+/// in its default foreground, so the measured ratios are the default-pair
+/// ratios — dark 15.39:1, light 14.56:1, high-contrast 21.0:1 — each
+/// clearing its theme's documented floor (AA for dark/light, AAA for
+/// high-contrast) with the same margin as ordinary text.
+#[test]
+fn every_theme_cursor_colour_meets_its_theme_contrast_floor() {
+    for name in [ThemeName::Dark, ThemeName::Light, ThemeName::HighContrast] {
+        let theme = name.palette();
+        let ratio = contrast_ratio(theme.cursor_u8(), theme.background_u8());
+        let floor = if matches!(name, ThemeName::HighContrast) {
+            7.0
+        } else {
+            4.5
+        };
+        assert!(
+            ratio >= floor,
+            "{name}: cursor colour is {ratio:.2}:1, below the {floor}:1 floor"
+        );
+        // A block cursor is the reading pair inverted (block in the cursor
+        // colour, glyph in the background colour); WCAG ratios are
+        // order-independent, so the glyph inside the block measures the
+        // same ratio as the block itself. Pin that identity structurally.
+        assert_eq!(
+            contrast_ratio(theme.cursor_u8(), theme.background_u8()),
+            contrast_ratio(theme.foreground_u8(), theme.background_u8()),
+            "{name}: cursor colour must inherit the measured default-pair contrast"
+        );
+    }
+}
+
 /// The light theme was designed, not assumed: every ANSI slot keeps AA on
 /// the light background. Measured minimum: 5.07:1 (`bright green`).
 #[test]

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -118,6 +118,10 @@ pub(crate) enum EraseMode {
 pub(crate) enum PrivateMode {
     AlternateScreen,
     ApplicationCursorKey,
+    /// DECTCEM (DEC text cursor enable mode): whether the terminal should
+    /// display its cursor. Programs hide it during redraws (`vim`) and
+    /// re-show it at rest, so the renderer must honour both directions.
+    CursorVisibility,
     BracketedPaste,
     MouseTrackingNormal,
     MouseTrackingButtonEvent,
@@ -528,6 +532,7 @@ impl Csi {
     fn private_mode(&self, param: u16) -> Option<PrivateMode> {
         match param {
             1 => Some(PrivateMode::ApplicationCursorKey),
+            25 => Some(PrivateMode::CursorVisibility),
             1049 => Some(PrivateMode::AlternateScreen),
             2004 => Some(PrivateMode::BracketedPaste),
             1000 => Some(PrivateMode::MouseTrackingNormal),
@@ -729,6 +734,23 @@ mod tests {
                 Action::SetPrivateMode {
                     mode: PrivateMode::BracketedPaste,
                     enabled: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cursor_visibility_mode_25_is_tracked_as_a_private_mode() {
+        assert_eq!(
+            actions(b"\x1b[?25l\x1b[?25h"),
+            [
+                Action::SetPrivateMode {
+                    mode: PrivateMode::CursorVisibility,
+                    enabled: false,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::CursorVisibility,
+                    enabled: true,
                 },
             ]
         );

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -272,6 +272,9 @@ pub struct TerminalModes {
     application_cursor_key: bool,
     application_keypad: bool,
     bracketed_paste: bool,
+    // Stored hidden-side-out so the derive-Default all-false value means the
+    // historical behaviour: a visible cursor. DECTCEM hides it.
+    cursor_hidden: bool,
     mouse_normal_tracking: bool,
     mouse_button_event_tracking: bool,
     mouse_any_event_tracking: bool,
@@ -307,6 +310,18 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_bracketed_paste_enabled(self) -> bool {
         self.bracketed_paste
+    }
+
+    /// Whether DEC private mode 25 (DECTCEM, text cursor enable) leaves the
+    /// cursor visible.
+    ///
+    /// The default is visible: a terminal that never draws its caret hides
+    /// where typing will land. Programs temporarily hide it during screen
+    /// redraws (`CSI ?25l`, e.g. vim) and re-show it at rest (`CSI ?25h`),
+    /// so a renderer must consult this before drawing.
+    #[must_use]
+    pub const fn is_cursor_visible(self) -> bool {
+        !self.cursor_hidden
     }
 
     /// Whether DEC private mode 1000 (normal mouse tracking) is enabled.
@@ -1330,6 +1345,9 @@ impl TerminalState {
         match (mode, enabled) {
             (PrivateMode::AlternateScreen, true) => self.enter_alternate_screen(),
             (PrivateMode::AlternateScreen, false) => self.leave_alternate_screen(),
+            (PrivateMode::CursorVisibility, enabled) => {
+                self.modes.cursor_hidden = !enabled;
+            }
             (PrivateMode::ApplicationCursorKey, enabled) => {
                 self.modes.application_cursor_key = enabled;
             }
@@ -1586,6 +1604,12 @@ impl TerminalSnapshot {
     #[must_use]
     pub const fn is_wrap_pending(&self) -> bool {
         self.wrap_pending
+    }
+
+    /// Whether DECTCEM leaves the cursor visible, captured with the screen.
+    #[must_use]
+    pub const fn is_cursor_visible(&self) -> bool {
+        self.modes.is_cursor_visible()
     }
 
     /// Terminal modes captured with the visible screen.

--- a/crates/noren-terminal/tests/cursor_visibility.rs
+++ b/crates/noren-terminal/tests/cursor_visibility.rs
@@ -1,0 +1,81 @@
+//! DEC private mode 25 (DECTCEM, text cursor enable) tracking in terminal
+//! state.
+//!
+//! Programs rely on hiding the cursor while they own the screen: `vim` sends
+//! `CSI ?25l` before every redraw and `CSI ?25h` at rest, and a renderer that
+//! ignores the mode paints a caret over screens that asked for none. The
+//! renderer therefore needs the mode as terminal state, alongside every other
+//! render-affecting mode, and the default must be *visible* — a terminal that
+//! never draws its caret (issue #197/#200) hides where typing will land.
+
+use noren_terminal::TerminalState;
+
+#[test]
+fn cursor_defaults_to_visible() {
+    let state = TerminalState::new(2, 4).expect("valid terminal");
+    assert!(state.modes().is_cursor_visible());
+    assert!(state.snapshot().is_cursor_visible());
+}
+
+#[test]
+fn cursor_visibility_toggles_with_csi_question_25_h_and_l() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?25l");
+    assert!(!state.modes().is_cursor_visible());
+    assert!(!state.snapshot().is_cursor_visible());
+
+    state.feed_bytes(b"\x1b[?25h");
+    assert!(state.modes().is_cursor_visible());
+    assert!(state.snapshot().is_cursor_visible());
+
+    // Repeated hiding is idempotent.
+    state.feed_bytes(b"\x1b[?25l\x1b[?25l");
+    assert!(!state.modes().is_cursor_visible());
+}
+
+#[test]
+fn cursor_visibility_survives_alternate_screen_transitions() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"\x1b[?25l");
+    // 1049 saves and restores the *position*, not DECTCEM; xterm keeps mode
+    // 25 global across screen buffers, and a program leaving the alternate
+    // screen without re-showing expects its own final `?25h` to be the
+    // authority.
+    state.feed_bytes(b"\x1b[?1049h");
+    assert!(!state.modes().is_cursor_visible());
+    state.feed_bytes(b"\x1b[?1049l");
+    assert!(!state.modes().is_cursor_visible());
+    state.feed_bytes(b"\x1b[?25h");
+    assert!(state.modes().is_cursor_visible());
+}
+
+#[test]
+fn cursor_visibility_participates_in_multi_param_private_modes() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?1;25;2004h");
+    let modes = state.modes();
+    assert!(modes.is_application_cursor_key_mode());
+    assert!(modes.is_cursor_visible());
+    assert!(modes.is_bracketed_paste_enabled());
+
+    state.feed_bytes(b"\x1b[?1;25;2004l");
+    let modes = state.modes();
+    assert!(!modes.is_application_cursor_key_mode());
+    assert!(!modes.is_cursor_visible());
+    assert!(!modes.is_bracketed_paste_enabled());
+}
+
+#[test]
+fn hiding_the_cursor_leaves_the_tracked_position_intact() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"ab");
+    let (row, column) = {
+        let cursor = state.cursor();
+        (cursor.row(), cursor.column())
+    };
+    state.feed_bytes(b"\x1b[?25l");
+    let cursor = state.cursor();
+    assert_eq!((cursor.row(), cursor.column()), (row, column));
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,24 +155,37 @@ floor under any palette.
 ### `[cursor]`
 
 Cursor appearance (issues #197/#200). The table is optional and the caret
-**ships drawn**: an absent `[cursor]` renders a focused block in the active
-theme's cursor colour — the same contrast-verified colour relationship as
-ordinary text — so a user who never opens this file still sees where typing
-lands. Configuration changes how the caret looks, never whether it exists;
-visibility belongs to the program through DECTCEM (`CSI ?25l`/`?25h`), not
-to a preference that could quietly reproduce the every-keystroke-blind
+**ships drawn**: an absent `[cursor]` renders a focused inverse-video block,
+using the cursor cell's resolved foreground for the block and its resolved
+background for the glyph. On an unstyled cell this is the active theme's
+contrast-verified cursor/default-foreground pair. On an SGR-painted cell it
+is the pair that actually occupies that cell, not a fixed colour measured
+only on the theme background. If that inverse foreground misses 4.5:1, the
+renderer chooses whichever of black/white has greater contrast; this keeps
+both the caret and the glyph inside a block at or above 4.5:1 on every sRGB
+background. Configuration changes how the caret looks, never whether it
+exists; visibility belongs to the program through DECTCEM (`CSI ?25l`/`?25h`),
+not to a preference that could quietly reproduce the every-keystroke-blind
 defect.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `shape` | string | `"block"` | `block` (filled, glyph inverted beneath), `bar` (left stroke), or `underline` (bottom stroke). |
-| `color` | string | the theme's cursor colour | One `#rrggbb` value overriding the theme colour. |
+| `color` | string | inverse cell foreground | One preferred `#rrggbb` cursor colour. |
 
 Accepted shapes, matched exactly (case-sensitive, closed vocabulary):
 `block`, `bar`, `underline`. An unfocused window always draws the caret as
 a hollow outline of the block footprint regardless of shape — the classic
 signal that the window no longer receives keys — because the shape setting
 is a *focused* typing aid.
+
+`color` is a preference, not permission to draw an invisible cursor. The
+configured colour is used exactly when it reaches 4.5:1 against the actual
+cursor-cell background. If it does not, the renderer falls back to a readable
+inverse cell foreground, then to contrast-maximising black/white if the cell
+pair itself is below 4.5:1. A usable override therefore remains fully under
+user control, while an override equal to an SGR background cannot silently
+erase the caret.
 
 Rejections follow the hard-error discipline: an unknown shape is a typed
 error naming the offending value (clipped to 120 characters, like the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,41 @@ bright black now sit close together (`[121,121,121]` vs
 cube, truecolor, and program-paired colours — those can draw below the
 floor under any palette.
 
+### `[cursor]`
+
+Cursor appearance (issues #197/#200). The table is optional and the caret
+**ships drawn**: an absent `[cursor]` renders a focused block in the active
+theme's cursor colour — the same contrast-verified colour relationship as
+ordinary text — so a user who never opens this file still sees where typing
+lands. Configuration changes how the caret looks, never whether it exists;
+visibility belongs to the program through DECTCEM (`CSI ?25l`/`?25h`), not
+to a preference that could quietly reproduce the every-keystroke-blind
+defect.
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `shape` | string | `"block"` | `block` (filled, glyph inverted beneath), `bar` (left stroke), or `underline` (bottom stroke). |
+| `color` | string | the theme's cursor colour | One `#rrggbb` value overriding the theme colour. |
+
+Accepted shapes, matched exactly (case-sensitive, closed vocabulary):
+`block`, `bar`, `underline`. An unfocused window always draws the caret as
+a hollow outline of the block footprint regardless of shape — the classic
+signal that the window no longer receives keys — because the shape setting
+is a *focused* typing aid.
+
+Rejections follow the hard-error discipline: an unknown shape is a typed
+error naming the offending value (clipped to 120 characters, like the
+`[theme]` name echo: shape names are closed-vocabulary grammar text, never
+a credential); a non-string value, an unknown key (including `blink`,
+deliberately not offered), or a colour that is not one `#rrggbb` value is
+an error naming the key — never a silent fallback, and never a guessed
+colour.
+
+Blink is deliberately absent: a blinking caret forces timer-driven
+repaints roughly twice a second even while idle, and this renderer rebuilds
+the full vertex list every frame. That is a CPU/battery decision, not a
+visual one, and it is not taken silently by a default.
+
 ### `[[agents]]`
 
 Configured AI-agent entries: each `[[agents]]` table names one agent with a

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -112,6 +112,29 @@ binary. What now actually happens on screen:
   races are handled at open time (`open_regular_file`) and pinned by bounded
   subprocess regression tests (`top_level_fifo_returns_promptly`,
   `included_fifo_sources_return_promptly`).
+- **A visible cursor is drawn** (issues #197/#200; the first UI/UX
+  evaluations ranked its absence at the top). The renderer draws the caret
+  at the position the terminal state already tracks: a focused block in the
+  active theme's cursor colour — each theme's default foreground, so the
+  caret inherits the measured default-pair WCAG contrast (dark 15.39:1,
+  light 14.56:1, high-contrast 21.0:1) — with the glyph beneath inverted so
+  the character under it stays readable. DECTCEM is honoured (`CSI ?25l`
+  hides the caret and renders byte-identically to the pre-cursor frames,
+  `CSI ?25h` restores it), a block on a wide character covers both its
+  columns (#174/#176), and window focus loss switches the mark to a hollow
+  outline. `[cursor]` in `config.toml` selects
+  `shape = "block" | "bar" | "underline"` and an optional
+  `color = "#rrggbb"` override; no configuration is required for a caret.
+  Proven on real pixels by the cursor tests in
+  `crates/noren-app/tests/frame_oracle.rs` (drawn-by-default,
+  blank-screen caret, move-changes-pixels, wide-character coverage, DECTCEM
+  hide/restore, per-theme pixel contrast, hollow-vs-filled focus), and both
+  failure modes were mutation-tested before landing: never drawing the
+  cursor fails eight tests, and counting cells instead of display columns
+  after a wide character fails the coverage test. Deliberately absent:
+  blink — a blinking caret forces timer-driven repaints roughly twice a
+  second even while idle (this renderer rebuilds the full vertex list every
+  frame), which is a CPU/battery decision, not a visual one.
 
 It is still **not** the full workspace product that [ADR
 0003](adr/0003-noren-zellij-responsibility-boundary.md) describes — several
@@ -134,14 +157,6 @@ below, which remains the more useful list. Milestones 3–8 are open on the
 
 Each item states what you would actually see if you ran the build.
 
-- **There is no visible cursor.** The terminal state tracks a cursor position
-  and moves it correctly, but the render path never draws it: the
-  `glyph_vertices` function (`crates/noren-app/src/renderer.rs`) emits sidebar
-  rows, optional per-cell background rectangles, character bitmaps from
-  `display_cells`, and an optional status line — never a cursor — and the
-  word "cursor" does not appear anywhere in `renderer.rs`. In practice: you type, characters appear,
-  and nothing shows you where the insertion point is. This is the first thing
-  most people notice.
 - **Colours render through a selectable theme; the default palette now
   clears WCAG AA on every slot, with two residual caveats.** `[theme] name`
   in `config.toml` selects one of three built-in palettes — `dark` (the
@@ -447,7 +462,7 @@ rather than trusting a copy from elsewhere. Nothing here should be
 read as "nearly done": the honest summary is that the foundation is tested, a
 first workspace slice is now real and visible, and what stands between this and
 a usable daily terminal is not workspace plumbing but the display itself — a
-real font and a cursor (the default theme's palette cleared WCAG AA on every
-slot with issue #168). SGR colour is drawn through selectable
+real font (the caret now ships drawn, and the default theme's palette cleared
+WCAG AA on every slot with issue #168). SGR colour is drawn through selectable
 light/dark/high-contrast themes with verified contrast, but the built-in
 palettes are not yet a custom theming system.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -114,24 +114,31 @@ binary. What now actually happens on screen:
   `included_fifo_sources_return_promptly`).
 - **A visible cursor is drawn** (issues #197/#200; the first UI/UX
   evaluations ranked its absence at the top). The renderer draws the caret
-  at the position the terminal state already tracks: a focused block in the
-  active theme's cursor colour — each theme's default foreground, so the
-  caret inherits the measured default-pair WCAG contrast (dark 15.39:1,
-  light 14.56:1, high-contrast 21.0:1) — with the glyph beneath inverted so
-  the character under it stays readable. DECTCEM is honoured (`CSI ?25l`
-  hides the caret and renders byte-identically to the pre-cursor frames,
-  `CSI ?25h` restores it), a block on a wide character covers both its
+  at the position the terminal state already tracks. A focused block uses
+  inverse video against the cell it actually covers: resolved cell foreground
+  becomes the block, and resolved cell background becomes the glyph. An
+  unstyled cell therefore retains the active theme's measured cursor/default
+  pair (dark 15.39:1, light 14.56:1, high-contrast 21.0:1), while an SGR cell
+  is not compared against a background it does not have. If that pair falls
+  below 4.5:1, contrast-maximising black/white guarantees a usable cursor and
+  readable block glyph on any sRGB background. DECTCEM is honoured
+  (`CSI ?25l` hides the caret and renders byte-identically to the pre-cursor
+  frames, `CSI ?25h` restores it), a block on a wide character covers both its
   columns (#174/#176), and window focus loss switches the mark to a hollow
   outline. `[cursor]` in `config.toml` selects
   `shape = "block" | "bar" | "underline"` and an optional
-  `color = "#rrggbb"` override; no configuration is required for a caret.
+  `color = "#rrggbb"` preference; a preference is used when it clears 4.5:1
+  on the actual cell and otherwise falls back rather than erasing the caret.
+  No configuration is required for a cursor.
   Proven on real pixels by the cursor tests in
   `crates/noren-app/tests/frame_oracle.rs` (drawn-by-default,
   blank-screen caret, move-changes-pixels, wide-character coverage, DECTCEM
-  hide/restore, per-theme pixel contrast, hollow-vs-filled focus), and both
-  failure modes were mutation-tested before landing: never drawing the
-  cursor fails eight tests, and counting cells instead of display columns
-  after a wide character fails the coverage test. Deliberately absent:
+  hide/restore, per-theme pixel contrast, four SGR-background contrasts,
+  readable SGR glyph inversion, safe/unsafe override handling,
+  SGR-plus-DECTCEM, hollow-vs-filled focus), and both original failure modes
+  were mutation-tested before landing: never drawing the cursor fails the
+  cursor oracle suite, and counting cells instead of display columns after a
+  wide character fails the coverage test. Deliberately absent:
   blink — a blinking caret forces timer-driven repaints roughly twice a
   second even while idle (this renderer rebuilds the full vertex list every
   frame), which is a CPU/battery decision, not a visual one.


### PR DESCRIPTION
Closes **#197** and **#200**. Noren rendered **no cursor at all** — two independent UI/UX evaluations ranked this at the top: "every keystroke edits blind."

## The owner's two questions, answered

**Does a user who reads nothing get a good result?** Yes — the cursor is drawn by default. It is not opt-in, because a terminal you cannot see your caret in is not usable, and configurability is no substitute for a working default.

**Can a user who wants control get it without patching source?** Yes — a `[cursor]` config section sets shape and colour. Configuration changes *how* it looks; it never decides *whether* the product works.

## What it draws

- **Position** comes from `TerminalSnapshot::cursor()`'s tracked row/column — this was a rendering gap, not a state gap.
- **DECTCEM (`CSI ?25h/l`) is honoured.** Programs rely on it: vim hides the cursor during redraw, and a caret painted over a hidden state is worse than none. Visibility tracking was added to the terminal.
- **Colour comes from the theme**, inheriting #167's measured contrast: **15.39:1** on `dark`, **14.56:1** on `light`, **21.0:1** on `high-contrast`.
- **Wide characters are covered correctly** — a block cursor on a CJK character covers both cells, honouring the contract #174 pinned and #176 fixed.
- Unfocused windows draw a hollow outline that differs from focused, which I had not asked for and which matches what every other terminal does.

## Blink was declined, with a reason

Idle repaints would rebuild the vertex buffer continuously. A blinking caret is a battery and CPU decision, not a visual one, so it is not implemented and the reasoning is recorded rather than left implicit.

## Verified through real pixels

Disabling the cursor plan fails **four** frame-oracle tests:

```
blank_screen_draws_only_the_cursor                          FAILED
a_block_cursor_on_a_wide_character_covers_both_columns      FAILED
a_cursor_colour_override_replaces_only_the_caret_colour     FAILED
an_unfocused_cursor_is_a_hollow_outline_and_differs...      FAILED
```

A test asserting `cursor_visible == true` would have proved nothing about what is drawn.

Gates: `fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` **1,137 passing, 0 failed**.
