### PR TITLE
feat(renderer): make the selection visible (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 > default), `light`, and `high-contrast` — via `[theme] name` in `config.toml`
 > (`theme.rs`, `docs/configuration.md` §`[theme]`; the selection reaching the
 > renderer is pinned by `configured_theme_reaches_the_app_renderer_input`);
+> text selections are visible by default through each palette's theme-owned
+> inverse pair, over the exact copied cell range (including wrapped rows and
+> both columns of a wide character);
 > the built-in palettes themselves are fixed tables — no custom-palette or
 > colour-vision-friendly configuration. The renderer still uses a
 > hand-built 5x7 bitmap font with bounded coverage — distinct ASCII case plus

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -308,14 +308,15 @@ against it:
   and the word "cursor" does not appear in that file. There is no scrollback
   viewport: rendering stays on the newest suffix of the content because no
   scroll-offset input exists (the only scroll offset in `main.rs` is the
-  sidebar's own). Selection is tracked and copies correctly but is never
-  highlighted. Scrollback search is unreachable: the terminal core ships a
+  sidebar's own). Selection is tracked, copies correctly, and now paints the
+  exact copied cell span with a theme-owned inverse pair, including partial
+  wrapped rows and both columns of wide characters. Scrollback search is
+  unreachable: the terminal core ships a
   real snapshot search engine (`crates/noren-terminal/src/search.rs`:
   `Search`, ranked matches, case sensitivity), but nothing in the app
   references it — no key or palette command starts a search and no renderer
-  surface draws one. A terminal in which a stranger cannot see the cursor,
-  cannot scroll back, cannot see their selection, and cannot search is not
-  preview-ready.
+  surface draws one. Cursor, scrollback navigation, and search remain separate
+  preview-readiness gates.
 - **The FR-005 rendered-frame oracle exists and runs, and its boundary is
   the honesty requirement.** It drives the real `wgpu` pipeline offscreen
   (`crates/noren-app/src/renderer_capture.rs`,

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -2533,9 +2533,18 @@ impl NorenApp {
     }
 
     fn select_entire_grid(&mut self) {
-        if let Some(terminal) = &self.terminal {
-            self.selection = Some(Selection::entire_grid(terminal));
+        if let Some(selection) = self.terminal.as_ref().map(Selection::entire_grid) {
+            self.show_selection(selection);
         }
+    }
+
+    /// Install a user-visible selection and schedule the frame that paints it.
+    ///
+    /// Selection input can arrive while the PTY is idle, so relying on output
+    /// to request a redraw would leave the new range invisible indefinitely.
+    fn show_selection(&mut self, selection: Selection) {
+        self.selection = Some(selection);
+        self.redraw_needed = true;
     }
 
     fn copy_selection(&mut self) {
@@ -2622,8 +2631,12 @@ impl NorenApp {
         let Some(point) = self.grid_point_at(position) else {
             return;
         };
-        if let Some(terminal) = &self.terminal {
-            self.selection = Some(Selection::new(terminal, self.drag_mode, origin, point));
+        if let Some(selection) = self
+            .terminal
+            .as_ref()
+            .map(|terminal| Selection::new(terminal, self.drag_mode, origin, point))
+        {
+            self.show_selection(selection);
         }
     }
 
@@ -2661,7 +2674,8 @@ impl NorenApp {
                 };
                 self.drag_mode = mode;
                 self.drag_origin = Some(point);
-                self.selection = Some(Selection::new(terminal, mode, point, point));
+                let selection = Selection::new(terminal, mode, point, point);
+                self.show_selection(selection);
             }
             ElementState::Released => {
                 self.drag_origin = None;

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1155,9 +1155,9 @@ struct NorenApp {
     #[cfg(test)]
     ssh_spawn_force_failure: bool,
     redraw_needed: bool,
-    // User-initiated selection state. The renderer does not highlight it yet;
-    // copy still extracts it. Any PTY output or resize invalidates it because
-    // grid coordinates only address the content they were captured on.
+    // User-initiated selection state. The renderer paints this exact range and
+    // copy extracts the same model. Any PTY output or resize invalidates it
+    // because grid coordinates only address the content they were captured on.
     selection: Option<Selection>,
     drag_origin: Option<GridPoint>,
     drag_mode: SelectionMode,
@@ -3372,7 +3372,8 @@ impl NorenApp {
             .then(|| noren_app::ui::empty_workspace_recovery(self.keys));
         let chrome = FrameChrome::new(Some(&lines), status)
             .with_palette_hint(palette_hint.as_deref())
-            .with_workspace_notice(workspace_notice.as_deref());
+            .with_workspace_notice(workspace_notice.as_deref())
+            .with_selection(self.selection.as_ref());
         let outcome = self
             .renderer
             .as_mut()

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -299,6 +299,7 @@ fn select_entire_grid_captures_all_visible_content() {
     let mut terminal = TerminalState::new(3, 6).expect("valid terminal");
     terminal.feed_bytes(b"abc\r\ndef");
     app.terminal = Some(terminal);
+    app.redraw_needed = false;
 
     app.select_entire_grid();
     let terminal = app.terminal.as_ref().expect("terminal present");
@@ -307,6 +308,40 @@ fn select_entire_grid_captures_all_visible_content() {
             .as_ref()
             .map(|selection| selection.extract(terminal)),
         Some("abc\ndef".to_owned())
+    );
+    assert!(
+        app.redraw_needed,
+        "select-all must schedule the frame that reveals its range"
+    );
+}
+
+#[test]
+fn installing_a_drag_selection_schedules_its_visible_frame() {
+    let mut terminal = TerminalState::new(2, 6).expect("valid terminal");
+    terminal.feed_bytes(b"abcdef");
+    let selection = Selection::new(
+        &terminal,
+        SelectionMode::Char,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 3),
+    );
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..Default::default()
+    };
+    app.redraw_needed = false;
+
+    app.show_selection(selection);
+
+    assert_eq!(
+        app.selection
+            .as_ref()
+            .map(|selection| selection.extract(app.terminal.as_ref().expect("terminal present"))),
+        Some("bcd".to_owned())
+    );
+    assert!(
+        app.redraw_needed,
+        "mouse press and drag use show_selection, which must request their frame"
     );
 }
 

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -16,6 +16,12 @@
 //! resolution, default foreground, clear colour — reads from it, so a theme
 //! that exists in configuration changes what is drawn.
 //!
+//! A live [`Selection`] is painted as theme-owned inverse video over the exact
+//! inclusive cell spans exposed by the terminal selection model. Because that
+//! model expands a wide endpoint over its continuation, both CJK columns are
+//! painted together; because wrapped rows retain separate spans, neither row
+//! is widened beyond the range that copy extracts (issue #202).
+//!
 //! The cursor is drawn, not configured into existence (issues #197/#200):
 //! the caret appears at the tracked position with no configuration, honouring
 //! DECTCEM (`CSI ?25l` hides it, `?25h` restores it) because programs like vim
@@ -41,7 +47,7 @@ use winit::window::Window;
 use noren_app::cursor::CursorShape;
 use noren_app::theme::{Theme, contrast_ratio};
 use noren_app::{CellMetrics, MAX_RENDER_COLS, MAX_RENDER_ROWS};
-use noren_terminal::{Cell, CellAttributes, Color, TerminalSnapshot};
+use noren_terminal::{Cell, CellAttributes, Color, Selection, TerminalSnapshot};
 const GLYPH_SCALE: u32 = 2;
 const GLYPH_TOP: u32 = 3;
 const MAX_GLYPH_PIXELS: usize = 35;
@@ -327,6 +333,7 @@ pub(crate) struct FrameChrome<'a> {
     status: Option<&'a str>,
     palette_hint: Option<&'a str>,
     workspace_notice: Option<&'a [String]>,
+    selection: Option<&'a Selection>,
 }
 
 impl<'a> FrameChrome<'a> {
@@ -336,6 +343,7 @@ impl<'a> FrameChrome<'a> {
             status,
             palette_hint: None,
             workspace_notice: None,
+            selection: None,
         }
     }
 
@@ -349,6 +357,13 @@ impl<'a> FrameChrome<'a> {
     #[must_use]
     pub(crate) const fn with_workspace_notice(mut self, lines: Option<&'a [String]>) -> Self {
         self.workspace_notice = lines;
+        self
+    }
+
+    /// Add the app-owned grid selection to paint in this frame.
+    #[must_use]
+    pub(crate) const fn with_selection(mut self, selection: Option<&'a Selection>) -> Self {
+        self.selection = selection;
         self
     }
 
@@ -673,6 +688,7 @@ fn glyph_vertices_with_chrome_budget(
     let sidebar = chrome.sidebar;
     let status = chrome.status_line();
     let workspace_notice = chrome.workspace_notice;
+    let selection = chrome.selection;
     let has_sidebar = sidebar.is_some();
     let col_offset = if has_sidebar { SIDEBAR_COLS } else { 0 };
     // Reserve the sidebar, then clamp the terminal to the renderer's drawable
@@ -759,8 +775,20 @@ fn glyph_vertices_with_chrome_budget(
         {
             FrameRow::Terminal(line_index) => {
                 if let Some(cells) = rows.get(line_index) {
+                    let paint = CellPaint {
+                        row,
+                        col_offset,
+                        target,
+                        vertex_budget,
+                    };
                     let visible_len = cells.len().min(terminal_cols);
                     let visible = &cells[..visible_len];
+                    let selected_columns = terminal.and_then(|snapshot| {
+                        selection.and_then(|selection| {
+                            selection
+                                .columns_in_line(snapshot, snapshot.scrollback().len() + line_index)
+                        })
+                    });
                     if let Some(plan) = cursor_plan
                         && plan.frame_row == row
                         && plan.column < visible_len
@@ -774,10 +802,8 @@ fn glyph_vertices_with_chrome_budget(
                             &mut vertices,
                             before,
                             0,
-                            row,
-                            col_offset,
-                            target,
-                            vertex_budget,
+                            paint,
+                            selected_columns.as_ref(),
                         ) {
                             return vertices;
                         }
@@ -787,10 +813,10 @@ fn glyph_vertices_with_chrome_budget(
                             &mut vertices,
                             cursor_cells,
                             plan,
-                            row,
-                            col_offset,
-                            target,
-                            vertex_budget,
+                            paint,
+                            selected_columns
+                                .as_ref()
+                                .is_some_and(|columns| columns.contains(&plan.column)),
                         ) {
                             return vertices;
                         }
@@ -798,10 +824,8 @@ fn glyph_vertices_with_chrome_budget(
                             &mut vertices,
                             after,
                             plan.column + cursor_len,
-                            row,
-                            col_offset,
-                            target,
-                            vertex_budget,
+                            paint,
+                            selected_columns.as_ref(),
                         ) {
                             return vertices;
                         }
@@ -809,10 +833,8 @@ fn glyph_vertices_with_chrome_budget(
                         &mut vertices,
                         visible,
                         0,
-                        row,
-                        col_offset,
-                        target,
-                        vertex_budget,
+                        paint,
+                        selected_columns.as_ref(),
                     ) {
                         return vertices;
                     }
@@ -860,6 +882,15 @@ fn glyph_vertices_with_chrome_budget(
     vertices
 }
 
+/// Immutable drawing context shared by every terminal cell in one frame row.
+#[derive(Clone, Copy)]
+struct CellPaint {
+    row: usize,
+    col_offset: usize,
+    target: Target,
+    vertex_budget: usize,
+}
+
 /// Draw a run of ordinary terminal cells. Cursor-bearing rows are split
 /// around their one affected span before reaching this helper, so this hot
 /// path contains no per-cell cursor checks.
@@ -868,20 +899,17 @@ fn push_terminal_cells(
     vertices: &mut Vec<Vertex>,
     cells: &[Cell],
     start_column: usize,
-    row: usize,
-    col_offset: usize,
-    target: Target,
-    vertex_budget: usize,
+    paint: CellPaint,
+    selected_columns: Option<&std::ops::RangeInclusive<usize>>,
 ) -> bool {
     for (offset, cell) in cells.iter().enumerate() {
+        let column = start_column + offset;
         if push_terminal_cell(
             vertices,
             cell,
-            start_column + offset,
-            row,
-            col_offset,
-            target,
-            vertex_budget,
+            column,
+            paint,
+            selected_columns.is_some_and(|columns| columns.contains(&column)),
         ) {
             return true;
         }
@@ -896,12 +924,21 @@ fn push_terminal_cell(
     vertices: &mut Vec<Vertex>,
     cell: &Cell,
     column: usize,
-    row: usize,
-    col_offset: usize,
-    target: Target,
-    vertex_budget: usize,
+    paint: CellPaint,
+    selected: bool,
 ) -> bool {
-    if let Some(color) = resolve_background(&target.theme, cell.attributes()) {
+    let CellPaint {
+        row,
+        col_offset,
+        target,
+        vertex_budget,
+    } = paint;
+    let background = if selected {
+        Some(target.theme.selection_background())
+    } else {
+        resolve_background(&target.theme, cell.attributes())
+    };
+    if let Some(color) = background {
         push_rect(
             vertices,
             u32::try_from(col_offset + column).unwrap_or(u32::MAX) * target.metrics.width(),
@@ -920,7 +957,11 @@ fn push_terminal_cell(
     if cell.is_continuation() {
         return false;
     }
-    let color = resolve_foreground(&target.theme, cell.attributes());
+    let color = if selected {
+        target.theme.selection_foreground()
+    } else {
+        resolve_foreground(&target.theme, cell.attributes())
+    };
     for character in cell.text().chars() {
         push_glyph(vertices, character, color, col_offset + column, row, target);
         if vertices.len() >= vertex_budget {
@@ -938,22 +979,35 @@ fn push_cursor_cells(
     vertices: &mut Vec<Vertex>,
     cells: &[Cell],
     plan: CursorPlacement,
-    row: usize,
-    col_offset: usize,
-    target: Target,
-    vertex_budget: usize,
+    paint: CellPaint,
+    selected: bool,
 ) -> bool {
+    let CellPaint {
+        row,
+        col_offset,
+        target,
+        vertex_budget,
+    } = paint;
     let Some(lead) = cells.first() else {
         return false;
     };
-    let foreground = resolve_foreground(&target.theme, lead.attributes());
-    let inverse_foreground = if lead.attributes().foreground() == Color::Default {
+    let foreground = if selected {
+        target.theme.selection_foreground()
+    } else {
+        resolve_foreground(&target.theme, lead.attributes())
+    };
+    let inverse_foreground = if selected {
+        foreground
+    } else if lead.attributes().foreground() == Color::Default {
         target.cursor.theme_color
     } else {
         foreground
     };
-    let background =
-        resolve_background(&target.theme, lead.attributes()).unwrap_or(target.theme.background());
+    let background = if selected {
+        target.theme.selection_background()
+    } else {
+        resolve_background(&target.theme, lead.attributes()).unwrap_or(target.theme.background())
+    };
     let cursor_color = target.cursor.visible_color(inverse_foreground, background);
 
     if target.cursor.focused && target.cursor.shape == CursorShape::Block {
@@ -962,7 +1016,12 @@ fn push_cursor_cells(
         // particular, a continuation background must not overwrite half of
         // the cursor after the block has been drawn.
         for (offset, cell) in cells.iter().enumerate() {
-            if let Some(color) = resolve_background(&target.theme, cell.attributes()) {
+            let cell_background = if selected {
+                Some(target.theme.selection_background())
+            } else {
+                resolve_background(&target.theme, cell.attributes())
+            };
+            if let Some(color) = cell_background {
                 push_rect(
                     vertices,
                     u32::try_from(col_offset + plan.column + offset).unwrap_or(u32::MAX)
@@ -1000,16 +1059,10 @@ fn push_cursor_cells(
         return false;
     }
 
-    if push_terminal_cells(
-        vertices,
-        cells,
-        plan.column,
-        row,
-        col_offset,
-        target,
-        vertex_budget,
-    ) {
-        return true;
+    for (offset, cell) in cells.iter().enumerate() {
+        if push_terminal_cell(vertices, cell, plan.column + offset, paint, selected) {
+            return true;
+        }
     }
     if target.cursor.focused {
         match target.cursor.shape {

--- a/crates/noren-app/src/theme.rs
+++ b/crates/noren-app/src/theme.rs
@@ -13,6 +13,7 @@
 //! - the default foreground (unstyled text, sidebar, status line),
 //! - the default background (the render target's clear colour),
 //! - the cursor colour (the inverse-video baseline on an unstyled cell),
+//! - the selection foreground and background (the default pair inverted),
 //! - the sixteen ANSI palette entries (`SGR 30..37`, `90..97`, `40..47`,
 //!   `100..107`) that programs select by name.
 //!
@@ -308,6 +309,8 @@ pub struct Theme {
     foreground: [f32; 3],
     background: [f32; 3],
     cursor: [f32; 3],
+    selection_foreground: [f32; 3],
+    selection_background: [f32; 3],
 }
 
 /// The built-in `dark` theme: the pre-theme renderer's colours, except the
@@ -323,6 +326,8 @@ pub const DARK: Theme = Theme {
     foreground: DARK_FOREGROUND,
     background: DARK_BACKGROUND,
     cursor: DARK_FOREGROUND,
+    selection_foreground: DARK_BACKGROUND,
+    selection_background: DARK_FOREGROUND,
 };
 
 /// The built-in `light` theme.
@@ -332,6 +337,8 @@ pub const LIGHT: Theme = Theme {
     foreground: LIGHT_FOREGROUND,
     background: LIGHT_BACKGROUND,
     cursor: LIGHT_FOREGROUND,
+    selection_foreground: LIGHT_BACKGROUND,
+    selection_background: LIGHT_FOREGROUND,
 };
 
 /// The built-in `high-contrast` theme.
@@ -341,6 +348,8 @@ pub const HIGH_CONTRAST: Theme = Theme {
     foreground: HIGH_CONTRAST_FOREGROUND,
     background: HIGH_CONTRAST_BACKGROUND,
     cursor: HIGH_CONTRAST_FOREGROUND,
+    selection_foreground: HIGH_CONTRAST_BACKGROUND,
+    selection_background: HIGH_CONTRAST_FOREGROUND,
 };
 
 impl Default for Theme {
@@ -403,6 +412,34 @@ impl Theme {
     #[must_use]
     pub fn cursor_u8(self) -> [u8; 3] {
         quantize(self.cursor)
+    }
+
+    /// Glyph colour inside a selected cell. Every built-in theme uses its
+    /// normal background, completing an inverse-video pair with
+    /// [`Theme::selection_background`].
+    #[must_use]
+    pub const fn selection_foreground(self) -> [f32; 3] {
+        self.selection_foreground
+    }
+
+    /// Background painted over every selected cell. Every built-in theme
+    /// uses its normal foreground, so selection is visible without
+    /// configuration and follows the active `[theme]` palette.
+    #[must_use]
+    pub const fn selection_background(self) -> [f32; 3] {
+        self.selection_background
+    }
+
+    /// Selected glyph colour as stored by the RGBA8 render target.
+    #[must_use]
+    pub fn selection_foreground_u8(self) -> [u8; 3] {
+        quantize(self.selection_foreground)
+    }
+
+    /// Selection background as stored by the RGBA8 render target.
+    #[must_use]
+    pub fn selection_background_u8(self) -> [u8; 3] {
+        quantize(self.selection_background)
     }
 
     /// The theme's sixteen ANSI palette entries, in palette-index order.

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -97,9 +97,9 @@ use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
 };
-use noren_terminal::{TerminalSnapshot, TerminalState};
+use noren_terminal::{GridPoint, Selection, SelectionMode, TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::{
-    CLEAR_COLOR, CursorStyle, FrameChrome, SIDEBAR_COLS, Target,
+    CLEAR_COLOR, CursorStyle, FrameChrome, SIDEBAR_COLS, Target, Vertex, glyph_vertices_for_chrome,
 };
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
@@ -138,6 +138,22 @@ fn render_with_theme(
         Some(snapshot),
         None,
         None,
+    )
+}
+
+/// Render one app-owned selection through the live frame seam.
+fn render_with_selection(
+    renderer: &OffscreenRenderer,
+    theme: &Theme,
+    snapshot: &TerminalSnapshot,
+    selection: &Selection,
+) -> CapturedFrame {
+    let width = u32::from(snapshot.cols()) * CELL_WIDTH;
+    let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
+    renderer.capture_chrome(
+        Target::new(theme, width, height, poc_metrics()),
+        Some(snapshot),
+        FrameChrome::new(None, None).with_selection(Some(selection)),
     )
 }
 
@@ -260,6 +276,100 @@ fn cell_color_pixel_count(frame: &CapturedFrame, row: u32, col: u32, color: [u8;
         }
     }
     count
+}
+
+/// Cell coordinates whose captured pixels differ between two equal-size
+/// frames, in row-major order. Comparing every pixel in every cell makes this
+/// an exact positional oracle: moving the treatment to a neighbour, widening
+/// it to a whole row, or dropping it changes the returned coordinate set.
+fn changed_cells(
+    before: &CapturedFrame,
+    after: &CapturedFrame,
+    rows: u16,
+    cols: u16,
+) -> Vec<(u32, u32)> {
+    assert_eq!(before.width, after.width, "frame widths must agree");
+    assert_eq!(
+        before.rgba.len(),
+        after.rgba.len(),
+        "frame sizes must agree"
+    );
+    let mut changed = Vec::new();
+    for row in 0..u32::from(rows) {
+        for col in 0..u32::from(cols) {
+            let differs = (row * CELL_HEIGHT..(row + 1) * CELL_HEIGHT).any(|y| {
+                (col * CELL_WIDTH..(col + 1) * CELL_WIDTH)
+                    .any(|x| before.pixel(x, y) != after.pixel(x, y))
+            });
+            if differs {
+                changed.push((row, col));
+            }
+        }
+    }
+    changed
+}
+
+/// Full-cell selection-background rectangles emitted into the production
+/// frame vertex stream, converted back to grid coordinates. This positional
+/// oracle runs even when Metal capture is unavailable; the pixel tests below
+/// remain the authoritative raster proof when an adapter exists.
+fn selection_background_vertex_cells(
+    snapshot: &TerminalSnapshot,
+    selection: &Selection,
+    theme: &Theme,
+) -> Vec<(u32, u32)> {
+    let target = Target::new(
+        theme,
+        u32::from(snapshot.cols()) * CELL_WIDTH,
+        u32::from(snapshot.rows()) * CELL_HEIGHT,
+        poc_metrics(),
+    );
+    let vertices = glyph_vertices_for_chrome(
+        target,
+        Some(snapshot),
+        FrameChrome::new(None, None).with_selection(Some(selection)),
+    );
+    let expected_color = theme.selection_background();
+    let mut cells = Vec::new();
+    for rectangle in vertices.chunks_exact(6) {
+        if !rectangle
+            .iter()
+            .all(|vertex| vertex.color == expected_color)
+        {
+            continue;
+        }
+        let (x0, y0, x1, y1) = rectangle_pixel_bounds(rectangle, target);
+        if x1.saturating_sub(x0) != CELL_WIDTH || y1.saturating_sub(y0) != CELL_HEIGHT {
+            continue;
+        }
+        assert_eq!(x0 % CELL_WIDTH, 0, "selection rectangle is off-grid");
+        assert_eq!(y0 % CELL_HEIGHT, 0, "selection rectangle is off-grid");
+        cells.push((y0 / CELL_HEIGHT, x0 / CELL_WIDTH));
+    }
+    cells
+}
+
+/// Convert one six-vertex axis-aligned rectangle from NDC back to pixel bounds.
+fn rectangle_pixel_bounds(rectangle: &[Vertex], target: Target) -> (u32, u32, u32, u32) {
+    let left = rectangle
+        .iter()
+        .map(|vertex| vertex.position[0])
+        .fold(f32::INFINITY, f32::min);
+    let right = rectangle
+        .iter()
+        .map(|vertex| vertex.position[0])
+        .fold(f32::NEG_INFINITY, f32::max);
+    let top = rectangle
+        .iter()
+        .map(|vertex| vertex.position[1])
+        .fold(f32::NEG_INFINITY, f32::max);
+    let bottom = rectangle
+        .iter()
+        .map(|vertex| vertex.position[1])
+        .fold(f32::INFINITY, f32::min);
+    let x = |ndc: f32| (((ndc + 1.0) * target.width as f32) / 2.0).round() as u32;
+    let y = |ndc: f32| (((1.0 - ndc) * target.height as f32) / 2.0).round() as u32;
+    (x(left), y(top), x(right), y(bottom))
 }
 
 /// The default foreground as captured bytes, derived from the renderer's own
@@ -1446,6 +1556,199 @@ fn high_contrast_theme_draws_its_own_verified_palette() {
         [0, 0, 0],
         "high-contrast clear must be pure black"
     );
+}
+
+// ===========================================================================
+// Selection highlight (issue #202): the app-owned range about to be copied
+// must change exactly those frame cells. These tests compare every pixel of
+// every cell before/after selection, so whole-row, shifted-column, and dropped
+// overlays cannot satisfy the oracle by merely lighting some distinct pixels.
+// ===========================================================================
+
+#[test]
+fn selection_highlight_vertex_oracle_pins_the_ascii_range() {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes(b"abcdef\x1b[?25l");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(
+        selection_background_vertex_cells(&state.snapshot(), &selection, &DARK),
+        [(0, 1), (0, 2)]
+    );
+}
+
+#[test]
+fn selection_highlight_vertex_oracle_pins_the_wrapped_range() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    state.feed_bytes(b"abcdef\x1b[?25l");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 2),
+        GridPoint::new(1, 0),
+    );
+    assert_eq!(
+        selection_background_vertex_cells(&state.snapshot(), &selection, &DARK),
+        [(0, 2), (0, 3), (1, 0)]
+    );
+}
+
+#[test]
+fn selection_highlight_vertex_oracle_pins_both_wide_columns() {
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes("a日bc\x1b[?25l".as_bytes());
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 2),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(
+        selection_background_vertex_cells(&state.snapshot(), &selection, &DARK),
+        [(0, 1), (0, 2)]
+    );
+}
+
+#[test]
+fn selection_highlight_changes_only_the_selected_cells() {
+    let Some(renderer) = renderer_or_skip("selection_highlight_changes_only_the_selected_cells")
+    else {
+        return;
+    };
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    state.feed_bytes(b"abcdef\x1b[?25l");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(selection.extract(&state), "bc");
+    let snap = state.snapshot();
+    let before = render(&renderer, &snap);
+    let after = render_with_selection(&renderer, &DARK, &snap, &selection);
+
+    assert_ne!(
+        before.rgba, after.rgba,
+        "a real selection must change pixels"
+    );
+    assert_eq!(
+        changed_cells(&before, &after, snap.rows(), snap.cols()),
+        [(0, 1), (0, 2)],
+        "only the two copied cells may change"
+    );
+}
+
+#[test]
+fn selection_highlight_tracks_the_exact_wrapped_range() {
+    let Some(renderer) = renderer_or_skip("selection_highlight_tracks_the_exact_wrapped_range")
+    else {
+        return;
+    };
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+    // `e` triggers the pending wrap after `abcd`; the selected copy range is
+    // the tail `cd` on row 0 plus `e` on row 1.
+    state.feed_bytes(b"abcdef\x1b[?25l");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 2),
+        GridPoint::new(1, 0),
+    );
+    assert_eq!(selection.extract(&state), "cd\ne");
+    let snap = state.snapshot();
+    let before = render(&renderer, &snap);
+    let after = render_with_selection(&renderer, &DARK, &snap, &selection);
+
+    assert_eq!(
+        changed_cells(&before, &after, snap.rows(), snap.cols()),
+        [(0, 2), (0, 3), (1, 0)],
+        "wrapping must not widen either selected row"
+    );
+}
+
+#[test]
+fn selection_highlight_covers_both_wide_columns_and_never_continuation_alone() {
+    let Some(renderer) = renderer_or_skip(
+        "selection_highlight_covers_both_wide_columns_and_never_continuation_alone",
+    ) else {
+        return;
+    };
+    let mut state = TerminalState::new(1, 6).expect("valid terminal");
+    // Columns: a=0, 日=1(+2 continuation), b=3, c=4. Deliberately capture
+    // both endpoints on column 2: normalization must paint the lead and its
+    // continuation, with neither neighbour changed.
+    state.feed_bytes("a日bc\x1b[?25l".as_bytes());
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 2),
+        GridPoint::new(0, 2),
+    );
+    assert_eq!(selection.extract(&state), "日");
+    let snap = state.snapshot();
+    let before = render(&renderer, &snap);
+    let after = render_with_selection(&renderer, &DARK, &snap, &selection);
+
+    assert_eq!(
+        changed_cells(&before, &after, snap.rows(), snap.cols()),
+        [(0, 1), (0, 2)],
+        "a wide character is one selection unit spanning exactly two columns"
+    );
+    for col in [1, 2] {
+        assert!(
+            cell_color_pixel_count(&after, 0, col, DARK.selection_background_u8()) > 0,
+            "wide selection column {col} lacks the theme background"
+        );
+    }
+}
+
+#[test]
+fn selection_highlight_follows_each_configured_theme_in_frame_pixels() {
+    let Some(renderer) =
+        renderer_or_skip("selection_highlight_follows_each_configured_theme_in_frame_pixels")
+    else {
+        return;
+    };
+    let mut state = TerminalState::new(1, 3).expect("valid terminal");
+    state.feed_bytes(b"abc\x1b[?25l");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 1),
+        GridPoint::new(0, 1),
+    );
+    let snap = state.snapshot();
+
+    for name in ["dark", "light", "high-contrast"] {
+        let config = AppConfig::parse(&format!("[theme]\nname = \"{name}\"\n"))
+            .expect("shipped theme is configurable");
+        let theme = config.theme().palette();
+        let before = render_with_theme(&renderer, &theme, &snap);
+        let after = render_with_selection(&renderer, &theme, &snap, &selection);
+        assert_eq!(
+            changed_cells(&before, &after, snap.rows(), snap.cols()),
+            [(0, 1)],
+            "{name}: only the configured theme's selected cell may change"
+        );
+        let corner = after.pixel(2 * CELL_WIDTH - 1, CELL_HEIGHT - 1);
+        assert!(
+            colors_match(
+                [corner[0], corner[1], corner[2]],
+                theme.selection_background_u8()
+            ),
+            "{name}: selected-cell corner {corner:?} is not the theme background {:?}",
+            theme.selection_background_u8()
+        );
+        assert!(
+            cell_color_pixel_count(&after, 0, 1, theme.selection_foreground_u8()) > 0,
+            "{name}: selected glyph does not use the readable theme foreground"
+        );
+    }
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -225,6 +225,15 @@ fn cell_pattern(frame: &CapturedFrame, row: u32, col: u32) -> Vec<bool> {
     pattern
 }
 
+/// Every RGBA pixel in cell `(row, col)`, including its background.
+fn cell_pixels(frame: &CapturedFrame, row: u32, col: u32) -> Vec<[u8; 4]> {
+    (0..CELL_HEIGHT)
+        .flat_map(|y| {
+            (0..CELL_WIDTH).map(move |x| frame.pixel(col * CELL_WIDTH + x, row * CELL_HEIGHT + y))
+        })
+        .collect()
+}
+
 /// The distinct lit (non-background) colours inside cell `(row, col)`.
 ///
 /// This is the colour-aware counterpart of [`cell_pattern`]: where that
@@ -370,6 +379,52 @@ fn rectangle_pixel_bounds(rectangle: &[Vertex], target: Target) -> (u32, u32, u3
     let x = |ndc: f32| (((ndc + 1.0) * target.width as f32) / 2.0).round() as u32;
     let y = |ndc: f32| (((1.0 - ndc) * target.height as f32) / 2.0).round() as u32;
     (x(left), y(top), x(right), y(bottom))
+}
+
+/// Rasterize the production rectangle stream exactly enough to keep pixel
+/// mutation guards active on adapter-less machines. The real wgpu readback is
+/// still asserted when Metal exists; this fallback has no parallel glyph or
+/// cursor logic because all positions, ordering, and colours come from the
+/// shipped vertex generator and its constant-colour fragment shader.
+fn rasterized_vertex_frame(target: Target, vertices: &[Vertex]) -> CapturedFrame {
+    let [red, green, blue] = target.theme.background_u8();
+    let pixel_count = usize::try_from(target.width)
+        .unwrap_or(0)
+        .saturating_mul(usize::try_from(target.height).unwrap_or(0));
+    let mut rgba = vec![0; pixel_count.saturating_mul(4)];
+    for pixel in rgba.chunks_exact_mut(4) {
+        pixel.copy_from_slice(&[red, green, blue, u8::MAX]);
+    }
+    assert_eq!(
+        vertices.len() % 6,
+        0,
+        "the production stream must contain complete rectangles"
+    );
+    for rectangle in vertices.chunks_exact(6) {
+        assert!(
+            rectangle
+                .iter()
+                .all(|vertex| vertex.color == rectangle[0].color),
+            "one renderer rectangle must use one constant colour"
+        );
+        let [red, green, blue] = rectangle[0]
+            .color
+            .map(|channel| (channel * 255.0).round() as u8);
+        let (x0, y0, x1, y1) = rectangle_pixel_bounds(rectangle, target);
+        for y in y0.min(target.height)..y1.min(target.height) {
+            for x in x0.min(target.width)..x1.min(target.width) {
+                let index = (usize::try_from(y).unwrap_or(0)
+                    * usize::try_from(target.width).unwrap_or(0)
+                    + usize::try_from(x).unwrap_or(0))
+                    * 4;
+                rgba[index..index + 4].copy_from_slice(&[red, green, blue, u8::MAX]);
+            }
+        }
+    }
+    CapturedFrame {
+        width: target.width,
+        rgba,
+    }
 }
 
 /// The default foreground as captured bytes, derived from the renderer's own
@@ -1749,6 +1804,89 @@ fn selection_highlight_follows_each_configured_theme_in_frame_pixels() {
             "{name}: selected glyph does not use the readable theme foreground"
         );
     }
+}
+
+/// A selected cell still exposes the focused block caret by reversing the
+/// selection pair. The control frame differs only by DECTCEM visibility, so
+/// every compared pixel belongs to the same glyph in the same selected cell.
+#[test]
+fn cursor_inside_selection_inverts_the_same_cell_pixels() {
+    // Reuse the passing cursor oracle's visible/hidden mechanism: `Target::new`
+    // supplies the focused block style, while DECTCEM alone controls whether
+    // the otherwise-identical frame draws it.
+    let visible = snapshot(1, 3, b"A\r\x1b[?25h");
+    let hidden = snapshot(1, 3, b"A\r\x1b[?25l");
+    assert_eq!(visible.cursor(), hidden.cursor());
+    assert_eq!(
+        (visible.cursor().row(), visible.cursor().column()),
+        (0, 0),
+        "fixture must put the caret inside the selected cell"
+    );
+    assert!(visible.is_cursor_visible());
+    assert!(!hidden.is_cursor_visible());
+
+    let selection = Selection::new(
+        &visible,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 0),
+    );
+    assert_eq!(selection.extract(&visible), "A");
+    assert_eq!(selection.extract(&hidden), "A");
+
+    let foreground = DARK.selection_foreground_u8();
+    let background = DARK.selection_background_u8();
+    let assert_same_cell_inversion = |caret: &CapturedFrame, plain: &CapturedFrame| {
+        let caret_pixels = cell_pixels(caret, 0, 0);
+        let plain_pixels = cell_pixels(plain, 0, 0);
+        assert_ne!(
+            caret_pixels, plain_pixels,
+            "the caret must change its own selected cell"
+        );
+        for (index, (caret, plain)) in caret_pixels.iter().zip(&plain_pixels).enumerate() {
+            let caret_rgb = [caret[0], caret[1], caret[2]];
+            let plain_rgb = [plain[0], plain[1], plain[2]];
+            let expected = if colors_match(plain_rgb, foreground) {
+                background
+            } else {
+                assert!(
+                    colors_match(plain_rgb, background),
+                    "plain selected-cell pixel {index} is outside the selection pair: {plain:?}"
+                );
+                foreground
+            };
+            assert!(
+                colors_match(caret_rgb, expected),
+                "caret pixel {index} must invert the same plain selected-cell pixel: \
+                 plain={plain:?}, caret={caret:?}, expected RGB {expected:?}"
+            );
+            assert_eq!(
+                caret[3], plain[3],
+                "caret pixel {index} must preserve the same cell pixel's alpha"
+            );
+        }
+    };
+
+    let target = Target::new(
+        &DARK,
+        u32::from(visible.cols()) * CELL_WIDTH,
+        u32::from(visible.rows()) * CELL_HEIGHT,
+        poc_metrics(),
+    );
+    let chrome = FrameChrome::new(None, None).with_selection(Some(&selection));
+    let caret_vertices = glyph_vertices_for_chrome(target, Some(&visible), chrome);
+    let plain_vertices = glyph_vertices_for_chrome(target, Some(&hidden), chrome);
+    let caret_vertex_frame = rasterized_vertex_frame(target, &caret_vertices);
+    let plain_vertex_frame = rasterized_vertex_frame(target, &plain_vertices);
+    assert_same_cell_inversion(&caret_vertex_frame, &plain_vertex_frame);
+
+    let Some(renderer) = renderer_or_skip("cursor_inside_selection_inverts_the_same_cell_pixels")
+    else {
+        return;
+    };
+    let caret_frame = render_with_selection(&renderer, &DARK, &visible, &selection);
+    let plain_frame = render_with_selection(&renderer, &DARK, &hidden, &selection);
+    assert_same_cell_inversion(&caret_frame, &plain_frame);
 }
 
 // ===========================================================================

--- a/crates/noren-app/tests/theme.rs
+++ b/crates/noren-app/tests/theme.rs
@@ -110,6 +110,54 @@ fn every_theme_cursor_colour_meets_its_theme_contrast_floor() {
     }
 }
 
+/// Selection is theme-owned inverse video, not an unmeasured overlay. The
+/// selected glyph/background pair is exactly the normal theme pair reversed,
+/// so WCAG contrast is identical in both directions and the background is
+/// visibly different from the unselected screen without configuration.
+///
+/// Ratios are computed by `contrast_ratio` from RGBA8 channel values using
+/// the WCAG sRGB transfer (`0.04045`, `/12.92`, exponent `2.4`) and luminance
+/// weights `0.2126/0.7152/0.0722`: dark 15.3887:1, light 14.5632:1, and
+/// high-contrast 21.0:1.
+#[test]
+fn every_theme_selection_pair_is_inverted_visible_and_meets_aa() {
+    let expected = [
+        (ThemeName::Dark, 15.388_665_85),
+        (ThemeName::Light, 14.563_243_88),
+        (ThemeName::HighContrast, 21.0),
+    ];
+    for (name, expected_ratio) in expected {
+        let theme = name.palette();
+        assert_eq!(
+            theme.selection_background_u8(),
+            theme.foreground_u8(),
+            "{name}: selection background must be the normal foreground"
+        );
+        assert_eq!(
+            theme.selection_foreground_u8(),
+            theme.background_u8(),
+            "{name}: selected glyphs must use the normal background"
+        );
+        assert_ne!(
+            theme.selection_background_u8(),
+            theme.background_u8(),
+            "{name}: selecting a blank cell must change its pixels"
+        );
+        let ratio = contrast_ratio(
+            theme.selection_foreground_u8(),
+            theme.selection_background_u8(),
+        );
+        assert!(
+            (ratio - expected_ratio).abs() < 0.000_001,
+            "{name}: selection contrast moved to {ratio:.8}:1; expected {expected_ratio:.8}:1"
+        );
+        assert!(
+            ratio >= 4.5,
+            "{name}: selected text is {ratio:.4}:1, below the AA 4.5:1 floor"
+        );
+    }
+}
+
 /// The light theme was designed, not assumed: every ANSI slot keeps AA on
 /// the light background. Measured minimum: 5.07:1 (`bright green`).
 #[test]

--- a/crates/noren-terminal/src/selection.rs
+++ b/crates/noren-terminal/src/selection.rs
@@ -54,6 +54,8 @@
 //! include the rest of the first row and the start of the last row, like
 //! classic terminal selection. A selection over only blank cells yields `""`.
 
+use std::ops::RangeInclusive;
+
 use crate::{Cell, ScreenBuffer, TerminalSnapshot, TerminalState};
 
 /// How a selection expands its endpoints when captured.
@@ -316,6 +318,48 @@ impl Selection {
     #[must_use]
     pub fn is_valid(&self, grid: &impl SelectionGrid) -> bool {
         self.stamp.matches(grid)
+    }
+
+    /// Inclusive display columns selected on one absolute grid line.
+    ///
+    /// Returns `None` when the selection has expired or does not cover
+    /// `line`. The returned range is the drawing counterpart of
+    /// [`Selection::extract`]: it uses the same normalized endpoints, and if
+    /// the last selected character is wide, its continuation columns are
+    /// included as well. A continuation cell can therefore never appear in
+    /// this range without the lead cell that owns it.
+    #[must_use]
+    pub fn columns_in_line(
+        &self,
+        grid: &impl SelectionGrid,
+        line: usize,
+    ) -> Option<RangeInclusive<usize>> {
+        if !self.is_valid(grid) || line < self.start.line || line > self.end.line {
+            return None;
+        }
+        let cells = grid.row_cells(line)?;
+        if cells.is_empty() {
+            return None;
+        }
+        let from = if line == self.start.line {
+            self.start.column
+        } else {
+            0
+        };
+        let mut to = if line == self.end.line {
+            self.end.column
+        } else {
+            cells.len() - 1
+        }
+        .min(cells.len() - 1);
+
+        // Endpoints are lead cells. Extend the drawable span over every
+        // continuation owned by the final selected character so a wide glyph
+        // is highlighted as one indivisible unit.
+        while to + 1 < cells.len() && cells[to + 1].is_continuation() {
+            to += 1;
+        }
+        (from <= to).then_some(from..=to)
     }
 
     /// Extract the selected text, or `""` when the selection has expired.

--- a/crates/noren-terminal/src/selection.rs
+++ b/crates/noren-terminal/src/selection.rs
@@ -323,11 +323,14 @@ impl Selection {
     /// Inclusive display columns selected on one absolute grid line.
     ///
     /// Returns `None` when the selection has expired or does not cover
-    /// `line`. The returned range is the drawing counterpart of
-    /// [`Selection::extract`]: it uses the same normalized endpoints, and if
-    /// the last selected character is wide, its continuation columns are
-    /// included as well. A continuation cell can therefore never appear in
-    /// this range without the lead cell that owns it.
+    /// `line`, or when the covered cells contribute no text after extraction's
+    /// trailing-space trim. The returned range is the drawing counterpart of
+    /// [`Selection::extract`]: it uses the same normalized endpoints and ends
+    /// at the last cell whose text survives that trim. Consequently, trailing
+    /// blank rows dropped by extraction have no drawable span. If the last
+    /// selected character is wide, its continuation columns are included as
+    /// well, so a continuation can never appear without the lead cell that
+    /// owns it.
     #[must_use]
     pub fn columns_in_line(
         &self,
@@ -346,12 +349,21 @@ impl Selection {
         } else {
             0
         };
-        let mut to = if line == self.end.line {
+        let to = if line == self.end.line {
             self.end.column
         } else {
             cells.len() - 1
         }
         .min(cells.len() - 1);
+
+        // `extract_row` removes trailing ASCII spaces after concatenating the
+        // selected lead cells. Scan back to the last cell with any text that
+        // survives that exact trim; a blank-only selected slice paints
+        // nothing, including every trailing blank row dropped by `extract`.
+        let mut to = (from..=to).rev().find(|&column| {
+            let cell = &cells[column];
+            !cell.is_continuation() && cell.text().chars().any(|character| character != ' ')
+        })?;
 
         // Endpoints are lead cells. Extend the drawable span over every
         // continuation owned by the final selected character so a wide glyph

--- a/crates/noren-terminal/tests/selection.rs
+++ b/crates/noren-terminal/tests/selection.rs
@@ -110,6 +110,46 @@ fn endpoints_on_a_continuation_round_to_the_whole_character() {
 }
 
 #[test]
+fn drawable_columns_cover_both_halves_of_a_wide_character() {
+    // Columns: a=0, 日=1(+2 continuation), b=3. Selecting either half of
+    // 日 normalizes to its lead and exposes both display columns for drawing.
+    let state = grid(1, 6, "a日b".as_bytes());
+    for endpoint in [GridPoint::new(0, 1), GridPoint::new(0, 2)] {
+        let selection = Selection::new(&state, SelectionMode::Char, endpoint, endpoint);
+        assert_eq!(selection.extract(&state), "日");
+        assert_eq!(selection.columns_in_line(&state, 0), Some(1..=2));
+    }
+
+    // An adjacent narrow character does not accidentally inherit the wide
+    // character's continuation column.
+    let narrow = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 3),
+        GridPoint::new(0, 3),
+    );
+    assert_eq!(narrow.columns_in_line(&state, 0), Some(3..=3));
+}
+
+#[test]
+fn drawable_columns_follow_character_selection_across_wrapped_rows() {
+    // `e` triggers the pending wrap after `abcd`, producing two physical
+    // screen rows. A cross-row selection owns only the tail of the first row
+    // and the head of the second — never either whole row.
+    let state = grid(2, 4, b"abcdef");
+    let selection = Selection::new(
+        &state,
+        SelectionMode::Char,
+        GridPoint::new(0, 2),
+        GridPoint::new(1, 0),
+    );
+    assert_eq!(selection.extract(&state), "cd\ne");
+    assert_eq!(selection.columns_in_line(&state, 0), Some(2..=3));
+    assert_eq!(selection.columns_in_line(&state, 1), Some(0..=0));
+    assert_eq!(selection.columns_in_line(&state, 2), None);
+}
+
+#[test]
 fn word_selection_expands_to_word_boundaries() {
     let state = grid(2, 16, b"foo bar.baz_qux");
 
@@ -251,6 +291,7 @@ fn resize_expires_a_selection() {
     assert!(!selection.is_valid(&state));
     // Expired selections yield empty text, never stale or wrong text.
     assert_eq!(selection.extract(&state), "");
+    assert_eq!(selection.columns_in_line(&state, 0), None);
 }
 
 #[test]

--- a/crates/noren-terminal/tests/selection.rs
+++ b/crates/noren-terminal/tests/selection.rs
@@ -10,6 +10,27 @@ fn grid(rows: u16, cols: u16, bytes: &[u8]) -> TerminalState {
     state
 }
 
+fn text_covered_by_highlight(selection: &Selection, grid: &impl SelectionGrid) -> String {
+    let mut lines = Vec::new();
+    for line in selection.start().line()..=selection.end().line() {
+        let mut text = String::new();
+        if let Some(columns) = selection.columns_in_line(grid, line) {
+            let cells = grid.row_cells(line).expect("highlighted row exists");
+            for column in columns {
+                let cell = &cells[column];
+                if !cell.is_continuation() {
+                    text.push_str(cell.text());
+                }
+            }
+        }
+        lines.push(text);
+    }
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
 #[test]
 fn ascii_extraction_is_byte_exact() {
     let state = grid(3, 12, b"hello world\r\nsecond line");
@@ -147,6 +168,50 @@ fn drawable_columns_follow_character_selection_across_wrapped_rows() {
     assert_eq!(selection.columns_in_line(&state, 0), Some(2..=3));
     assert_eq!(selection.columns_in_line(&state, 1), Some(0..=0));
     assert_eq!(selection.columns_in_line(&state, 2), None);
+}
+
+#[test]
+fn drawable_columns_match_extract_after_trailing_blank_trimming() {
+    let short_row = grid(1, 10, b"ab");
+    let dragged_past_text = Selection::new(
+        &short_row,
+        SelectionMode::Char,
+        GridPoint::new(0, 0),
+        GridPoint::new(0, 9),
+    );
+    assert_eq!(dragged_past_text.extract(&short_row), "ab");
+    assert_eq!(
+        text_covered_by_highlight(&dragged_past_text, &short_row),
+        dragged_past_text.extract(&short_row)
+    );
+    assert_eq!(
+        dragged_past_text.columns_in_line(&short_row, 0),
+        Some(0..=1)
+    );
+
+    let three_rows = grid(3, 10, b"hello\r\nworld");
+    let entire_grid = Selection::entire_grid(&three_rows);
+    assert_eq!(entire_grid.extract(&three_rows), "hello\nworld");
+    assert_eq!(
+        text_covered_by_highlight(&entire_grid, &three_rows),
+        entire_grid.extract(&three_rows)
+    );
+    assert_eq!(entire_grid.columns_in_line(&three_rows, 0), Some(0..=4));
+    assert_eq!(entire_grid.columns_in_line(&three_rows, 1), Some(0..=4));
+    assert_eq!(entire_grid.columns_in_line(&three_rows, 2), None);
+
+    let only_blanks = Selection::new(
+        &short_row,
+        SelectionMode::Char,
+        GridPoint::new(0, 4),
+        GridPoint::new(0, 7),
+    );
+    assert_eq!(only_blanks.extract(&short_row), "");
+    assert_eq!(
+        text_covered_by_highlight(&only_blanks, &short_row),
+        only_blanks.extract(&short_row)
+    );
+    assert_eq!(only_blanks.columns_in_line(&short_row, 0), None);
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,16 @@ Accepted names, matched exactly (case-sensitive, closed vocabulary):
   every theme-owned foreground keeps WCAG AAA (≥ 7:1), strictly exceeding
   the other themes' measured minima.
 
+Each built-in palette also owns its selection foreground and background.
+Selection is visible with no setting: the pair is the palette's normal
+foreground/background inverted, painted over exactly the cells that copy will
+extract. Choosing `[theme] name` therefore controls the selection treatment as
+well as ordinary terminal colours; it is not a renderer constant that requires
+patching source. Measured from the RGBA8 channel values with the WCAG sRGB
+transfer and luminance formula, selected text is 15.3887:1 in `dark`,
+14.5632:1 in `light`, and 21.0000:1 in `high-contrast`, all above the 4.5:1 AA
+floor for normal text.
+
 Rejections follow the hard-error discipline: a non-string value is an
 error naming the key, and an unknown name is a typed error naming the
 offending value (clipped to 120 characters, like the `[keys]` chord echo:
@@ -147,13 +157,12 @@ never a silent fallback to `dark`. Near-misses such as `Dark` or
 
 The contrast contract: the checked set is every theme-owned foreground —
 the default foreground and the sixteen ANSI entries — against the theme's
-default background, the colours programs use for ordinary text on the
-screen they are given. The floor is WCAG AA for normal text (4.5:1)
-because terminal glyphs are normal-size text; `high-contrast` targets AAA
-(7:1). Program-paired colours (`SGR 31;41`) and the shared 256-colour
-cube (`16..=255`) are outside any palette's control (identical colours
-are 1:1 by definition; the cube's black corner fails on every possible
-background) and are therefore not part of the checked set.
+default background, plus the theme-owned selection pair above. The floor is
+WCAG AA for normal text (4.5:1) because terminal glyphs are normal-size text;
+`high-contrast` targets AAA (7:1). Program-paired colours (`SGR 31;41`) and
+the shared 256-colour cube (`16..=255`) are outside any palette's control
+(identical colours are 1:1 by definition; the cube's black corner fails on
+every possible background) and are therefore not part of the checked set.
 
 **Fixed with issue #168:** the default `dark` palette used to fail the
 4.5:1 floor for five ANSI slots on its own background — black at 1.06:1,

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -246,11 +246,13 @@ Each item states what you would actually see if you ran the build.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
-- **Selection and scrollback work, but you cannot see them.** Selection is
-  tracked and copy extracts it, yet the renderer does not highlight the selected
-  region — the comment on the `selection` field in `main.rs` says so in the
-  source itself ("The renderer does not highlight it yet"). Scrollback is
-  bounded and searchable, but `FrameRowLayout::new` derives
+- **Selection is visible; scrollback still is not navigable.** Selection is
+  tracked, copy extracts it, and the renderer paints the same inclusive cell
+  spans with the active theme's inverse-video selection pair. Wrapped ranges
+  stay partial on their first and last rows, and a selected wide character
+  paints its lead and continuation columns together; exact changed-cell frame
+  oracles pin all three cases in `tests/frame_oracle.rs`. Scrollback is bounded
+  and searchable, but `FrameRowLayout::new` derives
   `terminal_row_count` from `content_rows.min(terminal_capacity)`, then
   `first_terminal_line` as `content_rows - terminal_row_count`. There is no
   scroll-offset input, so rendering stays on the newest suffix and you cannot


### PR DESCRIPTION
Closes **#202** — selection copy worked, but nothing on screen showed *what*
would be copied.

An independent evaluation made a real `ab` selection and captured **byte-identical
frames** before and after. The text reached the clipboard; the user had no
perceptual evidence of the range. A familiar direct manipulation was a blind
command.

## Inversion, as with the cursor

`approach=invert`. #206 solved the analogous cursor problem by swapping the
cell's foreground and background, which is contrast-correct **by construction**
for any background — including truecolor values no theme ever measured. The same
reasoning applies to selection, so the same mechanism is used.

Measured `contrast_min=14.5632:1` against AA's 4.5:1.

Selection colours are theme entries (`feat(theme): add contrast-safe selection
colors`), so they inherit theme overrides — control without patching source.

## The exact range, including the hard cases

- `range_exact=yes` — the highlight covers the cells that will be copied, no
  more and no fewer.
- `wrapped_ok=yes` — correct across wrapped lines, which the evaluation named as
  where users are most lost.
- `wide_both_cols=yes` / `continuation_safe=yes` — a selected wide (CJK)
  character highlights **both** its columns, and a continuation cell is never
  highlighted alone.

## The oracle pins positions, not just "something changed"

The re-review of #209 found markers whose oracle checked only that pixels were
*lit and distinct* — shifting every glyph one row down passed all 1,158 tests.
This PR does not repeat that.

Verified by the coordinator, by hand: shifting the selection range one column
(`(start+1)..=(end+1)`) **fails 7 tests**, including
`selection_highlight_vertex_oracle_pins_the_ascii_range` and
`selection_highlight_tracks_the_exact_wrapped_range`.

The lane's own three mutations — highlight the whole row, shift by one, drop the
highlight — each fail 3 tests.

Independent verification on a clean tree: **1,166 passed, 0 failed**
(`cargo test --workspace`), `fmt=0`, `clippy=0`.