### PR TITLE
feat(app): make scrollback viewable (#199, #203)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -302,20 +302,19 @@ against it:
   only feedback. Pasting into a plain `zsh` prompt or `cat` therefore
   does nothing. Sending unbracketed bytes is deliberately not done, so
   a preview must tell users this before they call paste broken.
-- **The view layer is incomplete beyond colour and glyphs.** There is no
-  visible cursor: `glyph_vertices` in `renderer.rs` emits sidebar rows,
-  per-cell backgrounds, glyph bitmaps, and a status line — never a cursor —
-  and the word "cursor" does not appear in that file. There is no scrollback
-  viewport: rendering stays on the newest suffix of the content because no
-  scroll-offset input exists (the only scroll offset in `main.rs` is the
-  sidebar's own). Selection is tracked and copies correctly but is never
-  highlighted. Scrollback search is unreachable: the terminal core ships a
+- **The view layer remains incomplete beyond cursor, colour, glyphs, and
+  scrollback navigation.** The cursor is rendered, and retained primary-screen
+  history now has a clamped viewport driven by configurable
+  Shift+PageUp/Shift+PageDown defaults plus the wheel only when the application
+  has not enabled mouse tracking. A `History -N` indicator names the configured
+  route to `Latest`; alternate screens never borrow primary history. Selection
+  is tracked and copies correctly but is never highlighted. Scrollback search
+  is unreachable: the terminal core ships a
   real snapshot search engine (`crates/noren-terminal/src/search.rs`:
   `Search`, ranked matches, case sensitivity), but nothing in the app
   references it — no key or palette command starts a search and no renderer
-  surface draws one. A terminal in which a stranger cannot see the cursor,
-  cannot scroll back, cannot see their selection, and cannot search is not
-  preview-ready.
+  surface draws one. Selection feedback and search therefore remain
+  preview-readiness gaps even though cursor and history navigation now work.
 - **The FR-005 rendered-frame oracle exists and runs, and its boundary is
   the honesty requirement.** It drives the real `wgpu` pipeline offscreen
   (`crates/noren-app/src/renderer_capture.rs`,

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -18,9 +18,9 @@
 //! one is waiting on.
 //!
 //! The `[keys]` table configures the workspace key chords (the palette
-//! opener and the four palette command shortcuts). It follows the same
-//! discipline: an absent table keeps the compiled-in defaults, an
-//! unparseable chord is a typed [`ConfigError::InvalidChord`] naming the
+//! opener, four palette command shortcuts, and two scrollback page actions).
+//! It follows the same discipline: an absent table keeps the compiled-in
+//! defaults, an unparseable chord is a typed [`ConfigError::InvalidChord`] naming the
 //! offending key and value, an unknown action name is
 //! [`ConfigError::UnknownKey`], two actions on one chord is
 //! [`ConfigError::DuplicateChord`], and a palette chord the pass-through
@@ -216,10 +216,11 @@ impl SidebarConfig {
 
 /// Configurable workspace key chords.
 ///
-/// [`KeymapConfig::default`] is exactly the chord set the app shipped with
-/// before configuration existed: `super+p` opens the palette, and the bare
-/// characters `c`/`s`/`x`/`f` dispatch the four palette commands. Every
-/// chord is a normalized pass-through [`Chord`], so the binary compares
+/// [`KeymapConfig::default`] preserves every workspace chord the app shipped
+/// with before configuration existed: `super+p` opens the palette, and the
+/// bare characters `c`/`s`/`x`/`f` dispatch its four commands. Conventional
+/// `shift+pageup` / `shift+pagedown` defaults add scrollback navigation.
+/// Every chord is a normalized pass-through [`Chord`], so the binary compares
 /// configured bindings against live key events without re-parsing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KeymapConfig {
@@ -228,6 +229,8 @@ pub struct KeymapConfig {
     session_select: Chord,
     session_close: Chord,
     sidebar_focus: Chord,
+    scroll_page_up: Chord,
+    scroll_page_down: Chord,
 }
 
 impl Default for KeymapConfig {
@@ -238,6 +241,8 @@ impl Default for KeymapConfig {
             session_select: default_chord(KeyCode::Char('s'), Modifiers::empty()),
             session_close: default_chord(KeyCode::Char('x'), Modifiers::empty()),
             sidebar_focus: default_chord(KeyCode::Char('f'), Modifiers::empty()),
+            scroll_page_up: default_chord(KeyCode::PageUp, Modifiers::empty().shift()),
+            scroll_page_down: default_chord(KeyCode::PageDown, Modifiers::empty().shift()),
         }
     }
 }
@@ -271,6 +276,20 @@ impl KeymapConfig {
     #[must_use]
     pub const fn sidebar_focus(self) -> Chord {
         self.sidebar_focus
+    }
+
+    /// Scroll one terminal viewport toward older history; defaults to
+    /// `shift+pageup`.
+    #[must_use]
+    pub const fn scroll_page_up(self) -> Chord {
+        self.scroll_page_up
+    }
+
+    /// Scroll one terminal viewport toward the live tail; defaults to
+    /// `shift+pagedown`.
+    #[must_use]
+    pub const fn scroll_page_down(self) -> Chord {
+        self.scroll_page_down
     }
 }
 
@@ -875,7 +894,7 @@ fn parse_keys(table: &dyn TableLike, keys: &mut KeymapConfig) -> Result<(), Conf
         // value-type complaint.
         let value = match key {
             "palette_open" | "session_create" | "session_select" | "session_close"
-            | "sidebar_focus" => item
+            | "sidebar_focus" | "scroll_page_up" | "scroll_page_down" => item
                 .as_str()
                 .ok_or_else(|| ConfigError::ChordNotAString { key: clip(key) })?,
             _ => return Err(ConfigError::UnknownKey(clip(key))),
@@ -889,6 +908,8 @@ fn parse_keys(table: &dyn TableLike, keys: &mut KeymapConfig) -> Result<(), Conf
             "session_select" => keys.session_select = parse_command_chord(key, value)?,
             "session_close" => keys.session_close = parse_command_chord(key, value)?,
             "sidebar_focus" => keys.sidebar_focus = parse_command_chord(key, value)?,
+            "scroll_page_up" => keys.scroll_page_up = parse_scroll_chord(key, value)?,
+            "scroll_page_down" => keys.scroll_page_down = parse_scroll_chord(key, value)?,
             // Unreachable in practice: the value match above rejected every
             // other name as unknown.
             _ => return Err(ConfigError::UnknownKey(clip(key))),
@@ -945,6 +966,21 @@ fn parse_command_chord(key: &str, value: &str) -> Result<Chord, ConfigError> {
     Ok(chord)
 }
 
+/// Parse a global scrollback chord without allowing it to shadow Noren's
+/// frozen escape-to-workspace leader. Unlike the palette opener, an explicit
+/// scroll rebind may intentionally overlap a child/Zellij chord; only the
+/// application-owned exit leader is unconditionally reserved.
+fn parse_scroll_chord(key: &str, value: &str) -> Result<Chord, ConfigError> {
+    let chord = parse_configured_chord(key, value)?;
+    if default_exit_claim().seq.chords() == [chord] {
+        return Err(ConfigError::ReservedChord {
+            key: clip(key),
+            value: clip(value),
+        });
+    }
+    Ok(chord)
+}
+
 /// Validate that the pass-through policy could actually claim the configured
 /// palette chord, using the same enforcement point the live policy uses.
 ///
@@ -967,7 +1003,7 @@ fn validate_palette_claim(chord: Chord, key: &str, value: &str) -> Result<Chord,
     }
 }
 
-/// Reject any chord bound to two of the five actions.
+/// Reject any chord bound to two configured actions.
 ///
 /// The check runs on the final keymap, so it also catches a configured value
 /// that silently collides with an action the table left at its default.
@@ -978,6 +1014,8 @@ fn ensure_distinct_chords(keys: &KeymapConfig) -> Result<(), ConfigError> {
         ("session_select", keys.session_select),
         ("session_close", keys.session_close),
         ("sidebar_focus", keys.sidebar_focus),
+        ("scroll_page_up", keys.scroll_page_up),
+        ("scroll_page_down", keys.scroll_page_down),
     ];
     for (index, (first_name, first)) in bindings.iter().enumerate() {
         for (second_name, second) in bindings.iter().skip(index + 1) {
@@ -2011,10 +2049,10 @@ mod tests {
         Chord::new(code, modifiers).expect("test chords are normalized constants")
     }
 
-    /// With no `[keys]` surface at all, the keymap is exactly the chord set
-    /// the app shipped with before configuration existed.
+    /// With no `[keys]` surface at all, workspace chords remain unchanged and
+    /// scrollback receives conventional zero-configuration page chords.
     #[test]
-    fn default_keymap_matches_the_pre_configuration_chords() {
+    fn default_keymap_preserves_workspace_chords_and_adds_scrollback_pages() {
         let keys = KeymapConfig::default();
         assert_eq!(
             keys.palette_open(),
@@ -2036,6 +2074,14 @@ mod tests {
         assert_eq!(
             keys.sidebar_focus(),
             chord(KeyCode::Char('f'), Modifiers::empty())
+        );
+        assert_eq!(
+            keys.scroll_page_up(),
+            chord(KeyCode::PageUp, Modifiers::empty().shift())
+        );
+        assert_eq!(
+            keys.scroll_page_down(),
+            chord(KeyCode::PageDown, Modifiers::empty().shift())
         );
         assert_eq!(AppConfig::default().keys(), keys);
         assert_eq!(AppConfig::parse("# nothing\n").expect("valid").keys(), keys);
@@ -2095,6 +2141,26 @@ mod tests {
     }
 
     #[test]
+    fn custom_scrollback_chords_apply_without_changing_other_defaults() {
+        let config = AppConfig::parse(
+            "[keys]\nscroll_page_up = \"ctrl+u\"\nscroll_page_down = \"ctrl+d\"\n",
+        )
+        .expect("scrollback chords are configurable global actions");
+        assert_eq!(
+            config.keys().scroll_page_up(),
+            chord(KeyCode::Char('u'), Modifiers::empty().ctrl())
+        );
+        assert_eq!(
+            config.keys().scroll_page_down(),
+            chord(KeyCode::Char('d'), Modifiers::empty().ctrl())
+        );
+        assert_eq!(
+            config.keys().palette_open(),
+            KeymapConfig::default().palette_open()
+        );
+    }
+
+    #[test]
     fn keys_apply_alongside_font_in_one_file() {
         let config =
             AppConfig::parse("[font]\ncell_width = 12\n[keys]\npalette_open = \"super+b\"\n")
@@ -2139,6 +2205,8 @@ mod tests {
             "session_select",
             "session_close",
             "sidebar_focus",
+            "scroll_page_up",
+            "scroll_page_down",
         ];
         let reserved = [
             ("super+a", 'a'),
@@ -2309,6 +2377,19 @@ mod tests {
         assert!(AppConfig::parse("[keys]\npalette_open = \"super+enter\"\n").is_ok());
     }
 
+    #[test]
+    fn scrollback_chords_cannot_shadow_the_frozen_exit_leader() {
+        for action in ["scroll_page_up", "scroll_page_down"] {
+            assert_eq!(
+                AppConfig::parse(&format!("[keys]\n{action} = \"super+escape\"\n")),
+                Err(ConfigError::ReservedChord {
+                    key: action.to_owned(),
+                    value: "super+escape".to_owned(),
+                })
+            );
+        }
+    }
+
     /// `[keys]` values must be TOML strings.
     #[test]
     fn keys_values_must_be_chord_strings() {
@@ -2316,6 +2397,7 @@ mod tests {
             "[keys]\nsession_create = 3\n",
             "[keys]\npalette_open = true\n",
             "[keys]\nsession_select = ['c']\n",
+            "[keys]\nscroll_page_up = 3\n",
         ] {
             let error = AppConfig::parse(text).expect_err("non-string chord fails");
             assert!(

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -884,7 +884,7 @@ fn parse_cursor(table: &dyn TableLike, cursor: &mut CursorConfig) -> Result<(), 
 /// holding one parseable chord. Palette-command chords must avoid the keys
 /// the open palette always interprets structurally (Escape, Enter, and the
 /// vertical arrows), the palette opener must stay claimable by the
-/// pass-through policy, and after applying the table all five chords must
+/// pass-through policy, and after applying the table all seven chords must
 /// stay pairwise distinct — including the chords of actions the table left
 /// at their defaults.
 fn parse_keys(table: &dyn TableLike, keys: &mut KeymapConfig) -> Result<(), ConfigError> {

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -25,6 +25,7 @@ pub mod sidebar_text;
 pub mod ssh_config;
 pub mod theme;
 pub mod ui;
+pub mod wheel_routing;
 
 pub use clipboard::{
     BRACKET_PASTE_BEGIN, BRACKET_PASTE_END, ClipboardError, PasteReject, SystemClipboard,

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -53,6 +53,7 @@ use noren_app::{
     sidebar_text::{SidebarTextRow, visible_sidebar_text_rows_at_width},
     ssh_config::{HostDiscoveryKind, SshConfig},
     theme::Theme,
+    wheel_routing::{TerminalWheelOwner, terminal_wheel_owner},
 };
 use noren_pty::{
     PtyEvent, PtySession, PtySize, SshDestination, SshDestinationError, SshLaunchPolicy,
@@ -2353,10 +2354,7 @@ impl NorenApp {
     }
 
     fn application_tracks_mouse(terminal: &TerminalState) -> bool {
-        let modes = terminal.modes();
-        modes.is_mouse_normal_tracking_enabled()
-            || modes.is_mouse_button_event_tracking_enabled()
-            || modes.is_mouse_any_event_tracking_enabled()
+        terminal_wheel_owner(terminal.modes()) == TerminalWheelOwner::Application
     }
 
     fn clamped_scroll_offset(terminal: &TerminalState, requested: usize) -> usize {
@@ -3069,7 +3067,13 @@ impl NorenApp {
         cell: Option<(u32, u32)>,
     ) -> TerminalWheelRoute {
         let clicks = wheel_clicks(delta, self.geometry.cell_metrics());
-        if self.current_mouse_modes().is_tracked() {
+        let owner = self
+            .terminal
+            .as_ref()
+            .map_or(TerminalWheelOwner::LocalHistory, |terminal| {
+                terminal_wheel_owner(terminal.modes())
+            });
+        if owner == TerminalWheelOwner::Application {
             let mut reports = Vec::new();
             if let Some((col, row)) = cell {
                 let modifiers = self.pointer_modifiers();

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1124,6 +1124,23 @@ fn created_session_id(events: Vec<SessionEvent>) -> SessionId {
 struct ParkedSession {
     pty: PtySession,
     terminal: TerminalState,
+    scroll_offset: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScrollDirection {
+    Older,
+    Newer,
+}
+
+/// Boundary decision for one wheel delta over the terminal surface.
+///
+/// The variant is intentionally test-visible inside this binary: the central
+/// correctness property is ownership, not merely whether some state changed.
+#[derive(Debug, PartialEq, Eq)]
+enum TerminalWheelRoute {
+    ConsumedLocally { before: usize, after: usize },
+    ForwardedToApplication(Vec<Vec<u8>>),
 }
 
 struct NorenApp {
@@ -1135,6 +1152,10 @@ struct NorenApp {
     sidebar_columns: usize,
     pending_grid: Option<GridSize>,
     terminal: Option<TerminalState>,
+    /// Logical rows above the active terminal's live tail. Zero follows new
+    /// output automatically; a non-zero value is deliberate user history and
+    /// stays put until the user scrolls down. Rendering clamps defensively too.
+    scroll_offset: usize,
     pty: Option<PtySession>,
     pty_child: PtyChildStatus,
     modifiers: Modifiers,
@@ -1305,6 +1326,7 @@ impl NorenApp {
             sidebar_columns: config.sidebar().columns(),
             pending_grid: None,
             terminal: None,
+            scroll_offset: 0,
             pty: None,
             pty_child: PtyChildStatus::NotLaunched,
             modifiers: Modifiers::empty(),
@@ -1385,6 +1407,7 @@ impl NorenApp {
         let terminal = runtime.terminal_state()?;
         let pty = runtime.pty_size()?;
         self.terminal = Some(terminal);
+        self.scroll_offset = 0;
         Some(pty)
     }
 
@@ -1616,6 +1639,7 @@ impl NorenApp {
                 Ok(session) => {
                     self.retire_live_terminal();
                     self.pty = Some(session);
+                    self.scroll_offset = 0;
                     self.pty_child = PtyChildStatus::Running;
                     true
                 }
@@ -1689,8 +1713,15 @@ impl NorenApp {
             self.pty.take(),
             self.terminal.take(),
         ) {
-            self.parked_sessions
-                .insert(id, ParkedSession { pty, terminal });
+            let scroll_offset = std::mem::take(&mut self.scroll_offset);
+            self.parked_sessions.insert(
+                id,
+                ParkedSession {
+                    pty,
+                    terminal,
+                    scroll_offset,
+                },
+            );
             self.pty_child = PtyChildStatus::NotLaunched;
         }
     }
@@ -1736,6 +1767,7 @@ impl NorenApp {
                 self.park_active_session();
                 self.pty = Some(pty);
                 self.terminal = Some(terminal);
+                self.scroll_offset = 0;
                 self.active_session = Some(id);
                 self.pty_child = PtyChildStatus::Running;
                 // Grid coordinates captured on the previous session's screen
@@ -1816,6 +1848,7 @@ impl NorenApp {
                 self.park_active_session();
                 self.pty = Some(pty);
                 self.terminal = Some(terminal);
+                self.scroll_offset = 0;
                 self.active_session = Some(id);
                 self.pty_child = PtyChildStatus::Running;
                 self.selection = None;
@@ -1878,6 +1911,7 @@ impl NorenApp {
                 self.park_active_session();
                 self.pty = Some(pty);
                 self.terminal = Some(terminal);
+                self.scroll_offset = 0;
                 self.active_session = Some(id);
                 self.pty_child = PtyChildStatus::Running;
                 self.selection = None;
@@ -1953,6 +1987,7 @@ impl NorenApp {
                 self.park_active_session();
                 self.pty = Some(pty);
                 self.terminal = Some(terminal);
+                self.scroll_offset = 0;
                 self.active_session = Some(id);
                 self.pty_child = PtyChildStatus::Running;
                 self.selection = None;
@@ -2042,7 +2077,18 @@ impl NorenApp {
                         return None;
                     }
                     remaining -= bytes.len();
+                    let was_alternate = parked.terminal.modes().is_alternate_screen_active();
+                    let was_tracking_mouse = Self::application_tracks_mouse(&parked.terminal);
                     parked.terminal.feed_bytes(&bytes);
+                    let entered_alternate =
+                        !was_alternate && parked.terminal.modes().is_alternate_screen_active();
+                    let claimed_mouse =
+                        !was_tracking_mouse && Self::application_tracks_mouse(&parked.terminal);
+                    parked.scroll_offset = if entered_alternate || claimed_mouse {
+                        0
+                    } else {
+                        Self::clamped_scroll_offset(&parked.terminal, parked.scroll_offset)
+                    };
                 }
                 Ok(Some(PtyEvent::Eof)) => {
                     return Some(SessionStatus::Exited { code: None });
@@ -2101,6 +2147,9 @@ impl NorenApp {
         self.park_active_session();
         self.pty = Some(parked.pty);
         self.terminal = Some(parked.terminal);
+        self.scroll_offset = self.terminal.as_ref().map_or(0, |terminal| {
+            Self::clamped_scroll_offset(terminal, parked.scroll_offset)
+        });
         self.active_session = Some(id);
         self.pty_child = PtyChildStatus::Running;
         // Grid coordinates captured on the previous session's screen can
@@ -2154,6 +2203,7 @@ impl NorenApp {
             self.active_session = None;
             self.exited_surface_session = None;
             self.terminal = None;
+            self.scroll_offset = 0;
             self.pty_child = PtyChildStatus::NotLaunched;
             self.selection = None;
             self.drag_origin = None;
@@ -2291,6 +2341,72 @@ impl NorenApp {
         self.modifiers = modifiers;
     }
 
+    /// Maximum locally addressable history for one terminal surface.
+    /// Alternate-screen applications own their complete view and expose no
+    /// Noren scrollback, even though primary history remains retained.
+    fn max_scroll_offset(terminal: &TerminalState) -> usize {
+        if terminal.modes().is_alternate_screen_active() {
+            0
+        } else {
+            terminal.scrollback_len()
+        }
+    }
+
+    fn application_tracks_mouse(terminal: &TerminalState) -> bool {
+        let modes = terminal.modes();
+        modes.is_mouse_normal_tracking_enabled()
+            || modes.is_mouse_button_event_tracking_enabled()
+            || modes.is_mouse_any_event_tracking_enabled()
+    }
+
+    fn clamped_scroll_offset(terminal: &TerminalState, requested: usize) -> usize {
+        requested.min(Self::max_scroll_offset(terminal))
+    }
+
+    fn clamp_active_scroll_offset(&mut self) {
+        self.scroll_offset = self.terminal.as_ref().map_or(0, |terminal| {
+            Self::clamped_scroll_offset(terminal, self.scroll_offset)
+        });
+    }
+
+    /// Move the active primary-screen viewport by a bounded number of rows.
+    /// Returns the before/after offsets so the wheel ownership test can prove
+    /// local consumption without relying on a frame merely changing.
+    fn scroll_view(&mut self, direction: ScrollDirection, rows: usize) -> (usize, usize) {
+        self.clamp_active_scroll_offset();
+        let before = self.scroll_offset;
+        let max_offset = self.terminal.as_ref().map_or(0, Self::max_scroll_offset);
+        self.scroll_offset = match direction {
+            ScrollDirection::Older => self.scroll_offset.saturating_add(rows).min(max_offset),
+            ScrollDirection::Newer => self.scroll_offset.saturating_sub(rows),
+        };
+        if self.scroll_offset != before {
+            self.selection = None;
+            self.drag_origin = None;
+            self.redraw_needed = true;
+        }
+        (before, self.scroll_offset)
+    }
+
+    fn handle_scrollback_chord(&mut self, chord: Chord) -> bool {
+        let Some(terminal) = self.terminal.as_ref() else {
+            return false;
+        };
+        if terminal.modes().is_alternate_screen_active() {
+            return false;
+        }
+        let direction = if chord == self.keys.scroll_page_up() {
+            ScrollDirection::Older
+        } else if chord == self.keys.scroll_page_down() {
+            ScrollDirection::Newer
+        } else {
+            return false;
+        };
+        let page_rows = usize::from(terminal.size().0).max(1);
+        self.scroll_view(direction, page_rows);
+        true
+    }
+
     fn handle_key(&mut self, event: &KeyEvent) {
         if self.handle_clipboard_shortcut(event) {
             return;
@@ -2306,6 +2422,12 @@ impl NorenApp {
         }
         if self.palette_open {
             self.handle_palette_key(event);
+            return;
+        }
+        if event.state == ElementState::Pressed
+            && let Some(chord) = chord_from_event(event, self.modifiers)
+            && self.handle_scrollback_chord(chord)
+        {
             return;
         }
         self.handle_passthrough_key(event);
@@ -2934,29 +3056,66 @@ impl NorenApp {
         self.encode_and_send_mouse(event);
     }
 
-    /// Handle a scroll-wheel event. Under tracking, each line of delta
-    /// generates one wheel report; without tracking, the event is ignored
-    /// (matching the pre-tracking behaviour where `MouseWheel` fell into the
-    /// `_ => {}` catch-all).
+    /// Resolve and apply the terminal-side ownership of one wheel delta.
+    ///
+    /// Any authoritative tracking mode (1000/1002/1003) gives the application
+    /// the wheel, including when Shift is held. Without tracking, Noren
+    /// consumes the delta as local primary-screen history navigation. This is
+    /// the ADR-0003 boundary in one branch: inside belongs to Zellij/vim when
+    /// they ask for it; otherwise the outer terminal supplies its own view.
+    fn route_terminal_wheel(
+        &mut self,
+        delta: MouseScrollDelta,
+        cell: Option<(u32, u32)>,
+    ) -> TerminalWheelRoute {
+        let clicks = wheel_clicks(delta, self.geometry.cell_metrics());
+        if self.current_mouse_modes().is_tracked() {
+            let mut reports = Vec::new();
+            if let Some((col, row)) = cell {
+                let modifiers = self.pointer_modifiers();
+                for direction in clicks {
+                    if let Some(report) =
+                        self.encode_mouse(PointerEvent::wheel(direction, col, row, modifiers))
+                    {
+                        reports.push(report);
+                    }
+                }
+            }
+            return TerminalWheelRoute::ForwardedToApplication(reports);
+        }
+
+        let before = self.scroll_offset;
+        for direction in clicks {
+            let direction = match direction {
+                noren_app::mouse::WheelDirection::Up => ScrollDirection::Older,
+                noren_app::mouse::WheelDirection::Down => ScrollDirection::Newer,
+            };
+            self.scroll_view(direction, 1);
+        }
+        TerminalWheelRoute::ConsumedLocally {
+            before,
+            after: self.scroll_offset,
+        }
+    }
+
+    /// Handle a scroll-wheel event. Sidebar chrome keeps its existing outside-
+    /// terminal ownership; over the terminal, [`Self::route_terminal_wheel`]
+    /// makes the application/local decision before any state is changed.
     fn handle_mouse_wheel(&mut self, delta: MouseScrollDelta) {
         if let Some(frame_size) = self.window.as_ref().map(|window| window.inner_size())
             && self.handle_sidebar_wheel_in_frame(delta, frame_size)
         {
             return;
         }
-        if !self.mouse_reportable() {
-            return;
-        }
-        let Some(position) = self.cursor_position else {
-            return;
-        };
-        let Some((col, row)) = self.mouse_cell_at(position) else {
-            return;
-        };
-        let mods = self.pointer_modifiers();
-        for direction in wheel_clicks(delta, self.geometry.cell_metrics()) {
-            let event = PointerEvent::wheel(direction, col, row, mods);
-            self.encode_and_send_mouse(event);
+        let cell = self
+            .cursor_position
+            .and_then(|position| self.mouse_cell_at(position));
+        if let TerminalWheelRoute::ForwardedToApplication(reports) =
+            self.route_terminal_wheel(delta, cell)
+        {
+            for report in reports {
+                self.send_input(&report);
+            }
         }
     }
 
@@ -2992,7 +3151,12 @@ impl NorenApp {
         if position.x < sidebar_pixel_width_at_width(cell_width, self.sidebar_columns) {
             return None;
         }
-        let content_rows = terminal.screen().display_row_count();
+        let scroll_offset = Self::clamped_scroll_offset(terminal, self.scroll_offset);
+        let content_rows = if scroll_offset == 0 {
+            terminal.screen().display_row_count()
+        } else {
+            usize::from(terminal.size().0)
+        };
         let window_rows =
             renderer::fully_drawable_rows(frame_size.height, self.geometry.cell_metrics())
                 .try_into()
@@ -3010,10 +3174,8 @@ impl NorenApp {
             return None;
         }
         let column = terminal_column_at_width(position.x, cols, cell_width, self.sidebar_columns)?;
-        Some(GridPoint::new(
-            terminal.scrollback_len() + line_index,
-            column,
-        ))
+        let logical_start = terminal.scrollback_len().saturating_sub(scroll_offset);
+        Some(GridPoint::new(logical_start + line_index, column))
     }
 
     /// Whether pointer events should be reported to the PTY instead of driving
@@ -3039,6 +3201,31 @@ impl NorenApp {
         frame_size: PhysicalSize<u32>,
     ) -> Option<(u32, u32)> {
         let terminal = self.terminal.as_ref()?;
+        if Self::application_tracks_mouse(terminal) {
+            if !position.x.is_finite()
+                || !position.y.is_finite()
+                || position.x < 0.0
+                || position.y < 0.0
+                || position.x >= f64::from(frame_size.width)
+                || position.y >= f64::from(frame_size.height)
+                || position.x
+                    < sidebar_pixel_width_at_width(self.geometry.cell_width(), self.sidebar_columns)
+            {
+                return None;
+            }
+            let (rows, cols) = terminal.size();
+            let row = pixel_row_index(position.y, self.geometry.cell_height())?;
+            if row >= usize::from(rows) {
+                return None;
+            }
+            let column = terminal_column_at_width(
+                position.x,
+                cols,
+                self.geometry.cell_width(),
+                self.sidebar_columns,
+            )?;
+            return Some((u32::try_from(column).ok()?, u32::try_from(row).ok()?));
+        }
         let point = self.grid_point_in_frame(position, frame_size)?;
         let visible_row = point.line().checked_sub(terminal.scrollback_len())?;
         let col = u32::try_from(point.column()).ok()?;
@@ -3185,6 +3372,7 @@ impl NorenApp {
                 self.status = "Noren terminal resize failed";
                 self.show_status = true;
             }
+            self.scroll_offset = Self::clamped_scroll_offset(terminal, self.scroll_offset);
         }
         if let (Some(session), Some(size)) = (&self.pty, runtime.pty_size()) {
             if session.resize(size).is_err() {
@@ -3200,6 +3388,8 @@ impl NorenApp {
                     self.status = "Noren terminal resize failed";
                     self.show_status = true;
                 }
+                parked.scroll_offset =
+                    Self::clamped_scroll_offset(&parked.terminal, parked.scroll_offset);
                 if parked.pty.resize(size).is_err() {
                     self.status = "Noren PTY resize failed";
                     self.show_status = true;
@@ -3213,7 +3403,21 @@ impl NorenApp {
     /// parser. Production and application tests share this exact byte path.
     fn apply_pty_output(&mut self, bytes: &[u8]) {
         if let Some(terminal) = &mut self.terminal {
+            let was_alternate = terminal.modes().is_alternate_screen_active();
+            let was_tracking_mouse = Self::application_tracks_mouse(terminal);
             terminal.feed_bytes(bytes);
+            // A program entering an alternate screen or claiming the mouse
+            // owns the visible terminal surface. Rejoin its live screen before
+            // routing subsequent input; ordinary output otherwise preserves a
+            // deliberate non-zero history offset and follows automatically at
+            // offset zero.
+            let entered_alternate = !was_alternate && terminal.modes().is_alternate_screen_active();
+            let claimed_mouse = !was_tracking_mouse && Self::application_tracks_mouse(terminal);
+            if entered_alternate || claimed_mouse {
+                self.scroll_offset = 0;
+            } else {
+                self.scroll_offset = Self::clamped_scroll_offset(terminal, self.scroll_offset);
+            }
         }
         // First output from an ssh child means the remote side is talking
         // through the normal I/O path: the launch is interactive now.
@@ -3338,6 +3542,7 @@ impl NorenApp {
     }
 
     fn redraw(&mut self, event_loop: &ActiveEventLoop) {
+        self.clamp_active_scroll_offset();
         let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
         let visible_rows = self
             .window
@@ -3386,13 +3591,17 @@ impl NorenApp {
         let palette_hint = status
             .as_ref()
             .and_then(|_| noren_app::ui::palette_hint(self.keys, self.ui));
+        let viewport_indicator = status
+            .as_ref()
+            .and_then(|_| noren_app::ui::scrollback_indicator(self.scroll_offset, self.keys));
         let workspace_notice = (self.workspace.sidebar().is_empty() && self.terminal.is_none())
             .then(|| noren_app::ui::empty_workspace_recovery(self.keys));
         let chrome = FrameChrome::new(None, status)
             .with_sidebar_rows(Some(&rows))
+            .with_viewport_indicator(viewport_indicator.as_deref())
             .with_palette_hint(palette_hint.as_deref())
             .with_workspace_notice(workspace_notice.as_deref())
-            .with_scroll_offset(0);
+            .with_scroll_offset(self.scroll_offset);
         let outcome = self
             .renderer
             .as_mut()

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3391,7 +3391,8 @@ impl NorenApp {
         let chrome = FrameChrome::new(None, status)
             .with_sidebar_rows(Some(&rows))
             .with_palette_hint(palette_hint.as_deref())
-            .with_workspace_notice(workspace_notice.as_deref());
+            .with_workspace_notice(workspace_notice.as_deref())
+            .with_scroll_offset(0);
         let outcome = self
             .renderer
             .as_mut()

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -3056,7 +3056,7 @@ impl NorenApp {
 
     /// Resolve and apply the terminal-side ownership of one wheel delta.
     ///
-    /// Any authoritative tracking mode (1000/1002/1003) gives the application
+    /// Any authoritative tracking mode (9/1000/1002/1003) gives the application
     /// the wheel, including when Shift is held. Without tracking, Noren
     /// consumes the delta as local primary-screen history navigation. This is
     /// the ADR-0003 boundary in one branch: inside belongs to Zellij/vim when
@@ -3183,7 +3183,8 @@ impl NorenApp {
     }
 
     /// Whether pointer events should be reported to the PTY instead of driving
-    /// local text selection. Active when a tracking mode (1000/1002/1003) is on
+    /// local text selection. Active when a tracking mode (9/1000/1002/1003) is
+    /// on
     /// and Shift is not held — Shift bypasses reporting so the user can still
     /// select text while a program tracks the mouse, matching xterm/iTerm.
     fn mouse_reportable(&self) -> bool {
@@ -3254,6 +3255,7 @@ impl NorenApp {
             return MouseModes::disabled();
         };
         MouseModes::disabled()
+            .with_x10(modes.is_mouse_x10_tracking_enabled())
             .with_normal(modes.is_mouse_normal_tracking_enabled())
             .with_button_event(modes.is_mouse_button_event_tracking_enabled())
             .with_any_event(modes.is_mouse_any_event_tracking_enabled())

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1437,6 +1437,90 @@ fn wheel_is_local_without_mouse_mode_and_forwarded_with_mouse_mode() {
     );
 }
 
+fn assert_tracking_mode_forwards_wheel(decset: &[u8]) {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 6)),
+        ..Default::default()
+    };
+    app.apply_pty_output(decset);
+    app.apply_pty_output(b"\x1b[?1006h");
+
+    assert_eq!(
+        app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 1.0), Some((1, 1))),
+        TerminalWheelRoute::ForwardedToApplication(vec![b"\x1b[<64;2;2M".to_vec()]),
+        "an application tracking mode must own the wheel"
+    );
+    assert_eq!(
+        app.scroll_offset, 0,
+        "forwarding must not consume the wheel as local history"
+    );
+}
+
+#[test]
+fn mode_1000_forwards_wheel_instead_of_consuming_scrollback() {
+    assert_tracking_mode_forwards_wheel(b"\x1b[?1000h");
+}
+
+#[test]
+fn mode_1002_forwards_wheel_instead_of_consuming_scrollback() {
+    assert_tracking_mode_forwards_wheel(b"\x1b[?1002h");
+}
+
+#[test]
+fn mode_1003_forwards_wheel_instead_of_consuming_scrollback() {
+    assert_tracking_mode_forwards_wheel(b"\x1b[?1003h");
+}
+
+#[test]
+fn mouse_tracking_enable_then_disable_restores_local_wheel_scrolling() {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 6)),
+        ..Default::default()
+    };
+    app.apply_pty_output(b"\x1b[?1000;1006h");
+
+    assert!(matches!(
+        app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 1.0), Some((0, 0))),
+        TerminalWheelRoute::ForwardedToApplication(_)
+    ));
+    assert_eq!(app.scroll_offset, 0);
+
+    app.apply_pty_output(b"\x1b[?1000l");
+    assert_eq!(
+        app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 1.0), Some((0, 0))),
+        TerminalWheelRoute::ConsumedLocally {
+            before: 0,
+            after: 1,
+        },
+        "DECRST must return an unclaimed wheel to local scrollback"
+    );
+    assert_eq!(app.scroll_offset, 1);
+}
+
+#[test]
+fn claiming_mouse_while_scrolled_snaps_to_tail_before_forwarding_wheel() {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 6)),
+        ..Default::default()
+    };
+    app.scroll_view(ScrollDirection::Older, 2);
+    assert_eq!(app.scroll_offset, 2, "fixture starts in history");
+
+    app.apply_pty_output(b"\x1b[?1002h");
+    assert_eq!(
+        app.scroll_offset, 0,
+        "a newly claimed mouse rejoins the application's live surface"
+    );
+    assert!(
+        matches!(
+            app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 1.0), Some((0, 0))),
+            TerminalWheelRoute::ForwardedToApplication(ref reports) if reports.len() == 1
+        ),
+        "the claiming mode must own the next wheel event"
+    );
+    assert_eq!(app.scroll_offset, 0);
+}
+
 // ── Authoritative application mouse modes ───────────────────────────
 
 #[test]

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1226,6 +1226,217 @@ fn palette_text_lines_show_selection_marker() {
     );
 }
 
+// ── Scrollback viewport input and ownership ──────────────────────────
+
+fn history_terminal(rows: u16, cols: u16) -> TerminalState {
+    let mut terminal = TerminalState::new(rows, cols).expect("valid history terminal");
+    terminal.feed_bytes(b"A\r\nB\r\nC\r\nD\r\nE\r\nF");
+    assert!(terminal.scrollback_len() >= 3, "fixture retains history");
+    terminal
+}
+
+#[test]
+fn default_and_configured_scrollback_chords_drive_the_live_offset() {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 4)),
+        ..Default::default()
+    };
+    let page_up = gate_chord(GateKeyCode::PageUp, GateModifiers::empty().shift());
+    let page_down = gate_chord(GateKeyCode::PageDown, GateModifiers::empty().shift());
+
+    assert!(app.handle_scrollback_chord(page_up));
+    assert_eq!(app.scroll_offset, 3, "one page is the three-row viewport");
+    assert!(app.handle_scrollback_chord(page_down));
+    assert_eq!(app.scroll_offset, 0, "page down reaches the live tail");
+
+    let config =
+        AppConfig::parse("[keys]\nscroll_page_up = \"ctrl+u\"\nscroll_page_down = \"ctrl+j\"\n")
+            .expect("valid scrollback rebinds");
+    let mut rebound = NorenApp {
+        terminal: Some(history_terminal(3, 4)),
+        ..NorenApp::new(config)
+    };
+    assert!(
+        !rebound.handle_scrollback_chord(page_up),
+        "the compiled default is released after rebinding"
+    );
+    assert!(rebound.handle_scrollback_chord(gate_chord(
+        GateKeyCode::Char('u'),
+        GateModifiers::empty().ctrl(),
+    )));
+    assert_eq!(rebound.scroll_offset, 3);
+    assert!(rebound.handle_scrollback_chord(gate_chord(
+        GateKeyCode::Char('j'),
+        GateModifiers::empty().ctrl(),
+    )));
+    assert_eq!(rebound.scroll_offset, 0);
+}
+
+#[test]
+fn scrolling_past_both_ends_clamps_without_blank_offsets() {
+    let terminal = history_terminal(3, 4);
+    let history_len = terminal.scrollback_len();
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        app.scroll_view(ScrollDirection::Older, usize::MAX),
+        (0, history_len)
+    );
+    assert_eq!(
+        app.scroll_view(ScrollDirection::Older, 1),
+        (history_len, history_len)
+    );
+    assert_eq!(
+        app.scroll_view(ScrollDirection::Newer, usize::MAX),
+        (history_len, 0)
+    );
+    assert_eq!(app.scroll_view(ScrollDirection::Newer, 1), (0, 0));
+}
+
+#[test]
+fn new_output_follows_at_zero_but_preserves_a_deliberate_history_view() {
+    let mut terminal = TerminalState::new(2, 4).expect("valid terminal");
+    terminal.feed_bytes(b"A\r\nB\r\nC");
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..Default::default()
+    };
+    app.scroll_view(ScrollDirection::Older, 1);
+    assert_eq!(app.scroll_offset, 1);
+
+    app.apply_pty_output(b"\r\nD");
+    assert_eq!(
+        app.scroll_offset, 1,
+        "ordinary output must not yank a deliberate history view to latest"
+    );
+
+    app.scroll_view(ScrollDirection::Newer, 1);
+    assert_eq!(app.scroll_offset, 0);
+    app.apply_pty_output(b"\r\nE");
+    assert_eq!(
+        app.scroll_offset, 0,
+        "offset zero remains the automatic live tail"
+    );
+}
+
+#[test]
+fn alternate_screen_resets_history_and_forwards_scrollback_chords() {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 6)),
+        ..Default::default()
+    };
+    app.scroll_view(ScrollDirection::Older, 2);
+    assert_eq!(app.scroll_offset, 2);
+
+    app.apply_pty_output(b"\x1b[?1049hALT");
+    assert_eq!(
+        app.scroll_offset, 0,
+        "alternate screen rejoins live content"
+    );
+    assert!(
+        !app.handle_scrollback_chord(gate_chord(
+            GateKeyCode::PageUp,
+            GateModifiers::empty().shift(),
+        )),
+        "alternate-screen application receives Shift+PageUp unchanged"
+    );
+    app.apply_pty_output(b"\x1b[?1049l");
+    assert_eq!(app.scroll_offset, 0, "primary screen resumes at latest");
+}
+
+#[test]
+fn resize_while_scrolled_preserves_offset_and_wide_history_cells() {
+    let mut terminal = TerminalState::new(2, 6).expect("valid terminal");
+    terminal.feed_bytes("日A\r\n語B\r\n界C".as_bytes());
+    assert_eq!(terminal.scrollback_len(), 1);
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..Default::default()
+    };
+    app.scroll_offset = 1;
+
+    let grid = app
+        .geometry
+        .update(Resize::new(200, 80))
+        .expect("resize changes the window grid");
+    app.pending_grid = Some(grid);
+    app.apply_pending_resize();
+
+    assert_eq!(app.scroll_offset, 1, "valid history offset survives resize");
+    let snapshot = app.terminal.as_ref().expect("terminal retained").snapshot();
+    let oldest = snapshot.scrollback().first().expect("history row retained");
+    assert_eq!(oldest[0].text(), "日");
+    assert_eq!(oldest[0].width(), 2);
+    assert!(oldest[1].is_continuation());
+    assert_eq!(oldest[2].text(), "A");
+}
+
+#[test]
+fn wheel_is_local_without_mouse_mode_and_forwarded_with_mouse_mode() {
+    let mut app = NorenApp {
+        terminal: Some(history_terminal(3, 6)),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 2.0), Some((1, 1))),
+        TerminalWheelRoute::ConsumedLocally {
+            before: 0,
+            after: 2,
+        }
+    );
+    assert_eq!(
+        app.scroll_offset, 2,
+        "unclaimed wheel scrolls Noren history"
+    );
+
+    app.apply_pty_output(b"\x1b[?1000;1006h");
+    assert_eq!(
+        app.scroll_offset, 0,
+        "an application claiming the mouse rejoins its live surface"
+    );
+    app.scroll_offset = 1;
+    app.modifiers = Modifiers::empty().shift();
+    let mapped = app.mouse_cell_in_frame(
+        PhysicalPosition::new(
+            sidebar_pixel_width(app.geometry.cell_width())
+                + f64::from(app.geometry.cell_width())
+                + 1.0,
+            f64::from(app.geometry.cell_height()) + 1.0,
+        ),
+        PhysicalSize::new(
+            (renderer::SIDEBAR_COLS as u32 + 6) * app.geometry.cell_width(),
+            4 * app.geometry.cell_height(),
+        ),
+    );
+    assert_eq!(
+        mapped,
+        Some((1, 1)),
+        "tracked wheel coordinates stay reportable while history is displayed"
+    );
+    let routed = app.route_terminal_wheel(MouseScrollDelta::LineDelta(0.0, 2.0), mapped);
+    assert_eq!(
+        routed,
+        TerminalWheelRoute::ForwardedToApplication(vec![
+            b"\x1b[<68;2;2M".to_vec(),
+            b"\x1b[<68;2;2M".to_vec(),
+        ]),
+        "tracking owns every wheel click, including with Shift held"
+    );
+    assert_eq!(
+        app.scroll_offset, 1,
+        "forwarding must not consume the wheel as local history"
+    );
+    app.apply_pty_output(b"X");
+    assert_eq!(
+        app.scroll_offset, 1,
+        "after the ownership transition, ordinary output preserves deliberate history"
+    );
+}
+
 // ── Authoritative application mouse modes ───────────────────────────
 
 #[test]

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -1472,6 +1472,11 @@ fn mode_1003_forwards_wheel_instead_of_consuming_scrollback() {
 }
 
 #[test]
+fn mode_9_forwards_wheel_instead_of_consuming_scrollback() {
+    assert_tracking_mode_forwards_wheel(b"\x1b[?9h");
+}
+
+#[test]
 fn mouse_tracking_enable_then_disable_restores_local_wheel_scrolling() {
     let mut app = NorenApp {
         terminal: Some(history_terminal(3, 6)),
@@ -1588,8 +1593,9 @@ fn app_decrst_mouse_output_disables_encoding() {
 }
 
 #[test]
-fn app_current_mouse_modes_projects_all_six_terminal_flags() {
+fn app_current_mouse_modes_projects_all_seven_terminal_flags() {
     let cases: &[(&[u8], MouseModes)] = &[
+        (b"\x1b[?9h", MouseModes::disabled().with_x10(true)),
         (b"\x1b[?1000h", MouseModes::disabled().with_normal(true)),
         (
             b"\x1b[?1002h",

--- a/crates/noren-app/src/mouse.rs
+++ b/crates/noren-app/src/mouse.rs
@@ -13,6 +13,7 @@
 //! # Mode model
 //!
 //! Tracking modes decide *whether* a report is produced:
+//! - **9** — X10 tracking: report button presses and wheel clicks.
 //! - **1000** — normal mouse tracking: report press, release, and wheel.
 //! - **1002** — button-event tracking: also report motion while a button is held.
 //! - **1003** — any-event tracking: report all motion, with or without a button.
@@ -54,7 +55,9 @@
 /// DEC private mode numbers for mouse tracking and encoding.
 ///
 /// These are the values carried by `CSI ? <mode> h` (DECSET) and
-/// `CSI ? <mode> l` (DECRST). Zellij's client enables all of these on attach.
+/// `CSI ? <mode> l` (DECRST). Zellij's client enables the 1000-series modes;
+/// mode 9 is the older X10 tracking claim.
+pub const MODE_X10: u16 = 9;
 pub const MODE_NORMAL: u16 = 1000;
 pub const MODE_BUTTON_EVENT: u16 = 1002;
 pub const MODE_ANY_EVENT: u16 = 1003;
@@ -81,13 +84,14 @@ const CB_CTRL: u32 = 16;
 
 /// Encoder-facing projection of the terminal's active mouse modes.
 ///
-/// Tracking flags (1000/1002/1003) gate *whether* a report is produced;
+/// Tracking flags (9/1000/1002/1003) gate *whether* a report is produced;
 /// encoding flags (1005/1006/1015) gate *how* it is formatted. The two
 /// groups are independent. The application derives this value from the active
 /// `TerminalState::modes()` for each pointer event; it is not a second source
 /// of DECSET/DECRST state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MouseModes {
+    x10: bool,
     normal: bool,
     button_event: bool,
     any_event: bool,
@@ -101,6 +105,7 @@ impl MouseModes {
     #[must_use]
     pub const fn disabled() -> Self {
         Self {
+            x10: false,
             normal: false,
             button_event: false,
             any_event: false,
@@ -108,6 +113,13 @@ impl MouseModes {
             sgr: false,
             urxvt: false,
         }
+    }
+
+    /// Set X10 mouse tracking (mode 9): button presses and wheel clicks.
+    #[must_use]
+    pub const fn with_x10(mut self, on: bool) -> Self {
+        self.x10 = on;
+        self
     }
 
     /// Set normal mouse tracking (mode 1000): press/release/wheel.
@@ -163,6 +175,7 @@ impl MouseModes {
     #[must_use]
     pub fn set(self, mode: u16, on: bool) -> Self {
         match mode {
+            MODE_X10 => self.with_x10(on),
             MODE_NORMAL => self.with_normal(on),
             MODE_BUTTON_EVENT => self.with_button_event(on),
             MODE_ANY_EVENT => self.with_any_event(on),
@@ -177,6 +190,14 @@ impl MouseModes {
     /// all. With this false every event produces `None`.
     #[must_use]
     pub const fn is_tracked(self) -> bool {
+        self.x10 || self.normal || self.button_event || self.any_event
+    }
+
+    /// Whether release reports are part of the active tracking mode.
+    ///
+    /// Plain mode 9 reports presses only. Any 1000-series tracking claim adds
+    /// release reporting even if mode 9 remains enabled alongside it.
+    const fn reports_release(self) -> bool {
         self.normal || self.button_event || self.any_event
     }
 
@@ -417,6 +438,9 @@ impl MouseEncoder {
             PointerKind::Press(button) => (button_code(button) | modifiers, false),
             PointerKind::Wheel(direction) => (wheel_code(direction) | modifiers, false),
             PointerKind::Release(button) => {
+                if !modes.reports_release() {
+                    return None;
+                }
                 // SGR is the only form that distinguishes the released button
                 // (it keeps the button code and switches the terminator to 'm').
                 // Legacy X10 and urxvt collapse every release to Cb = 3.

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -347,6 +347,7 @@ pub(crate) struct FrameChrome<'a> {
     status: Option<&'a str>,
     palette_hint: Option<&'a str>,
     workspace_notice: Option<&'a [String]>,
+    scroll_offset: usize,
 }
 
 impl<'a> FrameChrome<'a> {
@@ -356,6 +357,7 @@ impl<'a> FrameChrome<'a> {
             status,
             palette_hint: None,
             workspace_notice: None,
+            scroll_offset: 0,
         }
     }
 
@@ -379,6 +381,18 @@ impl<'a> FrameChrome<'a> {
     #[must_use]
     pub(crate) const fn with_workspace_notice(mut self, lines: Option<&'a [String]>) -> Self {
         self.workspace_notice = lines;
+        self
+    }
+
+    /// Select a viewport this many logical rows above the live tail.
+    ///
+    /// The renderer clamps the request to retained primary-screen history and
+    /// ignores it while the alternate screen is active. Keeping that safety at
+    /// the render boundary means a stale application offset can never produce
+    /// a blank frame or leak shell history into vim/less.
+    #[must_use]
+    pub(crate) const fn with_scroll_offset(mut self, offset: usize) -> Self {
+        self.scroll_offset = offset;
         self
     }
 
@@ -759,6 +773,7 @@ fn glyph_vertices_with_chrome_budget(
     let sidebar = chrome.sidebar;
     let status = chrome.status_line();
     let workspace_notice = chrome.workspace_notice;
+    let requested_scroll_offset = chrome.scroll_offset;
     let has_sidebar = sidebar.is_some();
     let col_offset = if has_sidebar { sidebar_columns } else { 0 };
     // Reserve the sidebar, then clamp the terminal to the renderer's drawable
@@ -784,15 +799,19 @@ fn glyph_vertices_with_chrome_budget(
     // column, so the cell index below is the display column for every glyph —
     // the same coordinate model the string path used, now carrying the
     // attributes that path threw away.
+    let effective_scroll_offset = terminal
+        .map(|snapshot| clamped_scroll_offset(snapshot, requested_scroll_offset))
+        .unwrap_or(0);
     let mut rows: Vec<&[noren_terminal::Cell]> = terminal
-        .map(|snapshot| snapshot.display_cells().collect())
+        .map(|snapshot| viewport_rows(snapshot, effective_scroll_offset))
         .unwrap_or_default();
     // A visible cursor makes its row content (issues #197/#200): the display
     // model trims trailing blank rows, so without this extension the caret
     // would vanish on a fresh screen — exactly the row typing lands in. A
     // hidden cursor skips the extension, keeping hidden-cursor frames
     // byte-identical to the pre-cursor renderer.
-    if let Some(snapshot) = terminal
+    if effective_scroll_offset == 0
+        && let Some(snapshot) = terminal
         && snapshot.is_cursor_visible()
     {
         let cursor_row = usize::from(snapshot.cursor().row())
@@ -808,7 +827,9 @@ fn glyph_vertices_with_chrome_budget(
     let content_rows = rows.len().max(workspace_notice.map_or(0, <[String]>::len));
     let layout = FrameRowLayout::new(height, metrics, content_rows, status.is_some())
         .expect("non-zero frame height has a row layout");
-    let cursor_plan = terminal.and_then(|snapshot| plan_cursor(snapshot, &layout, terminal_cols));
+    let cursor_plan = (effective_scroll_offset == 0)
+        .then(|| terminal.and_then(|snapshot| plan_cursor(snapshot, &layout, terminal_cols)))
+        .flatten();
     let mut vertices = Vec::new();
 
     // The sidebar is chrome, not terminal content: ordinary text draws in the
@@ -943,6 +964,45 @@ fn glyph_vertices_with_chrome_budget(
         }
     }
     vertices
+}
+
+/// Clamp a requested primary-screen history offset at the renderer boundary.
+///
+/// An offset addresses rows above the live tail, so the number of retained
+/// scrollback rows is the inclusive upper bound. Alternate-screen content is
+/// intentionally isolated: its effective offset is always zero even if the
+/// application carries a stale primary-screen view request.
+fn clamped_scroll_offset(snapshot: &TerminalSnapshot, requested: usize) -> usize {
+    if snapshot.modes().is_alternate_screen_active() {
+        0
+    } else {
+        requested.min(snapshot.scrollback().len())
+    }
+}
+
+/// Borrow the exact terminal rows selected by one effective scroll offset.
+///
+/// At the live tail this preserves the renderer's established trailing-blank
+/// trimming. Above the tail it selects one full screen-height window from the
+/// logical grid (`scrollback` followed by the visible screen). Each result is
+/// a complete cell slice, so wide-character lead/continuation pairs and cell
+/// attributes cross the viewport seam unchanged.
+fn viewport_rows(snapshot: &TerminalSnapshot, scroll_offset: usize) -> Vec<&[Cell]> {
+    if scroll_offset == 0 {
+        return snapshot.display_cells().collect();
+    }
+
+    let screen_rows = usize::from(snapshot.rows());
+    let logical_rows = snapshot.scrollback().len().saturating_add(screen_rows);
+    let end = logical_rows.saturating_sub(scroll_offset);
+    let start = end.saturating_sub(screen_rows);
+    (start..end)
+        .filter_map(|index| {
+            u32::try_from(index)
+                .ok()
+                .and_then(|index| snapshot.logical_row(index))
+        })
+        .collect()
 }
 
 /// Draw a run of ordinary terminal cells. Cursor-bearing rows are split
@@ -2023,9 +2083,105 @@ mod tests {
         terminal.snapshot()
     }
 
+    fn row_heads<'a>(rows: &[&'a [Cell]]) -> Vec<&'a str> {
+        rows.iter()
+            .map(|row| row.first().map_or("", Cell::text))
+            .collect()
+    }
+
     /// The PoC default cell metrics for tests that exercise the default path.
     fn poc_metrics() -> CellMetrics {
         GridGeometry::poc().cell_metrics()
+    }
+
+    #[test]
+    fn scrollback_viewport_pins_exact_rows_at_each_offset_and_clamps() {
+        let terminal = snapshot(3, 4, b"\x1b[?25lA\r\nB\r\nC\r\nD\r\nE");
+        assert_eq!(terminal.scrollback_lines(), ["A", "B"], "fixture history");
+        assert_eq!(terminal.lines(), ["C", "D", "E"], "fixture live screen");
+
+        let live = viewport_rows(&terminal, clamped_scroll_offset(&terminal, 0));
+        assert_eq!(row_heads(&live), ["C", "D", "E"]);
+
+        let one_up = viewport_rows(&terminal, clamped_scroll_offset(&terminal, 1));
+        assert_eq!(row_heads(&one_up), ["B", "C", "D"]);
+
+        let oldest = viewport_rows(&terminal, clamped_scroll_offset(&terminal, 2));
+        assert_eq!(row_heads(&oldest), ["A", "B", "C"]);
+
+        let past_oldest = viewport_rows(&terminal, clamped_scroll_offset(&terminal, usize::MAX));
+        assert_eq!(row_heads(&past_oldest), ["A", "B", "C"]);
+    }
+
+    #[test]
+    fn scrollback_viewport_keeps_wide_lead_and_continuation_together() {
+        let terminal = snapshot(2, 5, "\x1b[?25l日A\r\n語B\r\n界C".as_bytes());
+        assert_eq!(
+            terminal.scrollback().len(),
+            1,
+            "fixture has one history row"
+        );
+
+        let rows = viewport_rows(&terminal, clamped_scroll_offset(&terminal, 1));
+        let oldest = rows.first().expect("oldest history row is visible");
+        assert_eq!(oldest[0].text(), "日");
+        assert_eq!(oldest[0].width(), 2);
+        assert!(oldest[1].is_continuation());
+        assert_eq!(oldest[2].text(), "A");
+    }
+
+    #[test]
+    fn alternate_screen_forces_live_view_and_never_borrows_primary_history() {
+        let mut terminal = TerminalState::new(2, 5).expect("valid terminal");
+        terminal.feed_bytes(b"OLD1\r\nOLD2\r\nLIVE");
+        assert_eq!(terminal.scrollback_len(), 1, "primary fixture has history");
+        terminal.feed_bytes(b"\x1b[?1049hALT");
+        let alternate = terminal.snapshot();
+        assert!(alternate.modes().is_alternate_screen_active());
+
+        let effective = clamped_scroll_offset(&alternate, usize::MAX);
+        assert_eq!(effective, 0);
+        let rows = viewport_rows(&alternate, effective);
+        assert_eq!(row_heads(&rows), ["A"]);
+        assert!(
+            rows.iter()
+                .all(|row| row.iter().all(|cell| cell.text() != "O")),
+            "primary scrollback must not leak into the alternate screen"
+        );
+    }
+
+    #[test]
+    fn scrolled_view_suppresses_the_live_cursor_vertices() {
+        let visible = snapshot(2, 4, b"A\r\nB\r\nC");
+        let hidden = snapshot(2, 4, b"A\r\nB\r\nC\x1b[?25l");
+        let metrics = poc_metrics();
+        let target = Target::new(
+            &Theme::default(),
+            u32::from(visible.cols()) * metrics.width(),
+            u32::from(visible.rows()) * metrics.height(),
+            metrics,
+        );
+
+        let live_visible =
+            glyph_vertices_for_chrome(target, Some(&visible), FrameChrome::new(None, None));
+        let live_hidden =
+            glyph_vertices_for_chrome(target, Some(&hidden), FrameChrome::new(None, None));
+        assert_ne!(live_visible, live_hidden, "the live tail draws the caret");
+
+        let history_visible = glyph_vertices_for_chrome(
+            target,
+            Some(&visible),
+            FrameChrome::new(None, None).with_scroll_offset(1),
+        );
+        let history_hidden = glyph_vertices_for_chrome(
+            target,
+            Some(&hidden),
+            FrameChrome::new(None, None).with_scroll_offset(1),
+        );
+        assert_eq!(
+            history_visible, history_hidden,
+            "history frames must not draw the live cursor at a stale position"
+        );
     }
 
     /// Deterministic companion to the GPU frame oracle: configured chrome

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -337,15 +337,17 @@ pub(crate) enum RenderOutcome {
 
 /// Application-owned chrome drawn around terminal cells for one frame.
 ///
-/// The palette affordance travels separately from runtime status text so the
-/// renderer can keep it first in the permanent terminal-side status row. That
-/// ordering is load-bearing: a long diagnostic may be clipped by a narrow
-/// window, but it must never make the command surface undiscoverable.
+/// Viewport orientation and the palette affordance travel separately from
+/// runtime status text so the renderer can keep them first in the permanent
+/// terminal-side status row. That ordering is load-bearing: a long diagnostic
+/// may be clipped by a narrow window, but it must never hide how to leave
+/// history or make the command surface undiscoverable.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct FrameChrome<'a> {
     sidebar: Option<SidebarInput<'a>>,
     status: Option<&'a str>,
     palette_hint: Option<&'a str>,
+    viewport_indicator: Option<&'a str>,
     workspace_notice: Option<&'a [String]>,
     scroll_offset: usize,
 }
@@ -356,6 +358,7 @@ impl<'a> FrameChrome<'a> {
             sidebar: sidebar.map(SidebarInput::Plain),
             status,
             palette_hint: None,
+            viewport_indicator: None,
             workspace_notice: None,
             scroll_offset: 0,
         }
@@ -374,6 +377,15 @@ impl<'a> FrameChrome<'a> {
     #[must_use]
     pub(crate) const fn with_palette_hint(mut self, hint: Option<&'a str>) -> Self {
         self.palette_hint = hint;
+        self
+    }
+
+    /// Add the scrolled-history orientation/recovery copy. It is emitted
+    /// before every other status segment so a narrow frame cannot clip the
+    /// user's route back to the live tail.
+    #[must_use]
+    pub(crate) const fn with_viewport_indicator(mut self, indicator: Option<&'a str>) -> Self {
+        self.viewport_indicator = indicator;
         self
     }
 
@@ -397,12 +409,11 @@ impl<'a> FrameChrome<'a> {
     }
 
     fn status_line(self) -> Option<String> {
-        match (self.palette_hint, self.status) {
-            (None, None) => None,
-            (Some(hint), None) => Some(hint.to_owned()),
-            (None, Some(status)) => Some(status.to_owned()),
-            (Some(hint), Some(status)) => Some(format!("{hint} | {status}")),
-        }
+        let parts: Vec<&str> = [self.viewport_indicator, self.palette_hint, self.status]
+            .into_iter()
+            .flatten()
+            .collect();
+        (!parts.is_empty()).then(|| parts.join(" | "))
     }
 }
 

--- a/crates/noren-app/src/ui.rs
+++ b/crates/noren-app/src/ui.rs
@@ -34,6 +34,22 @@ pub fn empty_workspace_recovery(keys: KeymapConfig) -> Vec<String> {
     ]
 }
 
+/// Orient a viewport that is deliberately above the live tail.
+///
+/// The indicator is absent at offset zero. Above the tail it names both the
+/// exact distance and the active configured page-down chord, so returning to
+/// current output is discoverable without documentation and remains truthful
+/// after a rebind.
+#[must_use]
+pub fn scrollback_indicator(offset: usize, keys: KeymapConfig) -> Option<String> {
+    (offset > 0).then(|| {
+        format!(
+            "History -{offset} | {} Latest",
+            chord_label(keys.scroll_page_down())
+        )
+    })
+}
+
 /// Human-readable text for one normalized configured chord.
 ///
 /// This is intentionally generated from [`Chord`] rather than copied from a
@@ -113,6 +129,23 @@ mod tests {
         assert_eq!(
             empty_workspace_recovery(rebound.keys()),
             ["No sessions yet", "Press Ctrl+N to create a session"]
+        );
+    }
+
+    #[test]
+    fn scrollback_indicator_is_off_at_live_tail_and_follows_the_down_binding() {
+        let default = AppConfig::default();
+        assert_eq!(scrollback_indicator(0, default.keys()), None);
+        assert_eq!(
+            scrollback_indicator(37, default.keys()).as_deref(),
+            Some("History -37 | Shift+PageDown Latest")
+        );
+
+        let rebound = AppConfig::parse("[keys]\nscroll_page_down = \"ctrl+j\"\n")
+            .expect("valid scroll-down rebind");
+        assert_eq!(
+            scrollback_indicator(2, rebound.keys()).as_deref(),
+            Some("History -2 | Ctrl+J Latest")
         );
     }
 }

--- a/crates/noren-app/src/wheel_routing.rs
+++ b/crates/noren-app/src/wheel_routing.rs
@@ -23,7 +23,8 @@ pub enum TerminalWheelOwner {
 /// tracked wheel back to Noren.
 #[must_use]
 pub const fn terminal_wheel_owner(modes: TerminalModes) -> TerminalWheelOwner {
-    if modes.is_mouse_normal_tracking_enabled()
+    if modes.is_mouse_x10_tracking_enabled()
+        || modes.is_mouse_normal_tracking_enabled()
         || modes.is_mouse_button_event_tracking_enabled()
         || modes.is_mouse_any_event_tracking_enabled()
     {

--- a/crates/noren-app/src/wheel_routing.rs
+++ b/crates/noren-app/src/wheel_routing.rs
@@ -1,0 +1,34 @@
+//! Terminal wheel-ownership policy shared by the window adapter and
+//! integration tests.
+//!
+//! This module owns only the boundary decision. Platform delta translation,
+//! local viewport mutation, and mouse-report encoding stay with their existing
+//! owners; both paths must first pass through [`terminal_wheel_owner`].
+
+use noren_terminal::TerminalModes;
+
+/// The layer that owns a wheel event over the terminal surface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalWheelOwner {
+    /// Noren navigates retained primary-screen history.
+    LocalHistory,
+    /// The application receives a terminal mouse report.
+    Application,
+}
+
+/// Decide wheel ownership from the terminal parser's authoritative modes.
+///
+/// Tracking is an application claim even when Shift is held. Shift bypasses
+/// button and motion reporting for local selection, but it does not transfer a
+/// tracked wheel back to Noren.
+#[must_use]
+pub const fn terminal_wheel_owner(modes: TerminalModes) -> TerminalWheelOwner {
+    if modes.is_mouse_normal_tracking_enabled()
+        || modes.is_mouse_button_event_tracking_enabled()
+        || modes.is_mouse_any_event_tracking_enabled()
+    {
+        TerminalWheelOwner::Application
+    } else {
+        TerminalWheelOwner::LocalHistory
+    }
+}

--- a/crates/noren-app/tests/frame_oracle.rs
+++ b/crates/noren-app/tests/frame_oracle.rs
@@ -20,6 +20,9 @@
 //! - the drawn grid dimensions match the state's dimensions;
 //! - per-cell, lit/blank agrees with `TerminalSnapshot` across the FR-005
 //!   fixture classes (prompt, ASCII, UTF-8, control, scrolling);
+//! - scrollback offsets select the exact expected logical lines in captured
+//!   pixels (`C/D/E`, `B/C/D`, then `A/B/C`), clamp at the oldest row, and
+//!   retain a wide glyph's lead/continuation pair across the history seam;
 //! - two cells carrying different SGR foreground colours draw *different*
 //!   pixel colours, each matching the palette; a cell with no SGR colour keeps
 //!   the unchanged default; truecolor and 256-colour both resolve to their
@@ -35,7 +38,8 @@
 //! - a combining mark is drawn over its base cell without consuming a cell.
 //! - the default palette affordance is drawn in permanent terminal-side
 //!   chrome, rebinding `palette_open` changes the captured key glyph, and the
-//!   explicit UI opt-out removes those pixels (issue #191);
+//!   explicit UI opt-out removes those pixels (issue #191); the scrollback
+//!   indicator likewise draws first and names the active return binding;
 //! - after the last session closes, recovery copy and its active create chord
 //!   draw in the otherwise blank terminal area, with status chrome following
 //!   the recovery rows instead of overwriting them (issue #201);
@@ -95,14 +99,15 @@ use noren_app::session::{SessionKind, SessionRegistry, SessionStatus};
 use noren_app::sidebar::{EntryKind, SidebarEntry, SidebarView};
 use noren_app::sidebar_text::{SidebarTextRow, visible_sidebar_text_rows_at_width};
 use noren_app::theme::{DARK, HIGH_CONTRAST, LIGHT, Theme, contrast_ratio};
-use noren_app::ui::{empty_workspace_recovery, palette_hint};
+use noren_app::ui::{empty_workspace_recovery, palette_hint, scrollback_indicator};
 use noren_app::{
     GridGeometry, MAX_RENDER_COLS, MAX_RENDER_ROWS, POC_CELL_HEIGHT as CELL_HEIGHT,
     POC_CELL_WIDTH as CELL_WIDTH,
 };
 use noren_terminal::{TerminalSnapshot, TerminalState};
 use renderer_capture::renderer_source::{
-    CLEAR_COLOR, CursorStyle, FrameChrome, SIDEBAR_COLS, Target, glyph_vertices_for_sidebar_rows,
+    CLEAR_COLOR, CursorStyle, FrameChrome, SIDEBAR_COLS, Target, glyph_vertices_for_chrome,
+    glyph_vertices_for_sidebar_rows,
 };
 use renderer_capture::{CaptureError, CapturedFrame, OffscreenRenderer};
 
@@ -141,6 +146,21 @@ fn render_with_theme(
         Some(snapshot),
         None,
         None,
+    )
+}
+
+/// Render through the production chrome path with an explicit history offset.
+fn render_with_scroll_offset(
+    renderer: &OffscreenRenderer,
+    snapshot: &TerminalSnapshot,
+    offset: usize,
+) -> CapturedFrame {
+    let width = u32::from(snapshot.cols()) * CELL_WIDTH;
+    let height = u32::from(snapshot.rows()) * CELL_HEIGHT;
+    renderer.capture_chrome(
+        Target::new(&Theme::default(), width, height, poc_metrics()),
+        Some(snapshot),
+        FrameChrome::new(None, None).with_scroll_offset(offset),
     )
 }
 
@@ -511,6 +531,117 @@ fn distinct_ascii_glyphs_have_distinct_lit_patterns() {
     assert!(!a.iter().all(|&lit| !lit), "'A' cell drew nothing");
     assert!(!b.iter().all(|&lit| !lit), "'B' cell drew nothing");
     assert_ne!(a, b, "'A' and 'B' rendered the same lit pattern");
+}
+
+#[test]
+fn scrollback_viewport_captures_the_exact_lines_for_each_offset() {
+    let Some(renderer) =
+        renderer_or_skip("scrollback_viewport_captures_the_exact_lines_for_each_offset")
+    else {
+        return;
+    };
+    let snap = snapshot(3, 4, b"\x1b[?25lA\r\nB\r\nC\r\nD\r\nE");
+    assert_eq!(snap.scrollback_lines(), ["A", "B"], "fixture history");
+    assert_eq!(snap.lines(), ["C", "D", "E"], "fixture live rows");
+
+    // Each expected glyph is rendered independently in a one-row terminal.
+    // Comparing its complete cell mask pins identity and row placement; a
+    // global "some pixels changed" assertion would not catch a row shift.
+    let glyph_pattern = |character: char| {
+        let bytes = format!("\x1b[?25l{character}");
+        let reference = snapshot(1, 4, bytes.as_bytes());
+        cell_pattern(&render(&renderer, &reference), 0, 0)
+    };
+
+    for (offset, expected) in [
+        (0, ['C', 'D', 'E']),
+        (1, ['B', 'C', 'D']),
+        (2, ['A', 'B', 'C']),
+        (usize::MAX, ['A', 'B', 'C']),
+    ] {
+        let frame = render_with_scroll_offset(&renderer, &snap, offset);
+        for (row, character) in expected.into_iter().enumerate() {
+            assert_eq!(
+                cell_pattern(&frame, u32::try_from(row).unwrap_or(u32::MAX), 0),
+                glyph_pattern(character),
+                "offset {offset} row {row} must render exact glyph {character:?}"
+            );
+            for col in 1..u32::from(snap.cols()) {
+                assert!(
+                    !cell_is_lit(&frame, u32::try_from(row).unwrap_or(u32::MAX), col),
+                    "offset {offset} row {row} leaked content into blank column {col}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn scrollback_vertex_oracle_pins_exact_lines_without_a_gpu() {
+    let source = snapshot(3, 4, b"\x1b[?25lA\r\nB\r\nC\r\nD\r\nE");
+    let target = Target::new(
+        &Theme::default(),
+        u32::from(source.cols()) * CELL_WIDTH,
+        u32::from(source.rows()) * CELL_HEIGHT,
+        poc_metrics(),
+    );
+
+    for (offset, expected_bytes, expected_lines) in [
+        (0, b"\x1b[?25lC\r\nD\r\nE".as_slice(), ["C", "D", "E"]),
+        (1, b"\x1b[?25lB\r\nC\r\nD".as_slice(), ["B", "C", "D"]),
+        (2, b"\x1b[?25lA\r\nB\r\nC".as_slice(), ["A", "B", "C"]),
+        (
+            usize::MAX,
+            b"\x1b[?25lA\r\nB\r\nC".as_slice(),
+            ["A", "B", "C"],
+        ),
+    ] {
+        let expected = snapshot(3, 4, expected_bytes);
+        assert_eq!(expected.lines(), expected_lines, "expected frame fixture");
+        let actual_vertices = glyph_vertices_for_chrome(
+            target,
+            Some(&source),
+            FrameChrome::new(None, None).with_scroll_offset(offset),
+        );
+        let expected_vertices =
+            glyph_vertices_for_chrome(target, Some(&expected), FrameChrome::new(None, None));
+        assert_eq!(
+            actual_vertices, expected_vertices,
+            "offset {offset} must produce the complete frame for exact lines {expected_lines:?}"
+        );
+    }
+}
+
+#[test]
+fn scrollback_viewport_keeps_a_wide_pair_and_following_glyph_in_captured_pixels() {
+    let Some(renderer) = renderer_or_skip(
+        "scrollback_viewport_keeps_a_wide_pair_and_following_glyph_in_captured_pixels",
+    ) else {
+        return;
+    };
+    let snap = snapshot(2, 5, "\x1b[?25l日A\r\n語B\r\n界C".as_bytes());
+    assert_eq!(snap.scrollback_lines(), ["日A"], "fixture history");
+
+    let history_frame = render_with_scroll_offset(&renderer, &snap, 1);
+    let expected_row = render(&renderer, &snapshot(1, 5, "\x1b[?25l日A".as_bytes()));
+    for col in 0..u32::from(snap.cols()) {
+        assert_eq!(
+            cell_pattern(&history_frame, 0, col),
+            cell_pattern(&expected_row, 0, col),
+            "scrolled wide history row differs at display column {col}"
+        );
+    }
+    assert!(cell_is_lit(&history_frame, 0, 0), "wide lead is absent");
+    assert!(
+        !cell_is_lit(&history_frame, 0, 1),
+        "wide continuation column must remain blank"
+    );
+    let a_reference = render(&renderer, &snapshot(1, 1, b"\x1b[?25lA"));
+    assert_eq!(
+        cell_pattern(&history_frame, 0, 2),
+        cell_pattern(&a_reference, 0, 0),
+        "glyph after the wide pair must stay in display column 2"
+    );
 }
 
 #[test]
@@ -2258,6 +2389,51 @@ fn palette_hint_opt_out_removes_its_frame_pixels() {
             .chunks_exact(4)
             .all(|pixel| is_clear([pixel[0], pixel[1], pixel[2], pixel[3]])),
         "show_palette_hint=false must remove every affordance pixel"
+    );
+}
+
+#[test]
+fn scrollback_indicator_is_drawn_first_with_the_configured_return_chord() {
+    let Some(renderer) =
+        renderer_or_skip("scrollback_indicator_is_drawn_first_with_the_configured_return_chord")
+    else {
+        return;
+    };
+    const TERMINAL_COLS: u16 = 48;
+    let config = AppConfig::parse("[keys]\nscroll_page_down = \"ctrl+j\"\n")
+        .expect("custom history return chord is valid");
+    let indicator = scrollback_indicator(7, config.keys()).expect("nonzero offset is visible");
+    assert_eq!(indicator, "History -7 | Ctrl+J Latest");
+
+    let empty_sidebar: &[String] = &[];
+    let frame = renderer.capture_chrome(
+        Target::new(
+            &config.theme().palette(),
+            (SIDEBAR_COLS as u32 + u32::from(TERMINAL_COLS)) * CELL_WIDTH,
+            CELL_HEIGHT,
+            poc_metrics(),
+        ),
+        None,
+        FrameChrome::new(Some(empty_sidebar), None)
+            .with_viewport_indicator(Some(indicator.as_str())),
+    );
+
+    let mut reference_bytes = b"\x1b[?25l".to_vec();
+    reference_bytes.extend_from_slice(indicator.as_bytes());
+    let reference = render(
+        &renderer,
+        &snapshot(1, TERMINAL_COLS, reference_bytes.as_slice()),
+    );
+    for col in 0..u32::from(TERMINAL_COLS) {
+        assert_eq!(
+            cell_pattern(&frame, 0, SIDEBAR_COLS as u32 + col),
+            cell_pattern(&reference, 0, col),
+            "viewport indicator differs from configured copy at column {col}"
+        );
+    }
+    assert!(
+        cell_is_lit(&frame, 0, SIDEBAR_COLS as u32),
+        "the leading History indicator glyph was not drawn"
     );
 }
 

--- a/crates/noren-app/tests/mouse_encoding.rs
+++ b/crates/noren-app/tests/mouse_encoding.rs
@@ -10,9 +10,9 @@
 //! `col=9, row=4` on any grid that contains it resolves to `Cx=10, Cy=5`.
 
 use noren_app::mouse::{
-    MODE_ANY_EVENT, MODE_BUTTON_EVENT, MODE_NORMAL, MODE_SGR, MODE_URXVT, MODE_UTF8, MouseButton,
-    MouseEncoder, MouseGrid, MouseModes, PointerEvent, PointerModifiers, WheelDirection,
-    X10_MAX_COORD,
+    MODE_ANY_EVENT, MODE_BUTTON_EVENT, MODE_NORMAL, MODE_SGR, MODE_URXVT, MODE_UTF8, MODE_X10,
+    MouseButton, MouseEncoder, MouseGrid, MouseModes, PointerEvent, PointerModifiers,
+    WheelDirection, X10_MAX_COORD,
 };
 
 /// 80x24 grid; `(9, 4)` is always in range and resolves to `Cx=10, Cy=5`.
@@ -43,6 +43,24 @@ fn sgr_modes() -> MouseModes {
 /// X10 byte form: only normal tracking, no parameterized encoding.
 fn x10_modes() -> MouseModes {
     MouseModes::disabled().with_normal(true)
+}
+
+#[test]
+fn mode_9_x10_tracking_encodes_wheel_but_not_button_release() {
+    let modes = MouseModes::disabled().set(MODE_X10, true);
+    let wheel = PointerEvent::wheel(WheelDirection::Up, P9, ROW4, NO_MODS);
+    assert_eq!(
+        MouseEncoder::encode(wheel, modes, GRID).as_deref(),
+        Some(b"\x1b[M\x60\x2a\x25".as_slice()),
+        "mode 9 must carry wheel-up in the legacy byte form"
+    );
+
+    let release = PointerEvent::release(MouseButton::Left, P9, ROW4, NO_MODS);
+    assert_eq!(
+        MouseEncoder::encode(release, modes, GRID),
+        None,
+        "plain mode 9 reports presses, not releases"
+    );
 }
 
 // ── SGR (1006) byte-exact forms ─────────────────────────────────────────

--- a/crates/noren-app/tests/wheel_routing.rs
+++ b/crates/noren-app/tests/wheel_routing.rs
@@ -35,3 +35,21 @@ fn app_routes_wheel_by_authoritative_terminal_tracking_mode() {
         );
     }
 }
+
+#[test]
+fn x10_mode_9_routes_wheel_to_the_application() {
+    let mut terminal = TerminalState::new(3, 8).expect("valid terminal");
+    terminal.feed_bytes(b"\x1b[?9h");
+    assert_eq!(
+        terminal_wheel_owner(terminal.modes()),
+        TerminalWheelOwner::Application,
+        "mode 9 is an application wheel claim"
+    );
+
+    terminal.feed_bytes(b"\x1b[?9l");
+    assert_eq!(
+        terminal_wheel_owner(terminal.modes()),
+        TerminalWheelOwner::LocalHistory,
+        "resetting mode 9 restores local wheel ownership"
+    );
+}

--- a/crates/noren-app/tests/wheel_routing.rs
+++ b/crates/noren-app/tests/wheel_routing.rs
@@ -1,0 +1,37 @@
+//! Integration coverage for the app's terminal-wheel ownership boundary.
+//!
+//! Mouse encoder tests prove byte formats. This suite instead feeds real PTY
+//! output through `TerminalState` and asks the same app-layer routing seam the
+//! window adapter calls before it mutates scrollback or encodes a report.
+
+use noren_app::wheel_routing::{TerminalWheelOwner, terminal_wheel_owner};
+use noren_terminal::TerminalState;
+
+#[test]
+fn app_routes_wheel_by_authoritative_terminal_tracking_mode() {
+    let mut terminal = TerminalState::new(3, 8).expect("valid terminal");
+    assert_eq!(
+        terminal_wheel_owner(terminal.modes()),
+        TerminalWheelOwner::LocalHistory,
+        "without an application claim Noren owns the wheel"
+    );
+
+    for (set, reset, label) in [
+        (b"\x1b[?1000h".as_slice(), b"\x1b[?1000l".as_slice(), "1000"),
+        (b"\x1b[?1002h".as_slice(), b"\x1b[?1002l".as_slice(), "1002"),
+        (b"\x1b[?1003h".as_slice(), b"\x1b[?1003l".as_slice(), "1003"),
+    ] {
+        terminal.feed_bytes(set);
+        assert_eq!(
+            terminal_wheel_owner(terminal.modes()),
+            TerminalWheelOwner::Application,
+            "mode {label} must transfer wheel ownership to the application"
+        );
+        terminal.feed_bytes(reset);
+        assert_eq!(
+            terminal_wheel_owner(terminal.modes()),
+            TerminalWheelOwner::LocalHistory,
+            "resetting mode {label} must restore local wheel ownership"
+        );
+    }
+}

--- a/crates/noren-terminal/src/parser.rs
+++ b/crates/noren-terminal/src/parser.rs
@@ -123,6 +123,7 @@ pub(crate) enum PrivateMode {
     /// re-show it at rest, so the renderer must honour both directions.
     CursorVisibility,
     BracketedPaste,
+    MouseTrackingX10,
     MouseTrackingNormal,
     MouseTrackingButtonEvent,
     MouseTrackingAnyEvent,
@@ -535,6 +536,7 @@ impl Csi {
             25 => Some(PrivateMode::CursorVisibility),
             1049 => Some(PrivateMode::AlternateScreen),
             2004 => Some(PrivateMode::BracketedPaste),
+            9 => Some(PrivateMode::MouseTrackingX10),
             1000 => Some(PrivateMode::MouseTrackingNormal),
             1002 => Some(PrivateMode::MouseTrackingButtonEvent),
             1003 => Some(PrivateMode::MouseTrackingAnyEvent),
@@ -796,6 +798,23 @@ mod tests {
                 },
                 Action::SetPrivateMode {
                     mode: PrivateMode::MouseEncodingSgr,
+                    enabled: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn x10_mouse_tracking_mode_9_is_tracked_as_a_private_mode() {
+        assert_eq!(
+            actions(b"\x1b[?9h\x1b[?9l"),
+            [
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingX10,
+                    enabled: true,
+                },
+                Action::SetPrivateMode {
+                    mode: PrivateMode::MouseTrackingX10,
                     enabled: false,
                 },
             ]

--- a/crates/noren-terminal/src/state.rs
+++ b/crates/noren-terminal/src/state.rs
@@ -275,6 +275,7 @@ pub struct TerminalModes {
     // Stored hidden-side-out so the derive-Default all-false value means the
     // historical behaviour: a visible cursor. DECTCEM hides it.
     cursor_hidden: bool,
+    mouse_x10_tracking: bool,
     mouse_normal_tracking: bool,
     mouse_button_event_tracking: bool,
     mouse_any_event_tracking: bool,
@@ -322,6 +323,12 @@ impl TerminalModes {
     #[must_use]
     pub const fn is_cursor_visible(self) -> bool {
         !self.cursor_hidden
+    }
+
+    /// Whether DEC private mode 9 (X10 mouse tracking) is enabled.
+    #[must_use]
+    pub const fn is_mouse_x10_tracking_enabled(self) -> bool {
+        self.mouse_x10_tracking
     }
 
     /// Whether DEC private mode 1000 (normal mouse tracking) is enabled.
@@ -1353,6 +1360,9 @@ impl TerminalState {
             }
             (PrivateMode::BracketedPaste, enabled) => {
                 self.modes.bracketed_paste = enabled;
+            }
+            (PrivateMode::MouseTrackingX10, enabled) => {
+                self.modes.mouse_x10_tracking = enabled;
             }
             (PrivateMode::MouseTrackingNormal, enabled) => {
                 self.modes.mouse_normal_tracking = enabled;

--- a/crates/noren-terminal/tests/fuzz_feed_bytes.rs
+++ b/crates/noren-terminal/tests/fuzz_feed_bytes.rs
@@ -624,6 +624,7 @@ const CORPUS_TMUX: &[&[u8]] = &[
 /// programs still emit (47/1047/1048), DECRQM (`$p`), and device queries.
 /// The 9999/0/65535 entries are unknown modes that must be ignored cleanly.
 const CORPUS_DECSET: &[&[u8]] = &[
+    b"\x1b[?9h\x1b[?9l",
     b"\x1b[?7h\x1b[?7l",
     b"\x1b[?25h\x1b[?25l",
     b"\x1b[?12h\x1b[?12l",
@@ -791,7 +792,7 @@ fn gen_csi_private(rng: &mut Xorshift64) -> Vec<u8> {
         out.extend_from_slice(
             match rng.below(10) {
                 0..=5 => (*rng.pick(&[
-                    1_u16, 7, 12, 25, 47, 1000, 1002, 1003, 1004, 1005, 1006, 1015, 1047, 1048,
+                    1_u16, 7, 9, 12, 25, 47, 1000, 1002, 1003, 1004, 1005, 1006, 1015, 1047, 1048,
                     1049, 2004,
                 ]))
                 .to_string(),

--- a/crates/noren-terminal/tests/mouse_modes.rs
+++ b/crates/noren-terminal/tests/mouse_modes.rs
@@ -1,4 +1,4 @@
-//! DEC private mouse tracking (1000/1002/1003) and encoding (1005/1006/1015)
+//! DEC private mouse tracking (9/1000/1002/1003) and encoding (1005/1006/1015)
 //! mode tracking in terminal state.
 //!
 //! The terminal holds the mode state only; generating mouse reports stays in
@@ -13,12 +13,25 @@ use noren_terminal::TerminalState;
 fn mouse_modes_default_to_disabled() {
     let state = TerminalState::new(2, 4).expect("valid terminal");
     let modes = state.modes();
+    assert!(!modes.is_mouse_x10_tracking_enabled());
     assert!(!modes.is_mouse_normal_tracking_enabled());
     assert!(!modes.is_mouse_button_event_tracking_enabled());
     assert!(!modes.is_mouse_any_event_tracking_enabled());
     assert!(!modes.is_mouse_utf8_encoding_enabled());
     assert!(!modes.is_mouse_sgr_encoding_enabled());
     assert!(!modes.is_mouse_urxvt_encoding_enabled());
+}
+
+#[test]
+fn x10_mouse_tracking_mode_9_toggles_with_decset_and_decrst() {
+    let mut state = TerminalState::new(2, 4).expect("valid terminal");
+
+    state.feed_bytes(b"\x1b[?9h");
+    assert!(state.modes().is_mouse_x10_tracking_enabled());
+    assert!(!state.modes().is_mouse_normal_tracking_enabled());
+
+    state.feed_bytes(b"\x1b[?9l");
+    assert!(!state.modes().is_mouse_x10_tracking_enabled());
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,11 +126,12 @@ screen they are forwarded unchanged to the running application. Rebinding
 either action changes the live input match and the history indicator together.
 
 The mouse wheel follows the terminal/application boundary rather than a user
-toggle. When the running application has enabled DEC mouse tracking mode 1000,
-1002, or 1003, every terminal-side wheel click is forwarded to it (including
-with Shift held); this preserves Zellij/vim ownership. With no tracking mode,
-the wheel scrolls Noren's retained primary-screen history locally. The sidebar
-is Noren-owned chrome and keeps its own local wheel behavior.
+toggle. When the running application has enabled DEC mouse tracking mode 9,
+1000, 1002, or 1003, every terminal-side wheel click is forwarded to it
+(including with Shift held); this preserves X10 applications and Zellij/vim
+ownership. With no tracking mode, the wheel scrolls Noren's retained
+primary-screen history locally. The sidebar is Noren-owned chrome and keeps its
+own local wheel behavior.
 
 At offset zero, new output follows the live tail automatically. After a user
 deliberately scrolls above it, ordinary output preserves that non-zero offset

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,9 +67,10 @@ other tables.
 
 ### `[keys]`
 
-Configurable key chords for workspace chrome. Every key is optional; an
-absent `[keys]` table keeps the compiled-in defaults, which are exactly the
-chords the app shipped with before configuration existed.
+Configurable key chords for workspace chrome and the terminal scrollback
+viewport. Every key is optional; an absent `[keys]` table keeps the
+compiled-in defaults. Existing workspace defaults remain unchanged, and the
+scrollback actions follow conventional Shift+PageUp/Shift+PageDown defaults.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
@@ -78,6 +79,8 @@ chords the app shipped with before configuration existed.
 | `session_select` | string | `"s"` | Palette command dispatching `session.select` (Switch Session). |
 | `session_close` | string | `"x"` | Palette command dispatching `session.close` (Close Session). |
 | `sidebar_focus` | string | `"f"` | Palette command dispatching `sidebar.focus` (Focus Sidebar). |
+| `scroll_page_up` | string | `"shift+pageup"` | Scroll the primary terminal viewport one page toward older retained history. |
+| `scroll_page_down` | string | `"shift+pagedown"` | Scroll the primary terminal viewport one page toward the live tail. |
 
 A chord is zero or more modifiers followed by exactly one key, joined with
 `+`: the modifiers are `super`, `ctrl`, `alt`, and `shift` (each at most
@@ -101,7 +104,10 @@ never a silent fallback and never a silently dead binding:
   leader is an error, because Noren could never honor it;
 - the four palette command chords must not use `escape`, `enter`, `up`, or
   `down`, which the open palette always interprets as dismissal, confirm,
-  and navigation.
+  and navigation;
+- the two global scrollback chords cannot use the frozen `super+escape`
+  exit-to-workspace leader. Other child/Zellij overlap is allowed when a user
+  deliberately configures it.
 
 The four command chords normally apply only while the palette is open — the
 palette intercepts all keys then, so command chords never steal input from
@@ -112,6 +118,28 @@ sidebar is empty and no session can receive input, the configured
 empty-state action says. Chords with modifiers dispatch on the exact modifier
 set; inside the palette, a modifier-free character binding also matches the
 character with any modifiers held, as the pre-configuration palette did.
+
+The two scrollback chords apply only on the primary screen while the palette
+is closed. They are consumed locally even at a scroll boundary, matching an
+ordinary terminal's Shift+PageUp/Shift+PageDown ownership; on an alternate
+screen they are forwarded unchanged to the running application. Rebinding
+either action changes the live input match and the history indicator together.
+
+The mouse wheel follows the terminal/application boundary rather than a user
+toggle. When the running application has enabled DEC mouse tracking mode 1000,
+1002, or 1003, every terminal-side wheel click is forwarded to it (including
+with Shift held); this preserves Zellij/vim ownership. With no tracking mode,
+the wheel scrolls Noren's retained primary-screen history locally. The sidebar
+is Noren-owned chrome and keeps its own local wheel behavior.
+
+At offset zero, new output follows the live tail automatically. After a user
+deliberately scrolls above it, ordinary output preserves that non-zero offset
+instead of yanking the view down. A `History -N` indicator is then the first
+status-row segment and names the configured `scroll_page_down` chord followed
+by `Latest`; reaching offset zero removes the indicator and restores the live
+caret. Entering an alternate screen or an application mouse mode rejoins the
+live surface immediately, and primary scrollback is never drawn into an
+alternate screen.
 
 ### `[ui]`
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -246,15 +246,18 @@ Each item states what you would actually see if you ran the build.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.
-- **Selection and scrollback work, but you cannot see them.** Selection is
-  tracked and copy extracts it, yet the renderer does not highlight the selected
-  region — the comment on the `selection` field in `main.rs` says so in the
-  source itself ("The renderer does not highlight it yet"). Scrollback is
-  bounded and searchable, but `FrameRowLayout::new` derives
-  `terminal_row_count` from `content_rows.min(terminal_capacity)`, then
-  `first_terminal_line` as `content_rows - terminal_row_count`. There is no
-  scroll-offset input, so rendering stays on the newest suffix and you cannot
-  scroll back through it. The data is there; the view onto it is not.
+- **Selection works, but you cannot see it; scrollback search is still
+  unreachable.** Selection is tracked and copy extracts it, yet the renderer
+  does not highlight the selected region — the comment on the `selection`
+  field in `main.rs` says so in the source itself ("The renderer does not
+  highlight it yet"). Retained primary-screen history is now visible through
+  Shift+PageUp/Shift+PageDown (configurable as `scroll_page_up` and
+  `scroll_page_down`) and the mouse wheel when no application mouse mode is
+  active. A `History -N` status indicator names the configured route back to
+  `Latest`; alternate screens remain isolated and an application that enables
+  mouse tracking keeps every wheel event. The terminal core's snapshot search
+  engine is still not exposed by any app key, palette command, or renderer
+  surface.
 - **Paste is bracketed-paste-only.** `Cmd+V` never sends raw clipboard bytes:
   `paste_bytes` in `main.rs` wraps the text in bracketed-paste markers only
   when the program enabled DEC private mode 2004, and every other case is

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -49,10 +49,11 @@ binary. What now actually happens on screen:
   terminal state's authoritative mode tracking (`current_mouse_modes` in
   `main.rs`): a program that never enables a tracking mode receives no
   reports. Shift bypasses button/motion reporting so local text selection
-  still works (`mouse_reportable`), but a tracked wheel remains application
-  input even with Shift held; without tracking, that wheel navigates Noren's
-  retained history. Clicks, drags, and the wheel therefore reach programs that
-  ask for them — Zellij, `vim` with `set mouse=a`, and `tmux` among them.
+  still works (`mouse_reportable`), but a wheel claimed by mode 9, 1000, 1002,
+  or 1003 remains application input even with Shift held; without tracking,
+  that wheel navigates Noren's retained history. Clicks, drags, and the wheel
+  therefore reach programs that ask for them — Zellij, `vim` with `set
+  mouse=a`, and `tmux` among them.
 - **Configured cell size reaches the renderer.** `[font] cell_width` /
   `cell_height` flow through `GridGeometry::with_cells` to the drawing path;
   the regression test `configured_cell_sizes_drive_the_app_geometry` in the

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -42,15 +42,17 @@ binary. What now actually happens on screen:
   last one. The `f` command dispatches sidebar focus — currently a no-op, since
   the sidebar is always visible. Arrow
   keys and Enter navigate the same command list; Escape dismisses it.
-- **Mouse reporting reaches the program.** `handle_mouse_button`,
-  `handle_mouse_move`, and `handle_mouse_wheel` in `main.rs` each call
-  `encode_and_send_mouse`, the helper that invokes `MouseEncoder::encode` and
-  writes the resulting report bytes to the PTY. Encoding follows the terminal
-  state's authoritative mode tracking (`current_mouse_modes` in `main.rs`): a
-  program that never enables a tracking mode receives no reports, and holding
-  Shift bypasses reporting so local text selection still works
-  (`mouse_reportable`). Clicks, drags, and the wheel therefore reach programs
-  that ask for them — Zellij, `vim` with `set mouse=a`, and `tmux` among them.
+- **Mouse reporting reaches the program.** `handle_mouse_button` and
+  `handle_mouse_move` in `main.rs` call `encode_and_send_mouse`, while
+  `handle_mouse_wheel` makes its ownership decision in
+  `route_terminal_wheel` before sending encoded reports. Encoding follows the
+  terminal state's authoritative mode tracking (`current_mouse_modes` in
+  `main.rs`): a program that never enables a tracking mode receives no
+  reports. Shift bypasses button/motion reporting so local text selection
+  still works (`mouse_reportable`), but a tracked wheel remains application
+  input even with Shift held; without tracking, that wheel navigates Noren's
+  retained history. Clicks, drags, and the wheel therefore reach programs that
+  ask for them — Zellij, `vim` with `set mouse=a`, and `tmux` among them.
 - **Configured cell size reaches the renderer.** `[font] cell_width` /
   `cell_height` flow through `GridGeometry::with_cells` to the drawing path;
   the regression test `configured_cell_sizes_drive_the_app_geometry` in the


### PR DESCRIPTION
Closes **#199** and **#203** — the same defect. The terminal retained up to
10,000 scrollback lines while the viewport stayed frozen on the newest ones.

Observed on the release binary: `seq 1 60` in a 30-row viewport, then
Shift+PageUp — screen unchanged. Mouse wheel — unchanged. **The data was already
in memory; only the view was missing.** Rated S1: a terminal that cannot look at
its own history fails an ordinary-use task on day one.

## The Noren/Zellij boundary is the hard constraint here

Per ADR 0003, Noren owns outside the terminal and the application owns inside.
The wheel therefore scrolls Noren's history **only when the application has not
claimed the mouse**:

```rust
if self.current_mouse_modes().is_tracked() { /* forward to the application */ }
```

`wheel_is_local_without_mouse_mode_and_forwarded_with_mouse_mode` drives the real
`\x1b[?1000;1006h` sequence and asserts the routing flips — and that an
application claiming the mouse rejoins its live surface.

Verified by the coordinator: replacing that condition with `false`, so the wheel
is always consumed locally, **fails that test**. Stealing input Zellij or vim
expects cannot land silently.

## Both owner requirements

**Reads nothing → good result:** Shift+PageUp/PageDown and the wheel work
unconfigured, and an indicator appears when the view is off the newest line, so
the user knows they are in history.

**Wants control → no source patching:** the chords are `[keys]` entries like
every other binding.

Return-to-bottom: page-down to zero, new output follows at zero, and a
deliberate non-zero offset is preserved — so output arriving while you read
history does not yank the view away.

## Correctness cases

`resize_safe` (reflow while scrolled keeps the offset and wide history cells),
`clamp_safe` (past either end clamps, no panic, no blank frame), `wide_safe`,
`cursor_safe` (no caret at a stale position), `altscreen_safe` (scrollback does
not leak into vim/less — the alternate screen resets history and forwards the
chords).

## Proof

Lane mutations: off-by-one on the offset **5 tests**, offset ignored **5 tests**,
wheel always local **1 test**. The oracle pins *which lines are visible*, not
merely that the frame changed.

Independent verification on a clean tree: **1,192 passed, 0 failed**, `fmt=0`,
`clippy=0`.