### PR TITLE
feat(app): deliver IME commits to the PTY (#204)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Only evidence-backed work is marked complete.
 | 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress — vertical slice landed; see [Milestone 3 status](#milestone-3-status) |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | In progress — bounded, explicitly partial literal-alias discovery landed, and selecting an alias launches the fixed system `ssh` client in the terminal's PTY (PR #138); reconnect, remote panes, the daemon decision/PoC, and recovery are not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | In progress — the first launcher slice landed: `[[agents]]` configuration rows launch a configured, shell-free argv command in a real PTY (`AgentLaunchPolicy` requires an absolute program path, no shell, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure; agent sessions persist through `sessions.toml`). Verified adapters, trustworthy state, notifications, and jump-to-source are not started |
-| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette clears AA on every theme-owned slot since the issue-168 lift), and CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`). IME input is still discarded, and HiDPI, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
+| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette clears AA on every theme-owned slot since the issue-168 lift), CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`), and IME/dead-key commits reach the PTY by default. IME preedit display, CJK glyph rendering, HiDPI, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | In progress — the benchmark slice landed (PR #171): a criterion suite over the paths with a defect history (`feed_bytes`, `ssh_config_parse` incl. the #137 shape, renderer frame prep, per-frame `snapshot`, `search`) behind a `bench-support` feature gate with a recorded reference-machine baseline and a report-never-gate policy ([docs/testing/benchmarks.md](docs/testing/benchmarks.md)); its first finding (46.3 ms per-frame `snapshot` at full scrollback, filed as #172) has since been remediated — `TerminalSnapshot::from_state` shares scrollback rows instead of deep-copying them. A seeded soak harness (`crates/noren-terminal/tests/soak_feed_bytes.rs`) and a hand-rolled, dependency-free fuzz harness with a decoded-content oracle (`crates/noren-terminal/tests/fuzz_feed_bytes.rs`) landed; the fuzz campaign's first finding — SD/SU/DL stranding the cursor
 on a wide-character continuation cell — is remediated at this tree: those
 operations now end in the same shared `snap_cursor_to_lead` re-snap as
@@ -273,11 +273,12 @@ against it:
   non-ASCII rendering as `?` — are retired and guarded by running, passing
   tests (`lowercase_distinct_from_uppercase`,
   `non_ascii_glyph_is_not_the_question_mark`), not `#[ignore]`d ones.
-- **IME input is discarded, and there is no accessibility surface.** The
-  `WindowEvent::Ime(_)` arm in `main.rs`'s event handler drops the event
-  without forwarding it, so Japanese, Chinese, and Korean input methods
-  produce nothing; nothing in the tree integrates with assistive
-  technology. Both are Milestone 6 scope and neither has started.
+- **IME commits work, but preedit is not displayed; there is no accessibility
+  surface.** The window enables IME delivery by default and forwards composed
+  `Ime::Commit` text through typed-input encoding to the PTY, including
+  Japanese UTF-8 and dead-key commits. The in-progress `Ime::Preedit` string is
+  acknowledged without being drawn, CJK output still uses replacement boxes,
+  and nothing in the tree integrates with assistive technology.
 - **HiDPI / Retina displays are unhandled.** No scale-factor awareness
   exists anywhere in the app: the window is created at a fixed physical
   900x600 (`with_inner_size(PhysicalSize::new(WINDOW_WIDTH,

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -549,6 +549,43 @@ impl KeyEncoder {
         Ok(Self::alt_prefixed(alt, bytes))
     }
 
+    /// Encode text committed by an input method through the typed-input byte
+    /// contract.
+    ///
+    /// An IME commit is already composed text, so it has no live keyboard
+    /// modifiers. Printable scalars therefore take the same UTF-8 path as an
+    /// ordinary unmodified character. Newline and carriage return take the
+    /// ordinary Enter path (`CR`), while C0 controls take their equivalent
+    /// named-key or Ctrl-key path. The remaining Unicode control scalars have
+    /// no keyboard-key equivalent and retain their UTF-8 representation.
+    ///
+    /// Unlike one physical-key event, a commit can contain multiple scalars.
+    /// This method preserves all of them in order and cannot reject a
+    /// non-empty commit. An empty commit encodes to no bytes.
+    #[must_use]
+    pub fn encode_committed_text(text: &str, mode: InputMode) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(text.len());
+        for character in text.chars() {
+            let Some(input) = committed_text_input(character) else {
+                let mut buffer = [0_u8; 4];
+                bytes.extend_from_slice(character.encode_utf8(&mut buffer).as_bytes());
+                continue;
+            };
+            match Self::encode_with(input, mode) {
+                Ok(encoded) => bytes.extend_from_slice(&encoded),
+                // Every input constructed by `committed_text_input` is part
+                // of the encoder's supported typed-input vocabulary. Keep a
+                // lossless fallback in case that vocabulary is tightened in
+                // the future: a committed scalar must never disappear.
+                Err(_) => {
+                    let mut buffer = [0_u8; 4];
+                    bytes.extend_from_slice(character.encode_utf8(&mut buffer).as_bytes());
+                }
+            }
+        }
+        bytes
+    }
+
     /// Prepend the `ESC` byte that Alt adds in front of a key's base bytes.
     fn alt_prefixed(alt: bool, mut bytes: Vec<u8>) -> Vec<u8> {
         if alt {
@@ -585,6 +622,30 @@ impl KeyEncoder {
         }
         Ok(input::keypad_bytes(input.key(), mode.keypad()).to_vec())
     }
+}
+
+/// Map one committed scalar to the keyboard input that would produce the same
+/// terminal input. C1 and other Unicode controls return `None`: they have no
+/// ordinary key equivalent and are retained as UTF-8 by the caller.
+fn committed_text_input(character: char) -> Option<KeyInput> {
+    let (key, modifiers) = match character {
+        '\n' | '\r' => (Key::Enter, Modifiers::empty()),
+        '\t' => (Key::Tab, Modifiers::empty()),
+        '\u{1b}' => (Key::Escape, Modifiers::empty()),
+        '\u{7f}' => (Key::Backspace, Modifiers::empty()),
+        '\0' => (Key::Character('@'), Modifiers::empty().ctrl()),
+        '\u{1}'..='\u{1a}' => {
+            let letter = char::from_u32(u32::from('a') + u32::from(character) - 1)?;
+            (Key::Character(letter), Modifiers::empty().ctrl())
+        }
+        '\u{1c}' => (Key::Character('\\'), Modifiers::empty().ctrl()),
+        '\u{1d}' => (Key::Character(']'), Modifiers::empty().ctrl()),
+        '\u{1e}' => (Key::Character('^'), Modifiers::empty().ctrl()),
+        '\u{1f}' => (Key::Character('_'), Modifiers::empty().ctrl()),
+        control if control.is_control() => return None,
+        printable => (Key::Character(printable), Modifiers::empty()),
+    };
+    Some(KeyInput::new(key, KeyPhase::Pressed, modifiers))
 }
 
 /// Encode a navigation-class key carrying the xterm modifier parameter.
@@ -876,6 +937,20 @@ mod tests {
                 Ok(vec![byte])
             );
         }
+    }
+
+    #[test]
+    fn committed_text_uses_typed_input_encoding_without_losing_scalars() {
+        let text = "日本語é\n\u{3}\u{80}";
+        assert_eq!(
+            KeyEncoder::encode_committed_text(text, InputMode::normal()),
+            ["日本語é".as_bytes(), b"\r", b"\x03", "\u{80}".as_bytes(),].concat()
+        );
+    }
+
+    #[test]
+    fn empty_committed_text_encodes_to_no_input() {
+        assert!(KeyEncoder::encode_committed_text("", InputMode::normal()).is_empty());
     }
 
     #[test]

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1129,6 +1129,21 @@ struct ParkedSession {
     scroll_offset: usize,
 }
 
+/// Narrow window seam for positioning the platform IME candidate window.
+///
+/// Keeping this operation separate from the concrete winit window lets the
+/// frame lifecycle tests observe the area that production sends to the
+/// platform without creating a native window.
+trait ImeCursorAreaTarget {
+    fn set_ime_cursor_area(&self, position: PhysicalPosition<f64>, size: PhysicalSize<u32>);
+}
+
+impl ImeCursorAreaTarget for Window {
+    fn set_ime_cursor_area(&self, position: PhysicalPosition<f64>, size: PhysicalSize<u32>) {
+        Window::set_ime_cursor_area(self, position, size);
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ScrollDirection {
     Older,
@@ -2326,7 +2341,8 @@ impl NorenApp {
                 None
             }
         };
-        self.set_ime_cursor_area(&window);
+        let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
+        self.set_ime_cursor_area(window.as_ref(), snapshot.as_ref());
         window.request_redraw();
         self.window = Some(window);
     }
@@ -3353,26 +3369,48 @@ impl NorenApp {
 
     /// Keep the platform candidate window beside the terminal's insertion
     /// cell. The terminal grid is sized after reserving the sidebar and status
-    /// chrome, so its tracked cursor row maps directly to a frame row.
-    fn set_ime_cursor_area(&self, window: &Window) {
+    /// chrome. A scrolled viewport shifts the live insertion row down by its
+    /// renderer-clamped offset, so the platform area follows the same cell.
+    fn set_ime_cursor_area<T: ImeCursorAreaTarget + ?Sized>(
+        &self,
+        window: &T,
+        snapshot: Option<&noren_terminal::TerminalSnapshot>,
+    ) {
         let metrics = self.geometry.cell_metrics();
-        let (row, column) = self
-            .terminal
-            .as_ref()
-            .map(|terminal| {
-                let cursor = terminal.cursor();
-                (cursor.row(), cursor.column())
+        let (row, column) = snapshot
+            .map(|snapshot| {
+                let cursor = snapshot.cursor();
+                let scroll_offset = renderer::clamped_scroll_offset(snapshot, self.scroll_offset);
+                (
+                    usize::from(cursor.row()).saturating_add(scroll_offset),
+                    cursor.column(),
+                )
             })
             .unwrap_or((0, 0));
         let position = PhysicalPosition::new(
             sidebar_pixel_width_at_width(metrics.width(), self.sidebar_columns)
                 + f64::from(column) * f64::from(metrics.width()),
-            f64::from(row) * f64::from(metrics.height()),
+            f64::from(u32::try_from(row).unwrap_or(u32::MAX)) * f64::from(metrics.height()),
         );
         window.set_ime_cursor_area(
             position,
             PhysicalSize::new(metrics.width(), metrics.height()),
         );
+    }
+
+    /// Prepare the terminal snapshot and platform IME area consumed by one
+    /// redraw. Tests drive this window-independent seam with a recording
+    /// target, while production hands the returned snapshot to the renderer.
+    fn prepare_redraw<T: ImeCursorAreaTarget + ?Sized>(
+        &mut self,
+        window: Option<&T>,
+    ) -> Option<noren_terminal::TerminalSnapshot> {
+        self.clamp_active_scroll_offset();
+        let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
+        if let Some(window) = window {
+            self.set_ime_cursor_area(window, snapshot.as_ref());
+        }
+        snapshot
     }
 
     /// Toggle the opt-in diagnostics overlay.
@@ -3619,11 +3657,8 @@ impl NorenApp {
     }
 
     fn redraw(&mut self, event_loop: &ActiveEventLoop) {
-        if let Some(window) = &self.window {
-            self.set_ime_cursor_area(window);
-        }
-        self.clamp_active_scroll_offset();
-        let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
+        let window = self.window.as_ref().map(Arc::clone);
+        let snapshot = self.prepare_redraw(window.as_deref());
         let visible_rows = self
             .window
             .as_ref()

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -31,7 +31,8 @@ use noren_app::{
 };
 use noren_app::{
     CursorKeyMode, GridGeometry, GridSize, InputMode, KeyEncoder, KeypadMode, Modifiers,
-    PARSE_BUDGET_BYTES_PER_TURN, PRODUCT_NAME, PasteReject, Resize, SystemClipboard,
+    PARSE_BUDGET_BYTES_PER_TURN, PRODUCT_NAME, PasteReject, READ_CHUNK_BYTES, Resize,
+    SystemClipboard,
     config::{AppConfig, KeymapConfig, UiConfig},
     diagnostics::{self, PtyChildStatus},
     encode_paste,
@@ -68,7 +69,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
-use winit::event::{ElementState, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent};
+use winit::event::{ElementState, Ime, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
 #[cfg(test)]
@@ -2228,6 +2229,10 @@ impl NorenApp {
             return;
         };
         let window = Arc::new(window);
+        // winit disables IME delivery by default. On macOS this call is also
+        // what makes composed dead-key text arrive as `Ime::Commit` instead
+        // of being lost between keyboard events.
+        window.set_ime_allowed(true);
         let physical = window.inner_size();
         let Some(grid) = self
             .geometry
@@ -2270,6 +2275,7 @@ impl NorenApp {
                 None
             }
         };
+        self.set_ime_cursor_area(&window);
         window.request_redraw();
         self.window = Some(window);
     }
@@ -2309,6 +2315,33 @@ impl NorenApp {
             return;
         }
         self.handle_passthrough_key(event);
+    }
+
+    /// Consume the winit IME branch shared by the production event loop and
+    /// the event-to-PTY integration test.
+    ///
+    /// Preedit lifecycle events are acknowledged for now without drawing the
+    /// composing string. A later `Commit` is independent of that display gap:
+    /// it always takes the same typed-input encoder and PTY writer as ordinary
+    /// key input. No IME event reaches the drop diagnostic from this path.
+    fn handle_ime_window_event(&mut self, event: &WindowEvent) -> bool {
+        let WindowEvent::Ime(ime) = event else {
+            return false;
+        };
+        match ime {
+            Ime::Commit(text) => {
+                let bytes = KeyEncoder::encode_committed_text(text, self.current_input_mode());
+                // `PtySession` deliberately bounds one input command. Preserve
+                // a large commit in-order across that existing writer limit;
+                // an empty commit has no chunks and therefore performs no
+                // write at all.
+                for chunk in bytes.chunks(READ_CHUNK_BYTES) {
+                    self.send_input(chunk);
+                }
+            }
+            Ime::Enabled | Ime::Preedit(_, _) | Ime::Disabled => {}
+        }
+        true
     }
 
     /// Route one key event through the pass-through gate.
@@ -3125,6 +3158,30 @@ impl NorenApp {
         }
     }
 
+    /// Keep the platform candidate window beside the terminal's insertion
+    /// cell. The terminal grid is sized after reserving the sidebar and status
+    /// chrome, so its tracked cursor row maps directly to a frame row.
+    fn set_ime_cursor_area(&self, window: &Window) {
+        let metrics = self.geometry.cell_metrics();
+        let (row, column) = self
+            .terminal
+            .as_ref()
+            .map(|terminal| {
+                let cursor = terminal.cursor();
+                (cursor.row(), cursor.column())
+            })
+            .unwrap_or((0, 0));
+        let position = PhysicalPosition::new(
+            sidebar_pixel_width_at_width(metrics.width(), self.sidebar_columns)
+                + f64::from(column) * f64::from(metrics.width()),
+            f64::from(row) * f64::from(metrics.height()),
+        );
+        window.set_ime_cursor_area(
+            position,
+            PhysicalSize::new(metrics.width(), metrics.height()),
+        );
+    }
+
     /// Toggle the opt-in diagnostics overlay.
     ///
     /// Each activation emits exactly one bounded report line (window title
@@ -3352,6 +3409,9 @@ impl NorenApp {
     }
 
     fn redraw(&mut self, event_loop: &ActiveEventLoop) {
+        if let Some(window) = &self.window {
+            self.set_ime_cursor_area(window);
+        }
         let snapshot = self.terminal.as_ref().map(TerminalEngine::snapshot);
         let visible_rows = self
             .window
@@ -3478,6 +3538,9 @@ impl ApplicationHandler for NorenApp {
         if self.window.as_ref().map(|window| window.id()) != Some(window_id) {
             return;
         }
+        if self.handle_ime_window_event(&event) {
+            return;
+        }
         match event {
             WindowEvent::CloseRequested => self.close(event_loop),
             WindowEvent::Resized(physical) => self.handle_resize(physical),
@@ -3497,14 +3560,6 @@ impl ApplicationHandler for NorenApp {
             }
             WindowEvent::MouseWheel { delta, .. } => self.handle_mouse_wheel(delta),
             WindowEvent::KeyboardInput { event, .. } => self.handle_key(&event),
-            WindowEvent::Ime(_) => {
-                // An Ime event means composition replaced the keyboard path:
-                // the typed content is dropped unread because IME support
-                // itself is deferred. The record is argument-free, so the
-                // drop surfaces in diagnostics as a count that can never
-                // carry the composed text.
-                diagnostics::record_ime_drop();
-            }
             WindowEvent::RedrawRequested => self.redraw(event_loop),
             _ => {}
         }

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -1233,6 +1233,13 @@ struct NorenApp {
     /// arbitrarily long or read the terminal).
     #[cfg(test)]
     test_pty_home: Option<PathBuf>,
+    /// Test-only deterministic command-queue failure seam. Production learns
+    /// failure only from `PtySession::send_input`; tests use this counter to
+    /// prove a multi-chunk IME commit stops on the first rejected write.
+    #[cfg(test)]
+    test_input_send_attempts: usize,
+    #[cfg(test)]
+    test_input_failure_at: Option<usize>,
     palette_open: bool,
     palette_selection: usize,
     passthrough_gate: PassthroughGate,
@@ -1373,6 +1380,10 @@ impl NorenApp {
             parked_sessions: HashMap::new(),
             #[cfg(test)]
             test_pty_home: None,
+            #[cfg(test)]
+            test_input_send_attempts: 0,
+            #[cfg(test)]
+            test_input_failure_at: None,
             palette_open: false,
             palette_selection: 0,
             passthrough_gate: PassthroughGate::new(),
@@ -2470,9 +2481,13 @@ impl NorenApp {
                 // `PtySession` deliberately bounds one input command. Preserve
                 // a large commit in-order across that existing writer limit;
                 // an empty commit has no chunks and therefore performs no
-                // write at all.
+                // write at all. Stop after the first rejected chunk just as a
+                // bounded paste stops after its single rejected write, so the
+                // remainder is not silently dropped one chunk at a time.
                 for chunk in bytes.chunks(READ_CHUNK_BYTES) {
-                    self.send_input(chunk);
+                    if !self.send_input(chunk) {
+                        break;
+                    }
                 }
             }
             Ime::Enabled | Ime::Preedit(_, _) | Ime::Disabled => {}
@@ -2761,7 +2776,9 @@ impl NorenApp {
             }
         };
         match self.paste_bytes(&text) {
-            Ok(bytes) => self.send_input(&bytes),
+            Ok(bytes) => {
+                self.send_input(&bytes);
+            }
             Err(reject @ (PasteReject::Unbracketed | PasteReject::Oversized)) => {
                 self.show_paste_gate(reject);
             }
@@ -3357,14 +3374,34 @@ impl NorenApp {
         }
     }
 
-    fn send_input(&mut self, bytes: &[u8]) {
-        if let Some(session) = &self.pty {
-            if session.send_input(bytes).is_err() {
-                self.status = "Noren PTY input failed";
-                self.show_status = true;
-                self.redraw_needed = true;
+    /// Send one bounded input command, returning whether the caller may send
+    /// a subsequent chunk. Every input source shares the same visible failure
+    /// state; multi-chunk callers must stop when this returns `false`.
+    fn send_input(&mut self, bytes: &[u8]) -> bool {
+        #[cfg(test)]
+        {
+            self.test_input_send_attempts = self.test_input_send_attempts.saturating_add(1);
+            if self.test_input_failure_at == Some(self.test_input_send_attempts) {
+                self.show_pty_input_failure();
+                return false;
             }
         }
+
+        if self
+            .pty
+            .as_ref()
+            .is_some_and(|session| session.send_input(bytes).is_err())
+        {
+            self.show_pty_input_failure();
+            return false;
+        }
+        true
+    }
+
+    fn show_pty_input_failure(&mut self) {
+        self.status = "Noren PTY input failed";
+        self.show_status = true;
+        self.redraw_needed = true;
     }
 
     /// Keep the platform candidate window beside the terminal's insertion

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3898,6 +3898,137 @@ fn wait_for_shell_output(app: &mut NorenApp) {
     }
 }
 
+/// A real `WindowEvent::Ime` commit must survive the complete production path:
+/// event dispatch -> typed-input encoding -> `PtySession::send_input` -> the
+/// supervisor's PTY-master `write_all` -> bytes read by the child.
+///
+/// The child switches its slave to raw mode and lets `dd` read exactly the
+/// expected byte count before `od` reports those bytes back. The assertion is
+/// therefore downstream of the actual PTY write, not an assertion on the
+/// encoder result or the supervisor command buffer. Fallback bytes are queued
+/// after the IME events so dropping a commit or writing only its first byte
+/// makes `dd` finish promptly with visibly wrong bytes instead of timing out.
+#[test]
+fn ime_window_events_reach_the_real_pty_write_byte_for_byte() {
+    const READY: &str = "IME204_READY";
+    const DONE: &str = "IME204_DONE";
+    const EXPECTED: &[u8] = &[
+        0xe6, 0x97, 0xa5, // 日
+        0xe6, 0x9c, 0xac, // 本
+        0xe8, 0xaa, 0x9e, // 語
+        0xc3, 0xa9, // é (dead-key composition)
+        0x0d, // committed newline follows the ordinary Enter path
+        0x03, // committed ETX follows the ordinary Ctrl+C path
+    ];
+
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    wait_for_shell_output(&mut app);
+
+    // The child enables both alternate-screen and bracketed-paste modes before
+    // reading. IME remains typed input in that state: it must neither be gated
+    // by the alternate screen nor wrapped in paste markers just because mode
+    // 2004 is active.
+    let setup = format!(
+        "printf '\\033[?1049h\\033[?2004h{READY}\\r\\n'; \
+         /bin/stty raw -echo; \
+         /bin/dd bs=1 count={} 2>/dev/null | /usr/bin/od -An -v -tx1; \
+         /bin/stty sane; printf '\\r\\n{DONE}\\r\\n'\r",
+        EXPECTED.len()
+    );
+    app.send_input(setup.as_bytes());
+
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        app.drain_pty();
+        let ready = app.terminal.as_ref().is_some_and(|terminal| {
+            let modes = terminal.modes();
+            modes.is_alternate_screen_active()
+                && modes.is_bracketed_paste_enabled()
+                && terminal_text(terminal).contains(READY)
+        });
+        if ready {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "the raw-byte reader never became ready in alternate-screen + mode 2004; \
+             terminal said: {:?}",
+            app.terminal.as_ref().map(terminal_text).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let drops_before = diagnostics::ime_drop_count();
+    for event in [
+        WindowEvent::Ime(Ime::Enabled),
+        WindowEvent::Ime(Ime::Preedit("に".to_owned(), Some((3, 3)))),
+        WindowEvent::Ime(Ime::Preedit(String::new(), None)),
+        WindowEvent::Ime(Ime::Commit(String::new())),
+        WindowEvent::Ime(Ime::Commit("日本語".to_owned())),
+        WindowEvent::Ime(Ime::Preedit("´".to_owned(), Some((2, 2)))),
+        WindowEvent::Ime(Ime::Preedit(String::new(), None)),
+        WindowEvent::Ime(Ime::Commit("é".to_owned())),
+        WindowEvent::Ime(Ime::Commit("\n".to_owned())),
+        WindowEvent::Ime(Ime::Commit("\u{3}".to_owned())),
+        WindowEvent::Ime(Ime::Disabled),
+    ] {
+        assert!(
+            app.handle_ime_window_event(&event),
+            "the production IME branch must consume every winit IME variant"
+        );
+    }
+    assert_eq!(
+        diagnostics::ime_drop_count(),
+        drops_before,
+        "no preedit lifecycle or commit may reach the IME-drop diagnostic"
+    );
+
+    // FIFO ordering puts these bytes after everything the IME path wrote. In
+    // the working implementation `dd` has already consumed EXPECTED; under a
+    // drop/first-byte mutation it consumes this fallback and reports a
+    // deterministic mismatch without waiting for a timeout.
+    app.send_input(&vec![b'U'; EXPECTED.len()]);
+
+    let done_deadline = Instant::now() + Duration::from_secs(5);
+    let text = loop {
+        app.drain_pty();
+        let text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
+        if text.contains(DONE) {
+            break text;
+        }
+        assert!(
+            Instant::now() < done_deadline,
+            "the child never reported the bytes it read from the PTY write; terminal said: {text:?}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+
+    let between_markers = text
+        .split_once(READY)
+        .and_then(|(_, after_ready)| after_ready.split_once(DONE).map(|(bytes, _)| bytes))
+        .expect("the child's byte report is bounded by both markers");
+    let received: Vec<u8> = between_markers
+        .split_whitespace()
+        .filter(|token| token.len() == 2 && token.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .map(|token| u8::from_str_radix(token, 16).expect("od emitted a two-digit hex byte"))
+        .collect();
+
+    assert_eq!(
+        received, EXPECTED,
+        "the child must read the exact encoded commits from the PTY master write"
+    );
+    for marker in [b"\x1b[200~".as_slice(), b"\x1b[201~".as_slice()] {
+        assert!(
+            !received
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "an IME commit is typed input and must not use bracketed-paste markers"
+        );
+    }
+}
+
 /// The palette's session_create must spawn a real local PTY: the row is
 /// observed `Running` (never left `Starting`), it owns the live surface, and a
 /// second create parks the first live session instead of killing it.

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4507,6 +4507,31 @@ fn ime_large_commit_arrives_in_order_across_the_read_chunk_boundary() {
 }
 
 #[test]
+fn ime_large_commit_stops_at_the_first_failed_write_and_surfaces_it() {
+    let mut app = NorenApp::default();
+    let failed_chunk = noren_pty::COMMAND_CHANNEL_CAPACITY + 1;
+    let offered_chunks = failed_chunk + 2;
+    app.test_input_failure_at = Some(failed_chunk);
+    let commit = "Q".repeat(READ_CHUNK_BYTES * offered_chunks);
+
+    assert!(app.handle_ime_window_event(&WindowEvent::Ime(Ime::Commit(commit))));
+
+    assert_eq!(
+        app.test_input_send_attempts, failed_chunk,
+        "chunks after the first rejected command must not be attempted"
+    );
+    assert_eq!(app.status, "Noren PTY input failed");
+    assert!(
+        app.show_status,
+        "the failed write must be visible to the user"
+    );
+    assert!(
+        app.redraw_needed,
+        "the visible failure must schedule a frame"
+    );
+}
+
+#[test]
 fn ime_large_multibyte_commit_keeps_scalar_bytes_ordered_between_chunks() {
     let commit = [
         "境".repeat(READ_CHUNK_BYTES / "境".len() + 1),

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -8,6 +8,101 @@ use noren_app::{BRACKET_PASTE_BEGIN, BRACKET_PASTE_END};
 include!("../input_translation/tests.rs");
 include!("../frame_geometry/tests.rs");
 
+#[derive(Default)]
+struct RecordingImeCursorArea {
+    areas: std::cell::RefCell<Vec<(PhysicalPosition<f64>, PhysicalSize<u32>)>>,
+}
+
+impl ImeCursorAreaTarget for RecordingImeCursorArea {
+    fn set_ime_cursor_area(&self, position: PhysicalPosition<f64>, size: PhysicalSize<u32>) {
+        self.areas.borrow_mut().push((position, size));
+    }
+}
+
+impl RecordingImeCursorArea {
+    fn last(&self) -> (PhysicalPosition<f64>, PhysicalSize<u32>) {
+        self.areas
+            .borrow()
+            .last()
+            .copied()
+            .expect("redraw preparation must set the platform IME cursor area")
+    }
+
+    fn len(&self) -> usize {
+        self.areas.borrow().len()
+    }
+}
+
+#[test]
+fn redraw_preparation_sets_the_platform_ime_cursor_area() {
+    let mut app = NorenApp::default();
+    let target = RecordingImeCursorArea::default();
+    let metrics = app.geometry.cell_metrics();
+
+    let snapshot = app.prepare_redraw(Some(&target));
+
+    assert!(snapshot.is_none());
+    assert_eq!(target.len(), 1, "one redraw sets the area exactly once");
+    assert_eq!(
+        target.last(),
+        (
+            PhysicalPosition::new(
+                sidebar_pixel_width_at_width(metrics.width(), app.sidebar_columns),
+                0.0,
+            ),
+            PhysicalSize::new(metrics.width(), metrics.height()),
+        )
+    );
+}
+
+#[test]
+fn platform_ime_cursor_area_follows_the_caret_and_scrolled_viewport() {
+    let mut terminal = TerminalState::new(3, 8).expect("valid terminal");
+    terminal.feed_bytes(b"one\r\ntwo\r\nthree\r\nfour");
+    assert_eq!(terminal.scrollback_len(), 1, "fixture retains one row");
+
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..NorenApp::default()
+    };
+    let target = RecordingImeCursorArea::default();
+    let metrics = app.geometry.cell_metrics();
+    let sidebar_width = sidebar_pixel_width_at_width(metrics.width(), app.sidebar_columns);
+    let position_for = |row: u32, column: u16| {
+        PhysicalPosition::new(
+            sidebar_width + f64::from(column) * f64::from(metrics.width()),
+            f64::from(row) * f64::from(metrics.height()),
+        )
+    };
+
+    app.prepare_redraw(Some(&target));
+    assert_eq!(target.last().0, position_for(2, 4));
+
+    app.terminal
+        .as_mut()
+        .expect("terminal remains attached")
+        .feed_bytes(b"\x1b[2;3H");
+    app.prepare_redraw(Some(&target));
+    assert_eq!(
+        target.last().0,
+        position_for(1, 2),
+        "the platform area follows both caret axes at the live tail"
+    );
+
+    app.scroll_offset = usize::MAX;
+    app.prepare_redraw(Some(&target));
+    assert_eq!(
+        app.scroll_offset, 1,
+        "the retained history clamps the request"
+    );
+    assert_eq!(
+        target.last().0,
+        position_for(2, 2),
+        "the same clamped offset that moves the rendered live row also moves the IME area"
+    );
+    assert_eq!(target.len(), 3, "each redraw refreshes the platform area");
+}
+
 /// Issue #185: the artifact's own surfaces read the single product string,
 /// the title states the version the binary was built as, and no surface
 /// calls the binary a proof of concept.

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -4131,6 +4131,31 @@ fn ime_large_multibyte_commit_keeps_scalar_bytes_ordered_between_chunks() {
 }
 
 #[test]
+fn ime_large_commit_encodes_a_newline_at_the_chunk_boundary_without_reordering() {
+    let commit = [
+        "L".repeat(READ_CHUNK_BYTES - 1),
+        "\n".to_owned(),
+        "R".repeat(READ_CHUNK_BYTES + 1),
+    ]
+    .concat();
+    let expected = [
+        vec![b'L'; READ_CHUNK_BYTES - 1],
+        b"\r".to_vec(),
+        vec![b'R'; READ_CHUNK_BYTES + 1],
+    ]
+    .concat();
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit))],
+        expected.len(),
+        ImeCaptureScreen::Primary,
+    );
+
+    assert_eq!(received, expected);
+    assert_eq!(received[READ_CHUNK_BYTES - 1], b'\r');
+    assert_eq!(received[READ_CHUNK_BYTES], b'R');
+}
+
+#[test]
 fn ime_committed_newline_reaches_the_pty_through_enter_encoding() {
     let received = capture_ime_events(
         [WindowEvent::Ime(Ime::Commit("\n".to_owned()))],
@@ -4138,6 +4163,18 @@ fn ime_committed_newline_reaches_the_pty_through_enter_encoding() {
         ImeCaptureScreen::Primary,
     );
     assert_eq!(received, b"\r");
+}
+
+#[test]
+fn ime_multiline_commit_preserves_utf8_around_the_encoded_newline() {
+    let commit = "before日本\n語after";
+    let expected = ["before日本".as_bytes(), b"\r", "語after".as_bytes()].concat();
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit.to_owned()))],
+        expected.len(),
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(received, expected);
 }
 
 #[test]

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -3,6 +3,7 @@ use noren_app::palette::CommandId;
 use noren_app::passthrough::{self, collisions};
 use noren_app::session_persistence::{MAX_SESSION_STATE_BYTES, load};
 use noren_app::sidebar::EntryKind;
+use noren_app::{BRACKET_PASTE_BEGIN, BRACKET_PASTE_END};
 
 include!("../input_translation/tests.rs");
 include!("../frame_geometry/tests.rs");
@@ -3896,6 +3897,276 @@ fn wait_for_shell_output(app: &mut NorenApp) {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
+}
+
+#[derive(Clone, Copy)]
+enum ImeCaptureScreen {
+    Primary,
+    Alternate,
+    BracketedPaste,
+}
+
+impl ImeCaptureScreen {
+    const fn enable_sequence(self) -> &'static str {
+        match self {
+            Self::Primary => "",
+            Self::Alternate => "\\033[?1049h",
+            Self::BracketedPaste => "\\033[?2004h",
+        }
+    }
+
+    fn is_ready(self, app: &NorenApp) -> bool {
+        let Some(modes) = app.terminal.as_ref().map(TerminalState::modes) else {
+            return false;
+        };
+        match self {
+            Self::Primary => true,
+            Self::Alternate => modes.is_alternate_screen_active(),
+            Self::BracketedPaste => modes.is_bracketed_paste_enabled(),
+        }
+    }
+}
+
+/// Run committed IME events through the production handler and capture the
+/// bytes downstream of the real PTY-master write.
+///
+/// Each caller gets an isolated shell and capture file. The child opens the
+/// file before blocking in a raw one-byte `dd`, which gives the test a positive
+/// readiness signal. Fallback bytes are sent only if the commit has not filled
+/// the file during a short settling window: mutations that drop or truncate a
+/// commit therefore fail promptly, while the working path leaves no large
+/// fallback command queued in the shell during teardown.
+fn capture_ime_events<I>(events: I, byte_count: usize, screen: ImeCaptureScreen) -> Vec<u8>
+where
+    I: IntoIterator<Item = WindowEvent>,
+{
+    static CAPTURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _capture_guard = CAPTURE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    const DONE: &str = "IME204_CAPTURE_DONE";
+
+    let home = AppTestHome::new();
+    let capture_path = home.0.join("ime-commit-capture.bin");
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    wait_for_shell_output(&mut app);
+
+    let setup = format!(
+        "printf '{}'; /bin/stty raw -echo; \
+         /bin/dd bs=1 count={byte_count} of=\"$HOME/ime-commit-capture.bin\" 2>/dev/null; \
+         /bin/stty sane; printf '\\r\\nIME204_%s_DONE\\r\\n' CAPTURE\r",
+        screen.enable_sequence()
+    );
+    app.send_input(setup.as_bytes());
+
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        app.drain_pty();
+        if capture_path.exists() && screen.is_ready(&app) {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "raw IME capture never became ready; screen_ready={}, terminal said: {:?}",
+            screen.is_ready(&app),
+            app.terminal.as_ref().map(terminal_text).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    for event in events {
+        assert!(
+            app.handle_ime_window_event(&event),
+            "the production handler must consume every supplied IME event"
+        );
+    }
+
+    let settle_deadline = Instant::now() + Duration::from_millis(250);
+    loop {
+        let captured = std::fs::metadata(&capture_path)
+            .map(|metadata| metadata.len() as usize)
+            .unwrap_or(0);
+        if captured >= byte_count || Instant::now() >= settle_deadline {
+            if captured < byte_count {
+                let fallback = vec![b'U'; byte_count - captured];
+                for chunk in fallback.chunks(READ_CHUNK_BYTES) {
+                    app.send_input(chunk);
+                }
+            }
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let done_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        app.drain_pty();
+        let done = app
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal_text(terminal).contains(DONE));
+        let captured = std::fs::metadata(&capture_path)
+            .map(|metadata| metadata.len() as usize)
+            .unwrap_or(0);
+        if done && captured == byte_count {
+            break;
+        }
+        assert!(
+            Instant::now() < done_deadline,
+            "raw IME capture did not finish: captured={captured}/{byte_count}, terminal said: {:?}",
+            app.terminal.as_ref().map(terminal_text).unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    std::fs::read(capture_path).expect("read the child-side IME byte capture")
+}
+
+#[test]
+fn ime_multibyte_japanese_commit_reaches_the_pty_byte_for_byte() {
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit("日本語".to_owned()))],
+        "日本語".len(),
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(received, "日本語".as_bytes());
+}
+
+#[test]
+fn ime_dead_key_composition_reaches_the_pty_as_the_composed_scalar() {
+    let received = capture_ime_events(
+        [
+            WindowEvent::Ime(Ime::Preedit("´".to_owned(), Some((2, 2)))),
+            WindowEvent::Ime(Ime::Preedit(String::new(), None)),
+            WindowEvent::Ime(Ime::Commit("é".to_owned())),
+        ],
+        "é".len(),
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(received, "é".as_bytes());
+}
+
+#[test]
+fn ime_commit_reaches_the_pty_while_the_alternate_screen_is_active() {
+    let commit = "ALT-日本語";
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit.to_owned()))],
+        commit.len(),
+        ImeCaptureScreen::Alternate,
+    );
+    assert_eq!(received, commit.as_bytes());
+}
+
+#[test]
+fn ime_empty_commit_writes_nothing_to_the_pty() {
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(String::new()))],
+        1,
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(
+        received, b"U",
+        "the fallback must remain the first byte when an empty commit is a no-op"
+    );
+}
+
+#[test]
+fn ime_commit_is_never_wrapped_as_bracketed_paste() {
+    let commit = "typed-日本語-not-paste";
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit.to_owned()))],
+        commit.len(),
+        ImeCaptureScreen::BracketedPaste,
+    );
+    assert_eq!(received, commit.as_bytes());
+    for marker in [BRACKET_PASTE_BEGIN, BRACKET_PASTE_END] {
+        assert!(
+            !received
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "IME commits are typed input even when mode 2004 is active"
+        );
+    }
+}
+
+#[test]
+fn ime_large_commit_arrives_in_order_across_the_read_chunk_boundary() {
+    let commit = [
+        "A".repeat(READ_CHUNK_BYTES),
+        "B".repeat(READ_CHUNK_BYTES),
+        "C".to_owned(),
+    ]
+    .concat();
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit.clone()))],
+        commit.len(),
+        ImeCaptureScreen::Primary,
+    );
+
+    assert_eq!(received, commit.as_bytes());
+    assert_eq!(received[READ_CHUNK_BYTES - 1], b'A');
+    assert_eq!(received[READ_CHUNK_BYTES], b'B');
+    assert_eq!(received[READ_CHUNK_BYTES * 2], b'C');
+}
+
+#[test]
+fn ime_large_multibyte_commit_keeps_scalar_bytes_ordered_between_chunks() {
+    let commit = [
+        "境".repeat(READ_CHUNK_BYTES / "境".len() + 1),
+        "界".repeat(READ_CHUNK_BYTES / "界".len() + 1),
+        "終".to_owned(),
+    ]
+    .concat();
+    assert!(commit.len() > READ_CHUNK_BYTES * 2);
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit(commit.clone()))],
+        commit.len(),
+        ImeCaptureScreen::Primary,
+    );
+
+    assert_eq!(received, commit.as_bytes());
+    assert!(received.starts_with("境".as_bytes()));
+    assert!(received.ends_with("終".as_bytes()));
+}
+
+#[test]
+fn ime_committed_newline_reaches_the_pty_through_enter_encoding() {
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit("\n".to_owned()))],
+        1,
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(received, b"\r");
+}
+
+#[test]
+fn ime_committed_control_character_reaches_the_pty_through_control_encoding() {
+    let received = capture_ime_events(
+        [WindowEvent::Ime(Ime::Commit("\u{3}".to_owned()))],
+        1,
+        ImeCaptureScreen::Primary,
+    );
+    assert_eq!(received, b"\x03");
+}
+
+#[test]
+fn ime_commit_and_preedit_paths_never_increment_the_drop_counter() {
+    let before = diagnostics::ime_drop_count();
+    let mut app = NorenApp::default();
+    for event in [
+        WindowEvent::Ime(Ime::Enabled),
+        WindowEvent::Ime(Ime::Preedit("入力中".to_owned(), Some((0, 3)))),
+        WindowEvent::Ime(Ime::Commit("入力".to_owned())),
+        WindowEvent::Ime(Ime::Disabled),
+    ] {
+        assert!(app.handle_ime_window_event(&event));
+    }
+    assert_eq!(
+        diagnostics::ime_drop_count(),
+        before,
+        "accepted composition events cannot reach record_ime_drop"
+    );
 }
 
 /// A real `WindowEvent::Ime` commit must survive the complete production path:

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -1019,7 +1019,7 @@ fn glyph_vertices_with_chrome_budget(
 /// scrollback rows is the inclusive upper bound. Alternate-screen content is
 /// intentionally isolated: its effective offset is always zero even if the
 /// application carries a stale primary-screen view request.
-fn clamped_scroll_offset(snapshot: &TerminalSnapshot, requested: usize) -> usize {
+pub(crate) fn clamped_scroll_offset(snapshot: &TerminalSnapshot, requested: usize) -> usize {
     if snapshot.modes().is_alternate_screen_active() {
         0
     } else {

--- a/crates/noren-app/tests/ime_input.rs
+++ b/crates/noren-app/tests/ime_input.rs
@@ -175,8 +175,8 @@ fn production_commit_handler_uses_the_encoder_and_forward_chunk_loop() {
         "large commits must traverse chunks in their original iterator order"
     );
     assert!(
-        handler.contains("self.send_input(chunk);"),
-        "every complete chunk must reach the production PTY writer"
+        handler.contains("if !self.send_input(chunk) {") && handler.contains("break;"),
+        "every complete chunk must reach the production PTY writer until its first failure"
     );
 }
 

--- a/crates/noren-app/tests/ime_input.rs
+++ b/crates/noren-app/tests/ime_input.rs
@@ -1,0 +1,291 @@
+//! Independent integration guards for committed IME input.
+//!
+//! The binary's winit event adapter is private, so the externally observable
+//! byte contract is tested through the public encoder and a real PTY. Small
+//! source contracts separately pin the platform-only window calls and the
+//! private adapter wiring; those are the two seams a headless integration
+//! target cannot invoke through winit itself.
+
+use noren_app::{
+    BRACKET_PASTE_BEGIN, BRACKET_PASTE_END, InputMode, KeyDropReason, KeyEncoder, READ_CHUNK_BYTES,
+    diagnostics, encode_paste,
+};
+use noren_pty::{PtyEvent, PtySession, PtySize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+const MAIN_SOURCE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/main.rs"));
+const INPUT_TRANSLATION_SOURCE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/input_translation.rs"
+));
+
+fn source_function<'a>(source: &'a str, signature: &str) -> &'a str {
+    let start = source
+        .find(signature)
+        .unwrap_or_else(|| panic!("production source no longer contains {signature:?}"));
+    let body = &source[start..];
+    let open = body
+        .find('{')
+        .unwrap_or_else(|| panic!("{signature:?} has no function body"));
+    let mut depth = 0_usize;
+    for (offset, character) in body[open..].char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &body[..open + offset + 1];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("{signature:?} has an unterminated function body");
+}
+
+#[test]
+fn multibyte_japanese_commit_is_exact_utf8() {
+    assert_eq!(
+        KeyEncoder::encode_committed_text("日本語", InputMode::normal()),
+        "日本語".as_bytes()
+    );
+}
+
+#[test]
+fn dead_key_composition_is_one_complete_utf8_scalar() {
+    assert_eq!(
+        KeyEncoder::encode_committed_text("é", InputMode::normal()),
+        [0xc3, 0xa9]
+    );
+}
+
+#[test]
+fn empty_commit_encodes_no_pty_input() {
+    assert!(KeyEncoder::encode_committed_text("", InputMode::normal()).is_empty());
+}
+
+#[test]
+fn committed_newline_uses_the_normal_enter_encoding() {
+    assert_eq!(
+        KeyEncoder::encode_committed_text("\n", InputMode::normal()),
+        b"\r"
+    );
+}
+
+#[test]
+fn committed_control_character_uses_the_normal_control_key_encoding() {
+    assert_eq!(
+        KeyEncoder::encode_committed_text("\u{3}", InputMode::normal()),
+        b"\x03"
+    );
+}
+
+#[test]
+fn committed_text_is_not_encoded_as_bracketed_paste() {
+    let committed = KeyEncoder::encode_committed_text("日本語", InputMode::normal());
+    let pasted = encode_paste("日本語", true).expect("mode 2004 permits a bracketed paste");
+
+    assert_eq!(committed, "日本語".as_bytes());
+    assert!(pasted.starts_with(BRACKET_PASTE_BEGIN));
+    assert!(pasted.ends_with(BRACKET_PASTE_END));
+    for marker in [BRACKET_PASTE_BEGIN, BRACKET_PASTE_END] {
+        assert!(
+            !committed
+                .windows(marker.len())
+                .any(|window| window == marker),
+            "typed IME input must not contain a bracketed-paste marker"
+        );
+    }
+}
+
+#[test]
+fn alternate_screen_mode_does_not_change_committed_text_encoding() {
+    let mut terminal = noren_terminal::TerminalState::new(24, 80).expect("valid terminal grid");
+    terminal.feed_bytes(b"\x1b[?1049h");
+    assert!(terminal.modes().is_alternate_screen_active());
+
+    assert_eq!(
+        KeyEncoder::encode_committed_text("日本語", InputMode::normal()),
+        "日本語".as_bytes(),
+        "screen selection is output state and must not gate typed input"
+    );
+}
+
+#[test]
+fn large_commit_reassembles_in_order_across_every_chunk_boundary() {
+    let commit = boundary_distinct_commit();
+    let encoded = KeyEncoder::encode_committed_text(&commit, InputMode::normal());
+    let chunks: Vec<&[u8]> = encoded.chunks(READ_CHUNK_BYTES).collect();
+
+    assert_eq!(chunks.len(), 3, "fixture must cross two writer boundaries");
+    assert_eq!(chunks[0].len(), READ_CHUNK_BYTES);
+    assert_eq!(chunks[1].len(), READ_CHUNK_BYTES);
+    assert_eq!(chunks.concat(), commit.as_bytes());
+    assert_eq!(chunks[0].last(), Some(&b'A'));
+    assert_eq!(chunks[1].first(), Some(&0xe6));
+    assert_eq!(chunks[2].last(), Some(&b'Z'));
+}
+
+#[test]
+fn large_encoded_commit_reaches_a_real_pty_in_order() {
+    let home = TestHome::new();
+    let capture = home.path().join("ime-integration-capture.bin");
+    let commit = boundary_distinct_commit();
+    let encoded = KeyEncoder::encode_committed_text(&commit, InputMode::normal());
+    assert!(encoded.len() > READ_CHUNK_BYTES);
+
+    let mut session = PtySession::spawn_in_home(
+        home.path(),
+        PtySize::from_raw(24, 80).expect("24x80 is a valid PTY size"),
+    )
+    .expect("spawn the fixed isolated zsh session");
+    wait_for_any_output(&session);
+
+    let command = format!(
+        "/bin/stty raw -echo; /bin/dd bs=1 count={} of=\"$HOME/ime-integration-capture.bin\" 2>/dev/null; \
+         /bin/stty sane; printf '\\r\\nIME_INTEGRATION_DONE\\r\\n'\r",
+        encoded.len()
+    );
+    session
+        .send_input(command.as_bytes())
+        .expect("queue the raw capture command");
+    for chunk in encoded.chunks(READ_CHUNK_BYTES) {
+        session
+            .send_input(chunk)
+            .expect("queue every encoded commit chunk");
+    }
+
+    wait_for_marker(&session, b"IME_INTEGRATION_DONE");
+    let received = std::fs::read(&capture).expect("the child wrote its raw input capture");
+    assert_eq!(received, encoded);
+    session.shutdown().expect("reap the integration PTY child");
+}
+
+#[test]
+fn production_commit_handler_uses_the_encoder_and_forward_chunk_loop() {
+    let handler = source_function(MAIN_SOURCE, "fn handle_ime_window_event");
+    assert!(
+        handler.contains("KeyEncoder::encode_committed_text(text, self.current_input_mode())"),
+        "the private winit adapter must call the normal committed-text encoder"
+    );
+    assert!(
+        handler.contains("for chunk in bytes.chunks(READ_CHUNK_BYTES) {"),
+        "large commits must traverse chunks in their original iterator order"
+    );
+    assert!(
+        handler.contains("self.send_input(chunk);"),
+        "every complete chunk must reach the production PTY writer"
+    );
+}
+
+#[test]
+fn production_window_initialization_enables_ime_delivery() {
+    let initialize = source_function(MAIN_SOURCE, "fn initialize(");
+    assert_eq!(
+        initialize.matches("window.set_ime_allowed(true);").count(),
+        1,
+        "winit disables IME events by default; the created window must opt in exactly once"
+    );
+    let create = initialize
+        .find("event_loop.create_window(attributes)")
+        .expect("initialize creates the production window");
+    let enable = initialize
+        .find("window.set_ime_allowed(true);")
+        .expect("initialize enables IME delivery");
+    assert!(enable > create, "IME must be enabled on the created window");
+}
+
+#[test]
+fn commit_path_cannot_record_a_drop_while_genuine_drop_recording_remains() {
+    let handler = source_function(MAIN_SOURCE, "fn handle_ime_window_event");
+    assert!(
+        !handler.contains("record_ime_drop"),
+        "an accepted Ime::Commit must never increment the drop diagnostic"
+    );
+    assert!(
+        INPUT_TRANSLATION_SOURCE
+            .contains("WinitKey::Dead(_) => return Err(KeyDropReason::ImeOrDeadKey)"),
+        "an uncomposed physical dead key remains an explicit genuine drop"
+    );
+
+    let genuine_drop = KeyDropReason::ImeOrDeadKey;
+    let before = diagnostics::ime_drop_count();
+    if genuine_drop == KeyDropReason::ImeOrDeadKey {
+        diagnostics::record_ime_drop();
+    }
+    assert_eq!(
+        diagnostics::ime_drop_count(),
+        before + 1,
+        "the payload-free diagnostic must remain reachable for genuine drops"
+    );
+}
+
+fn boundary_distinct_commit() -> String {
+    let mut commit = "A".repeat(READ_CHUNK_BYTES);
+    commit.push_str("日本語");
+    commit.push_str(&"B".repeat(READ_CHUNK_BYTES - "日本語".len()));
+    commit.push('Z');
+    commit
+}
+
+fn wait_for_any_output(session: &PtySession) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match session.try_recv() {
+            Ok(Some(PtyEvent::Output(bytes))) if !bytes.is_empty() => return,
+            Ok(Some(_)) | Ok(None) => {}
+            Err(error) => panic!("PTY failed before its prompt: {error}"),
+        }
+        assert!(Instant::now() < deadline, "isolated zsh produced no prompt");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_marker(session: &PtySession, marker: &[u8]) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut output = Vec::new();
+    loop {
+        match session.try_recv() {
+            Ok(Some(PtyEvent::Output(bytes))) => output.extend_from_slice(&bytes),
+            Ok(Some(PtyEvent::Error(error))) => panic!("PTY capture failed: {error}"),
+            Ok(Some(PtyEvent::Eof | PtyEvent::Exited { .. })) | Ok(None) => {}
+            Err(error) => panic!("PTY channel failed: {error}"),
+        }
+        if output.windows(marker.len()).any(|window| window == marker) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "PTY child never completed the capture; output={:?}",
+            String::from_utf8_lossy(&output)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+struct TestHome(PathBuf);
+
+impl TestHome {
+    fn new() -> Self {
+        static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+        let sequence = SEQUENCE.fetch_add(1, Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!(
+            "noren-ime-integration-home-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).expect("create isolated integration-test home");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestHome {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).expect("remove isolated integration-test home");
+    }
+}

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -232,17 +232,18 @@ Each item states what you would actually see if you ran the build.
   pins the collision set to exactly that hardcoded allowlist, so a future
   glyph edit cannot reintroduce a case-blind or diacritic-losing collision
   (or invent a new box-drawing alias) silently.
-- **IME input is discarded.** `WindowEvent::Ime(_)` is dropped without reaching
-  the terminal — the `WindowEvent::Ime(_)` arm in `main.rs`'s event handler
-  drops the event without forwarding it. Japanese, Chinese, and
-  Korean input methods produce nothing. For a user typing Japanese into
-  Noren today this means: composing with an IME inserts no text at all
-  (the composition never reaches the PTY), and any Japanese that a running
-  program *outputs* (`cat`, `ls`, a build log) draws as unreadable
-  replacement boxes — laid out at the correct two-column width so the
-  surrounding ASCII stays aligned, but the characters themselves cannot be
-  read. Neither half works today; both are Milestone 6 scope, and the width
-  half is the only half that is verified.
+- **IME commits work, but preedit is not displayed and CJK glyphs remain
+  unreadable.** Noren enables IME delivery on the window with zero
+  configuration, keeps the platform candidate area at the terminal cursor,
+  and sends every `WindowEvent::Ime(Ime::Commit(text))` through the ordinary
+  typed-input encoder and PTY writer. Japanese multi-byte commits and composed
+  dead-key text such as `é` therefore reach the running program byte-for-byte;
+  committed newlines and controls retain ordinary key semantics, and commits
+  are never treated as bracketed paste. `Ime::Preedit`, enable, and disable are
+  acknowledged but the in-progress composition is not drawn inside Noren yet.
+  The separate output limitation also remains: when a program echoes Japanese
+  input, the terminal model keeps its correct two-column layout but the 5x7
+  renderer draws unreadable replacement boxes rather than CJK glyphs.
 - **There is no accessibility surface.** Nothing in the tree integrates with
   assistive technology (no AccessKit, AT-SPI, or AppKit accessibility wiring);
   a screen reader has nothing to work with.

--- a/docs/release/install-verification-checklist.md
+++ b/docs/release/install-verification-checklist.md
@@ -66,7 +66,8 @@ version** (`window_title()` in `crates/noren-app/src/main.rs` builds it from
 binary was built as) with a workspace
 sidebar and a working local `zsh` — but **no visible cursor**, a 5x7 bitmap
 font with bounded coverage (CJK and emoji draw as replacement boxes),
-discarded IME input, no accessibility surface, and no native tabs or panes
+IME commits that reach the PTY but no on-screen preedit, no accessibility
+surface, and no native tabs or panes
 (panes are Zellij's job by design). Programs that emit colour do render
 colour; the default dark theme clears the WCAG AA floor on every
 theme-owned slot (the issue-168 fix lifted the five entries that used to

--- a/scripts/release/generate_notes.py
+++ b/scripts/release/generate_notes.py
@@ -293,7 +293,8 @@ def render(
     lines.append("> preview, not a finished terminal. Decision"
                  " [D-M8-001](../../coordination/decisions/D-M8-001-preview-scope.md)")
     lines.append("> scoped it honestly: a bitmap font with bounded coverage (no CJK")
-    lines.append("> or emoji glyphs), no IME input, no accessibility surface, macOS")
+    lines.append("> or emoji glyphs), IME commits but no preedit display, no")
+    lines.append("> accessibility surface, macOS")
     lines.append("> (Apple Silicon) only, a workspace sidebar that is a first vertical")
     lines.append("> slice rather than the full product, and fixed built-in themes. What")
     lines.append("> does not work is enumerated clause by clause in"


### PR DESCRIPTION
Closes **#204** — Japanese could not be typed into Noren at all.

`main.rs` handled `WindowEvent::Ime(_)` by calling `diagnostics::record_ime_drop()`
and **discarding the composed text unread**. Dead-key composition was dropped the
same way. Not "renders poorly" — *cannot be entered*, for the audience whose
language this product is designed in.

## What now happens

`Ime::Commit(text)` goes through `KeyEncoder::encode_committed_text` and the
ordinary `send_input` path — the same path a typed key takes, so it is not
wrapped as a bracketed paste and control characters and newlines are encoded
normally. `record_ime_drop` is no longer reachable on the commit path; it stays
where drops genuinely remain, so the diagnostic stays honest.

`set_ime_allowed` is called, and the IME cursor area is set so the platform
places the candidate window — without this macOS delivers no `Ime` events at
all and the whole feature would be dead on the owner's platform.

Preedit is acknowledged without display for now; `docs/known-limitations.md`
says so plainly, and previously did not mention input at all.

## The test net was multiplied before this PR opened

The first pass was correct on every case but each mutation failed exactly **one**
test. The independent review of #211 had just raised that shape as a MAJOR —
*the property most expensive to get wrong had the thinnest net* — so this went
back for more guards before opening.

**24 guards**, including a dedicated integration file
`crates/noren-app/tests/ime_input.rs`. Mutation counts now:

| mutation | tests failing |
|---|---|
| drop the commit text | **12** |
| write only the first byte | **10** |
| skip the encoding path | **5** |
| reverse chunk order on a large commit | **4** |

Verified by the coordinator on the merged tree — dropping the commit fails 11
distinct tests, each for a different reason: byte-for-byte `日本語`, dead-key
composition, alternate screen, bracketed-paste, newline encoding, control
characters, UTF-8 across the `READ_CHUNK_BYTES` boundary, and ordering.

`product_code_changed=no` for the hardening pass — the behaviour was already
right; only the coverage was thin.

Independent verification: **1,244 passed, 0 failed**, `fmt=0`, `clippy=0`.