### PR TITLE
feat(sidebar): show all four lifecycle states at 16 columns (#196)

### DIFF
--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -28,6 +28,12 @@
 //! `Super+Escape` exit leader) is [`ConfigError::UnclaimableChord`] rather
 //! than a silently dead binding.
 //!
+//! The `[sidebar]` table controls the sidebar width in cell columns. Its
+//! absence keeps the shipped 16-column layout, where lifecycle markers are
+//! already visible; configuration is an additive workspace preference, not a
+//! prerequisite for seeing state. Bounds preserve the compact row grammar and
+//! at least one drawable terminal column.
+//!
 //! The `[theme]` table selects the built-in colour palette. It follows the
 //! same discipline: an absent table keeps `dark` — exactly the colours the
 //! app shipped with before themes existed — a non-string value is
@@ -76,6 +82,7 @@ use crate::passthrough::{
     CLAIM_ID_PALETTE, Chord, ChordError, ChordSeq, KeyCode, Modifiers, PassthroughAction,
     PassthroughClaim, PassthroughPolicy, default_exit_claim,
 };
+use crate::sidebar_text::{DEFAULT_SIDEBAR_COLUMNS, MAX_SIDEBAR_COLUMNS, MIN_SIDEBAR_COLUMNS};
 use crate::theme::{Theme, ThemeName};
 use crate::{POC_CELL_HEIGHT, POC_CELL_WIDTH};
 use std::env;
@@ -171,6 +178,34 @@ impl FontConfig {
     #[must_use]
     pub const fn cell_height(self) -> u32 {
         self.cell_height
+    }
+}
+
+/// Width of the application-owned sidebar in terminal cell columns.
+///
+/// The default remains the shipped 16 columns. Configuration is additive:
+/// lifecycle markers are already visible at that default, while a user may
+/// allocate more or less workspace without patching source. Validation keeps
+/// enough room for the compact row grammar and always leaves the renderer at
+/// least one terminal column.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SidebarConfig {
+    columns: usize,
+}
+
+impl Default for SidebarConfig {
+    fn default() -> Self {
+        Self {
+            columns: DEFAULT_SIDEBAR_COLUMNS,
+        }
+    }
+}
+
+impl SidebarConfig {
+    /// Sidebar width in cell columns; defaults to 16.
+    #[must_use]
+    pub const fn columns(self) -> usize {
+        self.columns
     }
 }
 
@@ -417,6 +452,7 @@ impl ProjectConfig {
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct AppConfig {
     font: FontConfig,
+    sidebar: SidebarConfig,
     keys: KeymapConfig,
     theme: ThemeConfig,
     cursor: CursorConfig,
@@ -429,6 +465,12 @@ impl AppConfig {
     #[must_use]
     pub const fn font(&self) -> FontConfig {
         self.font
+    }
+
+    /// Sidebar geometry settings.
+    #[must_use]
+    pub const fn sidebar(&self) -> SidebarConfig {
+        self.sidebar
     }
 
     /// Workspace key chord settings.
@@ -517,6 +559,7 @@ impl AppConfig {
                         .ok_or_else(|| ConfigError::WrongType { key: clip(key) })?;
                     match key {
                         "font" => parse_font(table, &mut config.font)?,
+                        "sidebar" => parse_sidebar(table, &mut config.sidebar)?,
                         "keys" => parse_keys(table, &mut config.keys)?,
                         "theme" => parse_theme(table, &mut config.theme)?,
                         "cursor" => parse_cursor(table, &mut config.cursor)?,
@@ -670,6 +713,19 @@ fn parse_font(table: &dyn TableLike, font: &mut FontConfig) -> Result<(), Config
                 font.cell_height = integer_in_range(key, item, min_height, max_edge)?
                     .try_into()
                     .expect("range-checked value fits u32");
+            }
+            _ => return Err(ConfigError::UnknownKey(clip(key))),
+        }
+    }
+    Ok(())
+}
+
+fn parse_sidebar(table: &dyn TableLike, sidebar: &mut SidebarConfig) -> Result<(), ConfigError> {
+    for (key, item) in table.iter() {
+        match key {
+            "columns" => {
+                sidebar.columns =
+                    integer_in_range(key, item, MIN_SIDEBAR_COLUMNS, MAX_SIDEBAR_COLUMNS)?;
             }
             _ => return Err(ConfigError::UnknownKey(clip(key))),
         }
@@ -1495,6 +1551,7 @@ mod tests {
         let config = AppConfig::default();
         assert_eq!(config.font().cell_width(), POC_CELL_WIDTH);
         assert_eq!(config.font().cell_height(), POC_CELL_HEIGHT);
+        assert_eq!(config.sidebar().columns(), DEFAULT_SIDEBAR_COLUMNS);
         assert_eq!(config, AppConfig::default());
     }
 
@@ -1531,6 +1588,46 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_columns_are_bounded_configurable_and_defaulted() {
+        assert_eq!(SidebarConfig::default().columns(), 16);
+        for columns in [MIN_SIDEBAR_COLUMNS, 24, MAX_SIDEBAR_COLUMNS] {
+            let config = AppConfig::parse(&format!("[sidebar]\ncolumns = {columns}\n"))
+                .expect("bounded sidebar width is valid");
+            assert_eq!(config.sidebar().columns(), columns);
+            assert_eq!(config.font(), FontConfig::default());
+        }
+    }
+
+    #[test]
+    fn sidebar_columns_reject_unusable_values_types_and_unknown_keys() {
+        for value in [
+            (MIN_SIDEBAR_COLUMNS - 1).to_string(),
+            (MAX_SIDEBAR_COLUMNS + 1).to_string(),
+            "0".to_string(),
+            "-1".to_string(),
+            "9223372036854775807".to_string(),
+        ] {
+            assert!(
+                matches!(
+                    AppConfig::parse(&format!("[sidebar]\ncolumns = {value}\n")),
+                    Err(ConfigError::OutOfRange { .. })
+                ),
+                "sidebar columns {value} must be rejected"
+            );
+        }
+        assert_eq!(
+            AppConfig::parse("[sidebar]\ncolumns = \"wide\"\n"),
+            Err(ConfigError::WrongType {
+                key: "columns".to_owned()
+            })
+        );
+        assert_eq!(
+            AppConfig::parse("[sidebar]\nwidth = 24\n"),
+            Err(ConfigError::UnknownKey("width".to_owned()))
+        );
+    }
+
+    #[test]
     fn the_terminal_table_is_rejected_until_the_cap_is_enforceable() {
         // `scrollback_lines` cannot be honored yet (the terminal foundation
         // retains a fixed hard cap), so accepting it would be a silent no-op.
@@ -1548,10 +1645,11 @@ mod tests {
 
     #[test]
     fn every_supported_key_applies_together() {
-        let text = "[font]\ncell_width = 11\ncell_height = 22\n";
+        let text = "[font]\ncell_width = 11\ncell_height = 22\n\n[sidebar]\ncolumns = 24\n";
         let config = AppConfig::parse(text).expect("valid configuration");
         assert_eq!(config.font().cell_width(), 11);
         assert_eq!(config.font().cell_height(), 22);
+        assert_eq!(config.sidebar().columns(), 24);
     }
 
     #[test]

--- a/crates/noren-app/src/frame_geometry.rs
+++ b/crates/noren-app/src/frame_geometry.rs
@@ -1,6 +1,8 @@
 //! Pure calculations shared by frame sizing and pointer hit testing.
 
-use crate::{NorenApp, renderer};
+use crate::NorenApp;
+#[cfg(test)]
+use crate::renderer;
 use noren_app::MAX_RENDER_COLS;
 
 impl NorenApp {
@@ -33,8 +35,16 @@ impl NorenApp {
 /// otherwise columns are clipped invisibly. `renderer::glyph_vertices` applies
 /// the identical formula independently; the sidebar geometry test pins that the
 /// two sites agree.
+#[cfg(test)]
 pub(super) fn terminal_cols(window_cols: u16) -> u16 {
-    let sidebar = u16::try_from(renderer::SIDEBAR_COLS).unwrap_or(u16::MAX);
+    terminal_cols_at_width(window_cols, renderer::SIDEBAR_COLS)
+}
+
+/// Configured-width form used by the running application. Validation keeps
+/// `sidebar_columns` below `MAX_RENDER_COLS`; the saturating conversion keeps
+/// this pure seam total for direct tests as well.
+pub(super) fn terminal_cols_at_width(window_cols: u16, sidebar_columns: usize) -> u16 {
+    let sidebar = u16::try_from(sidebar_columns).unwrap_or(u16::MAX);
     let budget = MAX_RENDER_COLS.saturating_sub(sidebar).max(1);
     window_cols.saturating_sub(sidebar).clamp(1, budget)
 }
@@ -52,8 +62,15 @@ pub(super) fn pixel_row_index(pixel: f64, cell_size: u32) -> Option<usize> {
 /// Pixel width of the sidebar's left strip: `SIDEBAR_COLS` cell columns. The
 /// terminal is drawn to the right of this edge, so a click at exactly this x is
 /// the first terminal column.
+#[cfg(test)]
 pub(super) fn sidebar_pixel_width(cell_width: u32) -> f64 {
-    f64::from((renderer::SIDEBAR_COLS as u32) * cell_width)
+    sidebar_pixel_width_at_width(cell_width, renderer::SIDEBAR_COLS)
+}
+
+/// Configured-width form used by sidebar hit testing.
+pub(super) fn sidebar_pixel_width_at_width(cell_width: u32, sidebar_columns: usize) -> f64 {
+    let columns = u32::try_from(sidebar_columns).unwrap_or(u32::MAX);
+    f64::from(columns.saturating_mul(cell_width))
 }
 
 /// Terminal cell column under pixel x, or `None` when the click lands in the
@@ -61,12 +78,23 @@ pub(super) fn sidebar_pixel_width(cell_width: u32) -> f64 {
 /// boundary is exclusive: x exactly at [`sidebar_pixel_width`] is the first
 /// terminal column and maps to cell 0; anything strictly left of it is the
 /// sidebar and is rejected.
+#[cfg(test)]
 pub(super) fn terminal_column_at(
     pixel_x: f64,
     terminal_cols: u16,
     cell_width: u32,
 ) -> Option<usize> {
-    let edge = sidebar_pixel_width(cell_width);
+    terminal_column_at_width(pixel_x, terminal_cols, cell_width, renderer::SIDEBAR_COLS)
+}
+
+/// Configured-width form used by terminal selection and mouse reporting.
+pub(super) fn terminal_column_at_width(
+    pixel_x: f64,
+    terminal_cols: u16,
+    cell_width: u32,
+    sidebar_columns: usize,
+) -> Option<usize> {
+    let edge = sidebar_pixel_width_at_width(cell_width, sidebar_columns);
     if !pixel_x.is_finite() || pixel_x < edge {
         return None;
     }

--- a/crates/noren-app/src/frame_geometry/tests.rs
+++ b/crates/noren-app/src/frame_geometry/tests.rs
@@ -28,13 +28,18 @@ fn pixel_row_index_truncates_and_rejects_non_finite() {
 /// arbitrary vertices would count that bleed as a drawn column and over-
 /// count by one. Each rect is emitted as a 6-vertex fan whose first vertex
 /// is its top-left corner, so the left edges are read from every 6th group.
-fn rendered_terminal_columns(vertices: &[renderer::Vertex], width: u32, cell_width: u32) -> usize {
+fn rendered_terminal_columns(
+    vertices: &[renderer::Vertex],
+    width: u32,
+    cell_width: u32,
+    sidebar_columns: usize,
+) -> usize {
     let rect_lefts: Vec<f32> = vertices
         .chunks_exact(6)
         .map(|rect| rect[0].position[0])
         .collect();
     let mut drawn = 0;
-    for col in renderer::SIDEBAR_COLS..usize::from(MAX_RENDER_COLS) {
+    for col in sidebar_columns..usize::from(MAX_RENDER_COLS) {
         let edge = ((col as u32) * cell_width) as f32 / width as f32 * 2.0 - 1.0;
         if rect_lefts.iter().any(|left| (left - edge).abs() < 1e-5) {
             drawn += 1;
@@ -53,12 +58,16 @@ fn rendered_terminal_columns(vertices: &[renderer::Vertex], width: u32, cell_wid
 /// value; instead this exercises the three real consumers and is shared by
 /// the swept agreement test below across every regime where they can drift
 /// apart — including non-default cell sizes.
-fn assert_three_consumers_agree_at(width: u32, metrics: CellMetrics) {
+fn assert_three_consumers_agree_at(
+    width: u32,
+    metrics: CellMetrics,
+    sidebar_columns: usize,
+) {
     let height = 600_u32;
     let cell_width = metrics.width();
     let cell_height = metrics.height();
     let window_cols = u16::try_from(width / cell_width).expect("fits in u16");
-    let cols = terminal_cols(window_cols);
+    let cols = terminal_cols_at_width(window_cols, sidebar_columns);
 
     // Consumer 1: the terminal state stores the sidebar-adjusted width.
     let rows = u16::try_from(height / cell_height).expect("fits in u16");
@@ -96,12 +105,13 @@ fn assert_three_consumers_agree_at(width: u32, metrics: CellMetrics) {
             width,
             height,
             metrics,
-        ),
+        )
+        .with_sidebar_columns(sidebar_columns),
         Some(&snapshot),
         Some(sidebar.as_slice()),
         None,
     );
-    let drawn = rendered_terminal_columns(&vertices, width, cell_width);
+    let drawn = rendered_terminal_columns(&vertices, width, cell_width, sidebar_columns);
     assert_eq!(
         drawn,
         usize::from(cols),
@@ -150,13 +160,23 @@ fn assert_three_consumers_agree_at(width: u32, metrics: CellMetrics) {
 fn terminal_cols_pty_winsize_and_renderer_agree_across_the_width_range() {
     let poc = GridGeometry::poc().cell_metrics();
     for width in [80_u32, 900, 1600, 2000] {
-        assert_three_consumers_agree_at(width, poc);
+        assert_three_consumers_agree_at(width, poc, renderer::SIDEBAR_COLS);
     }
     let big = GridGeometry::with_cells(20, 40)
         .expect("valid geometry")
         .cell_metrics();
     for width in [160_u32, 1800, 3200, 4000] {
-        assert_three_consumers_agree_at(width, big);
+        assert_three_consumers_agree_at(width, big, renderer::SIDEBAR_COLS);
+    }
+}
+
+#[test]
+fn configured_sidebar_width_reaches_terminal_pty_and_renderer_together() {
+    let metrics = GridGeometry::poc().cell_metrics();
+    for sidebar_columns in [8_usize, 24, 80, 159] {
+        for width in [900_u32, 1600, 2000] {
+            assert_three_consumers_agree_at(width, metrics, sidebar_columns);
+        }
     }
 }
 
@@ -246,7 +266,12 @@ fn terminal_cols_and_renderer_floor_at_one_below_the_sidebar() {
         Some(sidebar.as_slice()),
         None,
     );
-    let drawn = rendered_terminal_columns(&vertices, width, cell_width);
+    let drawn = rendered_terminal_columns(
+        &vertices,
+        width,
+        cell_width,
+        renderer::SIDEBAR_COLS,
+    );
     assert_eq!(
         drawn,
         usize::from(cols),

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -21,6 +21,7 @@ pub mod session;
 pub mod session_persistence;
 pub mod session_supervisor;
 pub mod sidebar;
+pub mod sidebar_text;
 pub mod ssh_config;
 pub mod theme;
 

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -44,6 +44,7 @@ use noren_app::{
         SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save_snapshot, snapshot,
     },
     sidebar::{SidebarEntry, SidebarView},
+    sidebar_text::visible_sidebar_text_lines,
     ssh_config::{HostDiscoveryKind, SshConfig},
     theme::Theme,
 };
@@ -3492,46 +3493,14 @@ impl RuntimeGridSize {
     }
 }
 
-/// Convert the sidebar view into text lines the renderer can draw.
+/// Convert the sidebar view into text lines at the shipped width.
 ///
-/// Each row is prefixed with `>` when selected, space otherwise, followed by
-/// the label and optional detail — using [`SidebarRow::label`] and
-/// [`SidebarRow::detail`] verbatim. When the sidebar is empty the
-/// empty-state message is returned as the sole line.
+/// Production and the integration frame oracle share the width-aware
+/// implementation in `sidebar_text`; this test seam keeps existing binary
+/// tests on the exact same projection.
 #[cfg(test)]
 fn sidebar_text_lines(sidebar: &SidebarView) -> Vec<String> {
     visible_sidebar_text_lines(sidebar, 0, usize::MAX)
-}
-
-/// Format only the visible slice of the sidebar. The scroll offset is clamped
-/// to the last full page so redraw work stays proportional to frame rows, not
-/// to hidden entries.
-fn visible_sidebar_text_lines(
-    sidebar: &SidebarView,
-    offset: usize,
-    max_rows: usize,
-) -> Vec<String> {
-    if max_rows == 0 {
-        return Vec::new();
-    }
-    if sidebar.is_empty() {
-        return sidebar
-            .empty_state()
-            .map(|state| vec![state.message().to_string()])
-            .unwrap_or_default();
-    }
-    let offset = offset.min(sidebar.rows().len().saturating_sub(max_rows));
-    sidebar.rows()[offset..]
-        .iter()
-        .take(max_rows)
-        .map(|row| {
-            let marker = if row.is_selected() { '>' } else { ' ' };
-            match row.detail() {
-                Some(detail) => format!("{marker} {} {}", row.label(), detail),
-                None => format!("{marker} {}", row.label()),
-            }
-        })
-        .collect()
 }
 
 /// Build text lines for the palette display, drawn at the top of the sidebar

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -21,7 +21,7 @@ use input_translation::{
 use persistence_state::{AttemptOutcome, Observation, PersistenceState, SaveOutcome};
 
 #[cfg(test)]
-use noren_app::sidebar_text::visible_sidebar_text_lines;
+use noren_app::sidebar_text::{visible_sidebar_text_lines, visible_sidebar_text_lines_at_width};
 #[cfg(test)]
 use noren_app::{
     Arrow, CellMetrics, FunctionKey, Key, KeyDropReason, KeyInput, KeyPhase, KeypadInput,
@@ -50,7 +50,7 @@ use noren_app::{
         SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save_snapshot, snapshot,
     },
     sidebar::{SidebarEntry, SidebarView},
-    sidebar_text::visible_sidebar_text_lines_at_width,
+    sidebar_text::{SidebarTextRow, visible_sidebar_text_rows_at_width},
     ssh_config::{HostDiscoveryKind, SshConfig},
     theme::Theme,
 };
@@ -3327,19 +3327,22 @@ impl NorenApp {
             .ok()
             .and_then(|rows| self.rendered_status_row(rows));
         self.clamp_sidebar_scroll(visible_rows);
-        let sidebar_lines = visible_sidebar_text_lines_at_width(
+        let sidebar_rows = visible_sidebar_text_rows_at_width(
             self.workspace.sidebar(),
             self.sidebar_scroll_offset,
             visible_rows,
             self.sidebar_columns,
         );
-        let lines = if self.palette_open {
-            let mut lines =
-                palette_text_lines(self.workspace.palette(), self.palette_selection, &self.keys);
-            lines.extend(sidebar_lines);
-            lines
+        let rows = if self.palette_open {
+            let mut rows: Vec<_> =
+                palette_text_lines(self.workspace.palette(), self.palette_selection, &self.keys)
+                    .into_iter()
+                    .map(SidebarTextRow::chrome)
+                    .collect();
+            rows.extend(sidebar_rows);
+            rows
         } else {
-            sidebar_lines
+            sidebar_rows
         };
         let status = status_row.map(|source| {
             source.text(
@@ -3354,7 +3357,7 @@ impl NorenApp {
         let outcome = self
             .renderer
             .as_mut()
-            .map(|renderer| renderer.render(snapshot.as_ref(), Some(&lines), status));
+            .map(|renderer| renderer.render(snapshot.as_ref(), Some(&rows), status));
         match outcome {
             Some(RenderOutcome::DeviceLost) => {
                 self.status = "Noren renderer device lost";

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -5,7 +5,11 @@ mod input_translation;
 mod persistence_state;
 mod renderer;
 
-use frame_geometry::{pixel_row_index, sidebar_pixel_width, terminal_cols, terminal_column_at};
+use frame_geometry::{
+    pixel_row_index, sidebar_pixel_width_at_width, terminal_cols_at_width, terminal_column_at_width,
+};
+#[cfg(test)]
+use frame_geometry::{sidebar_pixel_width, terminal_cols, terminal_column_at};
 #[cfg(test)]
 use input_translation::{
     app_modifiers_from_gate, gate_key_to_app, keypad_key, translate_logical_key,
@@ -16,6 +20,8 @@ use input_translation::{
 };
 use persistence_state::{AttemptOutcome, Observation, PersistenceState, SaveOutcome};
 
+#[cfg(test)]
+use noren_app::sidebar_text::visible_sidebar_text_lines;
 #[cfg(test)]
 use noren_app::{
     Arrow, CellMetrics, FunctionKey, Key, KeyDropReason, KeyInput, KeyPhase, KeypadInput,
@@ -44,7 +50,7 @@ use noren_app::{
         SESSION_STATE_FILE_NAME, SessionPersistenceError, load_snapshot, save_snapshot, snapshot,
     },
     sidebar::{SidebarEntry, SidebarView},
-    sidebar_text::visible_sidebar_text_lines,
+    sidebar_text::visible_sidebar_text_lines_at_width,
     ssh_config::{HostDiscoveryKind, SshConfig},
     theme::Theme,
 };
@@ -1124,6 +1130,9 @@ struct NorenApp {
     window: Option<Arc<Window>>,
     renderer: Option<Renderer>,
     geometry: GridGeometry,
+    /// Validated `[sidebar] columns`, shared by layout, drawing, formatting,
+    /// and hit testing so configured control cannot create split geometry.
+    sidebar_columns: usize,
     pending_grid: Option<GridSize>,
     terminal: Option<TerminalState>,
     pty: Option<PtySession>,
@@ -1290,6 +1299,7 @@ impl NorenApp {
             window: None,
             renderer: None,
             geometry,
+            sidebar_columns: config.sidebar().columns(),
             pending_grid: None,
             terminal: None,
             pty: None,
@@ -1367,7 +1377,7 @@ impl NorenApp {
     /// Keeping this as the initialization seam prevents the two consumers from
     /// independently reinterpreting the application-owned status row.
     fn prepare_initial_terminal(&mut self, grid: GridSize) -> Option<PtySize> {
-        let runtime = RuntimeGridSize::from_window(grid);
+        let runtime = RuntimeGridSize::from_window(grid, self.sidebar_columns);
         let terminal = runtime.terminal_state()?;
         let pty = runtime.pty_size()?;
         self.terminal = Some(terminal);
@@ -1660,7 +1670,7 @@ impl NorenApp {
         // `update` returns `None` for an unchanged grid; the current grid is
         // then exactly what a new session should use.
         let grid = changed.or_else(|| self.geometry.current())?;
-        let runtime = RuntimeGridSize::from_window(grid);
+        let runtime = RuntimeGridSize::from_window(grid, self.sidebar_columns);
         Some((runtime.terminal_state()?, runtime.pty_size()?))
     }
 
@@ -2244,6 +2254,7 @@ impl NorenApp {
         self.renderer = match Renderer::new(
             Arc::clone(&window),
             self.geometry.cell_metrics(),
+            self.sidebar_columns,
             self.theme,
             self.cursor_style,
         ) {
@@ -2771,7 +2782,8 @@ impl NorenApp {
             || position.y < 0.0
             || position.x >= f64::from(frame_size.width)
             || position.y >= f64::from(frame_size.height)
-            || position.x >= sidebar_pixel_width(self.geometry.cell_width())
+            || position.x
+                >= sidebar_pixel_width_at_width(self.geometry.cell_width(), self.sidebar_columns)
         {
             return None;
         }
@@ -2801,7 +2813,8 @@ impl NorenApp {
             || !position.y.is_finite()
             || position.x < 0.0
             || position.y < 0.0
-            || position.x >= sidebar_pixel_width(self.geometry.cell_width())
+            || position.x
+                >= sidebar_pixel_width_at_width(self.geometry.cell_width(), self.sidebar_columns)
             || position.x >= f64::from(frame_size.width)
             || position.y >= f64::from(frame_size.height)
         {
@@ -2948,9 +2961,9 @@ impl NorenApp {
         let terminal = self.terminal.as_ref()?;
         let cell_width = self.geometry.cell_width();
         let cell_height = self.geometry.cell_height();
-        // The sidebar occupies the leftmost SIDEBAR_COLS cell columns; clicks
+        // The sidebar occupies the configured leftmost cell columns; clicks
         // inside it do not address the terminal grid.
-        if position.x < sidebar_pixel_width(cell_width) {
+        if position.x < sidebar_pixel_width_at_width(cell_width, self.sidebar_columns) {
             return None;
         }
         let content_rows = terminal.screen().display_row_count();
@@ -2970,7 +2983,7 @@ impl NorenApp {
         if line_index >= usize::from(rows) {
             return None;
         }
-        let column = terminal_column_at(position.x, cols, cell_width)?;
+        let column = terminal_column_at_width(position.x, cols, cell_width, self.sidebar_columns)?;
         Some(GridPoint::new(
             terminal.scrollback_len() + line_index,
             column,
@@ -3140,7 +3153,7 @@ impl NorenApp {
         // Resize re-addresses the grid, so captured coordinates expire.
         self.selection = None;
         self.drag_origin = None;
-        let runtime = RuntimeGridSize::from_window(grid);
+        let runtime = RuntimeGridSize::from_window(grid, self.sidebar_columns);
         if let Some(terminal) = &mut self.terminal {
             if runtime.resize_terminal(terminal).is_err() {
                 self.status = "Noren terminal resize failed";
@@ -3314,10 +3327,11 @@ impl NorenApp {
             .ok()
             .and_then(|rows| self.rendered_status_row(rows));
         self.clamp_sidebar_scroll(visible_rows);
-        let sidebar_lines = visible_sidebar_text_lines(
+        let sidebar_lines = visible_sidebar_text_lines_at_width(
             self.workspace.sidebar(),
             self.sidebar_scroll_offset,
             visible_rows,
+            self.sidebar_columns,
         );
         let lines = if self.palette_open {
             let mut lines =
@@ -3473,10 +3487,10 @@ struct RuntimeGridSize {
 }
 
 impl RuntimeGridSize {
-    fn from_window(grid: GridSize) -> Self {
+    fn from_window(grid: GridSize, sidebar_columns: usize) -> Self {
         Self {
             rows: NorenApp::content_terminal_rows(grid.rows()),
-            cols: terminal_cols(grid.cols()),
+            cols: terminal_cols_at_width(grid.cols(), sidebar_columns),
         }
     }
 

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -385,6 +385,37 @@ fn configured_cell_sizes_drive_the_app_geometry() {
     assert_eq!((grid.rows(), grid.cols()), (15, 45));
 }
 
+#[test]
+fn configured_sidebar_columns_reach_app_terminal_pty_and_text() {
+    let config = AppConfig::parse("[sidebar]\ncolumns = 24\n").expect("valid configuration");
+    let mut app = NorenApp::new(config);
+    assert_eq!(app.sidebar_columns, 24);
+
+    let grid = app
+        .geometry
+        .update(Resize::new(900, 600))
+        .expect("initial grid");
+    let pty = app
+        .prepare_initial_terminal(grid)
+        .expect("configured grid has a PTY size");
+    assert_eq!((pty.rows(), pty.cols()), (29, 66));
+    let terminal = app.terminal.as_ref().expect("terminal installed");
+    assert_eq!(
+        (terminal.screen().rows(), terminal.screen().cols()),
+        (29, 66)
+    );
+
+    let session = app.workspace.create_session(SessionKind::Local);
+    let lines = visible_sidebar_text_lines_at_width(app.workspace.sidebar(), 0, 1, 24);
+    assert_eq!(lines[0].chars().count(), 24);
+    assert!(lines[0].contains(&session.to_string()));
+    assert_eq!(lines[0].chars().last(), Some('◌'));
+    assert_eq!(
+        sidebar_pixel_width_at_width(app.geometry.cell_width(), app.sidebar_columns),
+        240.0
+    );
+}
+
 /// The `[theme]` selection reaches the app's renderer input: `NorenApp`
 /// carries exactly the palette the configuration named, and a missing
 /// `[theme]` section carries the dark default. This is the app-level half of

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -409,7 +409,7 @@ fn configured_sidebar_columns_reach_app_terminal_pty_and_text() {
     let lines = visible_sidebar_text_lines_at_width(app.workspace.sidebar(), 0, 1, 24);
     assert_eq!(lines[0].chars().count(), 24);
     assert!(lines[0].contains(&session.to_string()));
-    assert_eq!(lines[0].chars().last(), Some('◌'));
+    assert_eq!(lines[0].chars().last(), Some('⌛'));
     assert_eq!(
         sidebar_pixel_width_at_width(app.geometry.cell_width(), app.sidebar_columns),
         240.0
@@ -683,10 +683,10 @@ fn sidebar_text_lines_format_a_real_workspace_sidebar() {
         lines[1]
     );
     // A freshly created session sits at Starting, whose reserved final cell
-    // carries the dotted-circle marker. The full detail remains on the view
+    // carries the hourglass marker. The full detail remains on the view
     // model; compact rendering never lets it push state beyond column 16.
     assert_eq!(lines[0].chars().count(), renderer::SIDEBAR_COLS);
-    assert_eq!(lines[0].chars().last(), Some('◌'));
+    assert_eq!(lines[0].chars().last(), Some('⌛'));
 }
 
 // ── Pass-through gate integration tests ──────────────────────────────

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -630,7 +630,7 @@ fn sidebar_text_lines_format_a_real_workspace_sidebar() {
     assert_eq!(lines.len(), 2, "one formatted line per sidebar row");
 
     // The selected row is prefixed with '>' and the unselected with a
-    // space; both carry the real descriptor's label and detail.
+    // space; both carry the real descriptor's label.
     assert!(
         lines[0].starts_with("> "),
         "selected row must be marked with '>': {:?}",
@@ -651,13 +651,11 @@ fn sidebar_text_lines_format_a_real_workspace_sidebar() {
         "unselected row carries the session label: {:?}",
         lines[1]
     );
-    // A freshly created session sits at the Starting status, so the detail
-    // is derived from the real descriptor, not a constant.
-    assert!(
-        lines[0].contains("local · starting"),
-        "detail comes from the real descriptor: {:?}",
-        lines[0]
-    );
+    // A freshly created session sits at Starting, whose reserved final cell
+    // carries the dotted-circle marker. The full detail remains on the view
+    // model; compact rendering never lets it push state beyond column 16.
+    assert_eq!(lines[0].chars().count(), renderer::SIDEBAR_COLS);
+    assert_eq!(lines[0].chars().last(), Some('◌'));
 }
 
 // ── Pass-through gate integration tests ──────────────────────────────

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -270,8 +270,13 @@ pub(crate) fn resolve_background(theme: &Theme, attributes: &CellAttributes) -> 
 
 /// Theme-owned colour reinforcing one lifecycle marker's collision-checked
 /// shape. Non-marker sidebar text keeps the default foreground.
-fn sidebar_glyph_color(theme: &Theme, character: char, column: usize) -> [f32; 3] {
-    if column + 1 == SIDEBAR_COLS
+fn sidebar_glyph_color(
+    theme: &Theme,
+    character: char,
+    column: usize,
+    sidebar_columns: usize,
+) -> [f32; 3] {
+    if column + 1 == sidebar_columns
         && let Some(color) = lifecycle_marker_color(character)
     {
         return resolve_color(theme, Color::Ansi(color), theme.foreground());
@@ -337,6 +342,7 @@ pub(crate) struct Renderer {
     vertex_capacity: u64,
     device_lost: Arc<AtomicBool>,
     metrics: CellMetrics,
+    sidebar_columns: usize,
     theme: Theme,
     cursor: CursorStyle,
 }
@@ -345,6 +351,7 @@ impl Renderer {
     pub(crate) fn new(
         window: Arc<Window>,
         metrics: CellMetrics,
+        sidebar_columns: usize,
         theme: Theme,
         cursor: CursorStyle,
     ) -> Result<Self, RendererError> {
@@ -437,6 +444,7 @@ impl Renderer {
             vertex_capacity,
             device_lost,
             metrics,
+            sidebar_columns,
             cursor,
             theme,
         })
@@ -473,6 +481,7 @@ impl Renderer {
             self.config.height,
             self.metrics,
         )
+        .with_sidebar_columns(self.sidebar_columns)
         .with_cursor_style(self.cursor);
         let vertices = glyph_vertices_for(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
@@ -566,14 +575,12 @@ fn block_on<F: Future>(future: F) -> F::Output {
 /// Exposed as `pub(crate)` for the offscreen frame-oracle (see
 /// `renderer_capture.rs`); no behaviour change.
 ///
-/// When `sidebar` is `Some`, the first [`SIDEBAR_COLS`] columns are reserved
-/// for the sidebar text and the terminal is drawn starting at column
-/// `SIDEBAR_COLS`. When `sidebar` is `None`, the terminal occupies the full
-/// width starting at column 0 (preserving the pre-sidebar behaviour the frame
-/// oracle's existing tests rely on). Every colour decision — palette
-/// resolution, the sidebar/status default foreground, the clear colour the
-/// caller loads — reads from the target's theme, which is how a configured
-/// theme changes what is drawn.
+/// When `sidebar` is `Some`, the target's configured sidebar columns are
+/// reserved for sidebar text and the terminal starts immediately after them.
+/// [`Target::new`] defaults to the shipped [`SIDEBAR_COLS`] for existing
+/// callers; production replaces it with validated configuration. When
+/// `sidebar` is `None`, the terminal occupies the full width starting at
+/// column 0. Every colour decision reads from the target's theme.
 pub(crate) fn glyph_vertices_for(
     target: Target,
     terminal: Option<&TerminalSnapshot>,
@@ -594,8 +601,13 @@ fn glyph_vertices_with_budget(
     status: Option<&str>,
     vertex_budget: usize,
 ) -> Vec<Vertex> {
-    let (width, height, metrics, theme) =
-        (target.width, target.height, target.metrics, target.theme);
+    let (width, height, metrics, theme, sidebar_columns) = (
+        target.width,
+        target.height,
+        target.metrics,
+        target.theme,
+        target.sidebar_columns,
+    );
     if width == 0 || height == 0 {
         return Vec::new();
     }
@@ -603,10 +615,10 @@ fn glyph_vertices_with_budget(
     let window_cols = usize::try_from(width / cell_width).unwrap_or(usize::MAX);
 
     let has_sidebar = sidebar.is_some();
-    let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
+    let col_offset = if has_sidebar { sidebar_columns } else { 0 };
     // Reserve the sidebar, then clamp the terminal to the renderer's drawable
-    // budget (`MAX_RENDER_COLS - SIDEBAR_COLS`), floored at one. This is the
-    // same formula `main::terminal_cols` applies — kept independent rather than
+    // budget (`MAX_RENDER_COLS - sidebar_columns`), floored at one. This is the
+    // same formula `main::terminal_cols_at_width` applies — kept independent rather than
     // shared so the sidebar geometry test can still pin that the two sites
     // agree (a single shared function would make their agreement structural and
     // the sidebar subtraction itself un-testable). The sidebar lives *inside*
@@ -614,9 +626,9 @@ fn glyph_vertices_with_budget(
     // than the renderer can draw beside it.
     let terminal_cols = if has_sidebar {
         let budget = usize::from(MAX_RENDER_COLS)
-            .saturating_sub(SIDEBAR_COLS)
+            .saturating_sub(sidebar_columns)
             .max(1);
-        window_cols.saturating_sub(SIDEBAR_COLS).clamp(1, budget)
+        window_cols.saturating_sub(sidebar_columns).clamp(1, budget)
     } else {
         // No sidebar (offscreen oracle's pre-sidebar mode): the terminal fills
         // the window, clamped to the renderer's column ceiling.
@@ -665,11 +677,11 @@ fn glyph_vertices_with_budget(
             .take(fully_drawable_rows(height, metrics))
             .enumerate()
         {
-            for (col, character) in line.chars().take(SIDEBAR_COLS).enumerate() {
+            for (col, character) in line.chars().take(sidebar_columns).enumerate() {
                 push_glyph(
                     &mut vertices,
                     character,
-                    sidebar_glyph_color(&theme, character, col),
+                    sidebar_glyph_color(&theme, character, col, sidebar_columns),
                     col,
                     row,
                     target,
@@ -1121,7 +1133,7 @@ fn push_cursor_hollow(
 /// The draw surface a frame is laid out against: the selected theme plus the
 /// pixel dimensions and cell size the grid is drawn at.
 ///
-/// These four travel together through every emit call and are constant for a
+/// These frame properties travel together through every emit call and are constant for a
 /// frame, so passing them as one value keeps the glyph/rect helpers to a
 /// readable arity; bundling the theme here is also what keeps the public
 /// vertex and capture seams under the argument-count lint without scattering
@@ -1132,6 +1144,7 @@ pub(crate) struct Target {
     pub(crate) width: u32,
     pub(crate) height: u32,
     pub(crate) metrics: CellMetrics,
+    pub(crate) sidebar_columns: usize,
     pub(crate) cursor: CursorStyle,
 }
 
@@ -1143,8 +1156,15 @@ impl Target {
             width,
             height,
             metrics,
+            sidebar_columns: SIDEBAR_COLS,
             cursor: CursorStyle::theme_default(theme),
         }
+    }
+
+    /// Replace the shipped sidebar width with validated configuration.
+    pub(crate) fn with_sidebar_columns(mut self, columns: usize) -> Self {
+        self.sidebar_columns = columns;
+        self
     }
 
     /// Replace the cursor drawing style (a `[cursor]` configuration

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -39,7 +39,8 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use noren_app::cursor::CursorShape;
-use noren_app::sidebar_text::{DEFAULT_SIDEBAR_COLUMNS, lifecycle_marker_color};
+use noren_app::sidebar::EntryKind;
+use noren_app::sidebar_text::{DEFAULT_SIDEBAR_COLUMNS, SidebarTextRow, lifecycle_marker_color};
 use noren_app::theme::{Theme, contrast_ratio};
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::{Cell, CellAttributes, Color, TerminalSnapshot};
@@ -275,8 +276,10 @@ fn sidebar_glyph_color(
     character: char,
     column: usize,
     sidebar_columns: usize,
+    row_kind: Option<EntryKind>,
 ) -> [f32; 3] {
-    if column + 1 == sidebar_columns
+    if row_kind == Some(EntryKind::Session)
+        && column + 1 == sidebar_columns
         && let Some(color) = lifecycle_marker_color(character)
     {
         return resolve_color(theme, Color::Ansi(color), theme.foreground());
@@ -468,7 +471,7 @@ impl Renderer {
     pub(crate) fn render(
         &mut self,
         terminal: Option<&TerminalSnapshot>,
-        sidebar: Option<&[String]>,
+        sidebar: Option<&[SidebarTextRow]>,
         status: Option<&str>,
     ) -> RenderOutcome {
         if self.device_lost.load(Ordering::Acquire) {
@@ -483,7 +486,7 @@ impl Renderer {
         )
         .with_sidebar_columns(self.sidebar_columns)
         .with_cursor_style(self.cursor);
-        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
+        let vertices = glyph_vertices_for_sidebar_rows(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
         let required = u64::try_from(bytes.len()).unwrap_or(u64::MAX).max(8);
         if required > self.vertex_capacity {
@@ -581,23 +584,89 @@ fn block_on<F: Future>(future: F) -> F::Output {
 /// callers; production replaces it with validated configuration. When
 /// `sidebar` is `None`, the terminal occupies the full width starting at
 /// column 0. Every colour decision reads from the target's theme.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn glyph_vertices_for(
     target: Target,
     terminal: Option<&TerminalSnapshot>,
     sidebar: Option<&[String]>,
     status: Option<&str>,
 ) -> Vec<Vertex> {
-    glyph_vertices_with_budget(target, terminal, sidebar, status, MAX_VERTICES)
+    glyph_vertices_with_input_budget(
+        target,
+        terminal,
+        sidebar.map(SidebarInput::Plain),
+        status,
+        MAX_VERTICES,
+    )
+}
+
+/// Production vertex path for sidebar text that retains its domain row kind.
+///
+/// Lifecycle colour is semantic reinforcement for session rows only; the
+/// text-only [`glyph_vertices_for`] seam deliberately supplies no row kind.
+pub(crate) fn glyph_vertices_for_sidebar_rows(
+    target: Target,
+    terminal: Option<&TerminalSnapshot>,
+    sidebar: Option<&[SidebarTextRow]>,
+    status: Option<&str>,
+) -> Vec<Vertex> {
+    glyph_vertices_with_input_budget(
+        target,
+        terminal,
+        sidebar.map(SidebarInput::Typed),
+        status,
+        MAX_VERTICES,
+    )
 }
 
 /// Internal seam for exercising the production vertex-budget backstop without
 /// allocating a clamp-sized frame. The shipped path above always supplies
 /// [`MAX_VERTICES`]; tests use a smaller budget but traverse this same emission
 /// code and the same post-primitive guards.
+#[cfg_attr(not(test), allow(dead_code))]
 fn glyph_vertices_with_budget(
     target: Target,
     terminal: Option<&TerminalSnapshot>,
     sidebar: Option<&[String]>,
+    status: Option<&str>,
+    vertex_budget: usize,
+) -> Vec<Vertex> {
+    glyph_vertices_with_input_budget(
+        target,
+        terminal,
+        sidebar.map(SidebarInput::Plain),
+        status,
+        vertex_budget,
+    )
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Copy)]
+enum SidebarInput<'a> {
+    Plain(&'a [String]),
+    Typed(&'a [SidebarTextRow]),
+}
+
+impl<'a> SidebarInput<'a> {
+    fn len(self) -> usize {
+        match self {
+            Self::Plain(lines) => lines.len(),
+            Self::Typed(rows) => rows.len(),
+        }
+    }
+
+    fn row(self, index: usize) -> (&'a str, Option<EntryKind>) {
+        match self {
+            Self::Plain(lines) => (&lines[index], None),
+            Self::Typed(rows) => (rows[index].text(), rows[index].kind()),
+        }
+    }
+}
+
+fn glyph_vertices_with_input_budget(
+    target: Target,
+    terminal: Option<&TerminalSnapshot>,
+    sidebar: Option<SidebarInput<'_>>,
     status: Option<&str>,
     vertex_budget: usize,
 ) -> Vec<Vertex> {
@@ -672,16 +741,14 @@ fn glyph_vertices_with_budget(
     // only drawn when the whole cell is visible; sidebar hit testing uses
     // this same count.
     if let Some(lines) = sidebar {
-        for (row, line) in lines
-            .iter()
-            .take(fully_drawable_rows(height, metrics))
-            .enumerate()
-        {
+        let visible_rows = lines.len().min(fully_drawable_rows(height, metrics));
+        for row in 0..visible_rows {
+            let (line, row_kind) = lines.row(row);
             for (col, character) in line.chars().take(sidebar_columns).enumerate() {
                 push_glyph(
                     &mut vertices,
                     character,
-                    sidebar_glyph_color(&theme, character, col, sidebar_columns),
+                    sidebar_glyph_color(&theme, character, col, sidebar_columns, row_kind),
                     col,
                     row,
                     target,

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -39,6 +39,7 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use noren_app::cursor::CursorShape;
+use noren_app::sidebar_text::{DEFAULT_SIDEBAR_COLUMNS, lifecycle_marker_color};
 use noren_app::theme::{Theme, contrast_ratio};
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
 use noren_terminal::{Cell, CellAttributes, Color, TerminalSnapshot};
@@ -68,7 +69,7 @@ const MAX_VERTICES: usize = (MAX_RENDER_ROWS as usize)
 /// Exposed as `pub(crate)` so `main.rs` can subtract it from the PTY/terminal
 /// grid, and so the frame oracle (`renderer_capture.rs`) can render sidebar
 /// content through the same pipeline.
-pub(crate) const SIDEBAR_COLS: usize = 16;
+pub(crate) const SIDEBAR_COLS: usize = DEFAULT_SIDEBAR_COLUMNS;
 
 /// What owns one row in a rendered terminal frame.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -265,6 +266,17 @@ pub(crate) fn resolve_background(theme: &Theme, attributes: &CellAttributes) -> 
         Color::Default => None,
         background => Some(resolve_color(theme, background, theme.background())),
     }
+}
+
+/// Theme-owned colour reinforcing one lifecycle marker's collision-checked
+/// shape. Non-marker sidebar text keeps the default foreground.
+fn sidebar_glyph_color(theme: &Theme, character: char, column: usize) -> [f32; 3] {
+    if column + 1 == SIDEBAR_COLS
+        && let Some(color) = lifecycle_marker_color(character)
+    {
+        return resolve_color(theme, Color::Ansi(color), theme.foreground());
+    }
+    theme.foreground()
 }
 
 /// Clear colour used by the glyph pipeline's load op.
@@ -641,8 +653,9 @@ fn glyph_vertices_with_budget(
     let cursor_plan = terminal.and_then(|snapshot| plan_cursor(snapshot, &layout, terminal_cols));
     let mut vertices = Vec::new();
 
-    // The sidebar is chrome, not terminal content: it carries no cell
-    // attributes, so it draws in the theme's default foreground. Unlike
+    // The sidebar is chrome, not terminal content: ordinary text draws in the
+    // theme's default foreground, while the reserved final-cell lifecycle
+    // marker receives a theme-owned semantic colour as reinforcement. Unlike
     // terminal and status rows, sidebar rows are interactive chrome and are
     // only drawn when the whole cell is visible; sidebar hit testing uses
     // this same count.
@@ -656,7 +669,7 @@ fn glyph_vertices_with_budget(
                 push_glyph(
                     &mut vertices,
                     character,
-                    theme.foreground(),
+                    sidebar_glyph_color(&theme, character, col),
                     col,
                     row,
                     target,
@@ -1341,6 +1354,10 @@ pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
 
 const QUESTION_MARK_GLYPH: [u8; 7] = [14, 17, 1, 2, 4, 0, 4];
 const UNICODE_REPLACEMENT_GLYPH: [u8; 7] = [4, 10, 17, 21, 17, 10, 4];
+const STARTING_MARKER_GLYPH: [u8; 7] = [14, 17, 16, 16, 17, 14, 4];
+const RUNNING_MARKER_GLYPH: [u8; 7] = [8, 12, 14, 15, 14, 12, 8];
+const EXITED_MARKER_GLYPH: [u8; 7] = [0, 14, 14, 14, 14, 14, 0];
+const FAILED_MARKER_GLYPH: [u8; 7] = [17, 10, 4, 14, 4, 10, 17];
 
 /// Add one visible diacritic row to an ASCII base glyph.
 ///
@@ -1689,6 +1706,10 @@ fn box_drawing_rows(character: char) -> Option<[u8; 7]> {
 #[rustfmt::skip]
 fn glyph_rows(character: char) -> [u8; 7] {
     match character {
+        '◌' => STARTING_MARKER_GLYPH,
+        '▶' => RUNNING_MARKER_GLYPH,
+        '■' => EXITED_MARKER_GLYPH,
+        '✕' => FAILED_MARKER_GLYPH,
         ' ' => [0, 0, 0, 0, 0, 0, 0],
         'A' => [14, 17, 17, 31, 17, 17, 17],
         'B' => [30, 17, 17, 30, 17, 17, 30],
@@ -2380,6 +2401,63 @@ mod tests {
         }
 
         assert_eq!(seen.len(), 95, "printable ASCII must contain 95 glyphs");
+    }
+
+    #[test]
+    fn lifecycle_markers_collide_with_none_of_320_existing_sidebar_glyphs() {
+        use noren_app::sidebar_text::LIFECYCLE_MARKERS;
+
+        // The sidebar can receive every renderer-covered text glyph through a
+        // configured or discovered label: 95 printable ASCII, 96 Latin-1
+        // Supplement, and 128 Box Drawing characters. Unsupported Unicode
+        // adds one replacement glyph. Check marker shapes against all 320
+        // inputs, not only against the three pre-existing chrome markers.
+        let mut existing: Vec<char> = (0x20_u8..=0x7e).map(char::from).collect();
+        existing.extend((0x00a0..=0x00ff).filter_map(char::from_u32));
+        existing.extend((0x2500..=0x257f).filter_map(char::from_u32));
+        assert_eq!(existing.len(), 319);
+
+        for (index, marker) in LIFECYCLE_MARKERS.into_iter().enumerate() {
+            let marker_rows = glyph_rows(marker);
+            assert_ne!(
+                marker_rows, UNICODE_REPLACEMENT_GLYPH,
+                "lifecycle marker {marker:?} collides with Unicode replacement"
+            );
+            for existing_glyph in &existing {
+                assert_ne!(
+                    marker_rows,
+                    glyph_rows(*existing_glyph),
+                    "lifecycle marker {marker:?} collides with existing sidebar glyph \
+                     {existing_glyph:?}"
+                );
+            }
+            for other in &LIFECYCLE_MARKERS[index + 1..] {
+                assert_ne!(
+                    marker_rows,
+                    glyph_rows(*other),
+                    "lifecycle markers {marker:?} and {other:?} collide"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn lifecycle_marker_colors_clear_aa_on_every_shipped_sidebar_background() {
+        use noren_app::sidebar_text::LIFECYCLE_MARKERS;
+        use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT};
+
+        for theme in [DARK, LIGHT, HIGH_CONTRAST] {
+            for marker in LIFECYCLE_MARKERS {
+                let ansi = lifecycle_marker_color(marker).expect("known lifecycle marker");
+                let color = theme.ansi()[usize::from(ansi.palette_index())];
+                let ratio = contrast_ratio(color, theme.background_u8());
+                assert!(
+                    ratio >= 4.5,
+                    "marker {marker:?} has only {ratio:.4}:1 contrast on {:?}",
+                    theme.background_u8()
+                );
+            }
+        }
     }
 
     /// Distinct covered characters may share a bitmap only where a 5×7 grid

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -2524,22 +2524,43 @@ mod tests {
             }
         }
 
-        let starting_rows = glyph_rows(LIFECYCLE_MARKERS[0]);
-        let (nearest_distance, nearest_glyph) = existing
+        // Pin the margin for EVERY marker, not just the starting one. The
+        // narrower single-marker form let a future edit to any of the other
+        // three shrink its margin unnoticed. The comparison set is the full
+        // sidebar glyph inventory plus the other markers, so the assertion
+        // covers the marker-vs-marker minimum as well.
+        let bit_distance = |first: [u8; 7], second: [u8; 7]| -> u32 {
+            first
+                .iter()
+                .zip(second)
+                .map(|(a, b)| (a ^ b).count_ones())
+                .sum()
+        };
+        let (global_minimum, worst_pair) = LIFECYCLE_MARKERS
             .iter()
-            .map(|existing_glyph| {
-                let distance = starting_rows
+            .enumerate()
+            .flat_map(|(index, marker)| {
+                let marker_rows = glyph_rows(*marker);
+                existing
                     .iter()
-                    .zip(glyph_rows(*existing_glyph))
-                    .map(|(first, second)| (first ^ second).count_ones())
-                    .sum::<u32>();
-                (distance, *existing_glyph)
+                    .copied()
+                    .chain(LIFECYCLE_MARKERS[index + 1..].iter().copied())
+                    .map(move |other| {
+                        (
+                            bit_distance(marker_rows, glyph_rows(other)),
+                            (*marker, other),
+                        )
+                    })
             })
             .min()
             .expect("the full 320-glyph comparison set is non-empty");
+        // `▶` vs `■` is the true global minimum: 5 of 7 rows differ, which
+        // reads as an unmistakable triangle against a filled square. This
+        // pins that margin so a redesign of any marker cannot silently
+        // erode it.
         assert_eq!(
-            nearest_distance, 10,
-            "starting marker is only {nearest_distance} bits from {nearest_glyph:?}"
+            global_minimum, 5,
+            "closest marker pair {worst_pair:?} is only {global_minimum} bits apart"
         );
     }
 

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -1441,7 +1441,7 @@ pub(crate) fn vertex_bytes(vertices: &[Vertex]) -> Vec<u8> {
 
 const QUESTION_MARK_GLYPH: [u8; 7] = [14, 17, 1, 2, 4, 0, 4];
 const UNICODE_REPLACEMENT_GLYPH: [u8; 7] = [4, 10, 17, 21, 17, 10, 4];
-const STARTING_MARKER_GLYPH: [u8; 7] = [14, 17, 16, 16, 17, 14, 4];
+const STARTING_MARKER_GLYPH: [u8; 7] = [31, 27, 14, 4, 14, 27, 31];
 const RUNNING_MARKER_GLYPH: [u8; 7] = [8, 12, 14, 15, 14, 12, 8];
 const EXITED_MARKER_GLYPH: [u8; 7] = [0, 14, 14, 14, 14, 14, 0];
 const FAILED_MARKER_GLYPH: [u8; 7] = [17, 10, 4, 14, 4, 10, 17];
@@ -1793,7 +1793,7 @@ fn box_drawing_rows(character: char) -> Option<[u8; 7]> {
 #[rustfmt::skip]
 fn glyph_rows(character: char) -> [u8; 7] {
     match character {
-        '◌' => STARTING_MARKER_GLYPH,
+        '⌛' => STARTING_MARKER_GLYPH,
         '▶' => RUNNING_MARKER_GLYPH,
         '■' => EXITED_MARKER_GLYPH,
         '✕' => FAILED_MARKER_GLYPH,
@@ -2502,14 +2502,11 @@ mod tests {
         let mut existing: Vec<char> = (0x20_u8..=0x7e).map(char::from).collect();
         existing.extend((0x00a0..=0x00ff).filter_map(char::from_u32));
         existing.extend((0x2500..=0x257f).filter_map(char::from_u32));
-        assert_eq!(existing.len(), 319);
+        existing.push('\u{fffd}');
+        assert_eq!(existing.len(), 320);
 
         for (index, marker) in LIFECYCLE_MARKERS.into_iter().enumerate() {
             let marker_rows = glyph_rows(marker);
-            assert_ne!(
-                marker_rows, UNICODE_REPLACEMENT_GLYPH,
-                "lifecycle marker {marker:?} collides with Unicode replacement"
-            );
             for existing_glyph in &existing {
                 assert_ne!(
                     marker_rows,
@@ -2526,6 +2523,24 @@ mod tests {
                 );
             }
         }
+
+        let starting_rows = glyph_rows(LIFECYCLE_MARKERS[0]);
+        let (nearest_distance, nearest_glyph) = existing
+            .iter()
+            .map(|existing_glyph| {
+                let distance = starting_rows
+                    .iter()
+                    .zip(glyph_rows(*existing_glyph))
+                    .map(|(first, second)| (first ^ second).count_ones())
+                    .sum::<u32>();
+                (distance, *existing_glyph)
+            })
+            .min()
+            .expect("the full 320-glyph comparison set is non-empty");
+        assert_eq!(
+            nearest_distance, 10,
+            "starting marker is only {nearest_distance} bits from {nearest_glyph:?}"
+        );
     }
 
     #[test]

--- a/crates/noren-app/src/renderer_capture.rs
+++ b/crates/noren-app/src/renderer_capture.rs
@@ -48,10 +48,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll, Wake, Waker};
 use std::thread;
 
+use noren_app::sidebar_text::SidebarTextRow;
 use noren_terminal::TerminalSnapshot;
 use renderer_source::{
-    SHADER, Target, VERTEX_ATTRIBUTES, VERTEX_BYTES, glyph_vertices_for, theme_clear_color,
-    vertex_bytes,
+    SHADER, Target, VERTEX_ATTRIBUTES, VERTEX_BYTES, Vertex, glyph_vertices_for,
+    glyph_vertices_for_sidebar_rows, theme_clear_color, vertex_bytes,
 };
 
 /// Linear RGBA8 (non-sRGB) offscreen target.
@@ -254,12 +255,29 @@ impl OffscreenRenderer {
         sidebar: Option<&[String]>,
         status: Option<&str>,
     ) -> CapturedFrame {
+        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
+        self.capture_vertices(target, vertices)
+    }
+
+    /// Render sidebar rows whose domain kinds are retained by the production
+    /// text projection, including the session-only lifecycle colour gate.
+    pub(crate) fn capture_sidebar_rows(
+        &self,
+        target: Target,
+        terminal: Option<&TerminalSnapshot>,
+        sidebar: Option<&[SidebarTextRow]>,
+        status: Option<&str>,
+    ) -> CapturedFrame {
+        let vertices = glyph_vertices_for_sidebar_rows(target, terminal, sidebar, status);
+        self.capture_vertices(target, vertices)
+    }
+
+    fn capture_vertices(&self, target: Target, vertices: Vec<Vertex>) -> CapturedFrame {
         assert!(
             target.width > 0 && target.height > 0,
             "capture target must be non-zero"
         );
 
-        let vertices = glyph_vertices_for(target, terminal, sidebar, status);
         let bytes = vertex_bytes(&vertices);
         let (width, height) = (target.width, target.height);
 

--- a/crates/noren-app/src/sidebar.rs
+++ b/crates/noren-app/src/sidebar.rs
@@ -46,6 +46,24 @@ pub enum EntryKind {
     Session,
 }
 
+/// The four user-visible lifecycle classes carried by a session row.
+///
+/// [`SessionStatus::Restored`] deliberately projects to [`Exited`](Self::Exited):
+/// a restored record has no running process, so the stopped marker is the
+/// truthful compact treatment. The persisted/restored detail remains available
+/// on the row; this enum exists only for the always-visible lifecycle signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SessionLifecycle {
+    /// The session exists but has not yet reported a running observation.
+    Starting,
+    /// The session has a live observed process.
+    Running,
+    /// The process exited, or the row was restored without a live process.
+    Exited,
+    /// Session startup or operation failed.
+    Failed,
+}
+
 impl EntryKind {
     /// The fixed, content-free name of this kind.
     ///
@@ -75,6 +93,7 @@ pub struct SidebarRow {
     kind: EntryKind,
     label: String,
     detail: Option<String>,
+    lifecycle: Option<SessionLifecycle>,
     selected: bool,
 }
 
@@ -95,6 +114,12 @@ impl SidebarRow {
     #[must_use]
     pub fn detail(&self) -> Option<&str> {
         self.detail.as_deref()
+    }
+
+    /// Compact lifecycle carried only by session rows.
+    #[must_use]
+    pub const fn lifecycle(&self) -> Option<SessionLifecycle> {
+        self.lifecycle
     }
 
     /// Whether this row carries the single selection.
@@ -309,12 +334,14 @@ impl SidebarView {
                     kind: EntryKind::Project,
                     label: name.clone(),
                     detail: Some(root.clone()),
+                    lifecycle: None,
                     selected: false,
                 },
                 SidebarEntry::Worktree { name, branch } => SidebarRow {
                     kind: EntryKind::Worktree,
                     label: name.clone(),
                     detail: Some(branch.clone()),
+                    lifecycle: None,
                     selected: false,
                 },
                 SidebarEntry::SshConnection {
@@ -330,6 +357,7 @@ impl SidebarView {
                         kind: EntryKind::SshConnection,
                         label: label.clone(),
                         detail: Some(host.clone()),
+                        lifecycle: None,
                         selected: is_selected,
                     }
                 }
@@ -337,6 +365,7 @@ impl SidebarView {
                     kind: EntryKind::Agent,
                     label: label.clone(),
                     detail: Some(status.clone()),
+                    lifecycle: None,
                     selected: false,
                 },
                 SidebarEntry::Session(descriptor) => {
@@ -354,6 +383,7 @@ impl SidebarView {
                         kind: EntryKind::Session,
                         label: session_label(descriptor),
                         detail: Some(session_detail(descriptor)),
+                        lifecycle: Some(session_lifecycle(descriptor.status())),
                         selected: is_selected,
                     }
                 }
@@ -433,6 +463,15 @@ fn session_status_text(status: &SessionStatus) -> &'static str {
         SessionStatus::Running => "running",
         SessionStatus::Exited { .. } => "exited",
         SessionStatus::Failed { .. } => "failed",
+    }
+}
+
+fn session_lifecycle(status: &SessionStatus) -> SessionLifecycle {
+    match status {
+        SessionStatus::Starting => SessionLifecycle::Starting,
+        SessionStatus::Running => SessionLifecycle::Running,
+        SessionStatus::Restored | SessionStatus::Exited { .. } => SessionLifecycle::Exited,
+        SessionStatus::Failed { .. } => SessionLifecycle::Failed,
     }
 }
 

--- a/crates/noren-app/src/sidebar_text.rs
+++ b/crates/noren-app/src/sidebar_text.rs
@@ -5,11 +5,19 @@
 //! the name for space. This projection stays separate from [`crate::sidebar`]
 //! so the view model remains renderer- and geometry-independent.
 
+use crate::MAX_RENDER_COLS;
 use crate::sidebar::{SessionLifecycle, SidebarRow, SidebarView};
 use noren_terminal::AnsiColor;
 
 /// Shipped sidebar width in cell columns.
 pub const DEFAULT_SIDEBAR_COLUMNS: usize = 16;
+
+/// Narrowest configurable sidebar: selection, one identity cell, ellipsis,
+/// separator, and the reserved lifecycle cell all remain representable.
+pub const MIN_SIDEBAR_COLUMNS: usize = 8;
+
+/// Widest configurable sidebar while retaining one drawable terminal column.
+pub const MAX_SIDEBAR_COLUMNS: usize = MAX_RENDER_COLS as usize - 1;
 
 /// Marker glyphs in lifecycle order: starting, running, exited, failed.
 ///

--- a/crates/noren-app/src/sidebar_text.rs
+++ b/crates/noren-app/src/sidebar_text.rs
@@ -6,7 +6,7 @@
 //! so the view model remains renderer- and geometry-independent.
 
 use crate::MAX_RENDER_COLS;
-use crate::sidebar::{SessionLifecycle, SidebarRow, SidebarView};
+use crate::sidebar::{EntryKind, SessionLifecycle, SidebarRow, SidebarView};
 use noren_terminal::AnsiColor;
 
 /// Shipped sidebar width in cell columns.
@@ -29,6 +29,49 @@ pub const LIFECYCLE_MARKERS: [char; 4] = ['◌', '▶', '■', '✕'];
 const ROW_PREFIX_COLUMNS: usize = 2;
 const STATE_SUFFIX_COLUMNS: usize = 2;
 const ELLIPSIS: &str = "...";
+
+/// One projected sidebar row with its domain kind preserved for rendering.
+///
+/// Text alone cannot identify a lifecycle row: non-session labels are
+/// user-derived and may place a marker-shaped character in the final visible
+/// cell. `None` is reserved for chrome that has no workspace entry, such as
+/// the empty-state notice or command palette rows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SidebarTextRow {
+    text: String,
+    kind: Option<EntryKind>,
+}
+
+impl SidebarTextRow {
+    /// Build a text-only chrome row that carries no workspace entry kind.
+    #[must_use]
+    pub fn chrome(text: String) -> Self {
+        Self { text, kind: None }
+    }
+
+    /// The text cells emitted for this row.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The domain entry kind, or `None` for non-entry chrome.
+    #[must_use]
+    pub const fn kind(&self) -> Option<EntryKind> {
+        self.kind
+    }
+
+    fn entry(text: String, kind: EntryKind) -> Self {
+        Self {
+            text,
+            kind: Some(kind),
+        }
+    }
+
+    fn into_text(self) -> String {
+        self.text
+    }
+}
 
 /// The marker glyph assigned to one lifecycle class.
 #[must_use]
@@ -76,20 +119,37 @@ pub fn visible_sidebar_text_lines_at_width(
     max_rows: usize,
     columns: usize,
 ) -> Vec<String> {
+    visible_sidebar_text_rows_at_width(sidebar, offset, max_rows, columns)
+        .into_iter()
+        .map(SidebarTextRow::into_text)
+        .collect()
+}
+
+/// Format visible rows while preserving the entry kind each line came from.
+///
+/// The renderer consumes this projection so semantic lifecycle colour is
+/// gated by `EntryKind::Session`, never by user-controlled text alone.
+#[must_use]
+pub fn visible_sidebar_text_rows_at_width(
+    sidebar: &SidebarView,
+    offset: usize,
+    max_rows: usize,
+    columns: usize,
+) -> Vec<SidebarTextRow> {
     if max_rows == 0 || columns == 0 {
         return Vec::new();
     }
     if sidebar.is_empty() {
         return sidebar
             .empty_state()
-            .map(|state| vec![state.message().to_string()])
+            .map(|state| vec![SidebarTextRow::chrome(state.message().to_string())])
             .unwrap_or_default();
     }
     let offset = offset.min(sidebar.rows().len().saturating_sub(max_rows));
     sidebar.rows()[offset..]
         .iter()
         .take(max_rows)
-        .map(|row| format_row(row, columns))
+        .map(|row| SidebarTextRow::entry(format_row(row, columns), row.kind()))
         .collect()
 }
 

--- a/crates/noren-app/src/sidebar_text.rs
+++ b/crates/noren-app/src/sidebar_text.rs
@@ -24,7 +24,7 @@ pub const MAX_SIDEBAR_COLUMNS: usize = MAX_RENDER_COLS as usize - 1;
 /// These code points receive explicit, collision-checked 5x7 bitmaps in the
 /// production renderer. They are shapes as well as colours, so remapped
 /// palettes and colour-vision differences cannot collapse the four states.
-pub const LIFECYCLE_MARKERS: [char; 4] = ['◌', '▶', '■', '✕'];
+pub const LIFECYCLE_MARKERS: [char; 4] = ['⌛', '▶', '■', '✕'];
 
 const ROW_PREFIX_COLUMNS: usize = 2;
 const STATE_SUFFIX_COLUMNS: usize = 2;
@@ -88,7 +88,7 @@ pub const fn lifecycle_marker(lifecycle: SessionLifecycle) -> char {
 #[must_use]
 pub const fn lifecycle_marker_color(marker: char) -> Option<AnsiColor> {
     match marker {
-        '◌' => Some(AnsiColor::Yellow),
+        '⌛' => Some(AnsiColor::Yellow),
         '▶' => Some(AnsiColor::Green),
         '■' => Some(AnsiColor::BrightBlack),
         '✕' => Some(AnsiColor::Red),

--- a/crates/noren-app/src/sidebar_text.rs
+++ b/crates/noren-app/src/sidebar_text.rs
@@ -1,0 +1,168 @@
+//! Width-aware text projection for the sidebar view.
+//!
+//! Session rows reserve their final cell for a lifecycle marker. Identity may
+//! truncate to a visible ASCII ellipsis, but the marker never competes with
+//! the name for space. This projection stays separate from [`crate::sidebar`]
+//! so the view model remains renderer- and geometry-independent.
+
+use crate::sidebar::{SessionLifecycle, SidebarRow, SidebarView};
+use noren_terminal::AnsiColor;
+
+/// Shipped sidebar width in cell columns.
+pub const DEFAULT_SIDEBAR_COLUMNS: usize = 16;
+
+/// Marker glyphs in lifecycle order: starting, running, exited, failed.
+///
+/// These code points receive explicit, collision-checked 5x7 bitmaps in the
+/// production renderer. They are shapes as well as colours, so remapped
+/// palettes and colour-vision differences cannot collapse the four states.
+pub const LIFECYCLE_MARKERS: [char; 4] = ['◌', '▶', '■', '✕'];
+
+const ROW_PREFIX_COLUMNS: usize = 2;
+const STATE_SUFFIX_COLUMNS: usize = 2;
+const ELLIPSIS: &str = "...";
+
+/// The marker glyph assigned to one lifecycle class.
+#[must_use]
+pub const fn lifecycle_marker(lifecycle: SessionLifecycle) -> char {
+    match lifecycle {
+        SessionLifecycle::Starting => LIFECYCLE_MARKERS[0],
+        SessionLifecycle::Running => LIFECYCLE_MARKERS[1],
+        SessionLifecycle::Exited => LIFECYCLE_MARKERS[2],
+        SessionLifecycle::Failed => LIFECYCLE_MARKERS[3],
+    }
+}
+
+/// Theme palette role reinforcing a lifecycle marker's shape.
+#[must_use]
+pub const fn lifecycle_marker_color(marker: char) -> Option<AnsiColor> {
+    match marker {
+        '◌' => Some(AnsiColor::Yellow),
+        '▶' => Some(AnsiColor::Green),
+        '■' => Some(AnsiColor::BrightBlack),
+        '✕' => Some(AnsiColor::Red),
+        _ => None,
+    }
+}
+
+/// Format the visible sidebar slice at the shipped 16-column width.
+#[must_use]
+pub fn visible_sidebar_text_lines(
+    sidebar: &SidebarView,
+    offset: usize,
+    max_rows: usize,
+) -> Vec<String> {
+    visible_sidebar_text_lines_at_width(sidebar, offset, max_rows, DEFAULT_SIDEBAR_COLUMNS)
+}
+
+/// Format the visible sidebar slice at an explicit cell width.
+///
+/// The scroll offset is clamped to the last full page so formatting work stays
+/// proportional to visible rows. Non-session rows preserve their established
+/// text. Session rows reserve the last cell for lifecycle and truncate only
+/// the identity region.
+#[must_use]
+pub fn visible_sidebar_text_lines_at_width(
+    sidebar: &SidebarView,
+    offset: usize,
+    max_rows: usize,
+    columns: usize,
+) -> Vec<String> {
+    if max_rows == 0 || columns == 0 {
+        return Vec::new();
+    }
+    if sidebar.is_empty() {
+        return sidebar
+            .empty_state()
+            .map(|state| vec![state.message().to_string()])
+            .unwrap_or_default();
+    }
+    let offset = offset.min(sidebar.rows().len().saturating_sub(max_rows));
+    sidebar.rows()[offset..]
+        .iter()
+        .take(max_rows)
+        .map(|row| format_row(row, columns))
+        .collect()
+}
+
+fn format_row(row: &SidebarRow, columns: usize) -> String {
+    match row.lifecycle() {
+        Some(lifecycle) => format_session_row(
+            row.is_selected(),
+            row.label(),
+            lifecycle_marker(lifecycle),
+            columns,
+        ),
+        None => {
+            let selection = if row.is_selected() { '>' } else { ' ' };
+            match row.detail() {
+                Some(detail) => format!("{selection} {} {detail}", row.label()),
+                None => format!("{selection} {}", row.label()),
+            }
+        }
+    }
+}
+
+fn format_session_row(selected: bool, label: &str, state: char, columns: usize) -> String {
+    let mut cells = vec![' '; columns];
+    let last = columns - 1;
+    cells[last] = state;
+
+    if columns > 1 {
+        cells[0] = if selected { '>' } else { ' ' };
+    }
+
+    let name_end = columns.saturating_sub(STATE_SUFFIX_COLUMNS);
+    if name_end > ROW_PREFIX_COLUMNS {
+        let available = name_end - ROW_PREFIX_COLUMNS;
+        for (index, character) in truncated_label(label, available).chars().enumerate() {
+            cells[ROW_PREFIX_COLUMNS + index] = character;
+        }
+    }
+
+    cells.into_iter().collect()
+}
+
+fn truncated_label(label: &str, columns: usize) -> String {
+    let count = label.chars().count();
+    if count <= columns {
+        return label.to_string();
+    }
+    let ellipsis_columns = ELLIPSIS.chars().count();
+    if columns <= ellipsis_columns {
+        return label.chars().take(columns).collect();
+    }
+    label
+        .chars()
+        .take(columns - ellipsis_columns)
+        .chain(ELLIPSIS.chars())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn long_session_identity_truncates_before_the_reserved_state_cell() {
+        let line = format_session_row(
+            true,
+            "session-name-that-is-much-too-long",
+            lifecycle_marker(SessionLifecycle::Failed),
+            DEFAULT_SIDEBAR_COLUMNS,
+        );
+
+        assert_eq!(line, "> session-n... ✕");
+        assert_eq!(line.chars().count(), DEFAULT_SIDEBAR_COLUMNS);
+        assert_eq!(line.chars().last(), Some('✕'));
+    }
+
+    #[test]
+    fn even_tiny_widths_keep_state_as_the_final_visible_cell() {
+        for columns in 1..DEFAULT_SIDEBAR_COLUMNS {
+            let line = format_session_row(false, "session-long", '▶', columns);
+            assert_eq!(line.chars().count(), columns);
+            assert_eq!(line.chars().last(), Some('▶'));
+        }
+    }
+}

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -2202,17 +2202,23 @@ fn lifecycle_sidebar_line(status: SessionStatus) -> String {
         .expect("one session produces one sidebar line")
 }
 
-fn lifecycle_cases() -> [(SessionStatus, char, usize); 4] {
+fn lifecycle_cases() -> [(SessionStatus, char, usize, [u8; 7]); 4] {
     [
-        (SessionStatus::Starting, '◌', 3),
-        (SessionStatus::Running, '▶', 2),
-        (SessionStatus::Exited { code: Some(0) }, '■', 8),
+        (SessionStatus::Starting, '◌', 3, [14, 17, 16, 16, 17, 14, 4]),
+        (SessionStatus::Running, '▶', 2, [8, 12, 14, 15, 14, 12, 8]),
+        (
+            SessionStatus::Exited { code: Some(0) },
+            '■',
+            8,
+            [0, 14, 14, 14, 14, 14, 0],
+        ),
         (
             SessionStatus::Failed {
                 reason: "frame fixture".to_string(),
             },
             '✕',
             1,
+            [17, 10, 4, 14, 4, 10, 17],
         ),
     ]
 }
@@ -2222,6 +2228,34 @@ fn lifecycle_cases() -> [(SessionStatus, char, usize); 4] {
 /// the same vertices feed the shipped shader and the offscreen pixel capture.
 type GlyphRect = (u32, u32, u32, u32);
 type SidebarCellVertexOracle = (Vec<GlyphRect>, Vec<[f32; 3]>);
+
+/// Reconstruct the renderer's 5x7 bitmap from the rectangles emitted inside
+/// one text cell. Keeping this decoder in the independent frame oracle makes
+/// the expected row registration separate from the renderer's glyph table:
+/// shifting a marker down while preserving its shape must fail here.
+fn glyph_rows_from_rectangles(rectangles: &[GlyphRect]) -> [u8; 7] {
+    const GLYPH_SCALE: u32 = 2;
+    const GLYPH_TOP: u32 = 3;
+
+    let mut rows = [0_u8; 7];
+    for &(left, top, width, height) in rectangles {
+        assert_eq!((width, height), (GLYPH_SCALE, GLYPH_SCALE));
+        assert_eq!(left % GLYPH_SCALE, 0, "glyph pixel is off the x grid");
+        assert!(top >= GLYPH_TOP, "glyph pixel is above the text inset");
+        assert_eq!(
+            (top - GLYPH_TOP) % GLYPH_SCALE,
+            0,
+            "glyph pixel is off the y grid"
+        );
+
+        let glyph_x = left / GLYPH_SCALE;
+        let glyph_y = (top - GLYPH_TOP) / GLYPH_SCALE;
+        assert!(glyph_x < 5, "glyph pixel exceeds the 5-column bitmap");
+        assert!(glyph_y < 7, "glyph pixel exceeds the 7-row bitmap");
+        rows[glyph_y as usize] |= 1 << (4 - glyph_x);
+    }
+    rows
+}
 
 fn sidebar_cell_vertex_oracle(line: &str, theme: &Theme, column: u32) -> SidebarCellVertexOracle {
     let width = SIDEBAR_COLS as u32 * CELL_WIDTH;
@@ -2254,7 +2288,7 @@ fn sidebar_cell_vertex_oracle(line: &str, theme: &Theme, column: u32) -> Sidebar
 #[test]
 fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
     let mut signatures = Vec::new();
-    for (status, expected_marker, expected_ansi) in lifecycle_cases() {
+    for (status, expected_marker, expected_ansi, expected_rows) in lifecycle_cases() {
         let line = lifecycle_sidebar_line(status);
         assert_eq!(
             line.chars().count(),
@@ -2279,6 +2313,11 @@ fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
         assert!(
             !signatures.contains(&signature),
             "marker {expected_marker:?} rendered the same shape as another lifecycle"
+        );
+        assert_eq!(
+            glyph_rows_from_rectangles(&signature),
+            expected_rows,
+            "marker {expected_marker:?} moved within its cell"
         );
         signatures.push(signature);
 
@@ -2319,7 +2358,7 @@ fn session_lifecycle_markers_reach_distinct_frame_pixels_at_16_columns() {
     let width = SIDEBAR_COLS as u32 * CELL_WIDTH;
     let marker_column = u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32");
     let mut patterns = Vec::new();
-    for (status, expected_marker, expected_ansi) in lifecycle_cases() {
+    for (status, expected_marker, expected_ansi, _) in lifecycle_cases() {
         let line = lifecycle_sidebar_line(status);
         let lines = [line];
         let frame = renderer.capture(

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -85,13 +85,18 @@ use std::io::Write;
 use std::process::Command;
 
 use noren_app::cursor::CursorShape;
+use noren_app::session::{SessionKind, SessionRegistry, SessionStatus};
+use noren_app::sidebar::{SidebarEntry, SidebarView};
+use noren_app::sidebar_text::visible_sidebar_text_lines_at_width;
 use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
-use renderer_capture::renderer_source::{CLEAR_COLOR, CursorStyle, SIDEBAR_COLS, Target};
+use renderer_capture::renderer_source::{
+    CLEAR_COLOR, CursorStyle, SIDEBAR_COLS, Target, glyph_vertices_for,
+};
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
 /// The PoC default cell metrics, used by every frame-oracle capture call so
@@ -2174,6 +2179,174 @@ fn render_with_sidebar(
         Some(sidebar),
         None,
     )
+}
+
+/// Build one real session row through the domain model and production text
+/// projection. No process is involved: the registry records an explicit
+/// observation and the view projects it into the same line the app renders.
+fn lifecycle_sidebar_line(status: SessionStatus) -> String {
+    let mut registry = SessionRegistry::new();
+    let id = registry.create(SessionKind::Local);
+    if status != SessionStatus::Starting {
+        registry
+            .observe(id, status)
+            .expect("fixture lifecycle advances monotonically");
+    }
+    let entries = [SidebarEntry::Session(
+        registry.get(id).expect("fixture id remains live"),
+    )];
+    let view = SidebarView::build(&entries, Some(id));
+    visible_sidebar_text_lines_at_width(&view, 0, 1, SIDEBAR_COLS)
+        .into_iter()
+        .next()
+        .expect("one session produces one sidebar line")
+}
+
+fn lifecycle_cases() -> [(SessionStatus, char, usize); 4] {
+    [
+        (SessionStatus::Starting, '◌', 3),
+        (SessionStatus::Running, '▶', 2),
+        (SessionStatus::Exited { code: Some(0) }, '■', 8),
+        (
+            SessionStatus::Failed {
+                reason: "frame fixture".to_string(),
+            },
+            '✕',
+            1,
+        ),
+    ]
+}
+
+/// Rectangle fingerprint and colours emitted inside one sidebar cell by the
+/// production vertex path. This is a frame oracle that needs no GPU adapter:
+/// the same vertices feed the shipped shader and the offscreen pixel capture.
+type GlyphRect = (u32, u32, u32, u32);
+type SidebarCellVertexOracle = (Vec<GlyphRect>, Vec<[f32; 3]>);
+
+fn sidebar_cell_vertex_oracle(line: &str, theme: &Theme, column: u32) -> SidebarCellVertexOracle {
+    let width = SIDEBAR_COLS as u32 * CELL_WIDTH;
+    let height = CELL_HEIGHT;
+    let lines = [line.to_string()];
+    let vertices = glyph_vertices_for(
+        Target::new(theme, width, height, poc_metrics()),
+        None,
+        Some(&lines),
+        None,
+    );
+    let pixel_x = |ndc: f32| (((ndc + 1.0) * 0.5 * width as f32).round()) as u32;
+    let pixel_y = |ndc: f32| (((1.0 - ndc) * 0.5 * height as f32).round()) as u32;
+    let mut signature = Vec::new();
+    let mut colors = Vec::new();
+    for rectangle in vertices.chunks_exact(6) {
+        let left = pixel_x(rectangle[0].position[0]);
+        if left / CELL_WIDTH != column {
+            continue;
+        }
+        let top = pixel_y(rectangle[0].position[1]);
+        let right = pixel_x(rectangle[2].position[0]);
+        let bottom = pixel_y(rectangle[2].position[1]);
+        signature.push((left - column * CELL_WIDTH, top, right - left, bottom - top));
+        colors.push(rectangle[0].color);
+    }
+    (signature, colors)
+}
+
+#[test]
+fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
+    let mut signatures = Vec::new();
+    for (status, expected_marker, expected_ansi) in lifecycle_cases() {
+        let line = lifecycle_sidebar_line(status);
+        assert_eq!(
+            line.chars().count(),
+            SIDEBAR_COLS,
+            "the compact session row must end at the shipped sidebar edge: {line:?}"
+        );
+        assert_eq!(
+            line.chars().nth(SIDEBAR_COLS - 1),
+            Some(expected_marker),
+            "each lifecycle owns an identifiable literal in visible column 16"
+        );
+
+        let (signature, _) = sidebar_cell_vertex_oracle(
+            &line,
+            &DARK,
+            u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32"),
+        );
+        assert!(
+            !signature.is_empty(),
+            "marker {expected_marker:?} emitted no geometry in visible column 16"
+        );
+        assert!(
+            !signatures.contains(&signature),
+            "marker {expected_marker:?} rendered the same shape as another lifecycle"
+        );
+        signatures.push(signature);
+
+        for theme in [DARK, LIGHT, HIGH_CONTRAST] {
+            let (_, colors) = sidebar_cell_vertex_oracle(
+                &line,
+                &theme,
+                u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32"),
+            );
+            let expected = theme.ansi()[expected_ansi].map(|channel| f32::from(channel) / 255.0);
+            assert!(
+                colors.iter().all(|color| *color == expected),
+                "marker {expected_marker:?} did not use ANSI slot {expected_ansi} on theme \
+                 background {:?}: {colors:?}",
+                theme.background_u8()
+            );
+            assert!(
+                contrast_ratio(theme.ansi()[expected_ansi], theme.background_u8()) >= 4.5,
+                "marker {expected_marker:?} fails WCAG AA on {:?}",
+                theme.background_u8()
+            );
+        }
+    }
+    assert_eq!(
+        signatures.len(),
+        4,
+        "all four lifecycle shapes were checked"
+    );
+}
+
+#[test]
+fn session_lifecycle_markers_reach_distinct_frame_pixels_at_16_columns() {
+    let Some(renderer) =
+        renderer_or_skip("session_lifecycle_markers_reach_distinct_frame_pixels_at_16_columns")
+    else {
+        return;
+    };
+    let width = SIDEBAR_COLS as u32 * CELL_WIDTH;
+    let marker_column = u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32");
+    let mut patterns = Vec::new();
+    for (status, expected_marker, expected_ansi) in lifecycle_cases() {
+        let line = lifecycle_sidebar_line(status);
+        let lines = [line];
+        let frame = renderer.capture(
+            Target::new(&DARK, width, CELL_HEIGHT, poc_metrics()),
+            None,
+            Some(&lines),
+            None,
+        );
+        assert!(
+            cell_is_lit(&frame, 0, marker_column),
+            "marker {expected_marker:?} is not visible in column 16"
+        );
+        assert!(
+            colors_match(
+                cell_color(&frame, 0, marker_column),
+                DARK.ansi()[expected_ansi]
+            ),
+            "marker {expected_marker:?} pixel colour is not its semantic palette role"
+        );
+        let pattern = cell_pattern(&frame, 0, marker_column);
+        assert!(
+            !patterns.contains(&pattern),
+            "marker {expected_marker:?} has the same frame pixels as another lifecycle"
+        );
+        patterns.push(pattern);
+    }
+    assert_eq!(patterns.len(), 4, "all four rendered markers were checked");
 }
 
 #[test]

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -2204,7 +2204,12 @@ fn lifecycle_sidebar_row(status: SessionStatus) -> SidebarTextRow {
 
 fn lifecycle_cases() -> [(SessionStatus, char, usize, [u8; 7]); 4] {
     [
-        (SessionStatus::Starting, '◌', 3, [14, 17, 16, 16, 17, 14, 4]),
+        (
+            SessionStatus::Starting,
+            '⌛',
+            3,
+            [31, 27, 14, 4, 14, 27, 31],
+        ),
         (SessionStatus::Running, '▶', 2, [8, 12, 14, 15, 14, 12, 8]),
         (
             SessionStatus::Exited { code: Some(0) },

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -86,8 +86,8 @@ use std::process::Command;
 
 use noren_app::cursor::CursorShape;
 use noren_app::session::{SessionKind, SessionRegistry, SessionStatus};
-use noren_app::sidebar::{SidebarEntry, SidebarView};
-use noren_app::sidebar_text::visible_sidebar_text_lines_at_width;
+use noren_app::sidebar::{EntryKind, SidebarEntry, SidebarView};
+use noren_app::sidebar_text::{SidebarTextRow, visible_sidebar_text_rows_at_width};
 use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
@@ -95,7 +95,7 @@ use noren_app::{
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::{
-    CLEAR_COLOR, CursorStyle, SIDEBAR_COLS, Target, glyph_vertices_for,
+    CLEAR_COLOR, CursorStyle, SIDEBAR_COLS, Target, glyph_vertices_for_sidebar_rows,
 };
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
@@ -2184,7 +2184,7 @@ fn render_with_sidebar(
 /// Build one real session row through the domain model and production text
 /// projection. No process is involved: the registry records an explicit
 /// observation and the view projects it into the same line the app renders.
-fn lifecycle_sidebar_line(status: SessionStatus) -> String {
+fn lifecycle_sidebar_row(status: SessionStatus) -> SidebarTextRow {
     let mut registry = SessionRegistry::new();
     let id = registry.create(SessionKind::Local);
     if status != SessionStatus::Starting {
@@ -2196,10 +2196,10 @@ fn lifecycle_sidebar_line(status: SessionStatus) -> String {
         registry.get(id).expect("fixture id remains live"),
     )];
     let view = SidebarView::build(&entries, Some(id));
-    visible_sidebar_text_lines_at_width(&view, 0, 1, SIDEBAR_COLS)
+    visible_sidebar_text_rows_at_width(&view, 0, 1, SIDEBAR_COLS)
         .into_iter()
         .next()
-        .expect("one session produces one sidebar line")
+        .expect("one session produces one sidebar row")
 }
 
 fn lifecycle_cases() -> [(SessionStatus, char, usize, [u8; 7]); 4] {
@@ -2257,14 +2257,17 @@ fn glyph_rows_from_rectangles(rectangles: &[GlyphRect]) -> [u8; 7] {
     rows
 }
 
-fn sidebar_cell_vertex_oracle(line: &str, theme: &Theme, column: u32) -> SidebarCellVertexOracle {
+fn sidebar_cell_vertex_oracle(
+    row: &SidebarTextRow,
+    theme: &Theme,
+    column: u32,
+) -> SidebarCellVertexOracle {
     let width = SIDEBAR_COLS as u32 * CELL_WIDTH;
     let height = CELL_HEIGHT;
-    let lines = [line.to_string()];
-    let vertices = glyph_vertices_for(
+    let vertices = glyph_vertices_for_sidebar_rows(
         Target::new(theme, width, height, poc_metrics()),
         None,
-        Some(&lines),
+        Some(std::slice::from_ref(row)),
         None,
     );
     let pixel_x = |ndc: f32| (((ndc + 1.0) * 0.5 * width as f32).round()) as u32;
@@ -2289,7 +2292,8 @@ fn sidebar_cell_vertex_oracle(line: &str, theme: &Theme, column: u32) -> Sidebar
 fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
     let mut signatures = Vec::new();
     for (status, expected_marker, expected_ansi, expected_rows) in lifecycle_cases() {
-        let line = lifecycle_sidebar_line(status);
+        let row = lifecycle_sidebar_row(status);
+        let line = row.text();
         assert_eq!(
             line.chars().count(),
             SIDEBAR_COLS,
@@ -2302,7 +2306,7 @@ fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
         );
 
         let (signature, _) = sidebar_cell_vertex_oracle(
-            &line,
+            &row,
             &DARK,
             u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32"),
         );
@@ -2323,7 +2327,7 @@ fn session_lifecycle_markers_are_identifiable_and_on_row_at_16_columns() {
 
         for theme in [DARK, LIGHT, HIGH_CONTRAST] {
             let (_, colors) = sidebar_cell_vertex_oracle(
-                &line,
+                &row,
                 &theme,
                 u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32"),
             );
@@ -2359,12 +2363,11 @@ fn session_lifecycle_markers_reach_distinct_frame_pixels_at_16_columns() {
     let marker_column = u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32");
     let mut patterns = Vec::new();
     for (status, expected_marker, expected_ansi, _) in lifecycle_cases() {
-        let line = lifecycle_sidebar_line(status);
-        let lines = [line];
-        let frame = renderer.capture(
+        let row = lifecycle_sidebar_row(status);
+        let frame = renderer.capture_sidebar_rows(
             Target::new(&DARK, width, CELL_HEIGHT, poc_metrics()),
             None,
-            Some(&lines),
+            Some(std::slice::from_ref(&row)),
             None,
         );
         assert!(
@@ -2386,6 +2389,39 @@ fn session_lifecycle_markers_reach_distinct_frame_pixels_at_16_columns() {
         patterns.push(pattern);
     }
     assert_eq!(patterns.len(), 4, "all four rendered markers were checked");
+}
+
+#[test]
+fn project_name_ending_in_running_marker_keeps_default_vertex_color() {
+    let entries = [SidebarEntry::Project {
+        name: "aaaaaaaaaaaaa▶".to_string(),
+        root: "/project".to_string(),
+    }];
+    let view = SidebarView::build(&entries, None);
+    let rows = visible_sidebar_text_rows_at_width(&view, 0, 1, SIDEBAR_COLS);
+    let row = rows.first().expect("one project produces one sidebar row");
+    assert_eq!(row.kind(), Some(EntryKind::Project));
+    assert_eq!(
+        row.text().chars().nth(SIDEBAR_COLS - 1),
+        Some('▶'),
+        "fixture must truncate with the marker-shaped project character in column 16"
+    );
+
+    let (_, colors) = sidebar_cell_vertex_oracle(
+        row,
+        &DARK,
+        u32::try_from(SIDEBAR_COLS - 1).expect("sidebar width fits u32"),
+    );
+    let false_running_signal = DARK.ansi()[2].map(|channel| f32::from(channel) / 255.0);
+    assert_ne!(DARK.foreground(), false_running_signal);
+    assert!(
+        !colors.is_empty(),
+        "project's final glyph emitted no vertices"
+    );
+    assert!(
+        colors.iter().all(|color| *color == DARK.foreground()),
+        "project text borrowed the running-session colour: {colors:?}"
+    );
 }
 
 #[test]

--- a/crates/noren-app/tests/sidebar_view.rs
+++ b/crates/noren-app/tests/sidebar_view.rs
@@ -11,8 +11,8 @@ use noren_app::session::{
     SessionDescriptor, SessionId, SessionKind, SessionRegistry, SessionStatus,
 };
 use noren_app::sidebar::{
-    EMPTY_SIDEBAR_MESSAGE, EmptyState, EntryKind, SessionViewport, SidebarEntry, SidebarRow,
-    SidebarView, fixtures,
+    EMPTY_SIDEBAR_MESSAGE, EmptyState, EntryKind, SessionLifecycle, SessionViewport, SidebarEntry,
+    SidebarRow, SidebarView, fixtures,
 };
 
 fn fixture_ids(registry: &SessionRegistry) -> Vec<SessionId> {
@@ -235,6 +235,42 @@ fn session_rows_report_observed_status() {
             Some("local · running"),
             Some("ssh · starting")
         ]
+    );
+    assert_eq!(
+        session_rows
+            .iter()
+            .map(|row| row.lifecycle())
+            .collect::<Vec<_>>(),
+        [
+            Some(SessionLifecycle::Failed),
+            Some(SessionLifecycle::Running),
+            Some(SessionLifecycle::Starting),
+        ]
+    );
+}
+
+#[test]
+fn exited_and_restored_rows_share_the_truthful_non_running_marker_class() {
+    let mut registry = SessionRegistry::new();
+    let exited = registry.create(SessionKind::Local);
+    registry
+        .observe(exited, SessionStatus::Exited { code: Some(0) })
+        .expect("starting may advance to exited");
+    let _restored = registry.restore(SessionKind::Local);
+    let view = SidebarView::build(
+        &registry
+            .sessions()
+            .into_iter()
+            .map(SidebarEntry::Session)
+            .collect::<Vec<_>>(),
+        None,
+    );
+
+    assert_eq!(view.rows().len(), 2);
+    assert!(
+        view.rows()
+            .iter()
+            .all(|row| row.lifecycle() == Some(SessionLifecycle::Exited))
     );
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,23 @@ grid (`MAX_RENDER_ROWS` by `MAX_RENDER_COLS`, 60 by 160), which is far inside
 the terminal foundation's `MAX_SCREEN_CELLS` bound, so no configuration value
 can push the grid past that ceiling.
 
+### `[sidebar]`
+
+Controls how many cell columns the sidebar occupies. This is an optional
+workspace preference: the default 16-column row already shows a distinct
+lifecycle marker in its final cell, without configuration.
+
+| Key | Type | Default | Accepted range | Meaning |
+| --- | --- | --- | --- | --- |
+| `columns` | integer | `16` | `8..=159` | Sidebar width in terminal cell columns. |
+
+Session identity text uses the available cells and truncates with `...` when
+necessary; the lifecycle cell is always reserved and never truncated. The
+upper bound is one less than `MAX_RENDER_COLS`, so even the widest configured
+sidebar leaves one drawable terminal column. Unknown keys, wrong types, and
+out-of-range widths are hard errors under the same closed-schema rules as the
+other tables.
+
 ### `[keys]`
 
 Configurable key chords for workspace chrome. Every key is optional; an
@@ -295,6 +312,9 @@ prints it.
 [font]
 cell_width = 12
 cell_height = 24
+
+[sidebar]
+columns = 24
 
 [keys]
 palette_open = "super+k"


### PR DESCRIPTION
Closes **#196** — the sidebar advertised session lifecycle state it never showed.

`SIDEBAR_COLS` is 16. A session row carried its lifecycle word (`starting`,
`running`, `exited`, `failed`) but at that width the word rendered **outside the
row**. The code set it; the user never saw it. The first independent UI/UX
evaluation measured `states_distinguishable=2/4` in the running product.

**Now 4/4, by default, with no configuration.**

## Shapes, not just colours

```rust
pub const LIFECYCLE_MARKERS: [char; 4] = ['◌', '▶', '■', '✕'];
```

Colour alone would fail a colour-blind user and any remapped palette. These are
four distinct **shapes**, each with an explicit collision-checked 5×7 bitmap in
the production renderer; colour reinforces rather than carries the meaning.

**320 glyphs enumerated, 0 collisions.** A previous review of this codebase found
9 glyph collisions, 2 of them real defects — so the whole set was checked, not a
sample.

Minimum contrast **4.5221:1** against the sidebar background across every shipped
theme, hand-computed (sRGB 0.04045/12.92/2.4; 0.2126/0.7152/0.0722). AA is 4.5:1.

## The owner's two requirements

**Reads nothing → good result:** the markers ship visible at the default 16
columns. No key to discover, nothing to enable.

**Wants control → no source patching:** sidebar width is now configurable
(`MIN_SIDEBAR_COLUMNS = 8` … `MAX_RENDER_COLS - 1`). This is *additional* to the
fix, never a substitute: the row is correct at its shipped width first.

The marker occupies a **reserved final cell**, so a long session name truncates
with an ellipsis and the state is never what gets clipped.

## Proof

Mutation-tested both ways, and **both were caught**:
- all four states rendering the same marker → suite fails
- the marker rendering off-row → suite fails

A test that passes under mutation proves nothing.

Verified independently by the coordinator on a clean tree: **1,158 passed, 0
failed** (`cargo test --workspace`), `fmt=0`, `clippy=0`.

Related: #208 records the pre-existing 16-column viewport overflow, a separate
symptom of the same cramped-sidebar regime.