### PR TITLE
feat(app): derive cell geometry from the display scale factor (#214)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Only evidence-backed work is marked complete.
 | 3 — Workspace | External workspace management (sidebar: projects, git worktrees, SSH connections, agents, terminal sessions), single-session view, session lifecycle, sidebar-state persistence, palette, configurable keybindings, Zellij pass-through — no native tabs/panes/layout (delegated to Zellij per [ADR 0003](docs/adr/0003-noren-zellij-responsibility-boundary.md)) | In progress — vertical slice landed; see [Milestone 3 status](#milestone-3-status) |
 | 4 — SSH and remote | OpenSSH configuration, connections, reconnect, remote panes, daemon decision/PoC and recovery | In progress — bounded, explicitly partial literal-alias discovery landed, and selecting an alias launches the fixed system `ssh` client in the terminal's PTY (PR #138); reconnect, remote panes, the daemon decision/PoC, and recovery are not started |
 | 5 — Agent experience | Launchers, verified adapters, trustworthy state, notifications and jump-to-source | In progress — the first launcher slice landed: `[[agents]]` configuration rows launch a configured, shell-free argv command in a real PTY (`AgentLaunchPolicy` requires an absolute program path, no shell, no `PATH` lookup; a missing or non-executable command is a visible per-row and status-row failure; agent sessions persist through `sessions.toml`). Verified adapters, trustworthy state, notifications, and jump-to-source are not started |
-| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette clears AA on every theme-owned slot since the issue-168 lift), CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`), and IME/dead-key commits reach the PTY by default. IME preedit display, CJK glyph rendering, HiDPI, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
+| 6 — Themes and accessibility | Light/dark/high-contrast palettes, contrast checks, IME/CJK/HiDPI and keyboard/accessibility work | In progress — the foundation slice landed: `[theme]` selects built-in `dark`/`light`/`high-contrast` palettes with measured, test-pinned WCAG contrast floors (`theme.rs`, `crates/noren-app/tests/theme.rs`; the default `dark` palette clears AA on every theme-owned slot since the issue-168 lift), CJK display width is verified end to end through real pixels (`crates/noren-app/tests/frame_oracle.rs`), IME/dead-key commits reach the PTY by default, and HiDPI geometry scales the logical window and configured logical cell through renderer, terminal, and PTY at startup and across display moves. IME preedit display, CJK glyph rendering, keyboard accessibility, custom palettes, and colour-vision-friendly work remain not started |
 | 7 — Quality | Unit/integration/compatibility/fault/security/visual tests, fuzzing, soak tests and benchmarks | In progress — the benchmark slice landed (PR #171): a criterion suite over the paths with a defect history (`feed_bytes`, `ssh_config_parse` incl. the #137 shape, renderer frame prep, per-frame `snapshot`, `search`) behind a `bench-support` feature gate with a recorded reference-machine baseline and a report-never-gate policy ([docs/testing/benchmarks.md](docs/testing/benchmarks.md)); its first finding (46.3 ms per-frame `snapshot` at full scrollback, filed as #172) has since been remediated — `TerminalSnapshot::from_state` shares scrollback rows instead of deep-copying them. A seeded soak harness (`crates/noren-terminal/tests/soak_feed_bytes.rs`) and a hand-rolled, dependency-free fuzz harness with a decoded-content oracle (`crates/noren-terminal/tests/fuzz_feed_bytes.rs`) landed; the fuzz campaign's first finding — SD/SU/DL stranding the cursor
 on a wide-character continuation cell — is remediated at this tree: those
 operations now end in the same shared `snap_cursor_to_lead` re-snap as
@@ -279,20 +279,19 @@ against it:
   Japanese UTF-8 and dead-key commits. The in-progress `Ime::Preedit` string is
   acknowledged without being drawn, CJK output still uses replacement boxes,
   and nothing in the tree integrates with assistive technology.
-- **HiDPI / Retina displays are unhandled.** No scale-factor awareness
-  exists anywhere in the app: the window is created at a fixed physical
-  900x600 (`with_inner_size(PhysicalSize::new(WINDOW_WIDTH,
-  WINDOW_HEIGHT))` in `main.rs`), the cell is a fixed 10x20 physical
-  pixels (`POC_CELL_WIDTH`/`POC_CELL_HEIGHT` in `lib.rs`), every grid
-  derivation downstream consumes physical pixels, and the string
-  `scale_factor` appears nowhere in the tree. On a Retina display — the
-  common case for an arm64-macOS preview, not an edge case — the window
-  opens at a quarter of the intended area with half-size glyphs, and
-  resizing grows the grid without ever growing the cell. A bigger
-  configured `[font]` cell is a workaround, not scaling. Milestone 6's
-  own line admits HiDPI has not started; the gate section must say it
-  too, because a preview user's first impression on the dominant
-  hardware class is a quarter-area window.
+- **HiDPI / Retina geometry is handled; the font is still a bitmap.** The
+  window opens at a logical 900x600, and `GridGeometry::rescale` applies the
+  active window scale factor once to the default or configured logical cell.
+  Renderer layout, terminal state, PTY winsize, pointer/selection mapping,
+  scrollback, sidebar markers, cursor placement, and IME candidate placement
+  consume the resulting physical `CellMetrics`. `ScaleFactorChanged` re-derives
+  and synchronizes the grid when a window moves between displays; a live-PTY
+  test observes the resulting `SIGWINCH`. Tests cover 1.0, fractional 1.5, and
+  2.0 factors, including byte-identical scale-1 renderer vertices and
+  configured cells scaled once. This fixes the quarter-area / half-size Retina
+  defect, but it does not turn the hand-built 5x7 glyph set into an
+  antialiased system-font renderer; the font-quality and coverage limitation
+  above remains.
 - **Paste works only inside programs that enable bracketed paste.**
   `Cmd+V` encodes the clipboard strictly as a bracketed paste:
   `paste_bytes` in `main.rs` consults the live terminal mode, and when

--- a/crates/noren-app/src/config.rs
+++ b/crates/noren-app/src/config.rs
@@ -104,7 +104,7 @@ use toml_edit::{DocumentMut, Item, TableLike};
 /// input is a [`ConfigError::TooLarge`] error instead.
 pub const MAX_CONFIG_BYTES: u64 = 64 * 1024;
 
-/// Largest accepted font cell edge in physical pixels.
+/// Largest accepted font cell edge in logical pixels.
 ///
 /// Zero is rejected outright because grid division would fault; the ceiling
 /// is policy, keeping absurdly large values an explicit error rather than a
@@ -165,7 +165,7 @@ impl Default for FontConfig {
 }
 
 impl FontConfig {
-    /// Cell width in physical pixels; defaults to [`POC_CELL_WIDTH`].
+    /// Cell width in logical pixels; defaults to [`POC_CELL_WIDTH`].
     ///
     /// Validation rejects values below the renderer's built-in
     /// [`POC_CELL_WIDTH`] or above [`MAX_CELL_EDGE`], keeping the configured
@@ -175,7 +175,7 @@ impl FontConfig {
         self.cell_width
     }
 
-    /// Cell height in physical pixels; defaults to [`POC_CELL_HEIGHT`].
+    /// Cell height in logical pixels; defaults to [`POC_CELL_HEIGHT`].
     ///
     /// Validation rejects values below the renderer's built-in
     /// [`POC_CELL_HEIGHT`] or above [`MAX_CELL_EDGE`], keeping the configured

--- a/crates/noren-app/src/frame_geometry/tests.rs
+++ b/crates/noren-app/src/frame_geometry/tests.rs
@@ -124,6 +124,143 @@ fn assert_three_consumers_agree_at(
     );
 }
 
+/// Drive the production scale -> geometry -> runtime-grid seam and compare
+/// all three consumers. Unlike `assert_three_consumers_agree_at`, this starts
+/// with configured logical cells and a window scale factor, then lets
+/// `NorenApp::prepare_initial_terminal` reserve application chrome before the
+/// terminal and PTY are created.
+fn assert_scaled_runtime_grids_agree(
+    config_text: &str,
+    scale_factor: f64,
+    physical: PhysicalSize<u32>,
+    expected_metrics: (u32, u32),
+    expected_window_grid: (u16, u16),
+) {
+    let config = AppConfig::parse(config_text).expect("valid scale test configuration");
+    let mut app = NorenApp::new(config);
+    let grid = app
+        .geometry
+        .rescale(
+            scale_factor,
+            Resize::new(physical.width, physical.height),
+        )
+        .expect("scale-aware geometry produces a window grid");
+    let metrics = app.geometry.cell_metrics();
+    assert_eq!(
+        (metrics.width(), metrics.height()),
+        expected_metrics,
+        "scale {scale_factor} must produce the expected physical cell"
+    );
+    assert_eq!(
+        (grid.rows(), grid.cols()),
+        expected_window_grid,
+        "scale {scale_factor} must produce the expected window grid"
+    );
+
+    let pty = app
+        .prepare_initial_terminal(grid)
+        .expect("window grid produces a PTY size");
+    let terminal_size = app
+        .terminal
+        .as_ref()
+        .expect("terminal installed")
+        .size();
+    assert_eq!(
+        pty.into_raw(),
+        terminal_size,
+        "scale {scale_factor}: terminal state and PTY winsize must agree"
+    );
+
+    let renderer_rows = renderer::fully_drawable_rows(physical.height, metrics);
+    assert_eq!(
+        renderer_rows,
+        usize::from(grid.rows()),
+        "scale {scale_factor}: renderer and window grid row counts must agree"
+    );
+    let layout = renderer::FrameRowLayout::new(
+        physical.height,
+        metrics,
+        usize::from(terminal_size.0),
+        true,
+    )
+    .expect("non-zero scaled frame");
+    assert_eq!(
+        layout.rendered_rows(),
+        renderer_rows,
+        "scale {scale_factor}: terminal rows plus status chrome must fill the renderer grid"
+    );
+    assert_eq!(
+        layout.row_at(usize::from(terminal_size.0)),
+        Some(renderer::FrameRow::Status),
+        "scale {scale_factor}: renderer must reserve the same status row omitted from PTY/state"
+    );
+
+    let terminal = app.terminal.as_mut().expect("terminal remains installed");
+    terminal.feed_bytes(b"\x1b[?25l");
+    terminal.feed_bytes(&vec![b'B'; usize::from(terminal_size.1)]);
+    let snapshot = terminal.snapshot();
+    let sidebar: Vec<String> = Vec::new();
+    let vertices = renderer::glyph_vertices_for(
+        renderer::Target::new(
+            &noren_app::theme::Theme::default(),
+            physical.width,
+            physical.height,
+            metrics,
+        )
+        .with_sidebar_columns(app.sidebar_columns),
+        Some(&snapshot),
+        Some(sidebar.as_slice()),
+        None,
+    );
+    let renderer_cols = rendered_terminal_columns(
+        &vertices,
+        physical.width,
+        metrics.width(),
+        app.sidebar_columns,
+    );
+    assert_eq!(
+        renderer_cols,
+        usize::from(terminal_size.1),
+        "scale {scale_factor}: renderer columns, terminal state, and PTY winsize must agree"
+    );
+}
+
+#[test]
+fn hidpi_default_scales_keep_renderer_terminal_and_pty_grids_equal() {
+    for (scale_factor, physical, expected_metrics) in [
+        (1.0, PhysicalSize::new(900, 600), (10, 20)),
+        (1.5, PhysicalSize::new(1_350, 900), (15, 30)),
+        (2.0, PhysicalSize::new(1_800, 1_200), (20, 40)),
+    ] {
+        assert_scaled_runtime_grids_agree(
+            "",
+            scale_factor,
+            physical,
+            expected_metrics,
+            (30, 90),
+        );
+    }
+}
+
+#[test]
+fn hidpi_configured_cells_scale_once_and_keep_all_three_grids_equal() {
+    let config = "[font]\ncell_width = 12\ncell_height = 24\n";
+    assert_scaled_runtime_grids_agree(
+        config,
+        1.0,
+        PhysicalSize::new(900, 600),
+        (12, 24),
+        (25, 75),
+    );
+    assert_scaled_runtime_grids_agree(
+        config,
+        2.0,
+        PhysicalSize::new(1_800, 1_200),
+        (24, 48),
+        (25, 75),
+    );
+}
+
 /// The PR's headline property: the three consumers agree once the sidebar
 /// reserves 16 columns — swept across the input range rather than pinned at
 /// one width. A single point cannot support "agreement across the range",

--- a/crates/noren-app/src/lib.rs
+++ b/crates/noren-app/src/lib.rs
@@ -72,9 +72,9 @@ pub const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(2);
 /// (issue #185) so they cannot drift apart again.
 pub const PRODUCT_NAME: &str = "Noren";
 
-/// Fixed PoC cell width in physical pixels.
+/// Default terminal-cell width in logical pixels.
 pub const POC_CELL_WIDTH: u32 = 10;
-/// Fixed PoC cell height in physical pixels.
+/// Default terminal-cell height in logical pixels.
 pub const POC_CELL_HEIGHT: u32 = 20;
 
 /// Maximum terminal grid rows the PoC renderer can draw.
@@ -150,16 +150,16 @@ impl GridSize {
     }
 }
 
-/// Runtime cell metrics: the configured width and height of one terminal grid
-/// cell in physical pixels.
+/// Runtime cell metrics: the scale-adjusted width and height of one terminal
+/// grid cell in physical pixels.
 ///
-/// `GridGeometry` produces this from configuration; every consumer — the
+/// [`GridGeometry`] applies the window scale factor exactly once to the
+/// configured logical cell size. Every physical-pixel consumer — the
 /// renderer's `glyph_vertices`, the offscreen capture path, and the binary's
-/// click-to-grid mappers — reads width and height from this single value
-/// rather than from a compile-time constant. Bundling the two dimensions
-/// prevents width and height from drifting to different origins at a call
-/// site (the defect from issue #76: the renderer drew at the constant while
-/// the geometry used the configured value).
+/// click-to-grid mappers — reads width and height from this single value.
+/// Bundling the two dimensions prevents width and height from drifting to
+/// different origins at a call site (the defect from issue #76: the renderer
+/// drew at the constant while the geometry used the configured value).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CellMetrics {
     width: u32,
@@ -180,26 +180,33 @@ impl CellMetrics {
     }
 }
 
-/// Deterministic fixed-cell geometry and resize coalescing.
+/// Deterministic scale-aware fixed-cell geometry and resize coalescing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GridGeometry {
+    configured_cell_width: u32,
+    configured_cell_height: u32,
     cell_width: u32,
     cell_height: u32,
+    scale_factor_bits: u64,
     current: Option<GridSize>,
 }
 
 impl GridGeometry {
-    /// PoC geometry: 10 physical pixels wide by 20 physical pixels high.
+    /// Default geometry: 10 logical pixels wide by 20 logical pixels high at
+    /// scale factor 1.0.
     #[must_use]
     pub const fn poc() -> Self {
         Self {
+            configured_cell_width: POC_CELL_WIDTH,
+            configured_cell_height: POC_CELL_HEIGHT,
             cell_width: POC_CELL_WIDTH,
             cell_height: POC_CELL_HEIGHT,
+            scale_factor_bits: 1.0_f64.to_bits(),
             current: None,
         }
     }
 
-    /// Geometry with configuration-chosen cell dimensions.
+    /// Geometry with configuration-chosen logical cell dimensions.
     ///
     /// A zero edge is rejected because grid division would fault; the
     /// configuration loader ([`crate::config`]) range-checks values before
@@ -210,13 +217,16 @@ impl GridGeometry {
             return None;
         }
         Some(Self {
+            configured_cell_width: cell_width,
+            configured_cell_height: cell_height,
             cell_width,
             cell_height,
+            scale_factor_bits: 1.0_f64.to_bits(),
             current: None,
         })
     }
 
-    /// Configured cell width in physical pixels.
+    /// Scale-adjusted cell width in physical pixels.
     ///
     /// This is the single runtime source of truth for cell width: the renderer,
     /// the click-to-grid mapper, and the sidebar boundary all read it from here
@@ -226,7 +236,7 @@ impl GridGeometry {
         self.cell_width
     }
 
-    /// Configured cell height in physical pixels.
+    /// Scale-adjusted cell height in physical pixels.
     ///
     /// See [`cell_width`](Self::cell_width) for the single-source rationale.
     #[must_use]
@@ -234,9 +244,9 @@ impl GridGeometry {
         self.cell_height
     }
 
-    /// The configured [`CellMetrics`] — the single runtime source of truth
-    /// for cell size, threaded to the renderer and click-handling code so
-    /// every consumer reads the same width and height.
+    /// The scale-adjusted [`CellMetrics`] — the single runtime source of truth
+    /// for physical cell size, threaded to the renderer and click-handling
+    /// code so every consumer reads the same width and height.
     #[must_use]
     pub const fn cell_metrics(self) -> CellMetrics {
         CellMetrics {
@@ -251,6 +261,12 @@ impl GridGeometry {
         self.current
     }
 
+    /// Window scale factor used to derive the current physical cell metrics.
+    #[must_use]
+    pub const fn scale_factor(self) -> f64 {
+        f64::from_bits(self.scale_factor_bits)
+    }
+
     /// Convert a physical resize and return only a changed, non-zero grid.
     ///
     /// A zero physical dimension keeps the previous grid. Pixel sizes smaller
@@ -260,6 +276,33 @@ impl GridGeometry {
     /// rendered grids can never disagree. This is the only place a grid is
     /// calculated; every consumer observes the same clamp.
     pub fn update(&mut self, resize: Resize) -> Option<GridSize> {
+        self.update_inner(resize, false)
+    }
+
+    /// Apply a window scale factor exactly once and re-derive the grid.
+    ///
+    /// Configured cell dimensions are logical pixels. They are always scaled
+    /// from their original configured values, never from the previously
+    /// scaled metrics, so moving 1.0 -> 2.0 -> 1.0 cannot accumulate or
+    /// double-apply scaling. A valid changed factor forces a returned grid
+    /// even when the resulting row/column counts equal the current grid; the
+    /// application uses that notification to refresh terminal state and the
+    /// PTY winsize on `ScaleFactorChanged`.
+    ///
+    /// Non-positive and non-finite factors are ignored. A zero-sized window
+    /// still updates the physical cell metrics but retains the last valid grid
+    /// until a subsequent non-zero resize arrives.
+    pub fn rescale(&mut self, scale_factor: f64, resize: Resize) -> Option<GridSize> {
+        let cell_width = scaled_cell_edge(self.configured_cell_width, scale_factor)?;
+        let cell_height = scaled_cell_edge(self.configured_cell_height, scale_factor)?;
+        let scale_changed = self.scale_factor_bits != scale_factor.to_bits();
+        self.cell_width = cell_width;
+        self.cell_height = cell_height;
+        self.scale_factor_bits = scale_factor.to_bits();
+        self.update_inner(resize, scale_changed)
+    }
+
+    fn update_inner(&mut self, resize: Resize, force: bool) -> Option<GridSize> {
         if resize.is_zero() {
             return None;
         }
@@ -272,13 +315,26 @@ impl GridGeometry {
             .try_into()
             .unwrap_or(MAX_RENDER_ROWS);
         let next = GridSize { rows, cols };
-        if self.current == Some(next) {
+        if !force && self.current == Some(next) {
             None
         } else {
             self.current = Some(next);
             Some(next)
         }
     }
+}
+
+/// Scale one configured logical cell edge with the same round-to-nearest
+/// convention winit uses for logical-to-physical conversion.
+fn scaled_cell_edge(configured: u32, scale_factor: f64) -> Option<u32> {
+    if !scale_factor.is_finite() || scale_factor <= 0.0 {
+        return None;
+    }
+    let scaled = f64::from(configured) * scale_factor;
+    if !scaled.is_finite() {
+        return None;
+    }
+    Some(scaled.round().clamp(1.0, f64::from(u32::MAX)) as u32)
 }
 
 /// Active modifier keys on an app-owned key event.
@@ -836,6 +892,133 @@ mod tests {
             (at_cap.rows(), at_cap.cols()),
             (MAX_RENDER_ROWS, MAX_RENDER_COLS)
         );
+    }
+
+    #[test]
+    fn scale_one_keeps_the_previous_cell_metrics_and_grid_exactly() {
+        let mut geometry = GridGeometry::poc();
+        let before = geometry.cell_metrics();
+        let grid = geometry.update(Resize::new(900, 600)).expect("new grid");
+
+        assert_eq!((before.width(), before.height()), (10, 20));
+        assert_eq!((grid.rows(), grid.cols()), (30, 90));
+        assert_eq!(geometry.rescale(1.0, Resize::new(900, 600)), None);
+        assert_eq!(geometry.cell_metrics(), before);
+        assert_eq!(geometry.current(), Some(grid));
+        assert_eq!(geometry.scale_factor(), 1.0);
+    }
+
+    #[test]
+    fn non_unit_scale_factors_change_physical_cells_without_changing_logical_grid() {
+        for (scale_factor, physical, expected_cell) in [
+            (1.5, Resize::new(1_350, 900), (15, 30)),
+            (2.0, Resize::new(1_800, 1_200), (20, 40)),
+        ] {
+            let mut geometry = GridGeometry::poc();
+            let grid = geometry
+                .rescale(scale_factor, physical)
+                .expect("scale change re-derives the grid");
+
+            assert_eq!(
+                (
+                    geometry.cell_metrics().width(),
+                    geometry.cell_metrics().height()
+                ),
+                expected_cell,
+                "scale {scale_factor} must change the physical cell"
+            );
+            assert_eq!(
+                (grid.rows(), grid.cols()),
+                (30, 90),
+                "scale {scale_factor} must preserve the 900x600 logical grid"
+            );
+        }
+    }
+
+    #[test]
+    fn configured_cells_are_scaled_from_the_config_once() {
+        let mut geometry = GridGeometry::with_cells(12, 24).expect("valid configured cell");
+
+        let grid = geometry
+            .rescale(2.0, Resize::new(2_160, 1_440))
+            .expect("scale change re-derives configured geometry");
+        assert_eq!(
+            (
+                geometry.cell_metrics().width(),
+                geometry.cell_metrics().height()
+            ),
+            (24, 48),
+            "12x24 at 2x is 24x48, not the 48x96 produced by double scaling"
+        );
+        assert_eq!((grid.rows(), grid.cols()), (30, 90));
+
+        geometry
+            .rescale(1.5, Resize::new(1_620, 1_080))
+            .expect("second scale change re-derives from configured cells");
+        assert_eq!(
+            (
+                geometry.cell_metrics().width(),
+                geometry.cell_metrics().height()
+            ),
+            (18, 36)
+        );
+        geometry
+            .rescale(2.0, Resize::new(2_160, 1_440))
+            .expect("returning to 2x re-derives from configured cells");
+        assert_eq!(
+            (
+                geometry.cell_metrics().width(),
+                geometry.cell_metrics().height()
+            ),
+            (24, 48),
+            "scale changes must not compound on the last physical metrics"
+        );
+    }
+
+    #[test]
+    fn fractional_scale_rounds_cell_edges_without_losing_a_default_row_or_column() {
+        let mut geometry = GridGeometry::poc();
+        let grid = geometry
+            .rescale(1.5, Resize::new(1_350, 900))
+            .expect("fractional scale is valid");
+
+        assert_eq!((geometry.cell_width(), geometry.cell_height()), (15, 30));
+        assert_eq!((grid.rows(), grid.cols()), (30, 90));
+        assert_eq!(
+            geometry.update(Resize::new(1_349, 899)),
+            Some(GridSize { rows: 29, cols: 89 }),
+            "only a genuinely incomplete physical cell may reduce the grid"
+        );
+    }
+
+    #[test]
+    fn a_changed_scale_forces_a_grid_notification_even_when_dimensions_match() {
+        let mut geometry = GridGeometry::poc();
+        let original = geometry.update(Resize::new(900, 600)).expect("new grid");
+
+        let rederived = geometry
+            .rescale(2.0, Resize::new(1_800, 1_200))
+            .expect("a scale event must not be coalesced as a duplicate grid");
+
+        assert_eq!(rederived, original);
+        assert_eq!(geometry.current(), Some(original));
+        assert_eq!((geometry.cell_width(), geometry.cell_height()), (20, 40));
+    }
+
+    #[test]
+    fn invalid_scale_factors_leave_metrics_and_grid_unchanged() {
+        for scale_factor in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let mut geometry = GridGeometry::poc();
+            let original = geometry.update(Resize::new(900, 600)).expect("new grid");
+
+            assert_eq!(
+                geometry.rescale(scale_factor, Resize::new(1_800, 1_200)),
+                None
+            );
+            assert_eq!((geometry.cell_width(), geometry.cell_height()), (10, 20));
+            assert_eq!(geometry.current(), Some(original));
+            assert_eq!(geometry.scale_factor(), 1.0);
+        }
     }
 
     #[test]

--- a/crates/noren-app/src/main.rs
+++ b/crates/noren-app/src/main.rs
@@ -69,7 +69,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use winit::application::ApplicationHandler;
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, Ime, KeyEvent, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key as WinitKey, ModifiersState, NamedKey};
@@ -1160,6 +1160,19 @@ enum TerminalWheelRoute {
     ForwardedToApplication(Vec<Vec<u8>>),
 }
 
+/// Native window geometry reduced to the physical facts the application
+/// consumes. Tests drive this seam without constructing winit's private
+/// `InnerSizeWriter`, while production maps both relevant `WindowEvent`
+/// variants into it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum WindowGeometryChange {
+    Resized(PhysicalSize<u32>),
+    ScaleFactorChanged {
+        scale_factor: f64,
+        physical: PhysicalSize<u32>,
+    },
+}
+
 struct NorenApp {
     window: Option<Arc<Window>>,
     renderer: Option<Renderer>,
@@ -1717,7 +1730,8 @@ impl NorenApp {
         let changed = match self.window.as_ref() {
             Some(window) => {
                 let size = window.inner_size();
-                self.geometry.update(Resize::new(size.width, size.height))
+                self.geometry
+                    .rescale(window.scale_factor(), Resize::new(size.width, size.height))
             }
             None => self
                 .geometry
@@ -2299,7 +2313,7 @@ impl NorenApp {
         }
         let attributes = Window::default_attributes()
             .with_title(window_title())
-            .with_inner_size(PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
+            .with_inner_size(LogicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT));
         let Ok(window) = event_loop.create_window(attributes) else {
             eprintln!("Noren window creation failed");
             event_loop.exit();
@@ -2311,10 +2325,10 @@ impl NorenApp {
         // of being lost between keyboard events.
         window.set_ime_allowed(true);
         let physical = window.inner_size();
-        let Some(grid) = self
-            .geometry
-            .update(Resize::new(physical.width, physical.height))
-        else {
+        let Some(grid) = self.geometry.rescale(
+            window.scale_factor(),
+            Resize::new(physical.width, physical.height),
+        ) else {
             eprintln!("Noren initial window size was invalid");
             event_loop.exit();
             return;
@@ -3495,14 +3509,26 @@ impl NorenApp {
             .with_keypad(keypad_mode)
     }
 
-    fn handle_resize(&mut self, physical: PhysicalSize<u32>) {
+    fn handle_window_geometry_change(&mut self, change: WindowGeometryChange) {
+        let physical = match change {
+            WindowGeometryChange::Resized(physical)
+            | WindowGeometryChange::ScaleFactorChanged { physical, .. } => physical,
+        };
         if let Some(renderer) = &mut self.renderer {
             renderer.resize(physical);
         }
-        if let Some(grid) = self
-            .geometry
-            .update(Resize::new(physical.width, physical.height))
-        {
+        let resize = Resize::new(physical.width, physical.height);
+        let changed_grid = match change {
+            WindowGeometryChange::Resized(_) => self.geometry.update(resize),
+            WindowGeometryChange::ScaleFactorChanged { scale_factor, .. } => {
+                let grid = self.geometry.rescale(scale_factor, resize);
+                if let Some(renderer) = &mut self.renderer {
+                    renderer.set_cell_metrics(self.geometry.cell_metrics());
+                }
+                grid
+            }
+        };
+        if let Some(grid) = changed_grid {
             self.pending_grid = Some(grid);
         }
         let visible_rows =
@@ -3515,10 +3541,19 @@ impl NorenApp {
         let Some(grid) = self.pending_grid.take() else {
             return;
         };
-        // Resize re-addresses the grid, so captured coordinates expire.
-        self.selection = None;
-        self.drag_origin = None;
         let runtime = RuntimeGridSize::from_window(grid, self.sidebar_columns);
+        // A changed grid re-addresses captured coordinates. A display move
+        // can force this synchronization with the same row/column counts;
+        // preserve a still-valid selection in that case while still updating
+        // terminal state and the PTY winsize.
+        let active_grid_changed = self
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal.size() != (runtime.rows, runtime.cols));
+        if active_grid_changed {
+            self.selection = None;
+            self.drag_origin = None;
+        }
         if let Some(terminal) = &mut self.terminal {
             if runtime.resize_terminal(terminal).is_err() {
                 self.status = "Noren terminal resize failed";
@@ -3831,7 +3866,20 @@ impl ApplicationHandler for NorenApp {
         }
         match event {
             WindowEvent::CloseRequested => self.close(event_loop),
-            WindowEvent::Resized(physical) => self.handle_resize(physical),
+            WindowEvent::Resized(physical) => {
+                self.handle_window_geometry_change(WindowGeometryChange::Resized(physical));
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                let physical = self
+                    .window
+                    .as_ref()
+                    .expect("accepted window event has a live window")
+                    .inner_size();
+                self.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+                    scale_factor,
+                    physical,
+                });
+            }
             WindowEvent::Focused(focused) => {
                 // Focus loss must be visible in the caret (issue #200): the
                 // renderer switches between the focused mark and the

--- a/crates/noren-app/src/main/tests.rs
+++ b/crates/noren-app/src/main/tests.rs
@@ -517,6 +517,177 @@ fn configured_cell_sizes_drive_the_app_geometry() {
 }
 
 #[test]
+fn scale_factor_change_rederives_an_equal_grid_and_forces_runtime_sync() {
+    let mut app = NorenApp::default();
+    let original = app
+        .geometry
+        .update(Resize::new(900, 600))
+        .expect("initial physical size produces a grid");
+    let initial_pty = app
+        .prepare_initial_terminal(original)
+        .expect("initial grid produces terminal and PTY sizes");
+    assert_eq!(initial_pty.into_raw(), (29, 74));
+
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 2.0,
+        physical: PhysicalSize::new(1_800, 1_200),
+    });
+
+    assert_eq!(app.geometry.scale_factor(), 2.0);
+    assert_eq!(
+        (app.geometry.cell_width(), app.geometry.cell_height()),
+        (20, 40)
+    );
+    assert_eq!(
+        app.pending_grid,
+        Some(original),
+        "the equal 30x90 grid must still be marked pending on a scale event"
+    );
+
+    app.apply_pending_resize();
+    assert_eq!(
+        app.terminal.as_ref().expect("terminal retained").size(),
+        (29, 74),
+        "terminal state must be synchronized through the scale event"
+    );
+    assert_eq!(app.pending_grid, None);
+}
+
+#[test]
+fn fractional_scale_factor_change_uses_new_cells_for_the_new_runtime_grid() {
+    let mut app = NorenApp::default();
+    let original = app
+        .geometry
+        .update(Resize::new(900, 600))
+        .expect("initial physical size produces a grid");
+    app.prepare_initial_terminal(original)
+        .expect("initial grid produces terminal and PTY sizes");
+
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 1.5,
+        physical: PhysicalSize::new(1_530, 960),
+    });
+
+    assert_eq!(
+        (app.geometry.cell_width(), app.geometry.cell_height()),
+        (15, 30)
+    );
+    let pending = app.pending_grid.expect("scale event re-derives the grid");
+    assert_eq!((pending.rows(), pending.cols()), (32, 102));
+    app.apply_pending_resize();
+    assert_eq!(
+        app.terminal.as_ref().expect("terminal retained").size(),
+        (31, 86),
+        "terminal rows/columns use the fractional physical cells before chrome is reserved"
+    );
+}
+
+#[test]
+fn scale_factor_change_scales_configured_cells_once_in_the_app_path() {
+    let config = AppConfig::parse("[font]\ncell_width = 12\ncell_height = 24\n")
+        .expect("valid configured cells");
+    let mut app = NorenApp::new(config);
+    let original = app
+        .geometry
+        .update(Resize::new(900, 600))
+        .expect("initial configured grid");
+    app.prepare_initial_terminal(original)
+        .expect("initial configured runtime surfaces");
+
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 2.0,
+        physical: PhysicalSize::new(1_800, 1_200),
+    });
+
+    assert_eq!(
+        (app.geometry.cell_width(), app.geometry.cell_height()),
+        (24, 48),
+        "the configured 12x24 cell is scaled to 24x48 exactly once"
+    );
+    assert_eq!(app.pending_grid, Some(original));
+    app.apply_pending_resize();
+    assert_eq!(
+        app.terminal.as_ref().expect("terminal retained").size(),
+        (24, 59)
+    );
+}
+
+#[test]
+fn equal_grid_scale_change_preserves_selection_and_scrollback_offset() {
+    let mut terminal = TerminalState::new(3, 8).expect("valid terminal");
+    terminal.feed_bytes(b"one\r\ntwo\r\nthree\r\nfour");
+    assert_eq!(terminal.scrollback_len(), 1);
+    let selection = Selection::entire_grid(&terminal);
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        selection: Some(selection),
+        scroll_offset: 1,
+        ..Default::default()
+    };
+    let initial = app
+        .geometry
+        .update(Resize::new(240, 80))
+        .expect("4x24 window grid");
+    assert_eq!((initial.rows(), initial.cols()), (4, 24));
+
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 2.0,
+        physical: PhysicalSize::new(480, 160),
+    });
+    app.apply_pending_resize();
+
+    let terminal = app.terminal.as_ref().expect("terminal retained");
+    assert_eq!(terminal.size(), (3, 8));
+    assert_eq!(
+        app.scroll_offset, 1,
+        "valid history offset survives display move"
+    );
+    assert!(
+        app.selection
+            .as_ref()
+            .is_some_and(|selection| selection.is_valid(terminal)),
+        "an equal logical grid keeps the selection's grid coordinates valid"
+    );
+}
+
+#[test]
+fn scaled_metrics_keep_selection_hit_testing_and_ime_on_the_same_pixels() {
+    let mut terminal = TerminalState::new(3, 8).expect("valid terminal");
+    terminal.feed_bytes(b"\x1b[2;3HA\x1b[2;3H");
+    let mut app = NorenApp {
+        terminal: Some(terminal),
+        ..Default::default()
+    };
+    app.geometry
+        .update(Resize::new(240, 80))
+        .expect("4x24 window grid");
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 2.0,
+        physical: PhysicalSize::new(480, 160),
+    });
+    app.apply_pending_resize();
+
+    let terminal_edge = sidebar_pixel_width_at_width(20, app.sidebar_columns);
+    let caret_pixel = PhysicalPosition::new(terminal_edge + 2.0 * 20.0 + 1.0, 40.0 + 1.0);
+    assert_eq!(
+        app.grid_point_in_frame(caret_pixel, PhysicalSize::new(480, 160)),
+        Some(GridPoint::new(1, 2)),
+        "scaled selection hit testing must land on the cursor's logical cell"
+    );
+
+    let target = RecordingImeCursorArea::default();
+    app.prepare_redraw(Some(&target));
+    assert_eq!(
+        target.last(),
+        (
+            PhysicalPosition::new(terminal_edge + 2.0 * 20.0, 40.0),
+            PhysicalSize::new(20, 40),
+        ),
+        "IME candidate area must use the same scaled cell box as hit testing"
+    );
+}
+
+#[test]
 fn configured_sidebar_columns_reach_app_terminal_pty_and_text() {
     let config = AppConfig::parse("[sidebar]\ncolumns = 24\n").expect("valid configuration");
     let mut app = NorenApp::new(config);
@@ -2866,7 +3037,7 @@ fn sidebar_scroll_reveals_and_selects_ssh_without_terminal_mouse_output() {
     );
 
     let tall_frame = PhysicalSize::new(frame_size.width, 7 * metrics.height());
-    app.handle_resize(tall_frame);
+    app.handle_window_geometry_change(WindowGeometryChange::Resized(tall_frame));
     assert_eq!(
         app.sidebar_scroll_offset, 0,
         "a taller frame clamps the obsolete scroll offset"
@@ -4293,6 +4464,73 @@ fn wait_for_shell_output(app: &mut NorenApp) {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
+}
+
+#[test]
+fn scale_factor_change_sends_sigwinch_with_rederived_pty_size() {
+    const READY: &str = "HIDPI_TRAP_READY";
+    const OBSERVED: &str = "HIDPI_WINCH:33 86";
+
+    let home = AppTestHome::new();
+    let mut app = home.app();
+    app.run_workspace_action(WorkspaceAction::CreateSession);
+    wait_for_shell_output(&mut app);
+    assert_eq!(
+        app.terminal.as_ref().expect("live terminal").size(),
+        (29, 74),
+        "headless test session starts at the 900x600 scale-one runtime grid"
+    );
+
+    assert!(app.send_input(
+        b"/bin/stty -echo\nTRAPWINCH() { printf 'HIDPI_WINCH:'; /bin/stty size; }\nprintf 'HIDPI_TRAP_READY\\n'\n"
+    ));
+    let ready_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        app.drain_pty();
+        let text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
+        if text.contains(READY) {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "SIGWINCH trap was not armed; terminal said: {text:?}"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    app.handle_window_geometry_change(WindowGeometryChange::ScaleFactorChanged {
+        scale_factor: 2.0,
+        physical: PhysicalSize::new(2_040, 1_360),
+    });
+    let pending = app
+        .pending_grid
+        .expect("scale change queues the re-derived 34x102 window grid");
+    assert_eq!((pending.rows(), pending.cols()), (34, 102));
+    app.apply_pending_resize();
+    assert_eq!(
+        app.terminal
+            .as_ref()
+            .expect("live terminal retained")
+            .size(),
+        (33, 86),
+        "terminal state must receive the same status/sidebar-adjusted grid as the PTY"
+    );
+
+    let winch_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        app.drain_pty();
+        let text = app.terminal.as_ref().map(terminal_text).unwrap_or_default();
+        if text.contains(OBSERVED) {
+            break;
+        }
+        assert!(
+            Instant::now() < winch_deadline,
+            "running zsh did not observe SIGWINCH with 33x86; terminal said: {text:?}"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    app.teardown();
 }
 
 #[derive(Clone, Copy)]

--- a/crates/noren-app/src/renderer.rs
+++ b/crates/noren-app/src/renderer.rs
@@ -556,6 +556,16 @@ impl Renderer {
         self.cursor = self.cursor.with_focus(focused);
     }
 
+    /// Replace the physical cell metrics after a window scale-factor change.
+    ///
+    /// The surface size and cell metrics change as one application geometry
+    /// event. Keeping this setter on the live renderer prevents the issue #76
+    /// split where grid derivation changed but glyph placement retained stale
+    /// metrics.
+    pub(crate) fn set_cell_metrics(&mut self, metrics: CellMetrics) {
+        self.metrics = metrics;
+    }
+
     pub(crate) fn resize(&mut self, size: PhysicalSize<u32>) {
         if size.width == 0 || size.height == 0 {
             return;
@@ -2131,11 +2141,11 @@ fn glyph_rows(character: char) -> [u8; 7] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use noren_app::GridGeometry;
     use noren_app::config::AppConfig;
     use noren_app::theme::DARK;
     use noren_app::ui::palette_hint;
-    use noren_terminal::TerminalState;
+    use noren_app::{GridGeometry, Resize};
+    use noren_terminal::{GridPoint, SelectionMode, TerminalState};
 
     /// Default-theme vertex emission for test call sites: the shape the
     /// pre-theme tests used, now entering through the [`Target`] seam.
@@ -3267,6 +3277,147 @@ mod tests {
                 .chunks_exact(6)
                 .any(|rect| (rect[0].position[0] - small_edge_1).abs() < 1e-5),
             "at cell_width=20, no vertex should land at the 10px column boundary"
+        );
+    }
+
+    #[test]
+    fn scale_one_keeps_renderer_vertex_bytes_identical() {
+        let terminal = snapshot(2, 8, b"AB\r\nCD");
+        let baseline_metrics = poc_metrics();
+        let baseline = frame_vertices(
+            Some(&terminal),
+            None,
+            Some("Noren ready"),
+            900,
+            600,
+            baseline_metrics,
+        );
+        let mut geometry = GridGeometry::poc();
+        geometry
+            .rescale(1.0, Resize::new(900, 600))
+            .expect("fresh scale-one geometry produces a grid");
+        let scaled = frame_vertices(
+            Some(&terminal),
+            None,
+            Some("Noren ready"),
+            900,
+            600,
+            geometry.cell_metrics(),
+        );
+
+        assert_eq!(
+            vertex_bytes(&scaled),
+            vertex_bytes(&baseline),
+            "scale 1.0 must preserve every renderer byte from the pre-HiDPI path"
+        );
+    }
+
+    #[test]
+    fn scaled_cells_keep_cursor_selection_scrollback_and_sidebar_marker_aligned() {
+        let mut geometry = GridGeometry::poc();
+        geometry
+            .rescale(2.0, Resize::new(480, 120))
+            .expect("2x geometry produces a grid");
+        let metrics = geometry.cell_metrics();
+        assert_eq!((metrics.width(), metrics.height()), (20, 40));
+        let target = Target::new(&Theme::default(), 480, 120, metrics);
+        let terminal_left = SIDEBAR_COLS as u32 * metrics.width();
+        let pixel_x = |ndc: f32| (((ndc + 1.0) * 0.5 * target.width as f32).round()) as u32;
+        let pixel_y = |ndc: f32| (((1.0 - ndc) * 0.5 * target.height as f32).round()) as u32;
+        let bounds = |vertices: &[Vertex]| {
+            let left = vertices
+                .iter()
+                .map(|vertex| pixel_x(vertex.position[0]))
+                .min()
+                .expect("geometry emits vertices");
+            let right = vertices
+                .iter()
+                .map(|vertex| pixel_x(vertex.position[0]))
+                .max()
+                .expect("geometry emits vertices");
+            let top = vertices
+                .iter()
+                .map(|vertex| pixel_y(vertex.position[1]))
+                .min()
+                .expect("geometry emits vertices");
+            let bottom = vertices
+                .iter()
+                .map(|vertex| pixel_y(vertex.position[1]))
+                .max()
+                .expect("geometry emits vertices");
+            (left, top, right, bottom)
+        };
+
+        let cursor = snapshot(3, 8, b"\x1b[2;3H");
+        let cursor_vertices =
+            glyph_vertices_for_chrome(target, Some(&cursor), FrameChrome::new(Some(&[]), None));
+        assert_eq!(
+            bounds(&cursor_vertices),
+            (terminal_left + 2 * 20, 40, terminal_left + 3 * 20, 80),
+            "the 2x cursor block must occupy exactly row 1, column 2"
+        );
+
+        let mut selected_terminal = TerminalState::new(3, 8).expect("valid selected terminal");
+        selected_terminal.feed_bytes(b"\x1b[?25l\x1b[2;3HAB");
+        let selection = Selection::new(
+            &selected_terminal,
+            SelectionMode::Char,
+            GridPoint::new(1, 2),
+            GridPoint::new(1, 3),
+        );
+        let selected = selected_terminal.snapshot();
+        let selected_vertices = glyph_vertices_for_chrome(
+            target,
+            Some(&selected),
+            FrameChrome::new(Some(&[]), None).with_selection(Some(&selection)),
+        );
+        let selection_color = target.theme.selection_background();
+        let selection_backgrounds: Vec<Vertex> = selected_vertices
+            .chunks_exact(VERTICES_PER_RECT)
+            .filter(|rectangle| {
+                rectangle
+                    .iter()
+                    .all(|vertex| vertex.color == selection_color)
+            })
+            .flat_map(|rectangle| rectangle.iter().copied())
+            .collect();
+        assert_eq!(selection_backgrounds.len(), 2 * VERTICES_PER_RECT);
+        assert_eq!(
+            bounds(&selection_backgrounds),
+            (terminal_left + 2 * 20, 40, terminal_left + 4 * 20, 80),
+            "the selected two-cell span must cover exactly the scaled cells"
+        );
+
+        let history = snapshot(2, 8, b"\x1b[?25l\x1b[1;4HA\r\nB\r\nC");
+        assert_eq!(history.scrollback_lines(), ["   A"], "history fixture");
+        let history_vertices = glyph_vertices_for_chrome(
+            target,
+            Some(&history),
+            FrameChrome::new(Some(&[]), None).with_scroll_offset(1),
+        );
+        assert!(
+            history_vertices.iter().any(|vertex| {
+                let x = pixel_x(vertex.position[0]);
+                let y = pixel_y(vertex.position[1]);
+                (terminal_left + 3 * 20..=terminal_left + 4 * 20).contains(&x) && y <= 40
+            }),
+            "the scrolled-back column-3 glyph must land in scaled row 0, column 3"
+        );
+
+        let marker = SidebarTextRow::chrome(format!("{:>width$}", '▶', width = SIDEBAR_COLS));
+        let marker_vertices = glyph_vertices_for_sidebar_rows(
+            target,
+            None,
+            Some(std::slice::from_ref(&marker)),
+            None,
+        );
+        let marker_bounds = bounds(&marker_vertices);
+        assert!(
+            marker_bounds.0 >= (SIDEBAR_COLS as u32 - 1) * 20
+                && marker_bounds.2 <= SIDEBAR_COLS as u32 * 20
+                && marker_bounds.1 < 40
+                && marker_bounds.3 <= 40,
+            "sidebar marker must remain inside its final scaled sidebar cell: {marker_bounds:?}"
         );
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,8 +35,8 @@ symlinks are followed like any user-owned file under those same bounds.
 
 | Key | Type | Default | Accepted range | Meaning |
 | --- | --- | --- | --- | --- |
-| `cell_width` | integer | `10` (`POC_CELL_WIDTH`) | `POC_CELL_WIDTH..=1024` | Cell width in physical pixels used to convert window size into the terminal grid. |
-| `cell_height` | integer | `20` (`POC_CELL_HEIGHT`) | `POC_CELL_HEIGHT..=1024` | Cell height in physical pixels used to convert window size into the terminal grid. |
+| `cell_width` | integer | `10` (`POC_CELL_WIDTH`) | `POC_CELL_WIDTH..=1024` | Cell width in logical pixels; the active window scale factor produces the physical renderer/grid width. |
+| `cell_height` | integer | `20` (`POC_CELL_HEIGHT`) | `POC_CELL_HEIGHT..=1024` | Cell height in logical pixels; the active window scale factor produces the physical renderer/grid height. |
 
 The lower bound is the renderer's built-in cell constant (`MAX_CELL_EDGE`,
 1024, is the upper bound). A cell smaller than the renderer constant would
@@ -47,6 +47,13 @@ would fault. The derived grid is still clamped to the renderer's drawable
 grid (`MAX_RENDER_ROWS` by `MAX_RENDER_COLS`, 60 by 160), which is far inside
 the terminal foundation's `MAX_SCREEN_CELLS` bound, so no configuration value
 can push the grid past that ceiling.
+
+Scaling is automatic and does not replace configured control. For example,
+`cell_width = 12` and `cell_height = 24` produce a 12x24 physical cell at
+scale 1.0 and a 24x48 physical cell at scale 2.0. Each physical edge is
+rounded once to the nearest pixel at fractional factors; scale changes always
+start from the configured logical value, so moving between displays cannot
+compound scaling.
 
 ### `[sidebar]`
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -54,12 +54,17 @@ binary. What now actually happens on screen:
   that wheel navigates Noren's retained history. Clicks, drags, and the wheel
   therefore reach programs that ask for them — Zellij, `vim` with `set
   mouse=a`, and `tmux` among them.
-- **Configured cell size reaches the renderer.** `[font] cell_width` /
-  `cell_height` flow through `GridGeometry::with_cells` to the drawing path;
-  the regression test `configured_cell_sizes_drive_the_app_geometry` in the
-  binary's extracted test module (`src/main/tests.rs`) pins it, and a mutation
-  note in `renderer.rs`'s tests records that
-  reverting `push_glyph` to the fixed `POC_CELL_WIDTH` constants must fail.
+- **Configured cell size and display scaling reach the renderer together.**
+  `[font] cell_width` / `cell_height` are logical-pixel controls that flow
+  through `GridGeometry::with_cells`; the active window `scale_factor` derives
+  physical `CellMetrics` exactly once for drawing, grid conversion, pointer
+  mapping, sidebar placement, and IME placement. `ScaleFactorChanged` refreshes
+  those metrics and synchronizes terminal state plus every live PTY. The
+  `hidpi_default_scales_keep_renderer_terminal_and_pty_grids_equal` and
+  `hidpi_configured_cells_scale_once_and_keep_all_three_grids_equal` tests pin
+  the complete 1.0/1.5/2.0 chain, while
+  `scale_factor_change_sends_sigwinch_with_rederived_pty_size` observes a live
+  shell receive the changed kernel winsize.
 - **Sidebar state survives a restart.** State is written to `sessions.toml`
   (`SESSION_STATE_FILE_NAME`) in the directory `config::default_path` resolves —
   `~/Library/Application Support/Noren/` on macOS — resolved by


### PR DESCRIPTION
Closes **#214** — `scale_factor` appeared **zero times** in the tree.

The window was sized in logical units while the cell was a fixed 10x20 *physical*
pixels, and every grid derivation downstream consumed physical pixels. On a
Retina display — **the dominant hardware for an arm64-macOS preview** — the
window opened at a quarter of the intended area with half-size glyphs, and
resizing grew the grid without ever growing the cell.

`scale_factor` now appears 52 times: the cell is derived from it, so the grid,
the glyph box, and the window agree in physical pixels on any display.

## The trap this repo has hit before

#35 was "renderer, PTY, and terminal grids disagree" and #76 was "config cell
size never reaches the renderer" — exactly what a scaling change reintroduces.

`grids_agree=1.0:pass,1.5:pass,2.0:pass`. The three grids are asserted equal at
each scale, including a fractional one.

## Both owner requirements

**Reads nothing → good result:** correct on both display classes with no
configuration. `scale1_unchanged=yes` — non-Retina rendering is unchanged, so
this is not a regression traded for a fix.

**Wants control → no source patching:** a configured `[font]` cell is still
honoured, and `font_config_scaled_once=yes` — scaled, not ignored and not
double-applied.

`scale_changed_event=handled`: dragging a window between a Retina and an
external non-Retina display re-derives the grid mid-session rather than leaving
it stale.

## Nothing that just landed is broken

`prior_features_ok=cursor,selection,scrollback,sidebar,ime` — #206, #210, #211,
#209/#213 and #212 all still land on the right pixels after scaling.

## Proof

Lane mutations: ignore the scale **14 tests**, apply it twice **14**, apply it to
the cell but not the grid **11**, ignore `ScaleFactorChanged` **5**.

Verified by the coordinator: making `scaled_cell_edge` drop the multiplication —
reproducing exactly today's behaviour on main — fails **4 independent tests**:
`non_unit_scale_factors_change_physical_cells_without_changing_logical_grid`,
`configured_cells_are_scaled_from_the_config_once`,
`fractional_scale_rounds_cell_edges_without_losing_a_default_row_or_column`, and
`a_changed_scale_forces_a_grid_notification_even_when_dimensions_match`.

Independent verification on a clean tree: **1,265 passed, 0 failed**, `fmt=0`,
and `cargo clippy --workspace --all-targets -- -D warnings` clean (the form CI
actually runs).