### PR TITLE
feat(app): make the palette discoverable and the empty state actionable (#191, #201)

### DIFF
--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -28,6 +28,11 @@
 //! `Super+Escape` exit leader) is [`ConfigError::UnclaimableChord`] rather
 //! than a silently dead binding.
 //!
+//! The `[ui]` table controls optional application chrome. The palette hint is
+//! visible by default so an unconfigured first run remains discoverable; the
+//! sole setting can turn that hint off, but configuration is never required
+//! to obtain the useful behavior.
+//!
 //! The `[theme]` table selects the built-in colour palette. It follows the
 //! same discipline: an absent table keeps `dark` — exactly the colours the
 //! app shipped with before themes existed — a non-string value is
@@ -233,6 +238,33 @@ impl KeymapConfig {
     }
 }
 
+/// Optional application-chrome settings.
+///
+/// The palette affordance defaults to visible. This is deliberately an
+/// opt-out rather than an opt-in: a user who never reads or creates a config
+/// file must still discover the command surface, while a user who prefers no
+/// persistent hint can remove it without patching the source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UiConfig {
+    show_palette_hint: bool,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            show_palette_hint: true,
+        }
+    }
+}
+
+impl UiConfig {
+    /// Whether the configured palette chord is shown in permanent chrome.
+    #[must_use]
+    pub const fn show_palette_hint(self) -> bool {
+        self.show_palette_hint
+    }
+}
+
 /// A default keymap chord constant; the values are printable characters and
 /// the Super modifier, which always normalize.
 fn default_chord(code: KeyCode, modifiers: Modifiers) -> Chord {
@@ -374,6 +406,7 @@ impl ProjectConfig {
 pub struct AppConfig {
     font: FontConfig,
     keys: KeymapConfig,
+    ui: UiConfig,
     theme: ThemeConfig,
     agents: Vec<AgentConfig>,
     projects: Vec<ProjectConfig>,
@@ -390,6 +423,12 @@ impl AppConfig {
     #[must_use]
     pub const fn keys(&self) -> KeymapConfig {
         self.keys
+    }
+
+    /// Optional application-chrome settings.
+    #[must_use]
+    pub const fn ui(&self) -> UiConfig {
+        self.ui
     }
 
     /// Colour theme settings.
@@ -467,6 +506,7 @@ impl AppConfig {
                     match key {
                         "font" => parse_font(table, &mut config.font)?,
                         "keys" => parse_keys(table, &mut config.keys)?,
+                        "ui" => parse_ui(table, &mut config.ui)?,
                         "theme" => parse_theme(table, &mut config.theme)?,
                         // `[terminal]` historically attracted a `scrollback_lines` key.
                         // The terminal foundation has no configurable retention cap yet,
@@ -634,6 +674,26 @@ fn integer_in_range(key: &str, item: &Item, min: usize, max: usize) -> Result<us
         .filter(|value| (min..=max).contains(value))
         .ok_or_else(|| ConfigError::OutOfRange { key: clip(key) })?;
     Ok(value)
+}
+
+/// Apply the `[ui]` table to application chrome.
+///
+/// The useful default is compiled in (`show_palette_hint = true`); this table
+/// exists only so a user who wants less chrome can explicitly turn it off.
+/// Wrong-typed values are rejected rather than silently preserving the
+/// default and pretending the override worked.
+fn parse_ui(table: &dyn TableLike, ui: &mut UiConfig) -> Result<(), ConfigError> {
+    for (key, item) in table.iter() {
+        match key {
+            "show_palette_hint" => {
+                ui.show_palette_hint = item
+                    .as_bool()
+                    .ok_or_else(|| ConfigError::UiNotABoolean { key: clip(key) })?;
+            }
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    Ok(())
 }
 
 /// Apply the `[theme]` table to the theme selection.
@@ -1154,6 +1214,8 @@ pub enum ConfigError {
     ChordNotAString { key: String },
     /// A `[theme]` value is not a TOML string.
     ThemeNotAString { key: String },
+    /// A `[ui]` value is not a TOML boolean.
+    UiNotABoolean { key: String },
     /// A `[theme]` name is not one of the built-in themes.
     ///
     /// **Echo allowlist** (issue #150): `value` carries the `[theme]` name
@@ -1270,6 +1332,10 @@ impl fmt::Display for ConfigError {
             Self::ThemeNotAString { key } => write!(
                 f,
                 "configuration key {key} must be a theme name string like \"light\""
+            ),
+            Self::UiNotABoolean { key } => write!(
+                f,
+                "configuration key {key} must be a boolean (true or false)"
             ),
             Self::UnknownTheme { value } => write!(
                 f,
@@ -1530,10 +1596,40 @@ mod tests {
                 "[terminal]\nscrollback_lines = 250\n",
                 ConfigError::UnknownKey("terminal".to_owned()),
             ),
+            (
+                "[ui]\nshow_palette_hint = \"no\"\n",
+                ConfigError::UiNotABoolean {
+                    key: "show_palette_hint".to_owned(),
+                },
+            ),
+            (
+                "[ui]\npalette_hint = false\n",
+                ConfigError::UnknownKey("palette_hint".to_owned()),
+            ),
         ];
         for (text, expected) in cases {
             assert_eq!(AppConfig::parse(text), Err(expected), "{text:?}");
         }
+    }
+
+    #[test]
+    fn palette_hint_is_visible_by_default_and_can_only_be_explicitly_hidden() {
+        assert!(
+            AppConfig::default().ui().show_palette_hint(),
+            "the discoverability hint must ship visible without configuration"
+        );
+        assert!(
+            AppConfig::parse("[ui]\nshow_palette_hint = true\n")
+                .expect("explicit visible setting is valid")
+                .ui()
+                .show_palette_hint()
+        );
+        assert!(
+            !AppConfig::parse("[ui]\nshow_palette_hint = false\n")
+                .expect("the power-user opt-out is valid")
+                .ui()
+                .show_palette_hint()
+        );
     }
 
     #[test]

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -22,6 +22,7 @@ pub mod session_supervisor;
 pub mod sidebar;
 pub mod ssh_config;
 pub mod theme;
+pub mod ui;
 
 pub use clipboard::{
     BRACKET_PASTE_BEGIN, BRACKET_PASTE_END, ClipboardError, PasteReject, SystemClipboard,

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -26,7 +26,7 @@ use noren_app::{
 use noren_app::{
     CursorKeyMode, GridGeometry, GridSize, InputMode, KeyEncoder, KeypadMode, Modifiers,
     PARSE_BUDGET_BYTES_PER_TURN, PRODUCT_NAME, PasteReject, Resize, SystemClipboard,
-    config::{AppConfig, KeymapConfig},
+    config::{AppConfig, KeymapConfig, UiConfig},
     diagnostics::{self, PtyChildStatus},
     encode_paste,
     git_worktree::{self, DiscoveredWorktree, WorktreeDiscovery, WorktreeListError},
@@ -53,7 +53,7 @@ use noren_pty::{
 use noren_terminal::{
     GridPoint, Selection, SelectionMode, TerminalEngine, TerminalError, TerminalState,
 };
-use renderer::{RenderOutcome, Renderer};
+use renderer::{FrameChrome, RenderOutcome, Renderer};
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
@@ -1193,6 +1193,9 @@ struct NorenApp {
     /// commands. The single source of truth for every workspace chord the
     /// binary honors; no hard-coded chord remains on the key paths.
     keys: KeymapConfig,
+    /// Optional application chrome. Its default keeps the palette affordance
+    /// visible; the validated config can explicitly remove that one hint.
+    ui: UiConfig,
     /// The configured colour theme, handed to the renderer at creation so
     /// every palette-derived draw colour — default foreground, ANSI
     /// resolution, clear colour — follows the `[theme]` selection. The
@@ -1320,6 +1323,7 @@ impl NorenApp {
             passthrough_gate: PassthroughGate::new(),
             passthrough_policy: palette_policy(config.keys()),
             keys: config.keys(),
+            ui: config.ui(),
             theme: config.theme().palette(),
         }
     }
@@ -2287,6 +2291,13 @@ impl NorenApp {
     /// same encoder path as before the gate existed, so a closed-palette key
     /// press is byte-identical to the pre-gate behaviour.
     fn handle_passthrough_key(&mut self, event: &KeyEvent) {
+        if event.state == ElementState::Pressed
+            && !event.repeat
+            && let Some(chord) = chord_from_event(event, self.modifiers)
+            && self.recover_empty_workspace_with_chord(chord)
+        {
+            return;
+        }
         let input_mode = self.current_input_mode();
         let encoded = if let Some(input) = translate_keypad_key(event) {
             KeyEncoder::encode_keypad_with(input.with_modifiers(self.modifiers), input_mode)
@@ -2304,6 +2315,21 @@ impl NorenApp {
             return;
         };
         self.send_input(&bytes);
+    }
+
+    /// Honor the configured create-session chord directly at the dead end.
+    ///
+    /// Outside an empty workspace the chord keeps its existing scope inside
+    /// the open palette, so ordinary terminal input is unchanged. When the UI
+    /// says `No sessions`, no PTY can receive the key; consuming the exact
+    /// chord shown by [`noren_app::ui::empty_workspace_recovery`] turns that
+    /// inert state into a real recovery action.
+    fn recover_empty_workspace_with_chord(&mut self, chord: Chord) -> bool {
+        if !self.workspace.sidebar().is_empty() || chord != self.keys.session_create() {
+            return false;
+        }
+        self.run_workspace_action(WorkspaceAction::CreateSession);
+        true
     }
 
     /// Route one pressed chord through the gate.
@@ -3321,10 +3347,21 @@ impl NorenApp {
                 self.ssh_diagnostic.as_deref(),
             )
         });
+        // A one-row window deliberately gives its only row to the PTY; keep
+        // the hint on the same status-row presence decision so rendering,
+        // terminal sizing, and pointer mapping cannot disagree there.
+        let palette_hint = status
+            .as_ref()
+            .and_then(|_| noren_app::ui::palette_hint(self.keys, self.ui));
+        let workspace_notice = (self.workspace.sidebar().is_empty() && self.terminal.is_none())
+            .then(|| noren_app::ui::empty_workspace_recovery(self.keys));
+        let chrome = FrameChrome::new(Some(&lines), status)
+            .with_palette_hint(palette_hint.as_deref())
+            .with_workspace_notice(workspace_notice.as_deref());
         let outcome = self
             .renderer
             .as_mut()
-            .map(|renderer| renderer.render(snapshot.as_ref(), Some(&lines), status));
+            .map(|renderer| renderer.render(snapshot.as_ref(), chrome));
         match outcome {
             Some(RenderOutcome::DeviceLost) => {
                 self.status = "Noren renderer device lost";

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -811,6 +811,55 @@ fn palette_close_reaps_the_live_owner_and_falls_back_to_an_empty_view() {
     assert!(app.show_status, "an empty workspace must say so honestly");
 }
 
+/// Issue #201: the action displayed beside `No sessions` is live, follows the
+/// configured create binding, and creates a real PTY-backed session. Removing
+/// the empty-workspace intercept leaves both tested chords inert and fails the
+/// final state assertions.
+#[test]
+fn empty_workspace_recovery_chord_creates_a_real_session() {
+    let home = AppTestHome::new();
+    let config =
+        AppConfig::parse("[keys]\nsession_create = \"n\"\n").expect("valid create-session rebind");
+    let mut app = NorenApp {
+        test_pty_home: Some(home.0.clone()),
+        ..NorenApp::new(config)
+    };
+    assert!(app.workspace.sidebar().is_empty());
+
+    assert!(
+        !app.recover_empty_workspace_with_chord(gate_chord(
+            GateKeyCode::Char('c'),
+            GateModifiers::empty()
+        )),
+        "the old create chord must not claim the empty state after rebinding"
+    );
+    assert!(app.workspace.registry().is_empty());
+
+    assert!(
+        app.recover_empty_workspace_with_chord(gate_chord(
+            GateKeyCode::Char('n'),
+            GateModifiers::empty()
+        )),
+        "the configured recovery chord must be consumed"
+    );
+    assert_eq!(app.workspace.registry().len(), 1);
+    assert!(!app.workspace.sidebar().is_empty());
+    assert!(app.pty.is_some() && app.terminal.is_some());
+    assert!(app.active_session.is_some());
+    assert!(
+        !app.recover_empty_workspace_with_chord(gate_chord(
+            GateKeyCode::Char('n'),
+            GateModifiers::empty()
+        )),
+        "once a session exists the chord returns to palette-only scope"
+    );
+    assert_eq!(
+        app.workspace.registry().len(),
+        1,
+        "the recovery intercept must not steal the create chord in a live workspace"
+    );
+}
+
 /// Escape dismisses the palette without running a command.
 #[test]
 fn escape_dismisses_palette_without_running_a_command() {

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -294,6 +294,53 @@ pub(crate) enum RenderOutcome {
     DeviceLost,
 }
 
+/// Application-owned chrome drawn around terminal cells for one frame.
+///
+/// The palette affordance travels separately from runtime status text so the
+/// renderer can keep it first in the permanent terminal-side status row. That
+/// ordering is load-bearing: a long diagnostic may be clipped by a narrow
+/// window, but it must never make the command surface undiscoverable.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct FrameChrome<'a> {
+    sidebar: Option<&'a [String]>,
+    status: Option<&'a str>,
+    palette_hint: Option<&'a str>,
+    workspace_notice: Option<&'a [String]>,
+}
+
+impl<'a> FrameChrome<'a> {
+    pub(crate) const fn new(sidebar: Option<&'a [String]>, status: Option<&'a str>) -> Self {
+        Self {
+            sidebar,
+            status,
+            palette_hint: None,
+            workspace_notice: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn with_palette_hint(mut self, hint: Option<&'a str>) -> Self {
+        self.palette_hint = hint;
+        self
+    }
+
+    /// Add terminal-side application copy shown in place of absent content.
+    #[must_use]
+    pub(crate) const fn with_workspace_notice(mut self, lines: Option<&'a [String]>) -> Self {
+        self.workspace_notice = lines;
+        self
+    }
+
+    fn status_line(self) -> Option<String> {
+        match (self.palette_hint, self.status) {
+            (None, None) => None,
+            (Some(hint), None) => Some(hint.to_owned()),
+            (None, Some(status)) => Some(status.to_owned()),
+            (Some(hint), Some(status)) => Some(format!("{hint} | {status}")),
+        }
+    }
+}
+
 pub(crate) struct Renderer {
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
@@ -418,8 +465,7 @@ impl Renderer {
     pub(crate) fn render(
         &mut self,
         terminal: Option<&TerminalSnapshot>,
-        sidebar: Option<&[String]>,
-        status: Option<&str>,
+        chrome: FrameChrome<'_>,
     ) -> RenderOutcome {
         if self.device_lost.load(Ordering::Acquire) {
             return RenderOutcome::DeviceLost;
@@ -431,7 +477,7 @@ impl Renderer {
             self.config.height,
             self.metrics,
         );
-        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
+        let vertices = glyph_vertices_for_chrome(target, terminal, chrome);
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
         if required > self.vertex_capacity {
@@ -531,6 +577,10 @@ fn block_on<F: Future>(future: F) -> F::Output {
 /// resolution, the sidebar/status default foreground, the clear colour the
 /// caller loads — reads from the target's theme, which is how a configured
 /// theme changes what is drawn.
+// Re-included directly by the frame oracle and benchmark. The live binary
+// uses the richer `glyph_vertices_for_chrome` seam below, so this compatibility
+// entry point is intentionally dead only in that one compilation target.
+#[allow(dead_code)]
 pub(crate) fn glyph_vertices_for(
     target: Target,
     terminal: Option<&TerminalSnapshot>,
@@ -540,15 +590,45 @@ pub(crate) fn glyph_vertices_for(
     glyph_vertices_with_budget(target, terminal, sidebar, status, MAX_VERTICES)
 }
 
+/// Emit a frame through the live application's complete chrome path.
+///
+/// Unlike [`glyph_vertices_for`], which preserves the historical terminal /
+/// sidebar / status seam for focused tests and benches, this entry point also
+/// renders the configured palette affordance. The window renderer and the
+/// frame oracle both call this function, so the oracle observes the same
+/// placement and clipping behavior users see.
+pub(crate) fn glyph_vertices_for_chrome(
+    target: Target,
+    terminal: Option<&TerminalSnapshot>,
+    chrome: FrameChrome<'_>,
+) -> Vec<Vertex> {
+    glyph_vertices_with_chrome_budget(target, terminal, chrome, MAX_VERTICES)
+}
+
 /// Internal seam for exercising the production vertex-budget backstop without
 /// allocating a clamp-sized frame. The shipped path above always supplies
 /// [`MAX_VERTICES`]; tests use a smaller budget but traverse this same emission
 /// code and the same post-primitive guards.
+#[allow(dead_code)]
 fn glyph_vertices_with_budget(
     target: Target,
     terminal: Option<&TerminalSnapshot>,
     sidebar: Option<&[String]>,
     status: Option<&str>,
+    vertex_budget: usize,
+) -> Vec<Vertex> {
+    glyph_vertices_with_chrome_budget(
+        target,
+        terminal,
+        FrameChrome::new(sidebar, status),
+        vertex_budget,
+    )
+}
+
+fn glyph_vertices_with_chrome_budget(
+    target: Target,
+    terminal: Option<&TerminalSnapshot>,
+    chrome: FrameChrome<'_>,
     vertex_budget: usize,
 ) -> Vec<Vertex> {
     let (width, height, metrics, theme) =
@@ -560,6 +640,9 @@ fn glyph_vertices_with_budget(
     let cell_height = metrics.height();
     let window_cols = usize::try_from(width / cell_width).unwrap_or(usize::MAX);
 
+    let sidebar = chrome.sidebar;
+    let status = chrome.status_line();
+    let workspace_notice = chrome.workspace_notice;
     let has_sidebar = sidebar.is_some();
     let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
     // Reserve the sidebar, then clamp the terminal to the renderer's drawable
@@ -588,7 +671,8 @@ fn glyph_vertices_with_budget(
     let rows: Vec<&[noren_terminal::Cell]> = terminal
         .map(|snapshot| snapshot.display_cells().collect())
         .unwrap_or_default();
-    let layout = FrameRowLayout::new(height, metrics, rows.len(), status.is_some())
+    let content_rows = rows.len().max(workspace_notice.map_or(0, <[String]>::len));
+    let layout = FrameRowLayout::new(height, metrics, content_rows, status.is_some())
         .expect("non-zero frame height has a row layout");
     let mut vertices = Vec::new();
 
@@ -625,36 +709,50 @@ fn glyph_vertices_with_budget(
             .expect("rendered row count only includes owned rows")
         {
             FrameRow::Terminal(line_index) => {
-                let cells = rows
-                    .get(line_index)
-                    .expect("terminal layout only names display rows");
-                for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
-                    if let Some(color) = resolve_background(&theme, cell.attributes()) {
-                        push_rect(
-                            &mut vertices,
-                            u32::try_from(col_offset + col).unwrap_or(u32::MAX) * cell_width,
-                            u32::try_from(row).unwrap_or(u32::MAX) * cell_height,
-                            cell_width,
-                            cell_height,
-                            color,
-                            target,
-                        );
+                if let Some(cells) = rows.get(line_index) {
+                    for (col, cell) in cells.iter().take(terminal_cols).enumerate() {
+                        if let Some(color) = resolve_background(&theme, cell.attributes()) {
+                            push_rect(
+                                &mut vertices,
+                                u32::try_from(col_offset + col).unwrap_or(u32::MAX) * cell_width,
+                                u32::try_from(row).unwrap_or(u32::MAX) * cell_height,
+                                cell_width,
+                                cell_height,
+                                color,
+                                target,
+                            );
+                        }
+                        if vertices.len() >= vertex_budget {
+                            return vertices;
+                        }
+                        // A continuation cell draws no glyph but still owns
+                        // its column, exactly as the placeholder space did in
+                        // `display_lines`.
+                        if cell.is_continuation() {
+                            continue;
+                        }
+                        let color = resolve_foreground(&theme, cell.attributes());
+                        for character in cell.text().chars() {
+                            push_glyph(
+                                &mut vertices,
+                                character,
+                                color,
+                                col_offset + col,
+                                row,
+                                target,
+                            );
+                            if vertices.len() >= vertex_budget {
+                                return vertices;
+                            }
+                        }
                     }
-                    if vertices.len() >= vertex_budget {
-                        return vertices;
-                    }
-                    // A continuation cell draws no glyph but still owns its
-                    // column, exactly as the placeholder space did in
-                    // `display_lines`.
-                    if cell.is_continuation() {
-                        continue;
-                    }
-                    let color = resolve_foreground(&theme, cell.attributes());
-                    for character in cell.text().chars() {
+                }
+                if let Some(line) = workspace_notice.and_then(|lines| lines.get(line_index)) {
+                    for (col, character) in line.chars().take(terminal_cols).enumerate() {
                         push_glyph(
                             &mut vertices,
                             character,
-                            color,
+                            theme.foreground(),
                             col_offset + col,
                             row,
                             target,
@@ -668,6 +766,7 @@ fn glyph_vertices_with_budget(
             FrameRow::Status => {
                 // The status line is renderer chrome with no cell backing.
                 for (col, character) in status
+                    .as_deref()
                     .unwrap_or_default()
                     .chars()
                     .take(terminal_cols)
@@ -1283,7 +1382,9 @@ fn glyph_rows(character: char) -> [u8; 7] {
 mod tests {
     use super::*;
     use noren_app::GridGeometry;
+    use noren_app::config::AppConfig;
     use noren_app::theme::DARK;
+    use noren_app::ui::palette_hint;
     use noren_terminal::TerminalState;
 
     /// Default-theme vertex emission for test call sites: the shape the
@@ -1313,6 +1414,48 @@ mod tests {
     /// The PoC default cell metrics for tests that exercise the default path.
     fn poc_metrics() -> CellMetrics {
         GridGeometry::poc().cell_metrics()
+    }
+
+    /// Deterministic companion to the GPU frame oracle: configured chrome
+    /// must reach the production vertex path even on runners where Metal is
+    /// unavailable and the read-back test has to report a skip.
+    #[test]
+    fn configured_palette_hint_reaches_production_vertices() {
+        let metrics = poc_metrics();
+        let target = Target::new(
+            &Theme::default(),
+            (SIDEBAR_COLS as u32 + 48) * metrics.width(),
+            metrics.height(),
+            metrics,
+        );
+        let render = |config: &AppConfig| {
+            let hint = palette_hint(config.keys(), config.ui());
+            glyph_vertices_for_chrome(
+                target,
+                None,
+                FrameChrome::new(Some(&[]), None).with_palette_hint(hint.as_deref()),
+            )
+        };
+
+        let default_vertices = render(&AppConfig::default());
+        let rebound =
+            AppConfig::parse("[keys]\npalette_open = \"super+k\"\n").expect("valid palette rebind");
+        let rebound_vertices = render(&rebound);
+        let hidden = AppConfig::parse("[ui]\nshow_palette_hint = false\n")
+            .expect("valid palette-hint opt-out");
+
+        assert!(
+            !default_vertices.is_empty(),
+            "default chrome must emit the visible palette affordance"
+        );
+        assert!(
+            default_vertices != rebound_vertices,
+            "rebinding palette_open must change production chrome geometry"
+        );
+        assert!(
+            render(&hidden).is_empty(),
+            "the explicit UI opt-out must emit no affordance vertices"
+        );
     }
 
     /// The dark theme's clear colour is the exact historical constant — f64

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -50,8 +50,8 @@ use std::thread;
 
 use noren_terminal::TerminalSnapshot;
 use renderer_source::{
-    SHADER, Target, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices_for, theme_clear_color,
-    vertex_bytes,
+    FrameChrome, SHADER, Target, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices_for_chrome,
+    theme_clear_color, vertex_bytes,
 };
 
 /// Linear RGBA8 (non-sRGB) offscreen target.
@@ -254,12 +254,26 @@ impl OffscreenRenderer {
         sidebar: Option<&[String]>,
         status: Option<&str>,
     ) -> CapturedFrame {
+        self.capture_chrome(target, terminal, FrameChrome::new(sidebar, status))
+    }
+
+    /// Render through the same complete chrome seam as the live window.
+    ///
+    /// Palette-hint tests use this path so their assertions are on read-back
+    /// pixels emitted by production vertex generation, not on configuration
+    /// values or pre-rendered strings.
+    pub(crate) fn capture_chrome(
+        &self,
+        target: Target,
+        terminal: Option<&TerminalSnapshot>,
+        chrome: FrameChrome<'_>,
+    ) -> CapturedFrame {
         assert!(
             target.width > 0 && target.height > 0,
             "capture target must be non-zero"
         );
 
-        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
+        let vertices = glyph_vertices_for_chrome(target, terminal, chrome);
         let bytes = vertex_bytes(&vertices);
         let (width, height) = (target.width, target.height);
 

--- a/crates/noren-app/src/ui.rs
+++ b/crates/noren-app/src/ui.rs
@@ -1,0 +1,118 @@
+//! Pure presentation text derived from validated application configuration.
+//!
+//! These helpers are shared by the live app and the rendered-frame oracle.
+//! Keeping chord presentation here means application chrome cannot drift from
+//! the [`KeymapConfig`](crate::config::KeymapConfig) the input path honors.
+
+use crate::config::{KeymapConfig, UiConfig};
+use crate::passthrough::{Chord, KeyCode};
+
+/// Build the persistent command-palette affordance from the active keymap.
+///
+/// `None` is returned only for the explicit `[ui] show_palette_hint = false`
+/// override. The default config therefore always yields a visible hint.
+#[must_use]
+pub fn palette_hint(keys: KeymapConfig, ui: UiConfig) -> Option<String> {
+    ui.show_palette_hint()
+        .then(|| format!("{} Commands", chord_label(keys.palette_open())))
+}
+
+/// Terminal-side copy for an empty workspace's direct recovery action.
+///
+/// The fixed 16-column sidebar keeps the compact `No sessions` locator. The
+/// otherwise blank terminal area has enough room to name the configured
+/// create-session chord without truncating ordinary bindings, and the input
+/// path honors this chord directly while the workspace is empty.
+#[must_use]
+pub fn empty_workspace_recovery(keys: KeymapConfig) -> Vec<String> {
+    vec![
+        "No sessions yet".to_owned(),
+        format!(
+            "Press {} to create a session",
+            chord_label(keys.session_create())
+        ),
+    ]
+}
+
+/// Human-readable text for one normalized configured chord.
+///
+/// This is intentionally generated from [`Chord`] rather than copied from a
+/// default string: rebinding an action changes both input dispatch and every
+/// UI label that describes it. ASCII words are used because the current
+/// bitmap renderer cannot draw the macOS Command glyph faithfully.
+#[must_use]
+pub fn chord_label(chord: Chord) -> String {
+    let modifiers = chord.modifiers();
+    let mut parts: Vec<String> = Vec::new();
+    if modifiers.is_ctrl() {
+        parts.push("Ctrl".to_owned());
+    }
+    if modifiers.is_alt() {
+        parts.push("Alt".to_owned());
+    }
+    if modifiers.is_shift() {
+        parts.push("Shift".to_owned());
+    }
+    if modifiers.is_super() {
+        parts.push("Super".to_owned());
+    }
+    parts.push(match chord.code() {
+        KeyCode::Char(character) => character.to_ascii_uppercase().to_string(),
+        KeyCode::Function(number) => format!("F{number}"),
+        KeyCode::Enter => "Enter".to_owned(),
+        KeyCode::Tab => "Tab".to_owned(),
+        KeyCode::Backspace => "Backspace".to_owned(),
+        KeyCode::Escape => "Escape".to_owned(),
+        KeyCode::Space => "Space".to_owned(),
+        KeyCode::Up => "Up".to_owned(),
+        KeyCode::Down => "Down".to_owned(),
+        KeyCode::Left => "Left".to_owned(),
+        KeyCode::Right => "Right".to_owned(),
+        KeyCode::Home => "Home".to_owned(),
+        KeyCode::End => "End".to_owned(),
+        KeyCode::PageUp => "PageUp".to_owned(),
+        KeyCode::PageDown => "PageDown".to_owned(),
+        KeyCode::Insert => "Insert".to_owned(),
+        KeyCode::Delete => "Delete".to_owned(),
+    });
+    parts.join("+")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+
+    #[test]
+    fn palette_hint_is_default_on_and_follows_the_active_keymap() {
+        let default = AppConfig::default();
+        assert_eq!(
+            palette_hint(default.keys(), default.ui()).as_deref(),
+            Some("Super+P Commands")
+        );
+
+        let rebound = AppConfig::parse("[keys]\npalette_open = \"ctrl+shift+k\"\n")
+            .expect("valid rebound keymap");
+        assert_eq!(
+            palette_hint(rebound.keys(), rebound.ui()).as_deref(),
+            Some("Ctrl+Shift+K Commands")
+        );
+    }
+
+    #[test]
+    fn explicit_ui_override_removes_the_palette_hint() {
+        let config = AppConfig::parse("[ui]\nshow_palette_hint = false\n")
+            .expect("valid palette-hint opt-out");
+        assert_eq!(palette_hint(config.keys(), config.ui()), None);
+    }
+
+    #[test]
+    fn empty_workspace_recovery_follows_the_configured_create_chord() {
+        let rebound = AppConfig::parse("[keys]\nsession_create = \"ctrl+n\"\n")
+            .expect("valid create-session rebind");
+        assert_eq!(
+            empty_workspace_recovery(rebound.keys()),
+            ["No sessions yet", "Press Ctrl+N to create a session"]
+        );
+    }
+}

--- a/crates/noren-app/tests/error_echo_contract.rs
+++ b/crates/noren-app/tests/error_echo_contract.rs
@@ -57,7 +57,7 @@ enum ValueEcho {
 
 /// Pinned variant count of [`ConfigError`]; a new variant must extend both
 /// the classifier and the sample table.
-const CONFIG_ERROR_VARIANTS: usize = 26;
+const CONFIG_ERROR_VARIANTS: usize = 27;
 /// Pinned variant count of [`SessionPersistenceError`].
 const SESSION_ERROR_VARIANTS: usize = 14;
 /// Pinned variant count of [`ChordParseError`].
@@ -96,6 +96,7 @@ fn classify_config(error: &ConfigError) -> ValueEcho {
         ConfigError::OutOfRange { .. } => ValueEcho::Never,
         ConfigError::ChordNotAString { .. } => ValueEcho::Never,
         ConfigError::ThemeNotAString { .. } => ValueEcho::Never,
+        ConfigError::UiNotABoolean { .. } => ValueEcho::Never,
         // Allowlist: the theme name vocabulary — a closed set the schema
         // publishes — and naming the failed value is the point of the
         // error, exactly the `[keys]` chord argument.
@@ -252,6 +253,7 @@ fn config_samples() -> Vec<(ConfigError, ValueEcho)> {
             ConfigError::ThemeNotAString { key: key() },
             ValueEcho::Never,
         ),
+        (ConfigError::UiNotABoolean { key: key() }, ValueEcho::Never),
         (
             ConfigError::UnknownTheme {
                 value: VALUE_SENTINEL.to_owned(),
@@ -648,6 +650,7 @@ fn config_values_outside_keys_never_reach_display_or_debug() {
     let cases = [
         format!("[font]\ncell_width = \"{SENTINEL}\"\n"),
         format!("[keys]\nsession_create = {SENTINEL}\n"),
+        format!("[ui]\nshow_palette_hint = \"{SENTINEL}\"\n"),
         // `[[agents]]` values: the command is agent-launch text (may embed a
         // private path), so its rejections name the key, never the text.
         format!("[[agents]]\nname = \"x\"\ncommand = \"{SENTINEL}\"\n"),

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -33,6 +33,12 @@
 //!   pair lands at its display column — the width contract whose loss corrupts
 //!   the rest of the line;
 //! - a combining mark is drawn over its base cell without consuming a cell.
+//! - the default palette affordance is drawn in permanent terminal-side
+//!   chrome, rebinding `palette_open` changes the captured key glyph, and the
+//!   explicit UI opt-out removes those pixels (issue #191);
+//! - after the last session closes, recovery copy and its active create chord
+//!   draw in the otherwise blank terminal area, with status chrome following
+//!   the recovery rows instead of overwriting them (issue #201).
 //!
 //! ## The lit/blank gate
 //!
@@ -75,17 +81,18 @@
 #[path = "../src/renderer_capture.rs"]
 mod renderer_capture;
 
-use std::fs;
 use std::io::Write;
 use std::process::Command;
 
+use noren_app::config::AppConfig;
 use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
+use noren_app::ui::{empty_workspace_recovery, palette_hint};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
-use renderer_capture::renderer_source::{CLEAR_COLOR, SIDEBAR_COLS, Target};
+use renderer_capture::renderer_source::{CLEAR_COLOR, FrameChrome, SIDEBAR_COLS, Target};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// The PoC default cell metrics, used by every frame-oracle capture call so
@@ -306,15 +313,15 @@ fn report_skip(test: &str) {
          AdapterUnavailable); rendered-frame evidence was NOT gathered. This is a \
          skip, not a pass."
     );
-    match fs::OpenOptions::new().write(true).open("/dev/stderr") {
-        Ok(mut file) => {
-            // One write, notice and newline together: 24 tests skip in
-            // parallel on an adapter-less machine, and two separate writes
-            // interleave into concatenated lines under the pipe buffer.
-            let _ = file.write_all(format!("{notice}\n").as_bytes());
-        }
-        Err(_) => eprintln!("{notice}"),
-    }
+    // Write the process's inherited stderr handle directly. Opening
+    // `/dev/stderr` can resolve to the controlling terminal instead of the
+    // child's piped fd on macOS, which makes `Command::output` observe an
+    // empty stream and defeats the visibility guard below. A direct `Write`
+    // bypasses libtest's print-macro capture while preserving the actual fd.
+    // One write, notice and newline together, also prevents parallel skips
+    // from interleaving into concatenated lines under the pipe buffer.
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(format!("{notice}\n").as_bytes());
 }
 
 /// The offscreen renderer, or `None` after reporting a skip, when this machine
@@ -1433,6 +1440,172 @@ fn utf8_cell_is_at_least_lit_so_the_pipeline_handles_wide_input() {
     let frame = render(&renderer, &snap);
     // c, a, f are ASCII and lit; the final cell holds the non-ASCII 'é' lead.
     assert!(cell_is_lit(&frame, 0, 3), "non-ASCII cell drew nothing");
+}
+
+// ===========================================================================
+// Palette discoverability (issue #191): the configured opener is permanent
+// terminal-side chrome. These assertions parse real AppConfig, derive the
+// label from its active KeymapConfig, run the production chrome vertex path,
+// and inspect read-back pixels. A string-only assertion cannot satisfy this
+// contract: deleting the draw path must make these tests fail.
+// ===========================================================================
+
+/// Render only the palette affordance, with a blank 16-column sidebar and
+/// enough terminal-side width for every ordinary configured chord.
+fn render_palette_hint(
+    renderer: &OffscreenRenderer,
+    config: &AppConfig,
+    status: Option<&str>,
+) -> CapturedFrame {
+    const TERMINAL_COLS: u32 = 48;
+    let hint = palette_hint(config.keys(), config.ui());
+    let empty_sidebar: &[String] = &[];
+    let chrome = FrameChrome::new(Some(empty_sidebar), status).with_palette_hint(hint.as_deref());
+    renderer.capture_chrome(
+        Target::new(
+            &config.theme().palette(),
+            (SIDEBAR_COLS as u32 + TERMINAL_COLS) * CELL_WIDTH,
+            CELL_HEIGHT,
+            poc_metrics(),
+        ),
+        None,
+        chrome,
+    )
+}
+
+#[test]
+fn palette_hint_default_and_rebind_are_drawn_in_frame_pixels() {
+    let Some(renderer) =
+        renderer_or_skip("palette_hint_default_and_rebind_are_drawn_in_frame_pixels")
+    else {
+        return;
+    };
+
+    let default_frame = render_palette_hint(&renderer, &AppConfig::default(), Some("Noren ready"));
+    let rebound = AppConfig::parse("[keys]\npalette_open = \"super+k\"\n")
+        .expect("super+k is a valid palette rebind");
+    let rebound_frame = render_palette_hint(&renderer, &rebound, Some("Noren ready"));
+
+    // Both labels begin `Super+`; the configured key is the seventh glyph.
+    // Compare that cell against independently rendered P/K glyph pixels so a
+    // hard-coded default cannot satisfy the rebound half of the assertion.
+    let configured_key_col = SIDEBAR_COLS as u32 + 6;
+    let p_reference = render(&renderer, &snapshot(1, 1, b"P"));
+    let k_reference = render(&renderer, &snapshot(1, 1, b"K"));
+    let default_key_pixels = cell_pattern(&default_frame, 0, configured_key_col);
+    let rebound_key_pixels = cell_pattern(&rebound_frame, 0, configured_key_col);
+
+    assert_eq!(
+        default_key_pixels,
+        cell_pattern(&p_reference, 0, 0),
+        "default chrome must draw the configured P key in real pixels"
+    );
+    assert_eq!(
+        rebound_key_pixels,
+        cell_pattern(&k_reference, 0, 0),
+        "rebinding palette_open to Super+K must draw K, not stale P, in real pixels"
+    );
+    assert_ne!(
+        default_key_pixels, rebound_key_pixels,
+        "the rebound opener did not change the captured frame"
+    );
+    assert!(
+        cell_is_lit(&default_frame, 0, SIDEBAR_COLS as u32),
+        "the default-on palette hint drew no first glyph in the terminal-side status row"
+    );
+    assert!(
+        !cell_is_lit(&default_frame, 0, 0),
+        "the affordance must not consume the narrow sidebar's first column"
+    );
+}
+
+#[test]
+fn palette_hint_opt_out_removes_its_frame_pixels() {
+    let Some(renderer) = renderer_or_skip("palette_hint_opt_out_removes_its_frame_pixels") else {
+        return;
+    };
+    let hidden = AppConfig::parse("[ui]\nshow_palette_hint = false\n")
+        .expect("the palette-hint opt-out is valid");
+    let frame = render_palette_hint(&renderer, &hidden, None);
+
+    assert!(
+        frame
+            .rgba
+            .chunks_exact(4)
+            .all(|pixel| is_clear([pixel[0], pixel[1], pixel[2], pixel[3]])),
+        "show_palette_hint=false must remove every affordance pixel"
+    );
+}
+
+/// Render the exact chrome the live app supplies after its last session is
+/// closed: the compact sidebar locator, terminal-side recovery copy, and the
+/// permanent palette affordance plus runtime status.
+fn render_empty_workspace(renderer: &OffscreenRenderer, config: &AppConfig) -> CapturedFrame {
+    const TERMINAL_COLS: u32 = 48;
+    const FRAME_ROWS: u32 = 4;
+    let sidebar = vec!["No sessions".to_owned()];
+    let recovery = empty_workspace_recovery(config.keys());
+    let hint = palette_hint(config.keys(), config.ui());
+    let chrome = FrameChrome::new(Some(&sidebar), Some("Noren last session closed"))
+        .with_palette_hint(hint.as_deref())
+        .with_workspace_notice(Some(&recovery));
+    renderer.capture_chrome(
+        Target::new(
+            &config.theme().palette(),
+            (SIDEBAR_COLS as u32 + TERMINAL_COLS) * CELL_WIDTH,
+            FRAME_ROWS * CELL_HEIGHT,
+            poc_metrics(),
+        ),
+        None,
+        chrome,
+    )
+}
+
+#[test]
+fn empty_workspace_recovery_action_is_drawn_in_terminal_frame_pixels() {
+    let Some(renderer) =
+        renderer_or_skip("empty_workspace_recovery_action_is_drawn_in_terminal_frame_pixels")
+    else {
+        return;
+    };
+    let default_frame = render_empty_workspace(&renderer, &AppConfig::default());
+    let rebound = AppConfig::parse("[keys]\nsession_create = \"n\"\n")
+        .expect("n is a valid create-session rebind");
+    let rebound_frame = render_empty_workspace(&renderer, &rebound);
+
+    let c_reference = render(&renderer, &snapshot(1, 1, b"C"));
+    let n_reference = render(&renderer, &snapshot(1, 1, b"N"));
+    let p_reference = render(&renderer, &snapshot(1, 1, b"P"));
+    let action_key_col = SIDEBAR_COLS as u32 + 6; // `Press ` then the key.
+
+    assert!(
+        cell_is_lit(&default_frame, 0, 0),
+        "the 16-column sidebar must retain its compact No sessions locator"
+    );
+    assert!(
+        cell_is_lit(&default_frame, 0, SIDEBAR_COLS as u32),
+        "the otherwise blank terminal area must draw No sessions yet"
+    );
+    assert_eq!(
+        cell_pattern(&default_frame, 1, action_key_col),
+        cell_pattern(&c_reference, 0, 0),
+        "the default direct recovery action must draw C in real pixels"
+    );
+    assert_eq!(
+        cell_pattern(&rebound_frame, 1, action_key_col),
+        cell_pattern(&n_reference, 0, 0),
+        "rebinding session_create must change the recovery action to N pixels"
+    );
+    assert_ne!(
+        cell_pattern(&default_frame, 1, action_key_col),
+        cell_pattern(&rebound_frame, 1, action_key_col),
+        "the recovery action stayed stale after rebinding"
+    );
+    assert_eq!(
+        cell_pattern(&default_frame, 2, SIDEBAR_COLS as u32 + 6),
+        cell_pattern(&p_reference, 0, 0),
+        "two recovery rows must be followed by the configured palette hint in status chrome"
+    );
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -2208,8 +2208,11 @@ fn palette_hint_default_and_rebind_are_drawn_in_frame_pixels() {
     // Compare that cell against independently rendered P/K glyph pixels so a
     // hard-coded default cannot satisfy the rebound half of the assertion.
     let configured_key_col = SIDEBAR_COLS as u32 + 6;
-    let p_reference = render(&renderer, &snapshot(1, 1, b"P"));
-    let k_reference = render(&renderer, &snapshot(1, 1, b"K"));
+    // A one-column terminal leaves delayed autowrap armed with the cursor on
+    // the glyph cell. Hide that cursor so these controls measure the ordinary
+    // P/K glyph masks, not #206's inverse-video caret over those glyphs.
+    let p_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lP"));
+    let k_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lK"));
     let default_key_pixels = cell_pattern(&default_frame, 0, configured_key_col);
     let rebound_key_pixels = cell_pattern(&rebound_frame, 0, configured_key_col);
 
@@ -2291,9 +2294,12 @@ fn empty_workspace_recovery_action_is_drawn_in_terminal_frame_pixels() {
         .expect("n is a valid create-session rebind");
     let rebound_frame = render_empty_workspace(&renderer, &rebound);
 
-    let c_reference = render(&renderer, &snapshot(1, 1, b"C"));
-    let n_reference = render(&renderer, &snapshot(1, 1, b"N"));
-    let p_reference = render(&renderer, &snapshot(1, 1, b"P"));
+    // These are ordinary-glyph controls for cursor-free application chrome.
+    // On a one-column terminal the delayed-wrap cursor occupies the glyph
+    // cell, so hide it rather than comparing against inverse-video masks.
+    let c_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lC"));
+    let n_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lN"));
+    let p_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lP"));
     let action_key_col = SIDEBAR_COLS as u32 + 6; // `Press ` then the key.
 
     assert!(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ chords the app shipped with before configuration existed.
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `palette_open` | string | `"super+p"` | Chord that opens the command palette while it is closed. |
-| `session_create` | string | `"c"` | Palette command dispatching `session.create` (New Session). |
+| `session_create` | string | `"c"` | Palette command dispatching `session.create` (New Session); also the direct recovery action while the workspace is empty. |
 | `session_select` | string | `"s"` | Palette command dispatching `session.select` (Switch Session). |
 | `session_close` | string | `"x"` | Palette command dispatching `session.close` (Close Session). |
 | `sidebar_focus` | string | `"f"` | Palette command dispatching `sidebar.focus` (Focus Sidebar). |
@@ -86,12 +86,33 @@ never a silent fallback and never a silently dead binding:
   `down`, which the open palette always interprets as dismissal, confirm,
   and navigation.
 
-The four command chords apply only while the palette is open — the palette
-intercepts all keys then, so command chords never steal input from Zellij or
-the terminal — which is why only `palette_open` is validated against the
-Zellij corpus. Chords with modifiers dispatch on the exact modifier set; a
-modifier-free character binding also matches the character with any
-modifiers held, as the pre-configuration palette did.
+The four command chords normally apply only while the palette is open — the
+palette intercepts all keys then, so command chords never steal input from
+Zellij or the terminal — which is why only `palette_open` is validated against
+the Zellij corpus. There is one bounded recovery exception: when the entire
+sidebar is empty and no session can receive input, the configured
+`session_create` chord creates a session directly, exactly as the terminal-side
+empty-state action says. Chords with modifiers dispatch on the exact modifier
+set; inside the palette, a modifier-free character binding also matches the
+character with any modifiers held, as the pre-configuration palette did.
+
+### `[ui]`
+
+Optional application chrome. The palette affordance is visible by default in
+the permanent status row and is generated from the active `[keys]`
+`palette_open` binding, so rebinding the command never leaves a stale shortcut
+on screen. Configuration is not required for discoverability.
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `show_palette_hint` | boolean | `true` | Show the configured palette opener followed by `Commands` in the terminal-side status row. Set to `false` to remove the persistent hint. |
+
+The setting is an explicit opt-out: omitting `[ui]` keeps the hint visible. A
+non-boolean value or an unknown key is a typed configuration error rather than
+a silently ignored preference. Turning the persistent palette hint off does
+not remove the actionable empty state: `No sessions` still shows the active
+`session_create` chord in the terminal area, and pressing it creates a session
+directly.
 
 ### `[theme]`
 
@@ -251,6 +272,9 @@ cell_height = 24
 [keys]
 palette_open = "super+k"
 session_create = "ctrl+shift+t"
+
+[ui]
+show_palette_hint = false
 
 [theme]
 name = "light"


### PR DESCRIPTION
Closes **#191** and **#201** — the finding all three independent UI/UX evaluations agreed on: **Noren is not discoverable without documentation.**

`Super+p` exposes every workspace operation and nothing on screen said so. Closing the last session left only `No sessions` — a dead end in a product that works.

## The owner's two questions

**Does a user who reads nothing get a good result?** Yes. The hint ships **visible by default**. A `[ui] show_palette_hint` key exists but defaults to `true`, so it can only ever turn the hint *off*. Making it opt-in would have satisfied "customisable" while failing "works unconfigured" — the trap the UX plan named first.

**Can a user who wants control get it without patching source?** Yes — the key turns it off, and the chord itself is already rebindable via `[keys]`.

## The chord is generated, not hardcoded

The hint renders from the **active `KeymapConfig`**. A user who rebinds `palette_open` sees their own chord. A hardcoded `⌘P` would show a rebound user a dead shortcut — **customisation that lies is worse than none**, and that was the plan's second named trap.

## Placement, with the reasoning

The terminal-side status row, not the sidebar: **16 columns cannot fit a valid rebinding**, so the sidebar would truncate exactly the text whose entire job is to be read. The empty state now names the configured `session_create` chord rather than stopping at `No sessions`.

## Verified through pixels

Flipping the default to `false` fails two tests:

```
configured_palette_hint_reaches_production_vertices     FAILED
palette_hint_default_and_rebind_are_drawn_in_frame_pixels  FAILED
```

The second covers both halves — the default hint *and* a rebind — in frame pixels, so a hint that renders the wrong chord is caught too.

## Note on process

The lane completed the work but never committed it (`commits=0` after ~40 minutes). I verified the tree, salvaged it to `wip/ux1-salvage` while it ran, and committed it here after confirming the gates and both anti-trap properties myself.

Gates: `fmt` 0, `clippy -D warnings` 0, `cargo test --workspace` **1,122 passing, 0 failed**.
